### PR TITLE
feat: add support for object and array parameter types in tools

### DIFF
--- a/huf/huf/doctype/agent_function_params/agent_function_params.json
+++ b/huf/huf/doctype/agent_function_params/agent_function_params.json
@@ -34,7 +34,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Type",
-   "options": "string\ninteger\nnumber\nfloat\nboolean",
+   "options": "string\ninteger\nnumber\nfloat\nboolean\nobject\narray",
    "reqd": 1
   },
   {
@@ -65,7 +65,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-19 11:44:46.026280",
+ "modified": "2025-12-09 10:50:19.450547",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Function Params",

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -458,6 +458,13 @@ class AgentToolFunction(Document):
 				"description": param.label,
 			}
 
+			# Explicitly allow any keys/values for object types
+			if param.type == "object":
+				obj["additionalProperties"] = True
+
+			if param.type == "array":
+				obj["items"] = {"type": "string"}
+
 			if param.type == "string" and param.options:
 				obj["enum"] = param.options.split("\n")
 
@@ -491,7 +498,7 @@ class AgentToolFunction(Document):
 					table_field = doctype_meta.get_field(child_table_name)
 				except Exception:
 					pass 
-			
+
 			properties[child_table_name] = child_table
 
 		if self.types == "Create Multiple Documents" or self.types == "Update Multiple Documents":


### PR DESCRIPTION
- Update 'Agent Function Params' DocType to include 'object' and 'array' in the 'type' field options.
- Update 'agent_tool_function.py' to correctly generate JSON schema for these new types:
    - 'object' types now include 'additionalProperties: True' to allow dynamic dictionaries (fixing 'dict' parameter support).
    - 'array' types now default to items of type string.
- This resolves issues where Custom Functions requiring dictionaries (e.g., filters) failed because the AI was not provided the correct schema.