### PR TITLE
feat: add support for dynamic prompt injection from reference document

### DIFF
--- a/huf/huf/doctype/agent_trigger/agent_trigger.js
+++ b/huf/huf/doctype/agent_trigger/agent_trigger.js
@@ -1,8 +1,32 @@
 // Copyright (c) 2025, Tridz Technologies Pvt Ltd and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Agent Trigger", {
-// 	refresh(frm) {
+frappe.ui.form.on('Agent Trigger', {
+    refresh: function(frm) {
+        if (frm.doc.reference_doctype) {
+            frm.trigger('set_prompt_field_options');
+        }
+    },
 
-// 	},
-// });
+    reference_doctype: function(frm) {
+        frm.set_value('prompt_field', '');
+        frm.trigger('set_prompt_field_options');
+    },
+
+    set_prompt_field_options: function(frm) {
+        if (!frm.doc.reference_doctype) return;
+
+        frappe.model.with_doctype(frm.doc.reference_doctype, function() {
+            let meta = frappe.get_meta(frm.doc.reference_doctype);
+
+            let options = meta.fields
+                .filter(df => !['Section Break', 'Column Break', 'Tab Break', 'Table'].includes(df.fieldtype))
+                .map(df => df.fieldname);
+
+            let standard_fields = ['name', 'owner', 'creation', 'modified', 'docstatus'];
+            options = [...standard_fields, ...options];
+
+            frm.set_df_property('prompt_field', 'options', options);
+        });
+    }
+});

--- a/huf/huf/doctype/agent_trigger/agent_trigger.json
+++ b/huf/huf/doctype/agent_trigger/agent_trigger.json
@@ -16,13 +16,14 @@
   "doc_event",
   "scheduled_interval",
   "next_execution",
+  "condition",
   "event_name",
   "webhook_slug",
   "column_break_hz7t",
   "reference_doctype",
+  "prompt_field",
   "interval_count",
   "last_execution",
-  "condition",
   "webhook_key",
   "app_name",
   "section_break_qam6",
@@ -173,12 +174,19 @@
   {
    "fieldname": "section_break_qam6",
    "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval: doc.trigger_type == \"Doc Event\"",
+   "description": "Enter the fieldname from the Reference DocType that contains the user's instructions.",
+   "fieldname": "prompt_field",
+   "fieldtype": "Select",
+   "label": "Prompt Field"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-11-05 16:55:00.008101",
+ "modified": "2025-12-09 19:09:53.068722",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Trigger",


### PR DESCRIPTION
- Updated 'get_doc_event_agents' to fetch 'prompt_field' configuration from Agent Trigger.
- Modified 'run_hooked_agents' to pass the configured field mapping to the background worker.
- Enhanced 'run_agent_for_doc' to dynamically extract custom instructions from the specified document field.
- Agent prompt construction now prioritises document-specific requests over standard instructions when present.