### PR TITLE
fix: handle unsupported params and safe error logging

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -508,7 +508,7 @@ def generate_conversation_title(conversation_name, agent_name):
             loop.close()
             
     except Exception as e:
-        frappe.log_error(f"Title generation failed: {str(e)}", "Agent Auto-naming")
+        frappe.log_error(title="Agent Auto-naming Error", message=f"Title generation failed: {str(e)}")
 
 @frappe.whitelist(allow_guest=True)
 def run_agent_sync(

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -545,9 +545,18 @@ async def get_simple_completion(model: str, messages: list, provider: str) -> st
         
         _setup_api_key(provider_name, api_key, completion_kwargs)
         
-        response = await asyncio.to_thread(
-            litellm.completion, **completion_kwargs
-        )
+        try:
+            response = await asyncio.to_thread(
+                litellm.completion, **completion_kwargs
+            )
+        except BadRequestError as e:
+            if "unsupported value" in str(e).lower() and "temperature" in str(e).lower():
+                completion_kwargs.pop("temperature", None)
+                response = await asyncio.to_thread(
+                    litellm.completion, **completion_kwargs
+                )
+            else:
+                raise e
         
         return response.choices[0].message.content
         


### PR DESCRIPTION
- Updates 'generate_conversation_title' in 'agent_integration.py' to use a fixed short title for 'frappe.log_error', preventing 'CharacterLengthExceededError' when the error message is too long.
- Adds retry logic to 'get_simple_completion' in 'litellm.py'. If a 'BadRequestError' occurs due to an unsupported 'temperature' parameter (e.g., with 'gpt-5.1-chat-latest'), the request is automatically retried without the parameter.