### PR TITLE
feat:Add google search tool

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+# Map Claude-related commits to primary contributor
+esafwan <esafwan@gmail.com> <claude@anthropic.com>
+esafwan <esafwan@gmail.com> Claude <claude@anthropic.com>
+esafwan <esafwan@gmail.com> claude <claude@anthropic.com>
+esafwan <esafwan@gmail.com> Anthropic Claude <claude@anthropic.com>
+
+# Map Cursor Agent commits to primary contributor
+esafwan <esafwan@gmail.com> Cursor Agent <cursoragent@cursor.com>
+esafwan <esafwan@gmail.com> <cursoragent@cursor.com>
+
+# Ensure consistent mapping for your own commits
+esafwan <esafwan@gmail.com> esafwan <esafwan@gmail.com>

--- a/agentflo/agentflo/doctype/agent_tool_function/agent_tool_function.json
+++ b/agentflo/agentflo/doctype/agent_tool_function/agent_tool_function.json
@@ -46,10 +46,10 @@
    "fieldname": "types",
    "fieldtype": "Select",
    "label": "Types",
-   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nSpeech to Text"
+   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nSpeech to Text\nGoogle Search"
   },
   {
-   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'Speech to Text'",
+   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'Speech to Text' && doc.types != 'Google Search'",
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
    "label": "Reference DocType",

--- a/agentflo/agentflo/doctype/agent_tool_function/agent_tool_function.py
+++ b/agentflo/agentflo/doctype/agent_tool_function/agent_tool_function.py
@@ -24,6 +24,7 @@ class AgentToolFunction(Document):
 				"Send Message",
 				"Get Report Result",
 				"Attach File to Document",
+				"Google Search",
 			]:
 				frappe.throw(_("Please select a DocType for this function."))
 
@@ -399,7 +400,51 @@ class AgentToolFunction(Document):
 				"required": [],
 				"additionalProperties": False
 			}
-					
+		elif self.types == "Google Search":
+			params = {
+				"type": "object",
+				"properties": {
+					"query": {
+						"type": "string",
+						"description": "The search query string"
+					},
+					"max_results": {
+						"type": "integer",
+						"description": "Maximum number of search results to return (default: 10)",
+						"default": 10
+					},
+					"search_domain_filter": {
+						"type": "array",
+						"items": {"type": "string"},
+						"description": "Optional list of domains to restrict search to (e.g., ['arxiv.org'])"
+					},
+					"date_restrict": {
+						"type": "string",
+						"description": "Optional date restriction filter (e.g., 'm6' for last 6 months, 'd7' for last 7 days)"
+					},
+					"language_restrict": {
+						"type": "string",
+						"description": "Optional language restriction (e.g., 'lang_en', 'lang_es')"
+					},
+					"safe": {
+						"type": "string",
+						"enum": ["active", "off"],
+						"description": "Search safety level ('active' or 'off', default: 'active')",
+						"default": "active"
+					},
+					"exact_terms": {
+						"type": "string",
+						"description": "Optional phrase that all documents must contain"
+					},
+					"file_type": {
+						"type": "string",
+						"description": "Optional file type to restrict results to (e.g., 'pdf')"
+					}
+				},
+				"required": ["query"],
+				"additionalProperties": False
+			}
+				
 		else:
 			params = self.build_params_json_from_table()
 

--- a/agentflo/ai/sdk_tools.py
+++ b/agentflo/ai/sdk_tools.py
@@ -76,7 +76,8 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         function_path = "agentflo.ai.sdk_tools.handle_attach_file_to_document"
                     elif function_doc.types == "Speech to Text":
                         function_path = "agentflo.ai.sdk_tools.handle_speech_to_text"
-
+                    elif function_doc.types == "Google Search":
+                        function_path = "agentflo.ai.sdk_tools.handle_google_search"
                     else:
                         continue
 
@@ -1026,4 +1027,115 @@ def handle_speech_to_text(
         return {"success": False, "error": f"Transcriptions API failed: {str(e)}"}
     except Exception as e:
         frappe.log_error(f"Speech to Text error: {frappe.get_traceback()}", "SpeechToText")
+        return {"success": False, "error": str(e)}
+
+
+def handle_google_search(
+    query: str,
+    max_results: int = 10,
+    search_domain_filter: list = None,
+    date_restrict: str = None,
+    language_restrict: str = None,
+    safe: str = "active",
+    exact_terms: str = None,
+    file_type: str = None,
+    **kwargs
+):
+    """
+    Perform a Google search using LiteLLM's search functionality.
+    
+    Reads API key and search engine ID from site_config.
+    
+    Args:
+        query: The search query string
+        max_results: Maximum number of results (default: 10)
+        search_domain_filter: Optional list of domains to restrict search to
+        date_restrict: Optional date restriction (e.g., 'm6', 'd7')
+        language_restrict: Optional language restriction (e.g., 'lang_en')
+        safe: Search safety level ('active' or 'off', default: 'active')
+        exact_terms: Optional phrase that all documents must contain
+        file_type: Optional file type to restrict results to (e.g., 'pdf')
+    
+    Returns:
+        dict: Search results with success status
+    """
+    try:
+        from litellm import search
+        
+        # Get API key and engine ID from site_config
+        site_config = frappe.get_site_config()
+        api_key = site_config.get("google_pse_api_key")
+        engine_id = site_config.get("google_pse_engine_id")
+        
+        if not api_key:
+            return {
+                "success": False,
+                "error": "Google PSE API key not found in site_config. Please set 'google_pse_api_key' in site_config."
+            }
+        
+        if not engine_id:
+            return {
+                "success": False,
+                "error": "Google PSE Engine ID not found in site_config. Please set 'google_pse_engine_id' in site_config."
+            }
+        
+        # Set environment variables for LiteLLM
+        import os
+        os.environ["GOOGLE_PSE_API_KEY"] = api_key
+        os.environ["GOOGLE_PSE_ENGINE_ID"] = engine_id
+        
+        # Prepare search parameters
+        search_kwargs = {
+            "query": query,
+            "search_provider": "google_pse",
+            "max_results": max_results,
+        }
+        
+        # Add optional Google PSE-specific parameters
+        if search_domain_filter:
+            search_kwargs["search_domain_filter"] = search_domain_filter
+        if date_restrict:
+            search_kwargs["dateRestrict"] = date_restrict
+        if language_restrict:
+            search_kwargs["lr"] = language_restrict
+        if safe:
+            search_kwargs["safe"] = safe
+        if exact_terms:
+            search_kwargs["exactTerms"] = exact_terms
+        if file_type:
+            search_kwargs["fileType"] = file_type
+        
+        # Perform search
+        response = search(**search_kwargs)
+        
+        # Format response
+        if isinstance(response, dict):
+            results = response.get("results", [])
+            return {
+                "success": True,
+                "query": query,
+                "results": results,
+                "total_results": len(results),
+            }
+        elif isinstance(response, list):
+            return {
+                "success": True,
+                "query": query,
+                "results": response,
+                "total_results": len(response),
+            }
+        else:
+            return {
+                "success": True,
+                "query": query,
+                "results": response,
+            }
+            
+    except ImportError:
+        return {
+            "success": False,
+            "error": "LiteLLM is not installed. Please install it using: pip install litellm"
+        }
+    except Exception as e:
+        frappe.log_error(f"Google Search error: {frappe.get_traceback()}", "GoogleSearch")
         return {"success": False, "error": str(e)}


### PR DESCRIPTION
Important: Merge after merging liteLLM PR.

# Add Google Search Tool

Adds Google Programmable Search Engine (PSE) support as a tool via LiteLLM.

- Implements Google Search tool in SDK tools
- Integrates with LiteLLM unified provider
- Adds configuration and error handling


```
### How to Add and Configure Google Search API Key in Frappe

#### Step 1: Add Keys in Site Config

The Google Search tool uses credentials stored in `site_config.json`. You need to add:

* `google_pse_api_key` → your Google Programmable Search API key
* `google_pse_engine_id` → your Google Custom Search Engine ID


~~~json
{
  "google_pse_api_key": "YOUR_API_KEY_HERE",
  "google_pse_engine_id": "YOUR_ENGINE_ID_HERE"
}
~~~

#### Step 2: Get Your Google API Credentials

1. Go to [[Google Cloud Console](https://console.cloud.google.com/)](https://console.cloud.google.com/)
2. Create/select a project
3. Enable **Custom Search API**
4. Under **APIs & Services → Credentials**, create an API key → this is `google_pse_api_key`
5. Visit [[Programmable Search Engine](https://programmablesearchengine.google.com/)](https://programmablesearchengine.google.com/)
6. Create or open your search engine
7. Copy the **Search Engine ID** → this is `google_pse_engine_id`

Once added, the tool automatically detects these values from `site_config` — no restart required.
