### PR TITLE
add:support per-user or shared conversation for doc event triggers

### DIFF
--- a/agentflo/agentflo/doctype/agent/agent.json
+++ b/agentflo/agentflo/doctype/agent/agent.json
@@ -19,6 +19,7 @@
   "disabled",
   "behaviour_tab",
   "conversation_settings_section",
+  "persist_user_history",
   "allow_chat",
   "column_break_vfhq",
   "persist_conversation",
@@ -177,12 +178,19 @@
    "fieldname": "metadata_tab",
    "fieldtype": "Tab Break",
    "label": "Metadata"
+  },
+  {
+   "default": "1",
+   "description": "When checked, Doc Event and Scheduled runs create / maintain conversation history per initiating user (or trigger owner). If unchecked, a single shared history is used.",
+   "fieldname": "persist_user_history",
+   "fieldtype": "Check",
+   "label": "Persist per User (Doc/Schedule)"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-05 14:44:16.304542",
+ "modified": "2025-11-12 11:43:42.729561",
  "modified_by": "Administrator",
  "module": "AgentFlo",
  "name": "Agent",

--- a/agentflo/ai/agent_hooks.py
+++ b/agentflo/ai/agent_hooks.py
@@ -95,11 +95,13 @@ def run_hooked_agents(doc, method=None, *args, **kwargs):
             event_name=method,
             provider=agent.get("provider"),
             model=agent.get("model"),
-            include_doc=False
+            include_doc=False,
+            initiating_user=frappe.session.user,
+            channel_id="doc_event" 
         )
 
 
-def run_agent_for_doc(doc, agent_name, instructions, event_name, provider,model,include_doc=False):
+def run_agent_for_doc(doc, agent_name, instructions, event_name, provider, model,include_doc=False, initiating_user=None, channel_id=None):
     """Background worker to run an agent when a Doc Event triggers"""
 
     #Add logic to inlude/not include full doctype data dict. If not, only name will be passed. 
@@ -127,8 +129,19 @@ def run_agent_for_doc(doc, agent_name, instructions, event_name, provider,model,
         #     {json_string}
         # ```
         # """
+        external_id = None
+        channel = channel_id or "doc_event"
 
-        run_agent_sync(agent_name, prompt,provider,model)
+        try:
+            agent_doc = frappe.get_doc("Agent", agent_name)
+            if getattr(agent_doc, "persist_user_history", False):
+                external_id = initiating_user or doc.get("owner") or doc.get("modified_by") or "unknown_user"
+            else:
+                external_id = f"shared:{agent_name}"
+        except Exception:
+            external_id = initiating_user or f"shared:{agent_name}"
+
+        run_agent_sync(agent_name, prompt, provider, model, channel_id=channel, external_id=external_id)
 
     except Exception:
         frappe.log_error(frappe.get_traceback(), "Hook Triggered Agent Error")


### PR DESCRIPTION
- capture initiating_user when enqueue doc-event jobs
- compute external_id in worker based on Agent.persist_user_history
  - if true → external_id = initiating_user (per-user conversation)
  - if false → external_id = shared:<agent> (single shared conversation)
- pass channel_id and external_id to run_agent_sync so ConversationManager
  selects/creates the correct conversation