### PR TITLE
feat: migrate speech-to-text to generic AI Provider Tool architecture

### DIFF
--- a/huf/ai/provider_tool_handler.py
+++ b/huf/ai/provider_tool_handler.py
@@ -1,0 +1,123 @@
+import frappe
+import requests
+import json
+from frappe import _
+from frappe.utils.file_manager import get_file_path
+
+def execute_provider_tool(provider=None, tool_type=None, tool_name=None, kwargs=None, file_doc=None):
+    """
+    Generic executor that finds a configured AI Provider Tool and runs it.
+    """
+    # 1. Find the Tool Configuration
+    filters = {"enabled": 1}
+    if tool_name:
+        filters["provider_tool_name"] = tool_name
+    elif provider and tool_type:
+        filters["provider"] = provider
+        filters["provider_tool_type"] = tool_type
+    else:
+        frappe.log_error("Provider Handler", "Missing provider/tool_type or tool_name")
+        return {"success": False, "error": "Missing configuration to identify the tool."}
+
+    tool_doc_name = frappe.db.get_value("AI Provider Tool", filters, "name")
+    
+    if not tool_doc_name:
+        # Passively return None so calling functions know no tool was found (and can error out gracefully)
+        return None
+
+    tool_doc = frappe.get_doc("AI Provider Tool", tool_doc_name)
+
+    # 2. Resolve API Key
+    # Priority: Tool specific key > Provider parent key
+    api_key = tool_doc.get_password("api_key")
+    if not api_key and tool_doc.provider:
+        provider_doc = frappe.get_doc("AI Provider", tool_doc.provider)
+        api_key = provider_doc.get_password("api_key")
+
+    if not api_key and tool_doc.select_ydlu != "None":
+        return {"success": False, "error": f"API Key missing for tool {tool_doc.name}"}
+
+    # 3. Build Headers
+    headers = {}
+    if tool_doc.select_ydlu == "Bearer Token":
+        headers["Authorization"] = f"Bearer {api_key}"
+    elif tool_doc.select_ydlu == "API Key Header":
+        # Defaulting to 'x-api-key', but allowing override via static_params if needed
+        headers["x-api-key"] = api_key
+
+    # 4. Build Payload (Merge Static Params + Runtime Args)
+    payload = {}
+    if tool_doc.static_params:
+        try:
+            static_data = json.loads(tool_doc.static_params)
+            if isinstance(static_data, dict):
+                payload.update(static_data)
+        except Exception:
+            frappe.log_error("JSON Error", f"Invalid Static Params in {tool_doc.name}")
+
+    if kwargs:
+        payload.update(kwargs)
+
+    # Explicit Model Override
+    if tool_doc.model:
+        payload["model"] = tool_doc.model
+
+    # 5. Handle Files (Specifically for Speech to Text)
+    files = None
+    opened_file = None
+    
+    if file_doc and tool_doc.file_param:
+        try:
+            # If we have a file_doc, we try to get the path
+            file_path = get_file_path(file_doc.file_name)
+            opened_file = open(file_path, 'rb')
+            files = {tool_doc.file_param: (file_doc.file_name, opened_file)}
+        except Exception:
+            # Fallback if file is remote (S3/URL)
+            if hasattr(file_doc, 'file_url') and file_doc.file_url.startswith('http'):
+                try:
+                    r = requests.get(file_doc.file_url, timeout=10)
+                    files = {tool_doc.file_param: (file_doc.file_name or "audio.wav", r.content)}
+                except Exception as e:
+                    return {"success": False, "error": f"Failed to download remote file: {str(e)}"}
+            else:
+                 return {"success": False, "error": "Could not locate file path on server."}
+
+    # 6. Execute Request
+    try:
+        method = tool_doc.method.upper()
+        
+        # Requests logic: 'data' for form-data (when files exist), 'json' otherwise
+        if files:
+            # When sending files, other payload data must be form-fields (data=payload)
+            response = requests.request(method, tool_doc.api_url, headers=headers, data=payload, files=files, timeout=60)
+        else:
+            response = requests.request(method, tool_doc.api_url, headers=headers, json=payload, timeout=60)
+        
+        if opened_file:
+            opened_file.close()
+
+        if response.status_code >= 400:
+            return {"success": False, "error": f"API Error ({response.status_code}): {response.text}"}
+
+        res_data = response.json()
+
+    except Exception as e:
+        if opened_file: opened_file.close()
+        return {"success": False, "error": f"Request Failed: {str(e)}"}
+
+    # 7. Extract Result via Response Path
+    # If path is "text", we look for data["text"]
+    result = res_data
+    if tool_doc.response_path:
+        try:
+            for key in tool_doc.response_path.split('.'):
+                if isinstance(result, list) and key.isdigit():
+                    result = result[int(key)]
+                else:
+                    result = result.get(key)
+        except Exception:
+            # If path extraction fails, return full response for debugging
+            pass
+
+    return {"success": True, "result": result, "raw": res_data}

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -47,10 +47,10 @@
    "fieldname": "types",
    "fieldtype": "Select",
    "label": "Types",
-   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nSpeech to Text"
+   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent"
   },
   {
-   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'App Provided' && doc.types != 'Custom Function' && doc.types != 'Speech to Text'",
+   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'App Provided' && doc.types != 'Custom Function'",
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
    "label": "Reference DocType",

--- a/huf/huf/doctype/ai_provider_tool/ai_provider_tool.js
+++ b/huf/huf/doctype/ai_provider_tool/ai_provider_tool.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Huf and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("AI Provider Tool", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/huf/huf/doctype/ai_provider_tool/ai_provider_tool.json
+++ b/huf/huf/doctype/ai_provider_tool/ai_provider_tool.json
@@ -1,0 +1,129 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:provider_tool_name",
+ "creation": "2025-12-15 12:58:42.295299",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "provider_tool_name",
+  "provider",
+  "api_url",
+  "method",
+  "auth_type",
+  "file_param",
+  "static_params",
+  "column_break_husm",
+  "model",
+  "provider_tool_type",
+  "enabled",
+  "api_key",
+  "response_path",
+  "param_schema"
+ ],
+ "fields": [
+  {
+   "fieldname": "provider_tool_name",
+   "fieldtype": "Data",
+   "label": "Provider Tool Name",
+   "unique": 1
+  },
+  {
+   "fieldname": "provider",
+   "fieldtype": "Link",
+   "label": "Provider",
+   "options": "AI Provider"
+  },
+  {
+   "fieldname": "provider_tool_type",
+   "fieldtype": "Select",
+   "label": "Provider Tool Type",
+   "options": "\nSpeech to Text\nText to Speech\nImage Generation\nImage Analysis (Vision)\nText Embedding\nContent Moderation\nVideo Generation\nDocument OCR\nTranslation\nObject Detection"
+  },
+  {
+   "default": "0",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "api_url",
+   "fieldtype": "Data",
+   "label": "API URL"
+  },
+  {
+   "fieldname": "method",
+   "fieldtype": "Select",
+   "label": "Method",
+   "options": "POST\nGET"
+  },
+  {
+   "fieldname": "api_key",
+   "fieldtype": "Password",
+   "label": "API Key",
+   "length": 200
+  },
+  {
+   "fieldname": "model",
+   "fieldtype": "Data",
+   "label": "Model"
+  },
+  {
+   "fieldname": "file_param",
+   "fieldtype": "Data",
+   "label": "File Param"
+  },
+  {
+   "fieldname": "response_path",
+   "fieldtype": "Data",
+   "label": "Response Path"
+  },
+  {
+   "fieldname": "static_params",
+   "fieldtype": "Code",
+   "label": "Static Params"
+  },
+  {
+   "fieldname": "param_schema",
+   "fieldtype": "Code",
+   "label": "Param Schema"
+  },
+  {
+   "fieldname": "auth_type",
+   "fieldtype": "Select",
+   "label": "Auth Type",
+   "options": "Bearer Token\nAPI Key Header\nNone"
+  },
+  {
+   "fieldname": "column_break_husm",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-12-17 11:54:09.458966",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "AI Provider Tool",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/huf/huf/doctype/ai_provider_tool/ai_provider_tool.py
+++ b/huf/huf/doctype/ai_provider_tool/ai_provider_tool.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Huf and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AIProviderTool(Document):
+	pass

--- a/huf/huf/doctype/ai_provider_tool/test_ai_provider_tool.py
+++ b/huf/huf/doctype/ai_provider_tool/test_ai_provider_tool.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Huf and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAIProviderTool(FrappeTestCase):
+	pass


### PR DESCRIPTION
- Refactor 'handle_speech_to_text' in 'sdk_tools.py' to remove hardcoded provider logic.
- Implement 'execute_provider_tool' in new 'provider_handler.py' to dynamically execute tools configured in 'AI Provider Tool' doctype.
- Update 'agent_chat.py' to use the new generic handler for transcriptions.

BREAKING CHANGE: Speech to Text no longer works out-of-the-box with hardcoded OpenAI logic. Users must now create an "AI Provider Tool" record configured for their provider (e.g., OpenAI Whisper) to enable this feature.