### PR TITLE
feat: auto-fetch params and generate schema for Custom Functions

### DIFF
--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.js
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.js
@@ -6,6 +6,21 @@ frappe.ui.form.on('Agent Tool Function', {
 		if (frm.doc.reference_doctype) {
 			_update_field_options(frm);
 		}
+		if (frm.doc.types === "Custom Function" && frm.doc.function_path) {
+            frm.add_custom_button(__('Fetch Params from Code'), function() {
+                frappe.call({
+                    doc: frm.doc,
+                    method: 'fetch_parameters_from_code',
+                    freeze: true,
+                    callback: function(r) {
+                        if (!r.exc) {
+                            frm.reload_doc();
+                            frappe.msgprint(__("Parameters updated from function signature."));
+                        }
+                    }
+                });
+            });
+        }
 	},
 
 	reference_doctype(frm) {

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -62,6 +62,7 @@
    "label": "Parameters"
   },
   {
+   "allow_bulk_edit": 1,
    "fieldname": "parameters",
    "fieldtype": "Table",
    "label": "Parameters",
@@ -135,7 +136,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-03 15:11:10.107074",
+ "modified": "2025-12-08 11:00:31.833795",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Tool Function",


### PR DESCRIPTION
- Added 'fetch_parameters_from_code' whitelisted method to 'AgentToolFunction'.
- Implemented python 'inspect' logic to auto-populate the 'parameters' child table from the function signature at 'function_path'.
- Automatically sets 'pass_parameters_as_json' to true when parameters are fetched.
- Updated 'prepare_function_params' to generate JSON schema from the child table for 'Custom Function' type when 'pass_parameters_as_json' is enabled.
- Refactored 'build_params_json_from_table' to remove dependency on 'reference_doctype', allowing Custom Functions to generate valid schemas purely from the child table definitions.