### PR TITLE
Fix child_table select not populating from reference doctype in Agent Trigger doctype

### DIFF
--- a/huf/huf/doctype/agent_trigger/agent_trigger.js
+++ b/huf/huf/doctype/agent_trigger/agent_trigger.js
@@ -30,3 +30,22 @@ frappe.ui.form.on('Agent Trigger', {
         });
     }
 });
+
+frappe.ui.form.on('Agent Trigger Attachment', {
+    source_type: function(frm, cdt, cdn) {
+        let row = locals[cdt][cdn];
+        if (row.source_type === "Child Table Field" && frm.doc.reference_doctype) {
+            frappe.model.with_doctype(frm.doc.reference_doctype, function() {
+                let parent_meta = frappe.get_meta(frm.doc.reference_doctype);
+
+                let tables = parent_meta.fields
+                    .filter(df => df.fieldtype === "Table")
+                    .map(df => df.fieldname);
+                frm.fields_dict["file_attachments"].grid.update_docfield_property(
+                    "child_table", "options", tables
+                );
+                frm.refresh_field("file_attachments");
+            });
+        }
+    }
+})


### PR DESCRIPTION
This PR fixes an issue in the Agent Trigger doctype where the child_table select field was not being populated when source_type was set to **"Child Table Field"**.

It now dynamically fetches all child table fields (fieldtype = "Table") from the selected reference_doctype and updates the dropdown options in the child table grid.

As a result, the child_table field in the Agent Trigger doctype correctly displays available child tables from the reference doctype