### PR TITLE
feat: implement Client Side Tool infrastructure for frontend actions

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -465,7 +465,9 @@ def run_agent_sync(
             "external_id": external_id,
             "conversation_history": history,
             "agent_name": agent_name,
-            "response_format": response_format
+            "response_format": response_format,
+            "conversation_id": conversation.name,
+            "agent_run_id": run_doc.name
         }
 
         base_prompt = f"""
@@ -496,7 +498,9 @@ def run_agent_sync(
                 "external_id": external_id,
                 "conversation_history": history,
                 "agent_name": agent_name,
-                "response_format": response_format
+                "response_format": response_format,
+                "conversation_id": conversation.name,
+                "agent_run_id": run_doc.name
             }
             run = RunProvider.run(agent, enhanced_prompt, provider, model,context)
 
@@ -762,7 +766,9 @@ async def run_agent_stream(
             "channel": channel_id,
             "external_id": external_id,
             "conversation_history": history,
-            "agent_name": agent_name
+            "agent_name": agent_name,
+            "conversation_id": conversation.name,
+            "agent_run_id": run_doc.name
         }
         
         enhanced_prompt = f"""

--- a/huf/ai/cilent_side_tool.py
+++ b/huf/ai/cilent_side_tool.py
@@ -1,5 +1,16 @@
 import frappe
 
 @frappe.whitelist()
-def client_side_function():
-    pass
+def client_side_function(conversation_id=None, agent_run_id=None, function_name=None, message_id=None, **kwargs):
+    frappe.publish_realtime(
+        event=f'conversation:{conversation_id}',
+        message={
+            "type": "frontend_tool_call_initiated",
+            "conversation_id": conversation_id,
+            "agent_run_id": agent_run_id,
+            "message_id": message_id,
+            "function_name": function_name,
+            "tool_params": kwargs      
+        },
+    )
+    return {"message": "Tool execution requested on frontend"}

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -38,9 +38,9 @@ class SimpleResult:
         self.cost = cost
 
 
-async def _execute_tool_call(tool, args_json):
+async def _execute_tool_call(tool, args_json, context=None):
     """Execute a tool call and return the result"""
-    return await tool.on_invoke_tool(None, args_json)
+    return await tool.on_invoke_tool(ctx=context, args_json=args_json)
 
 
 def _find_tool(agent, tool_name):
@@ -403,7 +403,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                 if tool_to_run:
                     try:
                         result_content = await _execute_tool_call(
-                            tool_to_run, tool_args
+                            tool_to_run, tool_args, context
                         )
                     except Exception as e:
                         result_content = f"Error executing tool {tool_name}: {str(e)}"
@@ -684,7 +684,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                 if tool_to_run:
                                     try:
                                         result_content = await _execute_tool_call(
-                                            tool_to_run, tool_args
+                                            tool_to_run, tool_args, context
                                         )
                                     except Exception as e:
                                         result_content = f"Error executing tool {tool_name}: {str(e)}"

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -17,6 +17,7 @@
   "provider_app",
   "pass_parameters_as_json",
   "function_path",
+  "function_name",
   "header_section",
   "http_headers",
   "parameters_section",
@@ -47,10 +48,10 @@
    "fieldname": "types",
    "fieldtype": "Select",
    "label": "Types",
-   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent"
+   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nClient Side Tool"
   },
   {
-   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'App Provided' && doc.types != 'Custom Function'",
+   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'App Provided' && doc.types != 'Custom Function'&& doc.types != 'Client Side Tool'",
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
    "label": "Reference DocType",
@@ -87,8 +88,8 @@
    "label": "Function Path"
   },
   {
-   "default": "eval: doc.types == \"Custom Function\";",
-   "depends_on": "eval: doc.types == \"Custom Function\";",
+   "default": "0",
+   "depends_on": "eval: doc.types == \"Custom Function\" &&  doc.types == 'Client Side Tool';",
    "fieldname": "pass_parameters_as_json",
    "fieldtype": "Check",
    "label": "Pass parameters as JSON"
@@ -131,12 +132,18 @@
    "label": "Tool Type",
    "options": "Agent Tool Type",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval: doc.types == 'Client Side Tool'",
+   "fieldname": "function_name",
+   "fieldtype": "Data",
+   "label": "Function Name"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-12-08 11:00:31.833795",
+ "modified": "2026-01-15 17:25:38.558518",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Tool Function",

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -39,7 +39,8 @@ class AgentToolFunction(Document):
 				"Run Agent",
 				"Attach File to Document",
 				"App Provided",
-				"Speech to Text"
+				"Speech to Text",
+				"Client Side Tool"
 			]:
 				frappe.throw(_("Please select a DocType for this function."))
 
@@ -580,6 +581,7 @@ class AgentToolFunction(Document):
 	def before_save(self):
 
 		params = self.get_params_as_dict()
+		self.params = json.dumps(params, indent=4)
 
 		function_definition = {
 			"name": self.tool_name,


### PR DESCRIPTION
- Introduce "Client Side Tool" as a new type in `Agent Tool Function` DocType.
- Add `client_side_function` handler in `huf.ai.cilent_side_tool` to broadcast real-time socket events.
- Update `sdk_tools.py` to route "Client Side Tool" definitions to the socket handler.
- Define `frontend_tool_call_initiated` event payload structure (function_name, tool_params) to allow agents to trigger JavaScript execution on the client side.