### PR TITLE
fix: skip agent hooks during migration to prevent circular dependency

### DIFF
--- a/agentflo/ai/agent_hooks.py
+++ b/agentflo/ai/agent_hooks.py
@@ -10,22 +10,37 @@ CACHE_KEY = "agentflo:doc_event_agents"
 
 def get_doc_event_agents(event: str):
     """Fetch & cache Doc Event triggers (Agent Trigger doctype)."""
+    # Skip during migration - tables may not exist yet
+    if getattr(frappe.flags, "in_migrate", False):
+        return []
+    
+    # Check if DocType exists and table is created
     if not frappe.db.exists("DocType", "Agent Trigger"):
+        return []
+    
+    # Check if table actually exists (not just DocType record)
+    try:
+        frappe.db.sql("SELECT 1 FROM `tabAgent Trigger` LIMIT 1")
+    except Exception:
         return []
 
     cached = frappe.cache().hget(CACHE_KEY, f"doc_event:{event}")
     if cached:
         return frappe.parse_json(cached)
 
-    triggers = frappe.get_list(
-        "Agent Trigger",
-        filters={
-            "trigger_type": "Doc Event",
-            "disabled": 0,
-            "doc_event": event
-        },
-        fields=["name", "agent", "reference_doctype", "doc_event", "condition"]
-    )
+    try:
+        triggers = frappe.get_list(
+            "Agent Trigger",
+            filters={
+                "trigger_type": "Doc Event",
+                "disabled": 0,
+                "doc_event": event
+            },
+            fields=["name", "agent", "reference_doctype", "doc_event", "condition"]
+        )
+    except Exception:
+        # Table might not be ready yet
+        return []
 
     result = []
     for t in triggers:
@@ -57,6 +72,10 @@ def clear_doc_event_agents_cache(doc=None, method=None):
 
 
 def run_hooked_agents(doc, method=None, *args, **kwargs):
+    # Skip hook execution during migration to avoid circular dependencies
+    if getattr(frappe.flags, "in_migrate", False):
+        return
+    
     if not method:
         return
 


### PR DESCRIPTION
## Problem
Migration fails when creating `Agent Trigger` DocType due to circular dependency. The `after_insert` hook fires during DocType creation and tries to query the `Agent Trigger` table before it exists, causing a `TableMissingError`.

## Error Encountered

```
Traceback (most recent call last):
  File "/workspace/development/huf16/apps/frappe/frappe/utils/bench_helper.py", line 48, in invoke
    return super().invoke(ctx)
  File "/workspace/development/huf16/apps/frappe/frappe/commands/site.py", line 708, in migrate
    ).run(site=site)
  File "/workspace/development/huf16/apps/frappe/frappe/migrate.py", line 270, in run
    self.run_schema_updates()
  File "/workspace/development/huf16/apps/frappe/frappe/migrate.py", line 142, in run_schema_updates
    frappe.model.sync.sync_all()
  File "/workspace/development/huf16/apps/frappe/frappe/model/sync.py", line 112, in sync_for
    imported = import_file_by_path(...)
  File "/workspace/development/huf16/apps/frappe/frappe/modules/import_file.py", line 238, in import_doc
    doc.insert()
  File "/workspace/development/huf16/apps/frappe/frappe/model/document.py", line 447, in insert
    self.run_method("after_insert")
  File "/workspace/development/huf16/apps/frappe/frappe/model/document.py", line 1162, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/workspace/development/huf16/apps/agentflo/agentflo/ai/agent_hooks.py", line 63, in run_hooked_agents
    agents = get_doc_event_agents(method)
  File "/workspace/development/huf16/apps/agentflo/agentflo/ai/agent_hooks.py", line 20, in get_doc_event_agents
    triggers = frappe.get_list("Agent Trigger", ...)
  File "/workspace/development/huf16/apps/frappe/frappe/model/db_query.py", line 657, in get_table_columns
    return get_table_columns(self.doctype)
  File "/workspace/development/huf16/apps/frappe/frappe/model/meta.py", line 109, in get_table_columns
    return frappe.db.get_table_columns(doctype)
  File "/workspace/development/huf16/apps/frappe/frappe/database/database.py", line 1358, in get_table_columns
    raise self.TableMissingError("DocType", doctype)
MySQLdb.ProgrammingError: ('DocType', 'Agent Trigger')
```

## Root Cause
- During migration, `Agent Trigger` DocType record is created
- `after_insert` hook fires and calls `run_hooked_agents()`
- Hook tries to query `tabAgent Trigger` table before it exists
- Migration fails with `TableMissingError`

## Solution
Skip hook execution during migration by:
1. Checking `frappe.flags.in_migrate` flag to detect migration mode
2. Verifying table exists before querying (not just DocType record)
3. Wrapping queries in try-except for additional safety

## Changes
- Added migration check in `get_doc_event_agents()` - returns empty list during migration
- Added table existence verification before querying
- Added early exit in `run_hooked_agents()` - skips hook execution during migration
- Wrapped `frappe.get_list()` in try-except for graceful error handling

## Testing & Success
After this fix was applied, code ran without the error on migration

```
frappe@12155d7f3c38:/workspace/development/huf16$ bench --site hufmcp.localhost migrate
Migrating hufmcp.localhost
Updating DocTypes for frappe        : [========================================] 100%
Updating DocTypes for agentflo      : [========================================] 100%
Syncing jobs...
Syncing fixtures...
Syncing dashboards...
Updating Dashboard for frappe
Updating Dashboard for agentflo
Syncing customizations...
Syncing languages...
Flushing deferred inserts...
Removing orphan doctypes...
Orphaned DocType(s) found: Agent Orchestration Run, Agent Orchestration Config, Provider Settings
Deleting orphaned DocTypes          : [========================================] 100%
Syncing portal menu...
Updating installed applications...
Executing `after_migrate` hooks...

Queued rebuilding of search index for hufmcp.localhost
```