### PR TITLE
fix: use parameter description in generated tool JSON

### DIFF
--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -107,7 +107,7 @@ class AgentToolFunction(Document):
 			for param in self.parameters:
 				properties[param.fieldname] = {
 					"type": param.type,
-					"description": param.label,
+					"description": param.description or param.label,
 				}
 
 			params = {
@@ -205,7 +205,7 @@ class AgentToolFunction(Document):
 				for param in self.parameters:
 					properties[param.fieldname] = {
 						"type": "string",
-						"description": f"File URL/Path for field '{param.label or param.fieldname}'"
+						"description": param.description or f"File URL/Path for field '{param.label or param.fieldname}'"
 					}
 			else:
 				properties["file_url"] = {
@@ -230,7 +230,7 @@ class AgentToolFunction(Document):
 			for param in self.parameters:
 				filter_properties[param.fieldname] = {
 					"type": param.type,
-					"description": param.label or f"Filter by {param.fieldname}"
+					"description": param.description or param.label or f"Filter by {param.fieldname}"
 				}
 
 			params = {
@@ -335,7 +335,7 @@ class AgentToolFunction(Document):
 			query_required = []
 
 			for param in self.parameters:
-				field_schema = {"type": param.type, "description": param.label}
+				field_schema = {"type": param.type, "description": param.description or param.label}
 				if param.type == "string" and param.options:
 					field_schema["enum"] = param.options.split("\n")
 
@@ -368,7 +368,7 @@ class AgentToolFunction(Document):
 			body_required = []
 
 			for param in self.parameters:
-				field_schema = {"type": param.type, "description": param.label}
+				field_schema = {"type": param.type, "description": param.description or param.label}
 
 				if param.type == "string" and param.options:
 					field_schema["enum"] = param.options.split("\n")
@@ -520,7 +520,7 @@ class AgentToolFunction(Document):
 		for param in self.parameters:
 			obj = {
 				"type": param.type,
-				"description": param.label,
+				"description": param.description or param.label,
 			}
 
 			# Explicitly allow any keys/values for object types


### PR DESCRIPTION
 -Previously, the tool schema generation relied solely on the 'label' field, ignoring the 'description' field in the parameters table.

 -This change updates 'prepare_function_params' and 'build_params_json_from_table' to prioritize 'param.description'. It now falls back to 'param.label' only if the description is empty. This ensures the AI agent receives more accurate context for function arguments.