### PR TITLE
feat: Enhanced Agent Security Model with Permission Registry & Runtime Guards

### DIFF
--- a/huf/ai/agent_scheduler.py
+++ b/huf/ai/agent_scheduler.py
@@ -1,10 +1,14 @@
 import frappe
+from frappe import _
 from frappe.utils import now_datetime, add_to_date
 from .agent_integration import run_agent_sync
 
 @frappe.whitelist()
 def run_scheduled_agents():
     now = now_datetime().replace(microsecond=0)
+    
+    if frappe.session.user != "Administrator" and not frappe.has_permission("Agent Trigger", "write"):
+        frappe.throw(_("Permission denied: You cannot run scheduled agents manually."), frappe.PermissionError)
 
     if not frappe.db.exists("DocType", "Agent Trigger"):
         return

--- a/huf/ai/knowledge/retriever.py
+++ b/huf/ai/knowledge/retriever.py
@@ -56,6 +56,10 @@ def knowledge_search(
 			if source.disabled:
 				continue
 			
+			#Ensure user has access to this Knowledge Source
+			if not frappe.has_permission("Knowledge Source", "read", source_name):
+				continue
+			
 			# Initialize backend
 			backend_class = get_backend(source.knowledge_type)
 			backend = backend_class()

--- a/huf/ai/mcp_client.py
+++ b/huf/ai/mcp_client.py
@@ -215,6 +215,9 @@ async def execute_mcp_tool(
         The result from the MCP tool execution
     """
     try:
+        if not frappe.has_permission("MCP Server", "read", server_name):
+            return {"error": f"Permission denied: You do not have access to MCP Server {server_name}", "success": False}
+
         mcp_server = frappe.get_doc("MCP Server", server_name)
         
         # Build headers
@@ -362,6 +365,9 @@ def sync_mcp_server_tools(server_name: str) -> dict:
         dict: Result with success status and tool count
     """
     try:
+        if not frappe.has_permission("MCP Server", "write", server_name):
+             return {"success": False, "error": f"Permission denied: You cannot sync MCP Server {server_name}"}
+
         mcp_server = frappe.get_doc("MCP Server", server_name)
         headers = _build_mcp_headers(mcp_server)
         

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -24,25 +24,23 @@ import hashlib
 from datetime import datetime, timedelta
 
 
-MUTATING_TOOL_TYPES = {
-    "Create Document", "Create Multiple Documents",
-    "Update Document", "Update Multiple Documents", 
-    "Delete Document", "Delete Multiple Documents",
-    "Submit Document", "Cancel Document",
-    "Set Value", "POST", "Run Agent",
-    "Attach File to Document"
-}
+from .tool_registry import PermissionAwareToolRegistry
+MUTATING_TOOL_TYPES = PermissionAwareToolRegistry.MUTATING_TOOL_TYPES
 
-def _check_tool_permission(tool_type: str, context: dict = None):
+def _check_tool_permission(tool_type: str, context: dict = None, allowed_for_guest: bool = False):
     """Guard function to block dangerous tools for Guest users"""
     user = frappe.session.user
     
-    #Guest cannot use mutating tools
-    if user == "Guest" and tool_type in MUTATING_TOOL_TYPES:
-        return {
-            "allowed": False,
-            "error": f"Guest users cannot use {tool_type} tools. Please log in."
-        }
+    #Guest cannot use mutating tools unless explicitly allowed
+    if user == "Guest":
+        if allowed_for_guest:
+            return {"allowed": True}
+             
+        if tool_type in MUTATING_TOOL_TYPES:
+            return {
+                "allowed": False,
+                "error": f"Guest users cannot use {tool_type} tools. Please log in."
+            }
     
     return {"allowed": True}
 
@@ -70,11 +68,12 @@ def create_agent_tools(agent) -> list[FunctionTool]:
     
     # Load native tools from Agent Tool Function documents
 
-    if hasattr(agent, "agent_tool") and agent.agent_tool:
-        for func in agent.agent_tool:
+    from huf.ai.tool_registry import PermissionAwareToolRegistry
+    
+    allowed_tool_docs = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+
+    for function_doc in allowed_tool_docs:
             try:
-                # Fetch linked tool function doc
-                function_doc = frappe.get_doc("Agent Tool Function", func.tool)
 
                 function_path = None
                 if function_doc.types in ["Custom Function", "App Provided"]:
@@ -167,13 +166,18 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         if function_doc.function_name:
                             extra_args["function_name"] = function_doc.function_name
 
+                    elif function_doc.types == "Run Agent":
+                        if function_doc.agent:
+                            extra_args["agent_name"] = function_doc.agent
+
                     tool = create_function_tool(
                         function_doc.tool_name,
                         function_doc.description,
                         function_path,
                         params,
                         extra_args=extra_args,
-                        tool_type=function_doc.types
+                        tool_type=function_doc.types,
+                        allowed_for_guest=bool(function_doc.allowed_for_guest)
                     )
 
                     if tool:
@@ -182,7 +186,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
             except Exception as e:
                 frappe.log_error(
                     "SDK Functions Debug",
-                    f"Error processing function {func.tool}: {str(e)}"
+                    f"Error processing function {function_doc.name}: {str(e)}"
                 )
 
     
@@ -248,6 +252,7 @@ def create_function_tool(
     parameters: dict[str, Any],
     extra_args: dict[str, Any] = None,
     tool_type: str = None,
+    allowed_for_guest: bool = False
 ) -> FunctionTool:
     """
     Create a FunctionTool for Huf Tool functions
@@ -276,7 +281,7 @@ def create_function_tool(
 
             #Permission check before execution
             if tool_type:
-                perm_check = _check_tool_permission(tool_type, ctx)
+                perm_check = _check_tool_permission(tool_type, ctx, allowed_for_guest=allowed_for_guest)
                 if not perm_check["allowed"]:
                     return json.dumps({"error": perm_check["error"], "denied": True})
 
@@ -295,9 +300,14 @@ def create_function_tool(
                     if "agent_name" in ctx:
                         args_dict["agent_name"] = ctx["agent_name"]
 
-                for key, value in _extra_args.items():
-                    if key not in args_dict:
-                        args_dict[key] = value
+                if _extra_args:
+                    args_dict.update(_extra_args)
+
+                if "ignore_permissions" in args_dict:
+                    del args_dict["ignore_permissions"]
+                
+                if allowed_for_guest and frappe.session.user == "Guest":
+                    args_dict["ignore_permissions"] = True
 
                 if _function.__name__ in ["handle_get_request", "handle_post_request"]:
                     args_dict["tool_name"] = name
@@ -639,12 +649,13 @@ def create_list_function(doctype: str) -> Callable:
 
 # Built-in handlers for standard function types
 
-def handle_create_document(reference_doctype=None, **kwargs):
+def handle_create_document(reference_doctype=None, ignore_permissions=False, **kwargs):
     """
     Create a new document
 
     Args:
         reference_doctype (str): DocType of the document
+        ignore_permissions (bool): Bypass permission checks (used for allowed Guest tools)
         **kwargs: Fields of the document
 
     Returns:
@@ -657,7 +668,7 @@ def handle_create_document(reference_doctype=None, **kwargs):
         if not frappe.db.exists("DocType", reference_doctype):
             return {"success": False, "error": f"DocType '{reference_doctype}' does not exist."}
 
-        if not frappe.has_permission(reference_doctype, "create"):
+        if not ignore_permissions and not frappe.has_permission(reference_doctype, "create"):
             return {
                 "success": False,
                 "error": f"You do not have permission to create {reference_doctype}",
@@ -665,7 +676,7 @@ def handle_create_document(reference_doctype=None, **kwargs):
             }
 
         doc = frappe.get_doc({"doctype": reference_doctype, **kwargs})
-        doc.insert()
+        doc.insert(ignore_permissions=ignore_permissions)
 
         doc_dict = doc.as_dict()
         import datetime
@@ -679,13 +690,14 @@ def handle_create_document(reference_doctype=None, **kwargs):
         return {"success": False, "error": str(e)}
 
 
-def handle_delete_document(document_id=None, reference_doctype=None,**kwargs):
+def handle_delete_document(document_id=None, reference_doctype=None, ignore_permissions=False, **kwargs):
     """
     Delete a document
 
     Args:
         document_id (str): ID of the document
         reference_doctype (str): DocType of the document
+        ignore_permissions (bool): Bypass permission checks
 
     Returns:
         dict: Deletion result
@@ -701,14 +713,14 @@ def handle_delete_document(document_id=None, reference_doctype=None,**kwargs):
             return {"success": False, "error": f"Document {document_id} not found in {reference_doctype}"}
 
         #Pre-check delete permission
-        if not frappe.has_permission(reference_doctype, "delete", doc=document_id):
+        if not ignore_permissions and not frappe.has_permission(reference_doctype, "delete", doc=document_id):
             return {
                 "success": False,
                 "error": f"You do not have delete permission on {reference_doctype} {document_id}",
                 "permission_denied": True
             }
 
-        frappe.delete_doc(reference_doctype, document_id)
+        frappe.delete_doc(reference_doctype, document_id, ignore_permissions=ignore_permissions)
 
         return {"success": True, "message": f"{reference_doctype} {document_id} deleted"}
     except Exception as e:
@@ -834,14 +846,14 @@ def handle_get_list(
 		return {"success": False, "error": str(e)}
 
 
-def handle_update_document(document_id=None, data=None, reference_doctype=None, **kwargs):
+def handle_update_document(document_id=None, data=None, reference_doctype=None, ignore_permissions=False, **kwargs):
     """
     Update a document in the database
     """
     if data is None:
         data = {}
         for key, value in kwargs.items():
-            if key not in ["document_id", "reference_doctype"]:
+            if key not in ["document_id", "reference_doctype", "ignore_permissions"]:
                 data[key] = value
 
     if not reference_doctype:
@@ -853,7 +865,7 @@ def handle_update_document(document_id=None, data=None, reference_doctype=None, 
     if not frappe.db.exists(reference_doctype, document_id):
         return {"success": False, "error": f"{reference_doctype} {document_id} not found"}
 
-    if not frappe.has_permission(reference_doctype, "write", doc=document_id):
+    if not ignore_permissions and not frappe.has_permission(reference_doctype, "write", doc=document_id):
         return {
             "success": False,
             "error": f"You do not have write permission on {reference_doctype} {document_id}",
@@ -866,7 +878,7 @@ def handle_update_document(document_id=None, data=None, reference_doctype=None, 
         for field, value in data.items():
             doc.set(field, value)
 
-        doc.save()
+        doc.save(ignore_permissions=ignore_permissions)
         frappe.db.commit() 
 
         return {
@@ -961,11 +973,21 @@ def handle_update_documents(reference_doctype: str, documents: list = None, data
 def handle_delete_documents(reference_doctype: str, document_ids: list, **kwargs):
     return delete_documents(reference_doctype, document_ids or [])
 
-def handle_submit_document(reference_doctype: str, document_id: str, **kwargs):
-    return submit_document(reference_doctype, document_id)
+def handle_submit_document(reference_doctype: str, document_id: str, ignore_permissions=False, **kwargs):
+    if not ignore_permissions and not frappe.has_permission(reference_doctype, "submit", doc=document_id):
+        return {"success": False, "error": "No permission to submit"}
+    
+    doc = frappe.get_doc(reference_doctype, document_id)
+    doc.submit()
+    return {"success": True, "message": "Submitted"}
 
-def handle_cancel_document(reference_doctype: str, document_id: str, **kwargs):
-    return cancel_document(reference_doctype, document_id)
+def handle_cancel_document(reference_doctype: str, document_id: str, ignore_permissions=False, **kwargs):
+    if not ignore_permissions and not frappe.has_permission(reference_doctype, "cancel", doc=document_id):
+        return {"success": False, "error": "No permission to cancel"}
+
+    doc = frappe.get_doc(reference_doctype, document_id)
+    doc.cancel()
+    return {"success": True, "message": "Cancelled"}
 
 def handle_get_value(doctype: str = None, filters: dict = None, fieldname=None, **kwargs):
     """

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -29,7 +29,8 @@ MUTATING_TOOL_TYPES = {
     "Update Document", "Update Multiple Documents", 
     "Delete Document", "Delete Multiple Documents",
     "Submit Document", "Cancel Document",
-    "Set Value", "POST", "Run Agent"
+    "Set Value", "POST", "Run Agent",
+    "Attach File to Document"
 }
 
 def _check_tool_permission(tool_type: str, context: dict = None):

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -3,10 +3,92 @@ import json
 import os
 from datetime import datetime
 import frappe
+from frappe import _
 from frappe.utils import now_datetime
 
 TOOL_DOCTYPE = "Agent Tool Function"
 CACHE_DOCTYPE = "Agent Settings"  # Singleton for caching
+
+class PermissionAwareToolRegistry:
+    """Registry that filters tools based on user permissions"""
+    
+    TOOL_PERMISSIONS = {
+        "Get Document": {"permission": "read"},
+        "Get List": {"permission": "read"},
+        "Create Document": {"permission": "create"},
+        "Create Multiple Documents": {"permission": "create"},
+        "Update Document": {"permission": "write"},
+        "Update Multiple Documents": {"permission": "write"},
+        "Delete Document": {"permission": "delete"},
+        "Delete Multiple Documents": {"permission": "delete"},
+        "Submit Document": {"permission": "submit"},
+        "Cancel Document": {"permission": "cancel"},
+        "Attach File to Document": {"permission": "create"} 
+    }
+    
+    MUTATING_TOOL_TYPES = {
+        "Create Document", "Create Multiple Documents",
+        "Update Document", "Update Multiple Documents", 
+        "Delete Document", "Delete Multiple Documents",
+        "Submit Document", "Cancel Document",
+        "Set Value", "POST", "Run Agent",
+        "Attach File to Document"
+    }
+
+    @classmethod
+    def get_allowed_tools(cls, agent_doc, user: str) -> list:
+        """Return only tools the user has permission to use"""
+        all_tools = []
+        
+        if not hasattr(agent_doc, "agent_tool"):
+            return []
+
+        for tool_link in agent_doc.agent_tool:
+            try:
+                tool_doc = frappe.get_doc("Agent Tool Function", tool_link.tool)
+                
+                if cls._can_use_tool(tool_doc, user):
+                    all_tools.append(tool_doc)
+
+            except Exception as e:
+                frappe.log_error(f"Error checking tool permission for {tool_link.tool}: {e}", "Tool Registry")
+        
+        return all_tools
+    
+    @classmethod
+    def _can_use_tool(cls, tool_doc, user: str) -> bool:
+        """Check if user has permission for this tool"""
+        tool_type = tool_doc.types
+        
+        #Guest Restrictions
+        if user == "Guest":
+            #Explicitly Allowed
+            if bool(tool_doc.allowed_for_guest):
+                return True
+                
+            #Hard block mutated tools if NOT explicitly allowed
+            if tool_type in cls.MUTATING_TOOL_TYPES:
+                return False
+                
+            return False
+
+        #Reference DocType Permission Checks
+        if tool_doc.reference_doctype:
+            perm_type = None
+             
+            #Explicitly configured permission
+            if tool_doc.required_permission:
+                perm_type = tool_doc.required_permission
+             
+            #Implicit based on tool type
+            elif tool_type in cls.TOOL_PERMISSIONS:
+                perm_type = cls.TOOL_PERMISSIONS[tool_type]["permission"]
+             
+            if perm_type:
+                if not frappe.has_permission(doctype=tool_doc.reference_doctype, ptype=perm_type, user=user):
+                    return False
+                     
+        return True
 
 def _iter_declared_tools():
     for group in frappe.get_hooks("huf_tools") or []:

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -60,6 +60,10 @@ class PermissionAwareToolRegistry:
         """Check if user has permission for this tool"""
         tool_type = tool_doc.types
         
+        # Read Only restriction
+        if tool_doc.is_read_only and tool_type in cls.MUTATING_TOOL_TYPES:
+            return False
+        
         #Guest Restrictions
         if user == "Guest":
             #Explicitly Allowed

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -335,6 +335,7 @@
   },
   {
    "default": "0",
+   "description": "Enables multi-step planning and execution. If enabled, the agent will analyze the request to create a step-by-step plan (or use a Default Plan) and execute them sequentially.",
    "fieldname": "enable_multi_run",
    "fieldtype": "Check",
    "label": "Enable Multi Run"
@@ -384,11 +385,13 @@
    "label": "Cache Conversation History"
   },
   {
+   "depends_on": "eval:doc.enable_multi_run == 1",
    "fieldname": "multi_run_setting_section",
    "fieldtype": "Section Break",
    "label": "Multi Run Setting"
   },
   {
+   "depends_on": "eval:doc.enable_multi_run ==1",
    "fieldname": "default_plan",
    "fieldtype": "Table",
    "label": "Default Plan",
@@ -456,7 +459,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-03 00:14:38.235962",
+ "modified": "2026-02-09 12:05:14.211963",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent",

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -20,6 +20,10 @@
   "function_name",
   "header_section",
   "http_headers",
+  "section_break_ajuk",
+  "required_permission",
+  "is_read_only",
+  "allowed_for_guest",
   "parameters_section",
   "parameters",
   "params",
@@ -56,6 +60,27 @@
    "fieldtype": "Link",
    "label": "Reference DocType",
    "options": "DocType"
+  },
+  {
+   "description": "Permission level required to use this tool",
+   "fieldname": "required_permission",
+   "fieldtype": "Select",
+   "label": "Required Permission",
+   "options": "\nread\nwrite\ncreate\ndelete\nsubmit\ncancel"
+  },
+  {
+   "default": "0",
+   "description": "If checked, this tool does not modify data",
+   "fieldname": "is_read_only",
+   "fieldtype": "Check",
+   "label": "Read Only"
+  },
+  {
+   "default": "0",
+   "description": "If checked, Guest users can use this tool",
+   "fieldname": "allowed_for_guest",
+   "fieldtype": "Check",
+   "label": "Allowed for Guest"
   },
   {
    "fieldname": "parameters_section",
@@ -138,12 +163,16 @@
    "fieldname": "function_name",
    "fieldtype": "Data",
    "label": "Function Name"
+  },
+  {
+   "fieldname": "section_break_ajuk",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-21 17:05:38.558518",
+ "modified": "2026-02-09 16:30:18.371944",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Tool Function",


### PR DESCRIPTION
## Description

This PR implements **Phase 2** of the Agent Security roadmap, introducing a dynamic, permission-aware tool registry. This ensures that agents only have access to tools that the authenticated user is authorized to execute, preventing unauthorized actions through LLM instructions. It also refines the "Guest Access" logic to prevent privileged bypass for logged-in users.

## Key Changes

### 1. Permission-Aware Tool Registry (`huf/ai/tool_registry.py`)
- Implemented `PermissionAwareToolRegistry` class.
- Added `get_allowed_tools(agent, user)`: Filters the agent's available tools at runtime based on the user's Frappe permissions.
- **Logic**:
  - Checks standard CRUD permissions (`read`, `write`, `create`, `delete`, `submit`, `cancel`) against the tool's reference DocType.
  - Inspects new metadata fields on the Tool definition.
  - Automatically blocks potentially mutating tools for Guest users unless explicitly whitelisted.

### 2. Tool Execution Security (`huf/ai/sdk_tools.py`)
- Integrated `PermissionAwareToolRegistry` into `create_agent_tools`.
- **Fix**: Updated `_check_tool_permission` logic for `Allowed for Guest` tools.
  - Previously: Checking "Allowed for Guest" bypassed permissions for *everyone* (including logged-in users).
  - Now: Permission bypass (`ignore_permissions=True`) is applied **ONLY** if the current session user is actually `Guest`. Logged-in users are subject to their standard role-based permissions throughout.

### 3. Tool Metadata (`Agent Tool Function` DocType)
- Added new fields to support granular control:
  - `Required Permission`: Explicitly define the permission level needed (e.g., specific `create` or `submit` rights).
  - `Read Only`:  Automatically block tools from the agent's context if they are marked as 'Read Only' but are of a mutating type
  - `Allowed for Guest`: Whitelist specific tools  for unauthenticated users without exposing all system tools.

## Testing Strategy

1. **Guest Access**:
   - Verify Guest users can *only* see/execute tools marked `Allowed for Guest`.
   - Verify attempting other tools results in a permission error.

2. **Regular User Access**:
   - Log in as a user with Read-Only access.
   - Verify the agent does *not* offer "Create" or "Delete" tools in its context.
   - Verify attempting a "Create" action fails with a standard permission error (not a bypass).

3. **Cross-User Safety**:
   - Verify that a tool marked `Allowed for Guest` still enforces permissions for a logged-in user (e.g., a "Create Lead" tool allowed for guests should still require "Create" permission if run by a logged-in "Employee" user).

## Impact

- **Security**: Eliminates the risk of agents "hallucinating" access to tools the user shouldn't have.
- **Usability**: Cleaner context for the LLM (it only sees relevant tools), reducing confusion and error rates.