### PR TITLE
feat: add Attach File to Document tool capability

### DIFF
--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -191,29 +191,22 @@ class AgentToolFunction(Document):
 			}
 
 		elif self.types == "Attach File to Document":
+			properties = {
+                "document_id": {
+                    "type": "string",
+                    "description": "The ID of the document."
+                },
+                "file_url": {
+                    "type": "string",
+                    "description": "The URL/path of the existing file."
+                }
+            }
 			params = {
-				"type": "object",
-				"properties": {
-					"reference_doctype": {
-						"type": "string",
-						"description": "The DocType of the document to attach the file to (e.g. Lead, Customer).",
-					},
-					"document_id": {
-						"type": "string",
-						"description": "The ID (name) of the document to attach the file to (e.g. CRM-LEAD-2025-00016).",
-					},
-					"file_url": {
-						"type": "string",
-						"description": "The URL/path of an existing file (e.g. /files/Sanju.jpg)."
-					},
-					"file_id": {
-						"type": "string",
-						"description": "The File document name if already uploaded (optional)."
-					}
-				},
-				"required": ["reference_doctype", "document_id"],
-				"additionalProperties": False,
-			}
+                "type": "object",
+                "properties": properties,
+                "required": ["document_id", "file_url"],
+                "additionalProperties": False,
+            }
 
 		elif self.types == "Custom Function":
 			if self.pass_parameters_as_json:


### PR DESCRIPTION
- Implement zero-config prompting: AI only sees 'document_id' and 'file_url', while target fields are injected automatically from tool configuration.
- Add 'handle_attach_file_to_document' to SDK tools to map configured parameters to backend arguments.
- Implement core 'attach_file_to_document' logic to:
  - Download remote files or resolve local paths.
  - Create/Link File documents in Frappe.
  - Update specific target fields with the clean file URL.
- Ensure strict permission checks and file URL validation.