### PR TITLE
Add Docker quick-try setup for easy HUF evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,41 @@ bench setup requirements  # Installs dependencies including litellm
 
 **Note**: After installation or update, run `bench setup requirements` to ensure all dependencies (including `litellm`) are installed. Then restart your site with `bench restart`.
 
+## Quick Try with Docker
+
+Want to try HUF without setting up a full Frappe environment? Use the Docker quick-try setup:
+
+```bash
+cd huf-quicktry
+docker compose up
+```
+
+Then open http://localhost:8000 and login with:
+- **User:** Administrator
+- **Password:** admin
+
+### Switching Branches
+
+To try a specific branch:
+
+```bash
+HUF_BRANCH=your-branch-name docker compose up
+```
+
+### Configuration
+
+You can customize the setup with environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SITE_NAME` | huf.localhost | Frappe site name |
+| `DB_ROOT_PW` | 123 | MariaDB root password |
+| `ADMIN_PW` | admin | Frappe admin password |
+| `HUF_REPO` | https://github.com/tridz-dev/huf.git | HUF repository URL |
+| `HUF_BRANCH` | main | Branch to install |
+
+> **Note:** This is a development/quick-try setup using `bench start`. For production deployments, use the official [frappe_docker](https://github.com/frappe/frappe_docker) pattern with nginx, gunicorn, and workers.
+
 ## Architecture Overview
 
 Huf is built around a set of interconnected DocTypes that define the components of an AI agent. The core logic is handled by Python classes that integrate with an AI provider (like OpenAI) and manage the agent's lifecycle.

--- a/huf-quicktry/docker-compose.yml
+++ b/huf-quicktry/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.7"
+name: huf
+
+services:
+  mariadb:
+    image: mariadb:10.8
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --skip-character-set-client-handshake
+      - --skip-innodb-read-only-compressed
+    environment:
+      MYSQL_ROOT_PASSWORD: 123
+    volumes:
+      - mariadb-data:/var/lib/mysql
+
+  redis:
+    image: redis:alpine
+
+  frappe:
+    image: frappe/bench:latest
+    command: bash /workspace/init.sh
+    environment:
+      - SHELL=/bin/bash
+    working_dir: /home/frappe
+    volumes:
+      - .:/workspace
+      - sites:/home/frappe/frappe-bench/sites
+      - logs:/home/frappe/frappe-bench/logs
+    ports:
+      - "8000:8000"
+      - "9000:9000"
+    depends_on:
+      - mariadb
+      - redis
+
+volumes:
+  mariadb-data:
+  sites:
+  logs:

--- a/huf-quicktry/init.sh
+++ b/huf-quicktry/init.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -e
+
+SITE_NAME=${SITE_NAME:-huf.localhost}
+DB_ROOT_PW=${DB_ROOT_PW:-123}
+ADMIN_PW=${ADMIN_PW:-admin}
+HUF_REPO=${HUF_REPO:-https://github.com/tridz-dev/huf.git}
+HUF_BRANCH=${HUF_BRANCH:-main}
+
+if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
+  echo "Bench already exists. Starting..."
+  cd /home/frappe/frappe-bench
+  bench start
+  exit 0
+fi
+
+echo "Creating new bench..."
+export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION_DEVELOP}/bin/:${PATH}"
+
+cd /home/frappe
+bench init --skip-redis-config-generation frappe-bench
+cd /home/frappe/frappe-bench
+
+# Use containers instead of localhost
+bench set-mariadb-host mariadb
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
+
+# Remove redis, watch from Procfile (we run redis as a separate container)
+sed -i '/redis/d' ./Procfile
+sed -i '/watch/d' ./Procfile
+
+# Get apps
+bench get-app huf "${HUF_REPO}" --branch "${HUF_BRANCH}"
+
+# Create site
+bench new-site "${SITE_NAME}" \
+  --force \
+  --mariadb-root-password "${DB_ROOT_PW}" \
+  --admin-password "${ADMIN_PW}" \
+  --no-mariadb-socket
+
+# Install HUF
+bench --site "${SITE_NAME}" install-app huf
+
+# Dev conveniences
+bench --site "${SITE_NAME}" set-config developer_mode 1
+bench --site "${SITE_NAME}" clear-cache
+bench use "${SITE_NAME}"
+
+echo "Starting bench..."
+bench start


### PR DESCRIPTION
## Summary
This PR adds a Docker-based quick-try setup that allows users to evaluate HUF without setting up a full Frappe development environment. This lowers the barrier to entry for new users and developers who want to test the project quickly.

## Key Changes
- **Docker Compose Configuration**: Added `huf-quicktry/docker-compose.yml` with MariaDB, Redis, and Frappe services
- **Initialization Script**: Added `huf-quicktry/init.sh` that automates bench setup, HUF installation, and site configuration
- **Documentation**: Updated README.md with comprehensive quick-try instructions including:
  - Basic usage instructions
  - Branch switching capability
  - Configurable environment variables
  - Production deployment disclaimer

## Notable Implementation Details
- Uses official `frappe/bench:latest` Docker image for consistency
- Supports environment variable customization for site name, database password, admin password, repository URL, and branch
- Automatically detects existing bench installations to avoid re-initialization
- Configures Redis and MariaDB as separate containers with proper networking
- Removes unnecessary services (redis, watch) from Procfile since they run as containers
- Includes developer mode and cache clearing for optimal development experience
- Clearly notes that this is a development setup and recommends `frappe_docker` for production

## Benefits
- **Lower friction**: New users can try HUF in seconds with a single command
- **Flexible**: Supports testing different branches without manual setup
- **Documented**: Clear instructions and configuration options in README
- **Maintainable**: Reusable initialization script for consistent setups

https://claude.ai/code/session_01DCaRMvZ9o9dvkVmkSKQCXA