### PR TITLE
feat: implement multi run plan generation on agent creation

### DIFF
--- a/huf/ai/orchestration/planning.py
+++ b/huf/ai/orchestration/planning.py
@@ -10,6 +10,12 @@ Rules:
 - Return ONLY a numbered list, nothing else
 - Keep steps concise but clear
 
+CRITICAL RULES:
+- NO UI STEPS: Do not say "Click", "Open", "Navigate". The system is a backend API.
+- ONE STEP = ONE DOCUMENT: Group all fields for a record into a single "Create" step.
+- LOGICAL FLOW: Step 1 (Create Parent) -> Step 2 (Create Child).
+
+
 Example format:
 1. First action to take
 2. Second action to take

--- a/huf/ai/orchestration/scheduler.py
+++ b/huf/ai/orchestration/scheduler.py
@@ -1,13 +1,16 @@
 # huf/ai/orchestration/scheduler.py
 
 import frappe
+from frappe.utils import now_datetime, time_diff_in_seconds
 from huf.ai.orchestration.orchestrator import execute_next_step
 
+JOB_TIMEOUT_SECONDS = 900 # 15 minutes
 
 def process_orchestrations():
     """
     Called every minute via scheduler to process active orchestrations.
-    Executes one step per orchestration per run.
+    1. Checks for stuck jobs (timed out).
+    2. Enqueues next steps for idle orchestrations.
     """
     if not frappe.db.exists("DocType", "Agent Orchestration"):
         return
@@ -21,13 +24,38 @@ def process_orchestrations():
     for o in orchestrations:
         try:
             orch = frappe.get_doc("Agent Orchestration", o.name)
-            result = execute_next_step(orch)
             
-            if result == "failed":
-                frappe.log_error(
-                    f"Orchestration {o.name} step failed",
-                    "Orchestration Scheduler"
-                )
+            is_running = False
+            for step in orch.agent_orchestration_plan:
+                if step.status == "in_progress":
+                    last_update = step.modified
+                    if not last_update:
+                        last_update = orch.modified
+                        
+                    if time_diff_in_seconds(now_datetime(), last_update) > JOB_TIMEOUT_SECONDS:
+                        frappe.log_error(f"Orchestration {o.name} Step {step.step_index} timed out. Marking failed.", "Orchestration Scheduler")
+                        step.status = "failed"
+                        orch.error_log = (orch.error_log or "") + f"\nStep {step.step_index} timed out (stuck for > 15m)."
+                        orch.status = "Failed"
+                        orch.save(ignore_permissions=True)
+                        frappe.db.commit()
+                        is_running = False
+                    else:
+                        is_running = True
+                    
+                    break
+            
+            if is_running:
+                continue
+
+            frappe.enqueue(
+                "huf.ai.orchestration.orchestrator.execute_next_step",
+                queue="default",
+                timeout=1200,
+                orch=orch,
+                orch_name=orch.name
+            )
+
         except Exception as e:
             frappe.log_error(
                 f"Error processing orchestration {o.name}: {str(e)}\n{frappe.get_traceback()}",

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -32,6 +32,8 @@
   "enable_multi_run",
   "column_break_vfhq",
   "persist_conversation",
+  "multi_run_setting_section",
+  "default_plan",
   "section_break_yyoa",
   "instructions",
   "tools_and_mcp_tab",
@@ -323,6 +325,17 @@
    "fieldtype": "Table MultiSelect",
    "label": "Allowed Roles",
    "options": "Agent Role"
+  },
+  {
+   "fieldname": "multi_run_setting_section",
+   "fieldtype": "Section Break",
+   "label": "Multi Run Setting"
+  },
+  {
+   "fieldname": "default_plan",
+   "fieldtype": "Table",
+   "label": "Default Plan",
+   "options": "Agent Orchestration Plan"
   }
  ],
  "grid_page_length": 50,

--- a/huf/huf/doctype/agent_orchestration/agent_orchestration.js
+++ b/huf/huf/doctype/agent_orchestration/agent_orchestration.js
@@ -1,8 +1,39 @@
 // Copyright (c) 2025, Tridz Technologies Pvt Ltd and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Agent Orchestration", {
-// 	refresh(frm) {
+frappe.ui.form.on("Agent Orchestration", {
+    refresh: function (frm) {
+        // Requirement 3: Recreate Plan Button
+        if (frm.doc.status !== "Completed" && !frm.is_new()) {
+            frm.add_custom_button(__("Recreate Plan"), function () {
+                frappe.call({
+                    method: "huf.ai.orchestration.orchestrator.recreate_orchestration_plan",
+                    args: { orch_name: frm.doc.name },
+                    freeze: true,
+                    callback: function (r) {
+                        if (r.message) {
+                            frm.reload_doc();
+                            frappe.msgprint(__("Plan recreated from Agent instructions."));
+                        }
+                    }
+                });
+            });
+        }
 
-// 	},
-// });
+        // Feature: Stop Orchestration
+        if (["Planned", "Running", "Paused"].includes(frm.doc.status) && !frm.is_new()) {
+            frm.add_custom_button(__("Stop Execution"), function () {
+                frappe.confirm(__("Are you sure you want to stop this orchestration?"), function () {
+                    frappe.call({
+                        method: "huf.ai.orchestration.orchestrator.stop_orchestration",
+                        args: { orch_name: frm.doc.name },
+                        freeze: true,
+                        callback: function (r) {
+                            frm.reload_doc();
+                        }
+                    });
+                });
+            }).addClass("btn-danger");
+        }
+    }
+});

--- a/huf/huf/doctype/agent_orchestration/agent_orchestration.json
+++ b/huf/huf/doctype/agent_orchestration/agent_orchestration.json
@@ -28,7 +28,7 @@
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
-   "options": "Planned\nRunning\nPaused\nCompleted\nFailed"
+   "options": "Planned\nRunning\nPaused\nCompleted\nFailed\nCancelled"
   },
   {
    "fieldname": "current_step",


### PR DESCRIPTION
- Generate and save default orchestration plan immediately upon Agent creation when multi-run is enabled
- Store the generated plan in `default_plan` child table on the Agent DocType to prevent re-planning on every run
- Update `create_orchestration` to prioritize the Agent's `default_plan` (or an override plan) instead of generating a new plan at runtime
- Add "Recreate Plan" button to `Agent Orchestration` form to allow manual regeneration of the plan based on updated instructions
- Refactor `generate_default_plan` in Agent to return both run ID and steps, facilitating direct handoff to the orchestrator
- Resolve race condition during creation by reloading the Agent document before saving the plan to avoid modification errors