### PR TITLE
feat: enable multi-field file attachment support in Agent tools

### DIFF
--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -195,16 +195,23 @@ class AgentToolFunction(Document):
                 "document_id": {
                     "type": "string",
                     "description": "The ID of the document."
-                },
-                "file_url": {
-                    "type": "string",
-                    "description": "The URL/path of the existing file."
                 }
             }
+			if self.parameters:
+				for param in self.parameters:
+					properties[param.fieldname] = {
+						"type": "string",
+						"description": f"File URL/Path for field '{param.label or param.fieldname}'"
+					}
+			else:
+				properties["file_url"] = {
+					"type": "string",
+					"description": "The URL/path of the file to attach."
+				}
 			params = {
                 "type": "object",
                 "properties": properties,
-                "required": ["document_id", "file_url"],
+                "required": ["document_id"],
                 "additionalProperties": False,
             }
 


### PR DESCRIPTION
- Update `Attach File to Document` schema generation in `agent_tool_function.py` to expose configured fields as string inputs, allowing the AI to provide specific URLs for specific fields (e.g., `{"photo": "url1", "resume": "url2"}`).
- Refactor `handle_attach_file_to_document` in `sdk_tools.py` to accept dynamic `**kwargs` instead of hardcoded boolean flags, enabling multiple field-URL pairs in a single request.
- Update `tool_functions.py` to iterate through provided arguments, validating field existence and processing file attachments for each target field independently.
- Remove legacy logic that relied on hidden boolean field injection.