### PR TITLE
Feature/implement zvec portable vectordb

### DIFF
--- a/huf/ai/knowledge/backends/__init__.py
+++ b/huf/ai/knowledge/backends/__init__.py
@@ -65,9 +65,7 @@ def get_backend(backend_type: str) -> type:
 	"""Get backend class by type."""
 	backends = {
 		"sqlite_fts": "huf.ai.knowledge.backends.sqlite_fts.SQLiteFTSBackend",
-		# Future backends:
-		# "chroma": "huf.ai.knowledge.backends.chroma.ChromaBackend",
-		# "pgvector": "huf.ai.knowledge.backends.pgvector.PgVectorBackend",
+		"zvec": "huf.ai.knowledge.backends.zvec_backend.ZvecBackend",
 	}
 	
 	if backend_type not in backends:

--- a/huf/ai/knowledge/backends/zvec_backend.py
+++ b/huf/ai/knowledge/backends/zvec_backend.py
@@ -1,0 +1,300 @@
+"""
+Zvec Vector Database Backend for Knowledge System.
+
+Provides semantic (vector similarity) search using Zvec, an in-process
+vector database built on Alibaba's Proxima engine. Stores embeddings
+alongside text and metadata as a portable .zvec collection file.
+"""
+
+import os
+import uuid
+from typing import List, Dict, Any, Optional
+
+import frappe
+from frappe.utils import get_files_path
+
+from . import KnowledgeBackend, ChunkResult
+
+
+class ZvecBackend(KnowledgeBackend):
+	"""Zvec vector database backend for semantic search."""
+
+	# Default vector field name in the zvec collection
+	DEFAULT_VECTOR_FIELD = "embedding"
+
+	# Scalar fields stored alongside each chunk
+	SCALAR_FIELDS = [
+		("text", str),
+		("source_title", str),
+		("input_id", str),
+		("input_type", str),
+		("chunk_index", int),
+		("metadata_json", str),
+	]
+
+	def __init__(self):
+		self.collection = None
+		self.knowledge_source = None
+		self.db_path = None
+		self.vector_field = self.DEFAULT_VECTOR_FIELD
+		self.dimension = None
+		self._config = {}
+
+	def initialize(self, knowledge_source: str, config: Dict[str, Any]) -> None:
+		"""Initialize Zvec collection for knowledge source."""
+		import zvec
+
+		self.knowledge_source = knowledge_source
+		self._config = config
+		self.dimension = config.get("vector_dimension") or 1536
+		self.vector_field = self.DEFAULT_VECTOR_FIELD
+
+		# Determine database path
+		files_path = get_files_path(is_private=True)
+		knowledge_dir = os.path.join(files_path, "knowledge")
+		os.makedirs(knowledge_dir, exist_ok=True)
+
+		safe_name = frappe.scrub(knowledge_source)
+		self.db_path = os.path.join(knowledge_dir, f"{safe_name}.zvec")
+
+		# Build schema: scalar fields + one dense vector field
+		field_schemas = [
+			zvec.FieldSchema(name, zvec.DataType.STRING if dtype is str else zvec.DataType.INT64)
+			for name, dtype in self.SCALAR_FIELDS
+		]
+
+		vector_schema = zvec.VectorSchema(
+			self.vector_field,
+			zvec.DataType.VECTOR_FP32,
+			self.dimension,
+		)
+
+		schema = zvec.CollectionSchema(
+			name=knowledge_source,
+			fields=field_schemas,
+			vectors=vector_schema,
+		)
+
+		# Create or open collection
+		try:
+			self.collection = zvec.create_and_open(path=self.db_path, schema=schema)
+		except (RuntimeError, Exception):
+			# Collection already exists — open it
+			self.collection = zvec.open(self.db_path)
+
+	def add_chunks(self, chunks: List[Dict[str, Any]]) -> int:
+		"""
+		Add chunks to the Zvec collection.
+
+		Generates embeddings for each chunk text and stores them alongside
+		the original text and metadata as zvec documents.
+		"""
+		import zvec
+		import json
+
+		if not chunks:
+			return 0
+
+		# Get embedding configuration
+		embedding_model = self._config.get("embedding_model")
+		if not embedding_model:
+			frappe.throw("Embedding model is required for zvec backend")
+
+		# Gather texts for batch embedding
+		texts = [chunk["text"] for chunk in chunks]
+
+		# Generate embeddings in batch
+		from huf.ai.knowledge.embedding import get_embeddings, resolve_embedding_config
+
+		embed_config = resolve_embedding_config(self.knowledge_source)
+		vectors = get_embeddings(
+			texts=texts,
+			model=embed_config["model"],
+			api_key=embed_config.get("api_key"),
+			api_base=embed_config.get("api_base"),
+		)
+
+		# Build zvec documents
+		docs = []
+		for chunk, vector in zip(chunks, vectors):
+			chunk_id = chunk.get("chunk_id") or str(uuid.uuid4())
+			metadata = chunk.get("metadata", {})
+
+			doc = zvec.Doc(
+				id=chunk_id,
+				vectors={self.vector_field: vector},
+				fields={
+					"text": chunk["text"],
+					"source_title": chunk.get("source_title") or "",
+					"input_id": chunk["input_id"],
+					"input_type": chunk.get("input_type", ""),
+					"chunk_index": chunk["chunk_index"],
+					"metadata_json": json.dumps(metadata) if metadata else "{}",
+				},
+			)
+			docs.append(doc)
+
+		# Insert documents (use upsert, to handle re-indexing gracefully)
+		result = self.collection.upsert(docs)
+
+		# Count successes
+		if isinstance(result, list):
+			return sum(1 for status in result if status.ok())
+		# Single doc result
+		return 1 if result.ok() else 0
+
+	def delete_chunks(self, input_id: str) -> int:
+		"""Delete all chunks for a given input_id."""
+		try:
+			self.collection.delete_by_filter(filter=f"input_id == '{input_id}'")
+			# delete_by_filter doesn't return count in all zvec versions,
+			# so we can't reliably report count
+			return 0
+		except Exception as e:
+			frappe.log_error(
+				f"Zvec delete_chunks error for input_id={input_id}",
+				str(e),
+			)
+			return 0
+
+	def search(
+		self,
+		query: str,
+		top_k: int = 5,
+		filters: Optional[Dict[str, Any]] = None,
+	) -> List[ChunkResult]:
+		"""
+		Search for relevant chunks using vector similarity.
+
+		Embeds the query text, then performs approximate nearest-neighbor
+		search against the stored chunk embeddings.
+		"""
+		import zvec
+		import json
+
+		if not query or not query.strip():
+			return []
+
+		# Embed the query
+		from huf.ai.knowledge.embedding import get_embedding, resolve_embedding_config
+
+		embed_config = resolve_embedding_config(self.knowledge_source)
+		query_vector = get_embedding(
+			text=query,
+			model=embed_config["model"],
+			api_key=embed_config.get("api_key"),
+			api_base=embed_config.get("api_base"),
+		)
+
+		# Build vector query
+		vector_query = zvec.VectorQuery(
+			field_name=self.vector_field,
+			vector=query_vector,
+		)
+
+		# Build optional filter expression
+		filter_expr = None
+		if filters:
+			clauses = []
+			for key, value in filters.items():
+				if isinstance(value, str):
+					clauses.append(f"{key} == '{value}'")
+				else:
+					clauses.append(f"{key} == {value}")
+			filter_expr = " AND ".join(clauses)
+
+		# Execute query
+		query_kwargs = {
+			"vectors": vector_query,
+			"topk": top_k,
+			"output_fields": ["text", "source_title", "input_id", "chunk_index", "metadata_json"],
+		}
+		if filter_expr:
+			query_kwargs["filter"] = filter_expr
+
+		results = self.collection.query(**query_kwargs)
+
+		# Convert to ChunkResult objects
+		chunk_results = []
+		for doc in results:
+			metadata = {}
+			metadata_json = doc.fields.get("metadata_json", "{}")
+			if metadata_json:
+				try:
+					metadata = json.loads(metadata_json)
+				except (json.JSONDecodeError, TypeError):
+					pass
+
+			chunk_index = doc.fields.get("chunk_index")
+			if chunk_index is not None:
+				metadata["chunk_index"] = chunk_index
+
+			chunk_results.append(
+				ChunkResult(
+					chunk_id=doc.id,
+					text=doc.fields.get("text", ""),
+					title=doc.fields.get("source_title"),
+					score=doc.score if hasattr(doc, "score") else 0.0,
+					source=doc.fields.get("input_id"),
+					metadata=metadata,
+				)
+			)
+
+		return chunk_results
+
+	def clear(self) -> None:
+		"""Clear all documents from the collection."""
+		import zvec
+
+		if self.collection is None:
+			return
+
+		# Close current collection, remove files, recreate
+		try:
+			self.collection.close()
+		except Exception:
+			pass
+
+		# Remove the zvec directory/file and reinitialize
+		import shutil
+
+		if os.path.exists(self.db_path):
+			if os.path.isdir(self.db_path):
+				shutil.rmtree(self.db_path)
+			else:
+				os.remove(self.db_path)
+
+		# Reinitialize with same config
+		self.initialize(self.knowledge_source, self._config)
+
+	def get_stats(self) -> Dict[str, Any]:
+		"""Get collection statistics."""
+		stats = {
+			"chunk_count": 0,
+			"input_count": 0,
+			"size_bytes": 0,
+		}
+
+		if not self.db_path or not os.path.exists(self.db_path):
+			return stats
+
+		# Calculate size (zvec may store data in a directory)
+		if os.path.isdir(self.db_path):
+			total_size = 0
+			for dirpath, _dirnames, filenames in os.walk(self.db_path):
+				for f in filenames:
+					fp = os.path.join(dirpath, f)
+					total_size += os.path.getsize(fp)
+			stats["size_bytes"] = total_size
+		else:
+			stats["size_bytes"] = os.path.getsize(self.db_path)
+
+		# Try to get document count from collection stats
+		if self.collection:
+			try:
+				collection_stats = self.collection.stats()
+				stats["chunk_count"] = getattr(collection_stats, "doc_count", 0)
+			except Exception:
+				pass
+
+		return stats

--- a/huf/ai/knowledge/backends/zvec_llamaindex.py
+++ b/huf/ai/knowledge/backends/zvec_llamaindex.py
@@ -1,0 +1,204 @@
+"""
+LlamaIndex-compatible VectorStore adapter for Zvec.
+
+Wraps ZvecBackend as a LlamaIndex BasePydanticVectorStore, enabling
+Zvec collections to be used in standard LlamaIndex index/query pipelines.
+
+This is an optional integration layer — the primary path for Huf's
+knowledge system is through the KnowledgeBackend ABC.
+"""
+
+from typing import Any, List, Optional, Dict
+
+try:
+	from llama_index.core.vector_stores.types import (
+		BasePydanticVectorStore,
+		VectorStoreQuery,
+		VectorStoreQueryResult,
+	)
+	from llama_index.core.schema import BaseNode, TextNode
+	from pydantic import ConfigDict
+
+	LLAMAINDEX_AVAILABLE = True
+except ImportError:
+	LLAMAINDEX_AVAILABLE = False
+
+
+def _check_llamaindex():
+	if not LLAMAINDEX_AVAILABLE:
+		raise ImportError(
+			"llama-index-core is required for the LlamaIndex VectorStore adapter. "
+			"Install it with: pip install llama-index-core"
+		)
+
+
+if LLAMAINDEX_AVAILABLE:
+
+	class ZvecVectorStore(BasePydanticVectorStore):
+		"""
+		LlamaIndex VectorStore backed by Zvec.
+
+		Usage:
+			vector_store = ZvecVectorStore(
+				db_path="/path/to/collection.zvec",
+				dimension=1536,
+				collection_name="my_knowledge",
+			)
+			index = VectorStoreIndex.from_vector_store(vector_store)
+		"""
+
+		model_config = ConfigDict(arbitrary_types_allowed=True)
+
+		db_path: str
+		dimension: int = 1536
+		collection_name: str = "knowledge"
+		vector_field: str = "embedding"
+
+		_collection: Any = None
+
+		def __init__(self, **kwargs):
+			super().__init__(**kwargs)
+			self._init_collection()
+
+		def _init_collection(self):
+			"""Initialize or open the zvec collection."""
+			import zvec
+			import os
+
+			field_schemas = [
+				zvec.FieldSchema("text", zvec.DataType.STRING),
+				zvec.FieldSchema("ref_doc_id", zvec.DataType.STRING),
+				zvec.FieldSchema("metadata_json", zvec.DataType.STRING),
+			]
+
+			vector_schema = zvec.VectorSchema(
+				self.vector_field,
+				zvec.DataType.VECTOR_FP32,
+				self.dimension,
+			)
+
+			schema = zvec.CollectionSchema(
+				name=self.collection_name,
+				fields=field_schemas,
+				vectors=vector_schema,
+			)
+
+			try:
+				self._collection = zvec.create_and_open(path=self.db_path, schema=schema)
+			except (RuntimeError, Exception):
+				self._collection = zvec.open(self.db_path)
+
+		@property
+		def client(self) -> Any:
+			"""Return the underlying zvec collection."""
+			return self._collection
+
+		def add(self, nodes: List[BaseNode], **kwargs: Any) -> List[str]:
+			"""
+			Add nodes to the vector store.
+
+			Each node must have an embedding already set.
+			"""
+			import zvec
+			import json
+
+			docs = []
+			ids = []
+
+			for node in nodes:
+				node_id = node.node_id
+				embedding = node.get_embedding()
+				text = node.get_content()
+				metadata = node.metadata or {}
+				ref_doc_id = node.ref_doc_id or ""
+
+				doc = zvec.Doc(
+					id=node_id,
+					vectors={self.vector_field: embedding},
+					fields={
+						"text": text,
+						"ref_doc_id": ref_doc_id,
+						"metadata_json": json.dumps(metadata),
+					},
+				)
+				docs.append(doc)
+				ids.append(node_id)
+
+			if docs:
+				self._collection.upsert(docs)
+
+			return ids
+
+		def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+			"""Delete all nodes associated with a reference document ID."""
+			self._collection.delete_by_filter(
+				filter=f"ref_doc_id == '{ref_doc_id}'"
+			)
+
+		def query(
+			self,
+			query: VectorStoreQuery,
+			**kwargs: Any,
+		) -> VectorStoreQueryResult:
+			"""
+			Query the vector store with a VectorStoreQuery.
+
+			Uses the query embedding to perform similarity search.
+			"""
+			import zvec
+			import json
+
+			if query.query_embedding is None:
+				return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
+
+			vector_query = zvec.VectorQuery(
+				field_name=self.vector_field,
+				vector=query.query_embedding,
+			)
+
+			topk = query.similarity_top_k or 5
+
+			results = self._collection.query(
+				vectors=vector_query,
+				topk=topk,
+				output_fields=["text", "ref_doc_id", "metadata_json"],
+			)
+
+			nodes = []
+			similarities = []
+			ids = []
+
+			for doc in results:
+				metadata = {}
+				metadata_json = doc.fields.get("metadata_json", "{}")
+				if metadata_json:
+					try:
+						metadata = json.loads(metadata_json)
+					except (json.JSONDecodeError, TypeError):
+						pass
+
+				node = TextNode(
+					id_=doc.id,
+					text=doc.fields.get("text", ""),
+					metadata=metadata,
+				)
+				nodes.append(node)
+				similarities.append(doc.score if hasattr(doc, "score") else 0.0)
+				ids.append(doc.id)
+
+			return VectorStoreQueryResult(
+				nodes=nodes,
+				similarities=similarities,
+				ids=ids,
+			)
+
+		def get_nodes(
+			self,
+			node_ids: Optional[List[str]] = None,
+			filters: Optional[Any] = None,
+		) -> List[BaseNode]:
+			"""Retrieve nodes by ID. Limited implementation."""
+			# Zvec doesn't support direct ID-based fetching easily,
+			# so we return empty for now. Full implementation would need
+			# per-ID vector queries or a separate lookup table.
+			return []

--- a/huf/ai/knowledge/embedding.py
+++ b/huf/ai/knowledge/embedding.py
@@ -1,0 +1,126 @@
+"""
+Embedding Infrastructure for Knowledge System.
+
+Provides model-agnostic embedding functions using LiteLLM's unified API.
+Supports OpenAI, Gemini, Cohere, HuggingFace, and any LiteLLM-compatible provider.
+"""
+
+import frappe
+from typing import List, Dict, Any, Optional
+
+
+# Maximum texts per batch request (most APIs cap at 2048, we use conservative default)
+DEFAULT_BATCH_SIZE = 100
+
+
+def get_embedding(
+	text: str,
+	model: str,
+	api_key: Optional[str] = None,
+	api_base: Optional[str] = None,
+) -> List[float]:
+	"""
+	Get embedding vector for a single text string.
+
+	Args:
+		text: The text to embed.
+		model: LiteLLM model identifier (e.g. 'openai/text-embedding-3-small').
+		api_key: Optional API key. If None, resolved from environment or provider config.
+		api_base: Optional API base URL for custom endpoints.
+
+	Returns:
+		List of floats representing the embedding vector.
+	"""
+	import litellm
+
+	kwargs = {"model": model, "input": [text]}
+	if api_key:
+		kwargs["api_key"] = api_key
+	if api_base:
+		kwargs["api_base"] = api_base
+
+	response = litellm.embedding(**kwargs)
+	return response.data[0]["embedding"]
+
+
+def get_embeddings(
+	texts: List[str],
+	model: str,
+	api_key: Optional[str] = None,
+	api_base: Optional[str] = None,
+	batch_size: int = DEFAULT_BATCH_SIZE,
+) -> List[List[float]]:
+	"""
+	Get embedding vectors for multiple texts with batched requests.
+
+	Processes texts in batches to respect API rate limits and payload size constraints.
+
+	Args:
+		texts: List of texts to embed.
+		model: LiteLLM model identifier.
+		api_key: Optional API key.
+		api_base: Optional API base URL.
+		batch_size: Number of texts per API call. Default: 100.
+
+	Returns:
+		List of embedding vectors, one per input text (preserves order).
+	"""
+	import litellm
+
+	if not texts:
+		return []
+
+	all_embeddings = []
+
+	for i in range(0, len(texts), batch_size):
+		batch = texts[i : i + batch_size]
+
+		kwargs = {"model": model, "input": batch}
+		if api_key:
+			kwargs["api_key"] = api_key
+		if api_base:
+			kwargs["api_base"] = api_base
+
+		response = litellm.embedding(**kwargs)
+
+		# Sort by index to guarantee order matches input
+		sorted_data = sorted(response.data, key=lambda x: x["index"])
+		batch_embeddings = [item["embedding"] for item in sorted_data]
+		all_embeddings.extend(batch_embeddings)
+
+	return all_embeddings
+
+
+def resolve_embedding_config(knowledge_source: str) -> Dict[str, Any]:
+	"""
+	Resolve embedding configuration from a Knowledge Source document.
+
+	Reads the embedding_model, vector_dimension, and embedding_provider fields
+	from the Knowledge Source DocType and resolves the API key from the linked
+	AI Provider.
+
+	Args:
+		knowledge_source: Name of the Knowledge Source document.
+
+	Returns:
+		Dict with keys: model, dimension, api_key, api_base
+	"""
+	source = frappe.get_doc("Knowledge Source", knowledge_source)
+
+	model = source.embedding_model
+	dimension = source.vector_dimension or 1536
+
+	api_key = None
+	api_base = None
+
+	if source.embedding_provider:
+		provider = frappe.get_doc("AI Provider", source.embedding_provider)
+		api_key = provider.get_password("api_key") if provider.api_key else None
+		api_base = getattr(provider, "api_base", None) or None
+
+	return {
+		"model": model,
+		"dimension": dimension,
+		"api_key": api_key,
+		"api_base": api_base,
+	}

--- a/huf/ai/knowledge/indexer.py
+++ b/huf/ai/knowledge/indexer.py
@@ -10,6 +10,26 @@ from .extractors import TextExtractor, ExtractedText
 from .chunkers.sentence import chunk_text
 
 
+def _build_backend_config(source) -> dict:
+	"""Build configuration dict for backend initialization.
+
+	Includes chunking settings for all backends and adds embedding
+	configuration for vector backends (e.g. zvec).
+	"""
+	config = {
+		"chunk_size": source.chunk_size,
+		"chunk_overlap": source.chunk_overlap,
+	}
+
+	# Vector backends need embedding configuration
+	if source.knowledge_type == "zvec":
+		config["embedding_model"] = source.embedding_model
+		config["vector_dimension"] = source.vector_dimension
+		config["embedding_provider"] = getattr(source, "embedding_provider", None)
+
+	return config
+
+
 def process_knowledge_input(knowledge_input: str) -> dict:
 	"""
 	Process a single knowledge input and add to index.
@@ -64,10 +84,7 @@ def process_knowledge_input(knowledge_input: str) -> dict:
 			# Initialize backend and add chunks
 			backend_class = get_backend(source.knowledge_type)
 			backend = backend_class()
-			backend.initialize(source.name, {
-				"chunk_size": source.chunk_size,
-				"chunk_overlap": source.chunk_overlap,
-			})
+			backend.initialize(source.name, _build_backend_config(source))
 			
 			# Delete existing chunks for this input (for reprocessing)
 			backend.delete_chunks(doc.name)
@@ -151,10 +168,7 @@ def rebuild_knowledge_index(knowledge_source: str) -> dict:
 			# Initialize backend and clear
 			backend_class = get_backend(source.knowledge_type)
 			backend = backend_class()
-			backend.initialize(source.name, {
-				"chunk_size": source.chunk_size,
-				"chunk_overlap": source.chunk_overlap,
-			})
+			backend.initialize(source.name, _build_backend_config(source))
 			backend.clear()
 			
 			# Reset all input statuses

--- a/huf/huf/doctype/knowledge_source/knowledge_source.js
+++ b/huf/huf/doctype/knowledge_source/knowledge_source.js
@@ -5,14 +5,14 @@ frappe.ui.form.on("Knowledge Source", {
 	refresh(frm) {
 		// Add Rebuild Index button
 		if (!frm.is_new() && frm.doc.status !== "Indexing" && frm.doc.status !== "Rebuilding") {
-			frm.add_custom_button(__("Rebuild Index"), function() {
+			frm.add_custom_button(__("Rebuild Index"), function () {
 				frappe.confirm(
 					__("This will clear the existing index and rebuild it from all inputs. Continue?"),
-					function() {
+					function () {
 						frappe.call({
 							method: "huf.huf.doctype.knowledge_source.knowledge_source.rebuild_index",
 							args: { knowledge_source: frm.doc.name },
-							callback: function(r) {
+							callback: function (r) {
 								if (r.message) {
 									frappe.show_alert({
 										message: r.message.message,
@@ -26,14 +26,14 @@ frappe.ui.form.on("Knowledge Source", {
 				);
 			}, __("Actions"));
 		}
-		
+
 		// Add Test Search button
 		if (!frm.is_new() && frm.doc.status === "Ready") {
-			frm.add_custom_button(__("Test Search"), function() {
+			frm.add_custom_button(__("Test Search"), function () {
 				show_test_search_dialog(frm);
 			}, __("Actions"));
 		}
-		
+
 		// Status indicator
 		if (frm.doc.status === "Ready") {
 			frm.dashboard.set_headline_alert(
@@ -49,13 +49,12 @@ frappe.ui.form.on("Knowledge Source", {
 			frm.dashboard.set_headline_alert(__("Indexing in progress..."), "blue");
 		}
 	},
-	
+
 	knowledge_type(frm) {
-		// Phase 1: Only sqlite_fts is supported
-		if (frm.doc.knowledge_type && frm.doc.knowledge_type !== "sqlite_fts") {
-			frappe.msgprint(__("Only SQLite FTS is supported in Phase 1"));
-			frm.set_value("knowledge_type", "sqlite_fts");
-		}
+		// Toggle visibility of vector-specific settings
+		const is_zvec = frm.doc.knowledge_type === "zvec";
+		frm.toggle_reqd("embedding_model", is_zvec);
+		frm.toggle_reqd("vector_dimension", is_zvec);
 	}
 });
 
@@ -90,7 +89,7 @@ function show_test_search_dialog(frm) {
 					query: values.query,
 					top_k: values.top_k || 5
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (r.message) {
 						let html = render_search_results(r.message);
 						d.fields_dict.results_html.$wrapper.html(html);
@@ -106,7 +105,7 @@ function render_search_results(results) {
 	if (!results || results.length === 0) {
 		return `<p class="text-muted">${__("No results found")}</p>`;
 	}
-	
+
 	let html = '<div class="search-results">';
 	results.forEach((r, i) => {
 		html += `

--- a/huf/huf/doctype/knowledge_source/knowledge_source.json
+++ b/huf/huf/doctype/knowledge_source/knowledge_source.json
@@ -1,197 +1,238 @@
 {
- "actions": [],
- "allow_rename": 1,
- "autoname": "field:source_name",
- "creation": "2026-01-10 00:00:00.000000",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "configuration_section",
-  "source_name",
-  "description",
-  "column_break_1",
-  "knowledge_type",
-  "scope",
-  "storage_settings_section",
-  "storage_mode",
-  "sqlite_file",
-  "sqlite_file_path",
-  "chunking_settings_section",
-  "chunk_size",
-  "chunk_overlap",
-  "status_section",
-  "status",
-  "last_indexed_at",
-  "column_break_status",
-  "total_chunks",
-  "total_inputs",
-  "index_size_bytes",
-  "error_message",
-  "disabled"
- ],
- "fields": [
-  {
-   "fieldname": "configuration_section",
-   "fieldtype": "Section Break",
-   "label": "Configuration"
-  },
-  {
-   "fieldname": "source_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Source Name",
-   "reqd": 1,
-   "unique": 1
-  },
-  {
-   "fieldname": "description",
-   "fieldtype": "Small Text",
-   "label": "Description"
-  },
-  {
-   "fieldname": "column_break_1",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "Site",
-   "fieldtype": "Select",
-   "label": "Scope",
-   "options": "Site\nWorkspace\nAgent\nGlobal",
-   "reqd": 1,
-   "fieldname": "scope"
-  },
-  {
-   "fieldname": "storage_settings_section",
-   "fieldtype": "Section Break",
-   "label": "Storage Settings"
-  },
-  {
-   "default": "Frappe File",
-   "fieldtype": "Select",
-   "label": "Storage Mode",
-   "options": "Frappe File",
-   "reqd": 1,
-   "fieldname": "storage_mode"
-  },
-  {
-   "fieldname": "sqlite_file",
-   "fieldtype": "Attach",
-   "label": "SQLite File",
-   "read_only": 1
-  },
-  {
-   "fieldname": "sqlite_file_path",
-   "fieldtype": "Data",
-   "label": "SQLite File Path",
-   "read_only": 1
-  },
-  {
-   "fieldname": "chunking_settings_section",
-   "fieldtype": "Section Break",
-   "label": "Chunking Settings"
-  },
-  {
-   "default": 512,
-   "fieldtype": "Int",
-   "label": "Chunk Size",
-   "non_negative": 1,
-   "fieldname": "chunk_size"
-  },
-  {
-   "default": 50,
-   "fieldtype": "Int",
-   "label": "Chunk Overlap",
-   "non_negative": 1,
-   "fieldname": "chunk_overlap"
-  },
-  {
-   "fieldname": "status_section",
-   "fieldtype": "Section Break",
-   "label": "Status"
-  },
-  {
-   "default": "Pending",
-   "fieldtype": "Select",
-   "label": "Status",
-   "options": "Pending\nIndexing\nReady\nError\nRebuilding",
-   "read_only": 1,
-   "fieldname": "status"
-  },
-  {
-   "fieldname": "last_indexed_at",
-   "fieldtype": "Datetime",
-   "label": "Last Indexed At",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_status",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": 0,
-   "fieldname": "total_chunks",
-   "fieldtype": "Int",
-   "label": "Total Chunks",
-   "read_only": 1
-  },
-  {
-   "default": 0,
-   "fieldname": "total_inputs",
-   "fieldtype": "Int",
-   "label": "Total Inputs",
-   "read_only": 1
-  },
-  {
-   "default": 0,
-   "fieldname": "index_size_bytes",
-   "fieldtype": "Int",
-   "label": "Index Size (bytes)",
-   "read_only": 1
-  },
-  {
-   "fieldname": "error_message",
-   "fieldtype": "Small Text",
-   "label": "Error Message",
-   "read_only": 1
-  },
-  {
-   "default": 0,
-   "fieldname": "disabled",
-   "fieldtype": "Check",
-   "label": "Disabled"
-  },
-  {
-   "fieldname": "knowledge_type",
-   "fieldtype": "Select",
-   "label": "Knowledge Type",
-   "options": "sqlite_fts",
-   "reqd": 1
-  }
- ],
- "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2026-01-10 00:00:00.000000",
- "modified_by": "Administrator",
- "module": "Huf",
- "name": "Knowledge Source",
- "naming_rule": "By fieldname",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "row_format": "Dynamic",
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+    "actions": [],
+    "allow_rename": 1,
+    "autoname": "field:source_name",
+    "creation": "2026-01-10 00:00:00.000000",
+    "doctype": "DocType",
+    "engine": "InnoDB",
+    "field_order": [
+        "configuration_section",
+        "source_name",
+        "description",
+        "column_break_1",
+        "knowledge_type",
+        "scope",
+        "vector_settings_section",
+        "embedding_model",
+        "vector_dimension",
+        "column_break_vector",
+        "embedding_provider",
+        "storage_settings_section",
+        "storage_mode",
+        "sqlite_file",
+        "sqlite_file_path",
+        "chunking_settings_section",
+        "chunk_size",
+        "chunk_overlap",
+        "status_section",
+        "status",
+        "last_indexed_at",
+        "column_break_status",
+        "total_chunks",
+        "total_inputs",
+        "index_size_bytes",
+        "error_message",
+        "disabled"
+    ],
+    "fields": [
+        {
+            "fieldname": "configuration_section",
+            "fieldtype": "Section Break",
+            "label": "Configuration"
+        },
+        {
+            "fieldname": "source_name",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Source Name",
+            "reqd": 1,
+            "unique": 1
+        },
+        {
+            "fieldname": "description",
+            "fieldtype": "Small Text",
+            "label": "Description"
+        },
+        {
+            "fieldname": "column_break_1",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "Site",
+            "fieldtype": "Select",
+            "label": "Scope",
+            "options": "Site\nWorkspace\nAgent\nGlobal",
+            "reqd": 1,
+            "fieldname": "scope"
+        },
+        {
+            "fieldname": "storage_settings_section",
+            "fieldtype": "Section Break",
+            "label": "Storage Settings"
+        },
+        {
+            "default": "Frappe File",
+            "fieldtype": "Select",
+            "label": "Storage Mode",
+            "options": "Frappe File",
+            "reqd": 1,
+            "fieldname": "storage_mode"
+        },
+        {
+            "fieldname": "sqlite_file",
+            "fieldtype": "Attach",
+            "label": "SQLite File",
+            "read_only": 1
+        },
+        {
+            "fieldname": "sqlite_file_path",
+            "fieldtype": "Data",
+            "label": "SQLite File Path",
+            "read_only": 1
+        },
+        {
+            "fieldname": "chunking_settings_section",
+            "fieldtype": "Section Break",
+            "label": "Chunking Settings"
+        },
+        {
+            "default": 512,
+            "fieldtype": "Int",
+            "label": "Chunk Size",
+            "non_negative": 1,
+            "fieldname": "chunk_size"
+        },
+        {
+            "default": 50,
+            "fieldtype": "Int",
+            "label": "Chunk Overlap",
+            "non_negative": 1,
+            "fieldname": "chunk_overlap"
+        },
+        {
+            "fieldname": "status_section",
+            "fieldtype": "Section Break",
+            "label": "Status"
+        },
+        {
+            "default": "Pending",
+            "fieldtype": "Select",
+            "label": "Status",
+            "options": "Pending\nIndexing\nReady\nError\nRebuilding",
+            "read_only": 1,
+            "fieldname": "status"
+        },
+        {
+            "fieldname": "last_indexed_at",
+            "fieldtype": "Datetime",
+            "label": "Last Indexed At",
+            "read_only": 1
+        },
+        {
+            "fieldname": "column_break_status",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": 0,
+            "fieldname": "total_chunks",
+            "fieldtype": "Int",
+            "label": "Total Chunks",
+            "read_only": 1
+        },
+        {
+            "default": 0,
+            "fieldname": "total_inputs",
+            "fieldtype": "Int",
+            "label": "Total Inputs",
+            "read_only": 1
+        },
+        {
+            "default": 0,
+            "fieldname": "index_size_bytes",
+            "fieldtype": "Int",
+            "label": "Index Size (bytes)",
+            "read_only": 1
+        },
+        {
+            "fieldname": "error_message",
+            "fieldtype": "Small Text",
+            "label": "Error Message",
+            "read_only": 1
+        },
+        {
+            "default": 0,
+            "fieldname": "disabled",
+            "fieldtype": "Check",
+            "label": "Disabled"
+        },
+        {
+            "fieldname": "knowledge_type",
+            "fieldtype": "Select",
+            "label": "Knowledge Type",
+            "options": "sqlite_fts\nzvec",
+            "reqd": 1
+        },
+        {
+            "fieldname": "vector_settings_section",
+            "fieldtype": "Section Break",
+            "label": "Vector Settings",
+            "depends_on": "eval:doc.knowledge_type=='zvec'"
+        },
+        {
+            "fieldname": "embedding_model",
+            "fieldtype": "Data",
+            "label": "Embedding Model",
+            "description": "LiteLLM model identifier, e.g. openai/text-embedding-3-small",
+            "depends_on": "eval:doc.knowledge_type=='zvec'",
+            "mandatory_depends_on": "eval:doc.knowledge_type=='zvec'"
+        },
+        {
+            "fieldname": "vector_dimension",
+            "fieldtype": "Int",
+            "label": "Vector Dimension",
+            "default": 1536,
+            "non_negative": 1,
+            "description": "Must match the embedding model output dimensionality",
+            "depends_on": "eval:doc.knowledge_type=='zvec'",
+            "mandatory_depends_on": "eval:doc.knowledge_type=='zvec'"
+        },
+        {
+            "fieldname": "column_break_vector",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "embedding_provider",
+            "fieldtype": "Link",
+            "label": "Embedding Provider",
+            "options": "AI Provider",
+            "description": "AI Provider for API key resolution",
+            "depends_on": "eval:doc.knowledge_type=='zvec'"
+        }
+    ],
+    "index_web_pages_for_search": 1,
+    "links": [],
+    "modified": "2026-01-10 00:00:00.000000",
+    "modified_by": "Administrator",
+    "module": "Huf",
+    "name": "Knowledge Source",
+    "naming_rule": "By fieldname",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "System Manager",
+            "share": 1,
+            "write": 1
+        }
+    ],
+    "row_format": "Dynamic",
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
 }

--- a/huf/huf/doctype/knowledge_source/knowledge_source.py
+++ b/huf/huf/doctype/knowledge_source/knowledge_source.py
@@ -9,12 +9,20 @@ from frappe import _
 class KnowledgeSource(Document):
 	def validate(self):
 		self.validate_chunk_settings()
+		self.validate_zvec_settings()
 		
 	def validate_chunk_settings(self):
 		if self.chunk_size and self.chunk_size < 100:
 			frappe.throw(_("Chunk size must be at least 100 characters"))
 		if self.chunk_overlap and self.chunk_overlap >= self.chunk_size:
 			frappe.throw(_("Chunk overlap must be less than chunk size"))
+
+	def validate_zvec_settings(self):
+		if self.knowledge_type == "zvec":
+			if not self.embedding_model:
+				frappe.throw(_("Embedding Model is required for Zvec knowledge type"))
+			if not self.vector_dimension or self.vector_dimension <= 0:
+				frappe.throw(_("Vector Dimension must be a positive integer for Zvec knowledge type"))
 	
 	def before_save(self):
 		if not self.chunk_size:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "openai-agents",
     "litellm>=1.0.0",
     "llama-index-core>=0.10.0",
+    "zvec",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Adds **Zvec** as a portable, in-process vector database backend for the Huf Knowledge System, enabling **semantic (vector similarity) search** alongside the existing SQLite FTS keyword search.

---

## Background: What is Zvec?

[Zvec](https://github.com/alivx/zvec) is a lightweight, in-process vector database built on **Alibaba's Proxima** approximate nearest-neighbor engine. It stores embeddings as portable `.zvec` collection files — no external server process required.

**Why Zvec for Huf?**

| Requirement | Zvec |
|---|---|
| In-process (no separate server) | ✅ |
| Portable file-based storage | ✅ `.zvec` files in `/private/files/knowledge/` |
| HNSW index with cosine similarity | ✅ |
| Schema-driven (typed scalar + vector fields) | ✅ |
| Multi-site / multi-agent safe | ✅ (read-concurrent, write-serialized via Redis locks) |

This mirrors the existing SQLite FTS pattern: one portable file per Knowledge Source, stored in Frappe's private files directory, shareable across agents and sites.

---

## What Was Added

### New Files

| File | Purpose |
|---|---|
| `huf/ai/knowledge/embedding.py` | Model-agnostic embedding generation via LiteLLM (`get_embedding`, `get_embeddings`, `resolve_embedding_config`) |
| `huf/ai/knowledge/backends/zvec_backend.py` | `ZvecBackend(KnowledgeBackend)` — full CRUD + vector search |
| `huf/ai/knowledge/backends/zvec_llamaindex.py` | Optional `ZvecVectorStore(BasePydanticVectorStore)` adapter for LlamaIndex pipeline compatibility |

### Modified Files

| File | Change |
|---|---|
| `huf/ai/knowledge/backends/__init__.py` | Register `zvec` in `get_backend()` factory |
| `huf/huf/doctype/knowledge_source/knowledge_source.json` | Add `zvec` to `knowledge_type` options; add Vector Settings section (`embedding_model`, `vector_dimension`, `embedding_provider`) |
| `huf/huf/doctype/knowledge_source/knowledge_source.py` | Add `validate_zvec_settings()` |
| `huf/huf/doctype/knowledge_source/knowledge_source.js` | Remove hard-coded `sqlite_fts`-only restriction; dynamic field visibility for vector settings |
| `huf/ai/knowledge/indexer.py` | `_build_backend_config()` helper — passes embedding config to vector backends |
| `pyproject.toml` | Add `zvec` dependency |

---

## Architecture

```
Knowledge Source (DocType)
  ├── knowledge_type: "sqlite_fts" | "zvec"
  ├── embedding_model (zvec only)
  ├── vector_dimension (zvec only)
  └── embedding_provider (zvec only)

Indexing Pipeline:
  Knowledge Input → TextExtractor → chunk_text()
    → _build_backend_config(source)
    → backend.initialize(source, config)
    → backend.add_chunks(chunks)  # embeds + upserts

Search Pipeline:
  query → backend.search(query, top_k)
    → embed query → zvec.VectorQuery → collection.query()
    → List[ChunkResult]
```

The embedding infrastructure is **provider-agnostic** — it uses `litellm.embedding()` and reads model/API key config from the Knowledge Source and its linked AI Provider document.

---

## How to Test

### Prerequisites
1. An AI Provider with an embedding-capable model configured (e.g., OpenAI `text-embedding-3-small`, Gemini `models/embedding-001`)
2. `bench pip install zvec` (or `bench setup requirements` to install from updated pyproject.toml)

### Steps

1. **Create a Knowledge Source**
   - Go to Knowledge Source list → New
   - Set `Knowledge Type` = `zvec`
   - The "Vector Settings" section should appear
   - Set `Embedding Model` (e.g., `text-embedding-3-small`)
   - Set `Vector Dimension` (e.g., `1536` for OpenAI, `768` for Gemini)
   - Optionally link an `Embedding Provider`
   - Save — validation should pass

2. **Validate field visibility**
   - Switch `Knowledge Type` back to `sqlite_fts` — vector settings should hide
   - Switch to `zvec` — vector settings should reappear and become required

3. **Add a Knowledge Input**
   - Add text or file input to the Knowledge Source
   - Trigger indexing (process the input)
   - Check that a `.zvec` file is created in `{site}/private/files/knowledge/`

4. **Test search**
   - From bench console or via the retriever, call:
     ```python
     from huf.ai.knowledge.backends import get_backend
     backend_class = get_backend("zvec")
     backend = backend_class()
     backend.initialize("YOUR-SOURCE-NAME", {
         "embedding_model": "text-embedding-3-small",
         "vector_dimension": 1536,
     })
     results = backend.search("your query here", top_k=3)
     for r in results:
         print(r.score, r.text[:100])
     ```

5. **Verify existing FTS still works** — creating/using `sqlite_fts` Knowledge Sources should be unaffected

---

## Commit History

```
77f1a45 feat: add embedding infrastructure for vector backends
fe1c900 feat: implement ZvecBackend for portable vector search
5da85b6 feat: add LlamaIndex VectorStore adapter for Zvec
006155e feat: add zvec to Knowledge Source DocType and backend registry
a437b87 feat: pass embedding config from indexer to vector backends
2d77d9b build: add zvec dependency to pyproject.toml
```
