### PR TITLE
feat - Persistent Conversation Data Management

### DIFF
--- a/huf/ai/conversation_data_tools.py
+++ b/huf/ai/conversation_data_tools.py
@@ -1,0 +1,121 @@
+import frappe
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+# Helper Functions
+def _now_iso_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+def _load_state(state_json: str | None | dict) -> dict:
+    if not state_json:
+        return {"version": 1, "scope": {}, "items": []}
+    if isinstance(state_json, dict):
+        data = state_json
+    else:
+        try:
+            data = json.loads(state_json)
+            if isinstance(data, str): # Handle double encoded
+                try: data = json.loads(data)
+                except: pass
+        except (json.JSONDecodeError, TypeError):
+             return {"version": 1, "scope": {}, "items": []}
+             
+    if "items" not in data or not isinstance(data["items"], list):
+        data["items"] = []
+    if "version" not in data:
+        data["version"] = 1
+    return data
+
+# Handler Functions
+def handle_get_conversation_data(name: str, default: Any = None, conversation_id: str = None, **kwargs):
+    """Get a value from conversation data."""
+    if not conversation_id:
+        return {"success": False, "error": "No conversation context provided"}
+    
+    try:
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+        
+        value = default
+        for item in state["items"]:
+            if item.get("name") == name:
+                value = item.get("value", default)
+                break
+                
+        return {"success": True, "value": value}
+    except Exception as e:
+        frappe.log_error(f"Error getting conversation data: {str(e)}", "Conversation Data")
+        return {"success": False, "error": str(e)}
+
+def handle_set_conversation_data(
+    name: str, 
+    value: Any, 
+    value_type: str = None, 
+    source: str = "agent", 
+    conversation_id: str = None, 
+    **kwargs
+):
+    """Set a value in conversation data."""
+    if not conversation_id:
+        return {"success": False, "error": "No conversation context provided"}
+    
+    try:
+        # Debug Log
+        frappe.logger().info(f"[Conversation Data] Setting {name} for {conversation_id}")
+
+        # Load fresh state
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+
+        # infer a simple type label if not provided
+        if value_type is None:
+            if isinstance(value, dict):
+                value_type = "object"
+            elif isinstance(value, list):
+                value_type = "array"
+            else:
+                value_type = "scalar"
+
+        updated_item = {
+            "name": name,
+            "value": value,
+            "meta": {
+                "type": value_type,
+                "updated_at": _now_iso_utc(),
+                "source": source
+            }
+        }
+
+        # Update or Append
+        found = False
+        for i, item in enumerate(state["items"]):
+            if item.get("name") == name:
+                state["items"][i] = updated_item
+                found = True
+                break
+        
+        if not found:
+            state["items"].append(updated_item)
+
+        new_json = json.dumps(state, ensure_ascii=False, indent=2)
+        
+        frappe.db.set_value("Agent Conversation", conversation_id, "conversation_data", new_json)
+        frappe.db.commit() # Persist changes immediately
+        
+        return {"success": True, "message": f"Set '{name}' match successfully"}
+    
+    except Exception as e:
+        frappe.log_error(f"Error setting conversation data: {str(e)}", "Conversation Data")
+        return {"success": False, "error": str(e)}
+
+def handle_load_conversation_data(conversation_id: str = None, **kwargs):
+    """Load the full conversation data."""
+    if not conversation_id:
+        return {"success": False, "error": "No conversation context provided"}
+    try:
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+        return {"success": True, "data": state}
+    except Exception as e:
+        return {"success": False, "error": str(e)}

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -100,6 +100,12 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         function_path = "huf.ai.sdk_tools.handle_run_agent"
                     elif function_doc.types == "Attach File to Document":
                         function_path = "huf.ai.sdk_tools.handle_attach_file_to_document"
+                    elif function_doc.types == "Get Conversation Data":
+                        function_path = "huf.ai.sdk_tools.handle_get_conversation_data"
+                    elif function_doc.types == "Set Conversation Data":
+                        function_path = "huf.ai.sdk_tools.handle_set_conversation_data"
+                    elif function_doc.types == "Load Conversation Data":
+                        function_path = "huf.ai.sdk_tools.handle_load_conversation_data"
 
                     else:
                         continue
@@ -155,6 +161,60 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                     "SDK Functions Debug",
                     f"Error processing function {func.tool}: {str(e)}"
                 )
+
+    
+    if hasattr(agent, "enable_conversation_data") and agent.enable_conversation_data:
+        existing_types = [t.name for t in tools]
+        
+        # Get Conversation Data
+        if "get_conversation_data" not in existing_types:
+            tool = create_function_tool(
+                name="get_conversation_data",
+                description="Retrieve a specific value from the conversation data context.",
+                tool_name="huf.ai.sdk_tools.handle_get_conversation_data",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Name of the item to retrieve"},
+                        "default": {"type": "string", "description": "Default value if not found"}
+                    },
+                    "required": ["name"]
+                }
+            )
+            if tool: tools.append(tool)
+
+        # Set Conversation Data
+        if "set_conversation_data" not in existing_types:
+            tool = create_function_tool(
+                name="set_conversation_data",
+                description="Store a value in the conversation data context.",
+                tool_name="huf.ai.sdk_tools.handle_set_conversation_data",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Name of the item to set"},
+                        "value": {"type": "string", "description": "Value to store (scalar, object, or array)"},
+                        "value_type": {"type": "string", "description": "Type of value (scalar, object, array). Optional."},
+                        "source": {"type": "string", "description": "Source of data (agent/user). Default: agent"}
+                    },
+                    "required": ["name", "value"]
+                }
+            )
+            if tool: tools.append(tool)
+
+        # Load Conversation Data
+        if "load_conversation_data" not in existing_types:
+            tool = create_function_tool(
+                name="load_conversation_data",
+                description="Load the entire conversation data context.",
+                tool_name="huf.ai.sdk_tools.handle_load_conversation_data",
+                parameters={
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            )
+            if tool: tools.append(tool)
 
     return tools
 
@@ -961,5 +1021,123 @@ def handle_attach_file_to_document(reference_doctype, document_id, **kwargs):
         return {"success": True, "result": result}
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), "handle_attach_file_to_document: failed")
+        return {"success": False, "error": str(e)}
+
+
+# Conversation Data Helpers
+def _now_iso_utc() -> str:
+    from datetime import timezone
+    return datetime.now(timezone.utc).isoformat()
+
+def _load_state(state_json: str | None | dict) -> dict:
+    if not state_json:
+        return {"version": 1, "scope": {}, "items": []}
+    if isinstance(state_json, dict):
+        data = state_json
+    else:
+        try:
+            data = json.loads(state_json)
+            if isinstance(data, str): # Handle double encoded
+                try: data = json.loads(data)
+                except: pass
+        except (json.JSONDecodeError, TypeError):
+             return {"version": 1, "scope": {}, "items": []}
+             
+    if "items" not in data or not isinstance(data["items"], list):
+        data["items"] = []
+    if "version" not in data:
+        data["version"] = 1
+    return data
+
+def handle_get_conversation_data(name: str, default: Any = None, conversation_id: str = None, **kwargs):
+    """Get a value from conversation data."""
+    if not conversation_id:
+        return {"success": False, "error": "No conversation context provided"}
+    
+    try:
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+        
+        value = default
+        for item in state["items"]:
+            if item.get("name") == name:
+                value = item.get("value", default)
+                break
+                
+        return {"success": True, "value": value}
+    except Exception as e:
+        frappe.log_error(f"Error getting conversation data: {str(e)}", "Conversation Data")
+        return {"success": False, "error": str(e)}
+
+def handle_set_conversation_data(
+    name: str, 
+    value: Any, 
+    value_type: str = None, 
+    source: str = "agent", 
+    conversation_id: str = None, 
+    **kwargs
+):
+    """Set a value in conversation data."""
+    if not conversation_id:
+        return {"success": False, "error": "No conversation context provided"}
+    
+    try:
+        # Debug Log
+        frappe.logger().info(f"[Conversation Data] Setting {name} for {conversation_id}")
+
+        # Load fresh state
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+
+        # infer a simple type label if not provided
+        if value_type is None:
+            if isinstance(value, dict):
+                value_type = "object"
+            elif isinstance(value, list):
+                value_type = "array"
+            else:
+                value_type = "scalar"
+
+        updated_item = {
+            "name": name,
+            "value": value,
+            "meta": {
+                "type": value_type,
+                "updated_at": _now_iso_utc(),
+                "source": source
+            }
+        }
+
+        # Update or Append
+        found = False
+        for i, item in enumerate(state["items"]):
+            if item.get("name") == name:
+                state["items"][i] = updated_item
+                found = True
+                break
+        
+        if not found:
+            state["items"].append(updated_item)
+
+        new_json = json.dumps(state, ensure_ascii=False, indent=2)
+        
+        frappe.db.set_value("Agent Conversation", conversation_id, "conversation_data", new_json)
+        frappe.db.commit() # Persist changes immediately
+        
+        return {"success": True, "message": f"Set '{name}' match successfully"}
+    
+    except Exception as e:
+        frappe.log_error(f"Error setting conversation data: {str(e)}", "Conversation Data")
+        return {"success": False, "error": str(e)}
+
+def handle_load_conversation_data(conversation_id: str = None, **kwargs):
+    """Load the full conversation data."""
+    if not conversation_id:
+        return {"success": False, "error": "No conversation context provided"}
+    try:
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+        return {"success": True, "data": state}
+    except Exception as e:
         return {"success": False, "error": str(e)}
 

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -47,8 +47,10 @@
         "context_settings_section",
         "context_strategy",
         "history_limit",
+        "enable_conversation_data",
         "column_break_ctx",
         "summary_ratio",
+        "summary_model",
         "max_knowledge_tokens",
         "max_turns",
         "permissions_tab",
@@ -415,12 +417,19 @@
             "fieldtype": "Table MultiSelect",
             "label": "Allowed Roles",
             "options": "Agent Role"
+        },
+        {
+        "default": "0",
+        "description": "If enabled, the agent can store key-value pairs in the conversation context.",
+        "fieldname": "enable_conversation_data",
+        "fieldtype": "Check",
+        "label": "Allow Conversation Data Management"
         }
     ],
     "grid_page_length": 50,
     "index_web_pages_for_search": 1,
     "links": [],
-    "modified": "2026-01-19 16:45:11.145310",
+    "modified": "2026-01-21 15:28:02.892806",
     "modified_by": "Administrator",
     "module": "Huf",
     "name": "Agent",

--- a/huf/huf/doctype/agent_conversation/agent_conversation.json
+++ b/huf/huf/doctype/agent_conversation/agent_conversation.json
@@ -12,6 +12,7 @@
   "session_id",
   "channel",
   "external_id",
+  "conversation_data",
   "column_break_9v4t",
   "is_active",
   "summary",
@@ -33,7 +34,7 @@
    "fieldtype": "Long Text",
    "label": "Summary"
   },
-{
+  {
    "fieldname": "agent",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -119,12 +120,18 @@
    "fieldname": "external_id",
    "fieldtype": "Data",
    "label": "External ID"
+  },
+  {
+   "default": "{\"version\": 1, \"items\": []}",
+   "fieldname": "conversation_data",
+   "fieldtype": "JSON",
+   "label": "Conversation Data"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-20 11:11:11.599292",
+ "modified": "2026-01-21 15:28:46.958647",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Conversation",

--- a/huf/huf/doctype/agent_conversation/agent_conversation.json
+++ b/huf/huf/doctype/agent_conversation/agent_conversation.json
@@ -4,23 +4,29 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "overview_tab",
   "title",
-  "last_activity",
-  "created_at",
   "agent",
   "model",
-  "session_id",
-  "channel",
-  "external_id",
-  "conversation_data",
   "column_break_9v4t",
   "is_active",
+  "session_id",
+  "created_at",
+  "last_activity",
+  "details_tab",
   "summary",
-  "total_messages",
+  "conversation_data",
+  "metrics_tab",
+  "token_breakdown_section",
   "total_input_tokens",
-  "total_output_tokens",
   "total_tokens",
-  "total_cost"
+  "total_messages",
+  "column_break_metrics",
+  "total_output_tokens",
+  "total_cost",
+  "system_tab",
+  "channel",
+  "external_id"
  ],
  "fields": [
   {
@@ -153,12 +159,41 @@
    "fieldtype": "JSON",
    "label": "Conversation Data",
    "read_only": 1
+  },
+  {
+   "fieldname": "overview_tab",
+   "fieldtype": "Tab Break",
+   "label": "Overview"
+  },
+  {
+   "fieldname": "details_tab",
+   "fieldtype": "Tab Break",
+   "label": "Context & Memory"
+  },
+  {
+   "fieldname": "metrics_tab",
+   "fieldtype": "Tab Break",
+   "label": "Metrics"
+  },
+  {
+   "fieldname": "system_tab",
+   "fieldtype": "Tab Break",
+   "label": "System Info"
+  },
+  {
+   "fieldname": "column_break_metrics",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "token_breakdown_section",
+   "fieldtype": "Section Break",
+   "label": "Token Breakdown"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-21 19:06:37.583621",
+ "modified": "2026-01-21 19:13:42.068454",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Conversation",

--- a/huf/huf/doctype/agent_conversation/agent_conversation.json
+++ b/huf/huf/doctype/agent_conversation/agent_conversation.json
@@ -24,40 +24,53 @@
  ],
  "fields": [
   {
+   "description": "Auto-generated title based on the first few interactions of the conversation.",
    "fieldname": "title",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Title"
+   "label": "Title",
+   "read_only": 1
   },
   {
+   "description": "Rolling summary of the conversation context, used when the history limit is exceeded.",
    "fieldname": "summary",
    "fieldtype": "Long Text",
-   "label": "Summary"
+   "in_list_view": 1,
+   "label": "Summary",
+   "read_only": 1
   },
   {
+   "description": "The AI Agent configuration used for this conversation.",
    "fieldname": "agent",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Agent",
-   "options": "Agent"
+   "options": "Agent",
+   "read_only": 1
   },
   {
+   "description": "The specific AI model (e.g., GPT-4) used by the agent during this session.",
    "fieldname": "model",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Model",
    "options": "AI Model",
    "read_only": 1
   },
   {
+   "description": "Timestamp when the conversation started.",
    "fieldname": "created_at",
    "fieldtype": "Datetime",
    "in_list_view": 1,
-   "label": "Created At"
+   "label": "Created At",
+   "read_only": 1
   },
   {
+   "description": "Timestamp of the most recent message or activity in this conversation.",
    "fieldname": "last_activity",
    "fieldtype": "Datetime",
-   "label": "Last Activity"
+   "label": "Last Activity",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_9v4t",
@@ -65,12 +78,14 @@
   },
   {
    "default": "1",
+   "description": "Indicates if the conversation is currently active. Archived conversations may be read-only.",
    "fieldname": "is_active",
    "fieldtype": "Check",
    "label": "Is Active",
    "read_only": 1
   },
   {
+   "description": "Total count of messages exchanged in this conversation.",
    "fieldname": "total_messages",
    "fieldtype": "Int",
    "label": "Total Messages",
@@ -78,6 +93,7 @@
   },
   {
    "default": "0",
+   "description": "Cumulative number of input tokens sent to the LLM.",
    "fieldname": "total_input_tokens",
    "fieldtype": "Int",
    "label": "Total Input Tokens",
@@ -85,6 +101,7 @@
   },
   {
    "default": "0",
+   "description": "Cumulative number of output tokens received from the LLM.",
    "fieldname": "total_output_tokens",
    "fieldtype": "Int",
    "label": "Total Output Tokens",
@@ -92,6 +109,7 @@
   },
   {
    "default": "0",
+   "description": "Total token usage (Input + Output) for this conversation.",
    "fieldname": "total_tokens",
    "fieldtype": "Int",
    "label": "Total Tokens",
@@ -99,6 +117,7 @@
   },
   {
    "default": "0.0",
+   "description": "Estimated total cost of the conversation based on model pricing.",
    "fieldname": "total_cost",
    "fieldtype": "Currency",
    "label": "Total Cost",
@@ -106,32 +125,40 @@
    "read_only": 1
   },
   {
+   "description": "Unique identifier for the session, often linked to a browser session or API client.",
    "fieldname": "session_id",
    "fieldtype": "Data",
    "label": "Session ID",
+   "read_only": 1,
    "reqd": 1
   },
   {
+   "description": "The communication channel (e.g., 'API', 'WhatsApp', 'Desk').",
    "fieldname": "channel",
    "fieldtype": "Data",
-   "label": "Channel"
+   "label": "Channel",
+   "read_only": 1
   },
   {
+   "description": "Optional external reference ID (e.g., a WhatsApp phone number or external user ID).",
    "fieldname": "external_id",
    "fieldtype": "Data",
-   "label": "External ID"
+   "label": "External ID",
+   "read_only": 1
   },
   {
    "default": "{\"version\": 1, \"items\": []}",
+   "description": "Persistent memory store for the agent. Contains structured key-value pairs (user preferences, constraints, etc.) that survive summarization.",
    "fieldname": "conversation_data",
    "fieldtype": "JSON",
-   "label": "Conversation Data"
+   "label": "Conversation Data",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-21 15:28:46.958647",
+ "modified": "2026-01-21 19:06:37.583621",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Conversation",

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -48,10 +48,10 @@
    "fieldname": "types",
    "fieldtype": "Select",
    "label": "Types",
-   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nClient Side Tool"
+   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nClient Side Tool\nGet Conversation Data\nSet Conversation Data\nLoad Conversation Data"
   },
   {
-   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'App Provided' && doc.types != 'Custom Function'&& doc.types != 'Client Side Tool'",
+   "depends_on": "eval:doc.types != 'Run Agent' && doc.types != 'App Provided' && doc.types != 'Custom Function'&& doc.types != 'Client Side Tool' && doc.types != 'Get Conversation Data' && doc.types != 'Set Conversation Data' && doc.types != 'Load Conversation Data'",
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
    "label": "Reference DocType",
@@ -143,7 +143,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-15 17:25:38.558518",
+ "modified": "2026-01-21 17:05:38.558518",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Tool Function",

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -40,7 +40,10 @@ class AgentToolFunction(Document):
 				"Attach File to Document",
 				"App Provided",
 				"Speech to Text",
-				"Client Side Tool"
+				"Client Side Tool",
+				"Get Conversation Data",
+				"Set Conversation Data",
+				"Load Conversation Data"
 			]:
 				frappe.throw(_("Please select a DocType for this function."))
 
@@ -426,6 +429,54 @@ class AgentToolFunction(Document):
 						"description": "Optional API key override (leave empty to use AI Provider)."
 					}
 				},
+				"required": [],
+				"additionalProperties": False
+			}
+
+		elif self.types == "Get Conversation Data":
+			params = {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Name of the item to retrieve."
+					},
+					"default": {
+						"type": "string",
+						"description": "Default value if not found."
+					}
+				},
+				"required": ["name"],
+				"additionalProperties": False
+			}
+		elif self.types == "Set Conversation Data":
+			params = {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string",
+						"description": "Name of the item to set."
+					},
+					"value": {
+						"type": "string",
+						"description": "Value to store (scalar, object, or array)."
+					},
+					"value_type": {
+						"type": "string",
+						"description": "Type of value (scalar, object, array). Optional."
+					},
+					"source": {
+						"type": "string",
+						"description": "Source of data (agent/user). Default: agent"
+					}
+				},
+				"required": ["name", "value"],
+				"additionalProperties": False
+			}
+		elif self.types == "Load Conversation Data":
+			params = {
+				"type": "object",
+				"properties": {},
 				"required": [],
 				"additionalProperties": False
 			}


### PR DESCRIPTION
## 📝 Description
This PR introduces a robust **Conversation Data Management** system (Memory) for Huf Agents. It addresses the limitation where agents lose context of critical user details when the conversation history is summarized or truncated.

With this feature, agents can be configured to persistently store key-value pairs (Strings, Arrays, or Objects) in a dedicated JSON field linked to the conversation. This data remains available throughout the lifecycle of the chat, regardless of context window length.

## 🚀 Key Features
1.  **Persistent Storage**: New `conversation_data` JSON field in `Agent Conversation` stores structured data (Version 1 schema).
2.  **Smart Tools**: Three new auto-injected tools for agents:
    *   `set_conversation_data`: Stores/Updates data with support for Complex Types (JSON Objects/Arrays).
    *   `get_conversation_data`: Retrieves specific values.
    *   `load_conversation_data`: Returns the full memory state.
3.  **Context Awareness**:
    *   **Auto-Injection**: The current memory snapshot is automatically injected into the agent's system prompt at every turn, so it "knows" what it has stored without needing to call `load` first.
    *   **System Instructions**: Agents are explicitly instructed on how to structure data (Snake Case keys, when to use Arrays vs Strings).
4.  **Concurrency Handling**: Implemented immediate DB commits (`frappe.db.commit()`) to prevent race conditions during rapid multi-turn chats.
5.  **Visibility**: Tool execution logic is visible in the chat interface for debugging, but keeps the raw JSON storage hidden from the user view until requested.

## 💻 Tech Implementation

### Schema Changes
*   **Doctype `Agent` **: Added `enable_conversation_data` (Check) to toggle the feature.
*   **Doctype `Agent Conversation`**: Added `conversation_data`  (JSON) to store the state.
*   **Doctype `Agent Tool Function`**: Registered new tool types (`Get/Set/Load Conversation Data`) and updated validation logic to allow functioning without a reference DocType.

### Backend
*   **`huf/ai/conversation_data_tools.py` **: New module containing the core logic `handle_set`, `handle_get`, `_load_state`. Handles JSON parsing, pretty-printing (indent=2), and metadata tracking `updated_at`, `source`.
*   **`huf/ai/sdk_tools.py`**: Refactored to import from the new module and dynamically inject these tools into the agent's function list if `agent.enable_conversation_data` is True.
*   **`huf/ai/agent_integration.py`**: Updated `run_agent_sync` to inject the system instructions and the real-time `conversation_data` snapshot into the chat history.

## 🧪 How to Test

1.  **Enable Feature**:
    *   Go to any **Agent** document.
    *   Check **"Allow Conversation Data Management"**.
    *   Save.

2.  **Verify Tool Injection**:
    *   Start a new chat with this agent.
    *   The agent should automatically have access to the memory tools (no manual setup needed).

3.  **Functional Test (Complex Data)**:
    *   **User**: "I am planning a trip to Japan and Korea with a budget of $5000."
    *   **Agent**: Should trigger `set_conversation_data`.
        *   **Verify**: Check the `Agent Conversation` document backend. The `conversation_data` field should contain a formatted JSON object similar to:
        ```json
        {
          "version": 1,
          "items": [
             {"name": "destinations", "value": ["Japan", "Korea"], "meta": {"type": "array"}},
             {"name": "budget", "value": 5000, "meta": {"type": "scalar"}}
          ]
        }
        ```

4.  **Context Persistence Test**:
    *   Continue the chat for long enough to trigger summarization (or manually clear chat history).
    *   **User**: "What is my budget again?"
    *   **Agent**: Should correctly reply "$5000" by reading from the injected memory snapshot.

## ✅ Checklist
- [x] Schema changes migrated (`bench migrate` required).
- [x] New tools registered in `Agent Tool Function`.
- [x] Concurrency safety (Explicit commits added).
- [x] Pretty printed JSON storage for easier debugging.
- [x] Code modularized into `conversation_data_tools.py`.