### PR TITLE
feat: implement agent message logging for tool calls

### DIFF
--- a/huf/ai/conversation_manager.py
+++ b/huf/ai/conversation_manager.py
@@ -72,9 +72,8 @@ class ConversationManager:
         conv.insert()
         return conv
 
-    def add_message(self, conversation, role, content, provider, model, agent,run_name=None):
+    def add_message(self, conversation, role, content, provider, model, agent, run_name=None, kind="Message", tool_call_id=None):
         """Add message to conversation"""
-        # Get next index
         try:
             last_index = frappe.db.sql("""
                 SELECT MAX(conversation_index) as last_index
@@ -90,17 +89,17 @@ class ConversationManager:
                 "content": content if isinstance(content, str) else json.dumps(content),
                 "user": self.external_id or frappe.session.user if role == "user" else "Agent",
                 "session_id": self.session_id,
-                "kind": "Message",
+                "kind": kind,
                 "agent_run": run_name,
-                "agent":agent,
-                "provider":provider,
-                "model":model,
+                "agent": agent,
+                "provider": provider,
+                "model": model,
                 "conversation_index": last_index + 1,
-                "is_agent_message": 1 if role == "agent" else 0
+                "is_agent_message": 1 if role == "agent" else 0,
+                "tool_calll": tool_call_id 
             })
             message.insert()
 
-            # Update conversation stats
             frappe.db.set_value("Agent Conversation", conversation.name, {
                 "total_messages": last_index + 1,
                 "last_activity": now()

--- a/huf/huf/doctype/agent_message/agent_message.json
+++ b/huf/huf/doctype/agent_message/agent_message.json
@@ -22,7 +22,10 @@
   "is_agent_message",
   "role",
   "conversation_index",
-  "status"
+  "status",
+  "tool_calll",
+  "tool_name",
+  "tool_args"
  ],
  "fields": [
   {
@@ -136,12 +139,33 @@
    "hidden": 1,
    "label": "Status",
    "options": "\nStarted\nQueues\nCompleted\nFailed"
+  },
+  {
+   "fieldname": "tool_calll",
+   "fieldtype": "Link",
+   "label": "Tool Calll",
+   "options": "Agent Tool Call",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "tool_calll.tool",
+   "fieldname": "tool_name",
+   "fieldtype": "Data",
+   "label": "Tool Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "tool_calll.tool_args",
+   "fieldname": "tool_args",
+   "fieldtype": "JSON",
+   "label": "Tool Args",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-24 12:47:12.375071",
+ "modified": "2025-12-03 19:21:41.425198",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Message",


### PR DESCRIPTION
   - Modified 'run_agent_sync' to generate an 'Agent Message' immediately when an agent requests a tool.
   - Messages now include the 'tool_name' and 'tool_args' (arguments), providing users with visibility into the agent's actions.
   - Implemented logic to update the *existing* tool call message when the execution result arrives, rather than creating a new, disconnected message row.
   - The message content is appended with the 'Tool Result', keeping the conversation timeline clean and consolidated.
   - Updated 'ConversationManager.add_message' to accept a 'tool_call_id'.
   - Populates the 'tool_calll' link field in 'Agent Message', allowing the UI to fetch and display detailed tool metadata (name/args) directly from the source record.
   - Introduced dynamic 'kind' support (e.g., 'Tool Call', 'Tool Result') in 'Agent Message' to distinguish between standard chat messages and system actions.