### PR TITLE
feat: expose client-side tool calls in agent response

### DIFF
--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -405,7 +405,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                 all_new_items.append(
                     SimpleNamespace(
                         type="tool_call_item",
-                        raw_item=SimpleNamespace(name=tool_name, arguments=tool_args),
+                        raw_item=SimpleNamespace(name=tool_name, arguments=tool_args, id=tool_call.id),
                     )
                 )
 


### PR DESCRIPTION
- Modified `run_agent_sync` to return a list of `client_side_tool_calls` in the response.
- Updated response format for client-side tools to strictly match the LiteLLM/OpenAI tool call schema (`id`, `type`, `function`).
- Updated `litellm.py` provider to preserve and pass the tool call 'id' from the upstream LLM response.