### PR TITLE
feat: Auto-naming of Conversations

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -461,6 +461,55 @@ def run_background_summarization(conversation_name, agent_name):
     except Exception as e:
         frappe.log_error(f"Background summarization failed: {str(e)}", "Agent Background Summarization")
 
+@frappe.whitelist()
+def generate_conversation_title(conversation_name, agent_name):
+    """
+    Background job to auto-name conversation based on context.
+    """
+    try:
+        # Check if title is still default to avoid overwriting user changes
+        current_title = frappe.db.get_value("Agent Conversation", conversation_name, "title")
+        if current_title and not (current_title.startswith("Chat with") or current_title.startswith("Conversation with") or current_title.startswith("Streaming chat with")):
+             return
+
+        conv_manager = ConversationManager(agent_name=agent_name)
+        history = conv_manager.get_conversation_history(conversation_name, limit=5)
+        
+        if not history:
+            return
+
+        prompt = f"""
+        Analyze the following conversation start and generate a short, concise title (max 6 words).
+        The title should summarize the user's intent or the main topic.
+        Do not use quotes.
+        Conversation:
+        {json.dumps(history)}
+        """
+        
+        agent_doc = frappe.get_doc("Agent", agent_name)
+        provider = agent_doc.provider
+        model = agent_doc.model
+        
+        from huf.ai.providers.litellm import get_simple_completion
+        
+        messages = [{"role": "user", "content": prompt}]
+        
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+             title = loop.run_until_complete(
+                get_simple_completion(model, messages, provider)
+            )
+             if title:
+                 title = title.strip().strip('"').strip("'")
+                 frappe.db.set_value("Agent Conversation", conversation_name, "title", title)
+                 frappe.db.commit()
+        finally:
+            loop.close()
+            
+    except Exception as e:
+        frappe.log_error(f"Title generation failed: {str(e)}", "Agent Auto-naming")
+
 @frappe.whitelist(allow_guest=True)
 def run_agent_sync(
     agent_name: str,
@@ -835,6 +884,17 @@ def run_agent_sync(
             "end_time": now_datetime()
         }, update_modified=True)
         safe_commit()
+
+        # Auto-naming check
+        if agent_doc.autonaming_of_conversation_title:
+            conv_title = conversation.title
+            if conv_title and (conv_title.startswith("Chat with") or conv_title.startswith("Conversation with")):
+                frappe.enqueue(
+                    "huf.ai.agent_integration.generate_conversation_title",
+                    queue="default",
+                    conversation_name=conversation.name,
+                    agent_name=agent_name
+                )
 
         if context_strategy == "Summarize":
             current_history_len = len(history)
@@ -1230,6 +1290,20 @@ async def run_agent_stream(
                         "end_time": now_datetime()
                     }, update_modified=True)
                     safe_commit()
+
+                    # Auto-naming check for stream
+                    try:
+                        if agent_doc.autonaming_of_conversation_title:
+                            conv_title = frappe.db.get_value("Agent Conversation", conversation.name, "title")
+                            if conv_title and (conv_title.startswith("Chat with") or conv_title.startswith("Conversation with") or conv_title.startswith("Streaming chat with")):
+                                frappe.enqueue(
+                                    "huf.ai.agent_integration.generate_conversation_title",
+                                    queue="default",
+                                    conversation_name=conversation.name,
+                                    agent_name=agent_name
+                                )
+                    except Exception:
+                        pass
                     
                     chunk["conversation_id"] = conversation.name
                     yield chunk

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -48,6 +48,7 @@
   "context_strategy",
   "history_limit",
   "enable_conversation_data",
+  "autonaming_of_conversation_title",
   "column_break_ctx",
   "summary_ratio",
   "summary_model",
@@ -454,12 +455,19 @@
    "fieldname": "agent_color",
    "fieldtype": "Data",
    "label": "Agent Color"
+  },
+  {
+   "default": "1",
+   "description": "If enabled, the conversation title will be automatically updated based on the initial context.",
+   "fieldname": "autonaming_of_conversation_title",
+   "fieldtype": "Check",
+   "label": "Autonaming of conversation title"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-09 12:05:14.211963",
+ "modified": "2026-02-09 18:23:31.825896",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent",


### PR DESCRIPTION
### Summary
This PR enhances the chat experience by automatically generating descriptive titles for new conversations based on the initial context. Instead of generic "Chat with {Agent}" titles, users will see relevant topics like "Python Script Help" or "Marketing Strategy Discussion".

### Implementation Details
- **Configuration**: introduced a new setting `Autonaming of conversation title` in the Agent settings.
- **Mechanism**: 
  - A background job (`generate_conversation_title`) is triggered after the first agent response.
  - It analyzes the first few messages of the conversation.
  - Uses the Agent's configured LLM Model to generate a short (max 6 words) title.
  - Updates the `Agent Conversation` title.
- **Safety Checks**: 
  - Only updates titles that match the default pattern ("Chat with...", "Conversation with...", etc.).
  - Respects user-renamed titles (won't overwrite if the user has already customized it).
  - Handles basic error scenarios gracefully without interrupting the chat flow.

###  How to Test
1.  Navigate to **Agent** list and open an Agent specificiation.
2.  Enable the **Autonaming of conversation title** checkbox.
3.  Start a new chat with this agent.
4.  Send a message (e.g., "Write a recipe for banana bread").
5.  Wait for the agent's response.
6.  Refresh the conversation list or check the title bar.
    - **Expected**: Title updates to something like "Banana Bread Recipe".
7.  Verify that existing conversations or manually renamed conversations are NOT affected.