### PR TITLE
Add Agent Prompt template system with versioning and mode switching

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -216,7 +216,8 @@ class AgentManager:
         if not self.agent_doc.model:
             frappe.throw(_("Agent model is not configured"))
 
-        instructions = self.agent_doc.instructions
+        from huf.ai.prompt_resolver import resolve_prompt
+        instructions = resolve_prompt(self.agent_doc) or ""
 
         # Enhance instructions with tool descriptions
         if self.tools:

--- a/huf/ai/agent_scheduler.py
+++ b/huf/ai/agent_scheduler.py
@@ -31,7 +31,8 @@ def run_scheduled_agents():
             agent_name = t.get("agent")
             agent = frappe.get_doc("Agent", agent_name)
 
-            prompt = agent.instructions or f"Run scheduled agent: {agent_name}"
+            from huf.ai.prompt_resolver import resolve_prompt
+            prompt = resolve_prompt(agent) or f"Run scheduled agent: {agent_name}"
             run_agent_sync(agent_name, prompt, agent.provider, agent.model)
 
             doc = frappe.get_doc("Agent Trigger", t["name"])

--- a/huf/ai/orchestration/orchestrator.py
+++ b/huf/ai/orchestration/orchestrator.py
@@ -75,7 +75,9 @@ def recreate_orchestration_plan(orch_name):
     orch = frappe.get_doc("Agent Orchestration", orch_name)
     agent_doc = frappe.get_doc("Agent", orch.agent)
     
-    plan_output = run_planning(orch.agent, agent_doc.instructions, agent_doc.provider, agent_doc.model)
+    from huf.ai.prompt_resolver import resolve_prompt
+    resolved_instructions = resolve_prompt(agent_doc) or ""
+    plan_output = run_planning(orch.agent, resolved_instructions, agent_doc.provider, agent_doc.model)
     steps = parse_plan_steps(plan_output)
     
     if steps:

--- a/huf/ai/prompt_api.py
+++ b/huf/ai/prompt_api.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""
+Whitelisted API methods for Agent Prompt management.
+
+Provides server-side operations for the prompt template system:
+- Creating new versions (immutable model)
+- Forking prompts
+- Detaching agents from templates
+- Saving local prompts as templates
+- Retrieving version history
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import cint
+
+
+@frappe.whitelist()
+def create_new_version(prompt_name, prompt_body, title=None, description=None):
+	"""Create a new immutable version of an existing Agent Prompt.
+
+	The current prompt is marked as ``is_latest = 0`` and a new row is
+	inserted with an incremented version number.  All agents that are
+	**not** version-locked will automatically pick up the new version
+	because they link to the latest via ``agent_prompt``.
+
+	Args:
+		prompt_name: Name (ID) of the current Agent Prompt to version.
+		prompt_body: The updated prompt text for the new version.
+		title:       Optional new title (inherits from previous if omitted).
+		description: Optional new description.
+
+	Returns:
+		dict: ``{"name": "<new_prompt_name>", "version": <int>}``
+	"""
+	current = frappe.get_doc("Agent Prompt", prompt_name)
+
+	if current.is_system:
+		frappe.throw(_("System prompts cannot be versioned by users."))
+
+	new_version = cint(current.version) + 1
+
+	# Mark current as no longer latest
+	frappe.db.set_value("Agent Prompt", prompt_name, "is_latest", 0, update_modified=False)
+
+	new_prompt = frappe.get_doc({
+		"doctype": "Agent Prompt",
+		"title": title or current.title,
+		"category": current.category,
+		"description": description or current.description,
+		"prompt_body": prompt_body,
+		"visibility": current.visibility,
+		"is_active": current.is_active,
+		"is_system": 0,
+		"tags": current.tags,
+		"version": new_version,
+		"is_latest": 1,
+		"previous_version": prompt_name,
+		"forked_from": current.forked_from,
+		"prompt_group": current.prompt_group or prompt_name,
+	})
+	new_prompt.insert(ignore_permissions=True)
+
+	# Update agents that point to the old version and are NOT locked
+	_update_agent_links(prompt_name, new_prompt.name, new_version)
+
+	frappe.db.commit()
+
+	return {"name": new_prompt.name, "version": new_version}
+
+
+def _update_agent_links(old_prompt_name, new_prompt_name, new_version):
+	"""Point unlocked agents from old prompt to new version."""
+	agents = frappe.get_all(
+		"Agent",
+		filters={
+			"prompt_mode": "Template",
+			"agent_prompt": old_prompt_name,
+			"prompt_version_locked": 0,
+		},
+		pluck="name",
+	)
+	for agent_name in agents:
+		frappe.db.set_value(
+			"Agent", agent_name,
+			{
+				"agent_prompt": new_prompt_name,
+				"template_version_at_attach": new_version,
+			},
+			update_modified=False,
+		)
+
+
+@frappe.whitelist()
+def fork_prompt(prompt_name, title=None):
+	"""Fork (copy) a prompt template into a new independent lineage.
+
+	Creates a version-1 prompt with ``forked_from`` pointing to the
+	source.  The fork has its own ``prompt_group`` so subsequent
+	versions are tracked independently.
+
+	Args:
+		prompt_name: Name of the prompt to fork.
+		title:       Optional title for the fork (defaults to
+		             ``"<original title> (Fork)"``).
+
+	Returns:
+		dict: ``{"name": "<new_prompt_name>", "version": 1}``
+	"""
+	source = frappe.get_doc("Agent Prompt", prompt_name)
+
+	forked = frappe.get_doc({
+		"doctype": "Agent Prompt",
+		"title": title or f"{source.title} (Fork)",
+		"category": source.category,
+		"description": source.description,
+		"prompt_body": source.prompt_body,
+		"visibility": "Private",
+		"is_active": 1,
+		"is_system": 0,
+		"tags": source.tags,
+		"version": 1,
+		"is_latest": 1,
+		"previous_version": None,
+		"forked_from": prompt_name,
+	})
+	forked.insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"name": forked.name, "version": 1}
+
+
+@frappe.whitelist()
+def detach_from_template(agent_name):
+	"""Detach an agent from its linked prompt template.
+
+	Copies the current resolved prompt body into the agent's
+	``instructions`` field, switches to Local mode, and records
+	``copied_from_prompt`` for traceability.
+
+	Args:
+		agent_name: Name of the Agent to detach.
+
+	Returns:
+		dict: ``{"success": True, "prompt_mode": "Local"}``
+	"""
+	agent = frappe.get_doc("Agent", agent_name)
+
+	if (agent.prompt_mode or "Local") != "Template":
+		frappe.throw(_("Agent is already in Local mode."))
+
+	if not agent.agent_prompt:
+		frappe.throw(_("No template is attached to detach from."))
+
+	# Resolve the current prompt body
+	from huf.ai.prompt_resolver import resolve_prompt
+	prompt_text = resolve_prompt(agent)
+
+	agent.instructions = prompt_text or ""
+	agent.copied_from_prompt = agent.agent_prompt
+	agent.agent_prompt = None
+	agent.prompt_mode = "Local"
+	agent.prompt_version_locked = 0
+	agent.template_version_at_attach = 0
+	agent.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"success": True, "prompt_mode": "Local"}
+
+
+@frappe.whitelist()
+def save_as_template(agent_name, title, category=None, visibility="Private", description=None):
+	"""Save an agent's local prompt as a new Agent Prompt template.
+
+	Creates a new Agent Prompt from the agent's current ``instructions``
+	and optionally switches the agent to Template mode.
+
+	Args:
+		agent_name:  Name of the Agent.
+		title:       Title for the new template.
+		category:    Optional category link.
+		visibility:  Public / App / Private (default Private).
+		description: Optional description.
+
+	Returns:
+		dict: ``{"name": "<prompt_name>", "version": 1}``
+	"""
+	agent = frappe.get_doc("Agent", agent_name)
+
+	if not agent.instructions:
+		frappe.throw(_("Agent has no instructions to save as a template."))
+
+	prompt = frappe.get_doc({
+		"doctype": "Agent Prompt",
+		"title": title,
+		"category": category,
+		"description": description or agent.description,
+		"prompt_body": agent.instructions,
+		"visibility": visibility,
+		"is_active": 1,
+		"is_system": 0,
+		"version": 1,
+		"is_latest": 1,
+	})
+	prompt.insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"name": prompt.name, "version": 1}
+
+
+@frappe.whitelist()
+def attach_template(agent_name, prompt_name, lock_version=0):
+	"""Attach an Agent Prompt template to an agent.
+
+	Switches the agent to Template mode and links the specified prompt.
+	Optionally locks to the current version.
+
+	Args:
+		agent_name:   Name of the Agent.
+		prompt_name:  Name of the Agent Prompt to attach.
+		lock_version: Whether to lock to the current version (0 or 1).
+
+	Returns:
+		dict: ``{"success": True, "prompt_mode": "Template", "version": <int>}``
+	"""
+	agent = frappe.get_doc("Agent", agent_name)
+	prompt = frappe.get_doc("Agent Prompt", prompt_name)
+
+	if not prompt.is_active:
+		frappe.throw(_("Cannot attach an inactive prompt template."))
+
+	agent.prompt_mode = "Template"
+	agent.agent_prompt = prompt_name
+	agent.prompt_version_locked = cint(lock_version)
+	agent.template_version_at_attach = prompt.version
+	agent.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"success": True, "prompt_mode": "Template", "version": prompt.version}
+
+
+@frappe.whitelist()
+def get_version_history(prompt_name):
+	"""Return the full version history for a prompt lineage.
+
+	Walks backward through ``previous_version`` links to build the
+	version chain, or queries by ``prompt_group`` for efficiency.
+
+	Args:
+		prompt_name: Name of any prompt in the lineage.
+
+	Returns:
+		list[dict]: Ordered list of versions (newest first) with
+		            ``name``, ``version``, ``title``, ``is_latest``,
+		            ``modified``, and ``owner``.
+	"""
+	prompt_group = frappe.db.get_value("Agent Prompt", prompt_name, "prompt_group")
+
+	if not prompt_group:
+		# Single prompt, no lineage
+		doc = frappe.get_doc("Agent Prompt", prompt_name)
+		return [{
+			"name": doc.name,
+			"version": doc.version,
+			"title": doc.title,
+			"is_latest": doc.is_latest,
+			"modified": str(doc.modified),
+			"owner": doc.owner,
+		}]
+
+	versions = frappe.get_all(
+		"Agent Prompt",
+		filters={"prompt_group": prompt_group},
+		fields=["name", "version", "title", "is_latest", "modified", "owner"],
+		order_by="version desc",
+	)
+
+	return versions

--- a/huf/ai/prompt_resolver.py
+++ b/huf/ai/prompt_resolver.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""
+Centralised prompt resolution for Agents.
+
+Every backend path that needs the agent's effective prompt MUST call
+``resolve_prompt(agent_doc)`` instead of reading ``agent_doc.instructions``
+directly.  This keeps the Template / Local / version-lock logic in one
+place and guarantees consistent behaviour across sync runs, streaming,
+triggers, and orchestration.
+"""
+
+import frappe
+from frappe import _
+
+
+def resolve_prompt(agent_doc):
+	"""Return the effective prompt text for an agent.
+
+	Args:
+		agent_doc: A loaded Agent document (``frappe.get_doc("Agent", …)``).
+
+	Returns:
+		str: The resolved prompt body, or ``None`` if the agent has no
+		     prompt configured.
+
+	Resolution rules
+	-----------------
+	* **Local mode** (default, backward-compatible): returns
+	  ``agent_doc.instructions`` directly.
+	* **Template mode**:
+	  - If ``prompt_version_locked`` is set, load the exact version that
+	    was recorded in ``template_version_at_attach``.
+	  - Otherwise load the latest version of the linked Agent Prompt.
+	"""
+	mode = getattr(agent_doc, "prompt_mode", None) or "Local"
+
+	if mode == "Template":
+		return _resolve_template_prompt(agent_doc)
+
+	# Local mode — straightforward
+	return agent_doc.instructions or None
+
+
+def _resolve_template_prompt(agent_doc):
+	"""Resolve prompt from the linked Agent Prompt template."""
+	prompt_name = agent_doc.agent_prompt
+	if not prompt_name:
+		return agent_doc.instructions or None
+
+	if agent_doc.prompt_version_locked and agent_doc.template_version_at_attach:
+		return _get_locked_version_body(prompt_name, agent_doc.template_version_at_attach)
+
+	# Not locked — use the linked prompt directly (which should be is_latest)
+	prompt_body = frappe.db.get_value("Agent Prompt", prompt_name, "prompt_body")
+	return prompt_body or agent_doc.instructions or None
+
+
+def _get_locked_version_body(prompt_name, target_version):
+	"""Walk the version lineage to find the exact version body.
+
+	The ``prompt_name`` on the Agent may point to the latest version.
+	If the agent is locked to an earlier version we need to find the
+	row whose ``version`` matches ``target_version`` within the same
+	prompt group.
+	"""
+	# First check if the linked prompt itself is the right version
+	prompt_doc_data = frappe.db.get_value(
+		"Agent Prompt", prompt_name, ["prompt_body", "version", "prompt_group"], as_dict=True
+	)
+	if not prompt_doc_data:
+		return None
+
+	if prompt_doc_data.version == target_version:
+		return prompt_doc_data.prompt_body
+
+	# Look up the correct version within the same prompt group
+	if prompt_doc_data.prompt_group:
+		match = frappe.db.get_value(
+			"Agent Prompt",
+			{"prompt_group": prompt_doc_data.prompt_group, "version": target_version},
+			"prompt_body",
+		)
+		if match:
+			return match
+
+	# Fallback: return the linked prompt body
+	return prompt_doc_data.prompt_body

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -35,6 +35,12 @@
   "multi_run_setting_section",
   "default_plan",
   "section_break_yyoa",
+  "prompt_mode",
+  "agent_prompt",
+  "column_break_prompt",
+  "prompt_version_locked",
+  "template_version_at_attach",
+  "copied_from_prompt",
   "instructions",
   "tools_and_mcp_tab",
   "agent_tool",
@@ -103,6 +109,52 @@
    "reqd": 1
   },
   {
+   "default": "Local",
+   "description": "How this agent's prompt is managed. 'Local' uses the instructions field below. 'Template' links to a reusable Agent Prompt.",
+   "fieldname": "prompt_mode",
+   "fieldtype": "Select",
+   "label": "Prompt Mode",
+   "options": "Local\nTemplate"
+  },
+  {
+   "depends_on": "eval:doc.prompt_mode=='Template'",
+   "description": "Link to a reusable prompt template from the Agent Prompt library.",
+   "fieldname": "agent_prompt",
+   "fieldtype": "Link",
+   "label": "Agent Prompt",
+   "options": "Agent Prompt"
+  },
+  {
+   "fieldname": "column_break_prompt",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.prompt_mode=='Template'",
+   "description": "If checked, this agent will stay on the prompt version it was attached to, ignoring newer versions.",
+   "fieldname": "prompt_version_locked",
+   "fieldtype": "Check",
+   "label": "Lock Prompt Version"
+  },
+  {
+   "depends_on": "eval:doc.prompt_mode=='Template'",
+   "description": "The version number of the prompt template when it was attached to this agent.",
+   "fieldname": "template_version_at_attach",
+   "fieldtype": "Int",
+   "label": "Attached at Version",
+   "read_only": 1
+  },
+  {
+   "description": "If this agent was detached from a template, this tracks the original prompt for traceability.",
+   "fieldname": "copied_from_prompt",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Copied From Prompt",
+   "options": "Agent Prompt",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.prompt_mode=='Local'",
    "description": "The system prompt or instructions that define the agent's personality, goals, and constraints. This is the core logic of the agent.",
    "fieldname": "instructions",
    "fieldtype": "Code",
@@ -159,10 +211,10 @@
    "label": "Disabled"
   },
   {
-   "description": "Define system prompt, goal, and constraints",
+   "description": "Define system prompt, goal, and constraints. Use 'Local' for inline prompts or 'Template' to link a reusable prompt from the library.",
    "fieldname": "section_break_yyoa",
    "fieldtype": "Section Break",
-   "label": "Instruction"
+   "label": "Prompt"
   },
   {
    "default": "0",
@@ -467,7 +519,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-09 18:23:31.825896",
+ "modified": "2026-02-20 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent",

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -132,13 +132,17 @@ class Agent(Document):
 
     def on_update(self):
         clear_doc_event_agents_cache()
-        
+
         if self.flags.in_insert:
             return
 
+        prompt_changed = (
+            self.has_value_changed("instructions")
+            or self.has_value_changed("agent_prompt")
+            or self.has_value_changed("prompt_mode")
+        )
         if self.enable_multi_run and (
-            self.has_value_changed("instructions") or 
-            self.has_value_changed("enable_multi_run")
+            prompt_changed or self.has_value_changed("enable_multi_run")
         ):
             self.generate_default_plan()
         
@@ -230,16 +234,16 @@ class Agent(Document):
         self.set_default_color()
         self.flags.in_insert = True
         from huf.ai.prompt_resolver import resolve_prompt
-        has_prompt = bool(resolve_prompt(self))
-        if self.enable_multi_run and has_prompt:
+        resolved = resolve_prompt(self)
+        if self.enable_multi_run and resolved:
             try:
-                planning_run_id, steps = self.generate_default_plan()                
+                planning_run_id, steps = self.generate_default_plan()
                 if planning_run_id:
                     create_orchestration(
-                        agent_name=self.name, 
-                        user_prompt=self.instructions,
+                        agent_name=self.name,
+                        user_prompt=resolved,
                         parent_run_id=planning_run_id,
-                        override_plan=steps 
+                        override_plan=steps
                     )
                 
             except Exception as e:

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -58,8 +58,7 @@ def get_permission_query_conditions(user):
 
 class Agent(Document):
     def validate(self):
-        if not self.instructions:
-            frappe.throw(_("Please provide an instruction for this AI Agent."))
+        self._validate_prompt()
 
         if self.allow_chat == 1 and self.persist_conversation == 0:
             frappe.throw(_("An agent cannot be allowed in Agent Chat when persistent conversation is off."))
@@ -104,6 +103,27 @@ class Agent(Document):
 
 
 
+    def _validate_prompt(self):
+        """Validate prompt configuration based on prompt_mode."""
+        mode = self.prompt_mode or "Local"
+
+        if mode == "Template":
+            if not self.agent_prompt:
+                frappe.throw(_("Please select an Agent Prompt when using Template mode."))
+            # Record the template version when first attached or when template changes
+            if self.has_value_changed("agent_prompt") or not self.template_version_at_attach:
+                self._record_template_version()
+        else:
+            # Local mode — require instructions (backward compatible)
+            if not self.instructions:
+                frappe.throw(_("Please provide an instruction for this AI Agent."))
+
+    def _record_template_version(self):
+        """Snapshot the current version of the linked Agent Prompt."""
+        if self.agent_prompt:
+            version = frappe.db.get_value("Agent Prompt", self.agent_prompt, "version")
+            self.template_version_at_attach = version or 1
+
     def get_indicator(doc):
         if doc.disabled:
             return _("Disabled"), "red", "disabled,=,Yes"
@@ -130,7 +150,10 @@ class Agent(Document):
         Generates the default plan using run_agent_sync directly.
         Returns the agent_run_id so it can be used as a Parent Run.
         """
-        if not self.instructions:
+        from huf.ai.prompt_resolver import resolve_prompt
+
+        resolved = resolve_prompt(self)
+        if not resolved:
             return None
 
         planning_prompt = f"""You are a planning assistant. Break down the user's objective into a sequence of clear, atomic steps that can be executed one at a time.
@@ -146,7 +169,7 @@ class Agent(Document):
             2. Second action to take
 
             Now break down this objective:
-            {self.instructions}"""
+            {resolved}"""
 
         try:
             result = run_agent_sync(
@@ -206,7 +229,9 @@ class Agent(Document):
         """
         self.set_default_color()
         self.flags.in_insert = True
-        if self.enable_multi_run and self.instructions:
+        from huf.ai.prompt_resolver import resolve_prompt
+        has_prompt = bool(resolve_prompt(self))
+        if self.enable_multi_run and has_prompt:
             try:
                 planning_run_id, steps = self.generate_default_plan()                
                 if planning_run_id:

--- a/huf/huf/doctype/agent_prompt/__init__.py
+++ b/huf/huf/doctype/agent_prompt/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt

--- a/huf/huf/doctype/agent_prompt/agent_prompt.json
+++ b/huf/huf/doctype/agent_prompt/agent_prompt.json
@@ -1,0 +1,182 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-02-20 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "details_section",
+  "title",
+  "slug",
+  "category",
+  "description",
+  "column_break_details",
+  "is_active",
+  "is_system",
+  "visibility",
+  "tags",
+  "prompt_section",
+  "prompt_body",
+  "version_section",
+  "version",
+  "is_latest",
+  "column_break_version",
+  "previous_version",
+  "forked_from",
+  "prompt_group"
+ ],
+ "fields": [
+  {
+   "fieldname": "details_section",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "description": "URL-friendly identifier for this prompt template. Auto-generated from title if left blank.",
+   "fieldname": "slug",
+   "fieldtype": "Data",
+   "label": "Slug",
+   "unique": 1
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Link",
+   "label": "Category",
+   "options": "Agent Prompt Category"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "column_break_details",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "description": "Whether this prompt template is active and available for use.",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Active"
+  },
+  {
+   "default": "0",
+   "description": "System prompts are managed by HUF and cannot be edited by users.",
+   "fieldname": "is_system",
+   "fieldtype": "Check",
+   "label": "Is System"
+  },
+  {
+   "default": "Private",
+   "description": "Controls who can see and use this prompt template.",
+   "fieldname": "visibility",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Visibility",
+   "options": "Public\nApp\nPrivate"
+  },
+  {
+   "fieldname": "tags",
+   "fieldtype": "Small Text",
+   "description": "Comma-separated tags for search and filtering.",
+   "label": "Tags"
+  },
+  {
+   "fieldname": "prompt_section",
+   "fieldtype": "Section Break",
+   "label": "Prompt"
+  },
+  {
+   "description": "The prompt template content. This is the system prompt or instructions text.",
+   "fieldname": "prompt_body",
+   "fieldtype": "Code",
+   "label": "Prompt Body",
+   "reqd": 1
+  },
+  {
+   "fieldname": "version_section",
+   "fieldtype": "Section Break",
+   "label": "Version History"
+  },
+  {
+   "default": "1",
+   "description": "Version number of this prompt. Incremented on each new version.",
+   "fieldname": "version",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Version",
+   "read_only": 1
+  },
+  {
+   "default": "1",
+   "description": "Marks this as the latest version in the prompt lineage.",
+   "fieldname": "is_latest",
+   "fieldtype": "Check",
+   "label": "Is Latest",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_version",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Link to the previous version of this prompt template.",
+   "fieldname": "previous_version",
+   "fieldtype": "Link",
+   "label": "Previous Version",
+   "options": "Agent Prompt",
+   "read_only": 1
+  },
+  {
+   "description": "If this prompt was forked from another, link to the original prompt.",
+   "fieldname": "forked_from",
+   "fieldtype": "Link",
+   "label": "Forked From",
+   "options": "Agent Prompt",
+   "read_only": 1
+  },
+  {
+   "description": "Shared identifier across all versions of the same prompt lineage. Auto-set on creation.",
+   "fieldname": "prompt_group",
+   "fieldtype": "Data",
+   "label": "Prompt Group",
+   "read_only": 1,
+   "hidden": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-02-20 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Agent Prompt",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/huf/huf/doctype/agent_prompt/agent_prompt.py
+++ b/huf/huf/doctype/agent_prompt/agent_prompt.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import cint
+
+
+class AgentPrompt(Document):
+	def before_insert(self):
+		self._generate_slug()
+		self._set_prompt_group()
+
+	def validate(self):
+		if not self.prompt_body:
+			frappe.throw(_("Prompt body is required."))
+
+		if not self.version:
+			self.version = 1
+
+	def _generate_slug(self):
+		"""Auto-generate slug from title if not provided."""
+		if not self.slug and self.title:
+			slug = frappe.scrub(self.title).replace("_", "-")
+			# Ensure uniqueness by appending version
+			if self.version and cint(self.version) > 1:
+				slug = f"{slug}-v{self.version}"
+			# Check for duplicates
+			if frappe.db.exists("Agent Prompt", {"slug": slug}):
+				slug = f"{slug}-v{self.version or 1}"
+				if frappe.db.exists("Agent Prompt", {"slug": slug}):
+					slug = f"{slug}-{frappe.generate_hash(length=4)}"
+			self.slug = slug
+
+	def _set_prompt_group(self):
+		"""Set prompt_group to tie versions together.
+
+		For a brand-new prompt lineage the group is the document name itself.
+		When a new version is created from an existing prompt the group is
+		inherited from the previous version so all versions share the same
+		identifier.
+		"""
+		if self.previous_version:
+			parent_group = frappe.db.get_value(
+				"Agent Prompt", self.previous_version, "prompt_group"
+			)
+			self.prompt_group = parent_group or self.previous_version
+		elif not self.prompt_group:
+			# Will be set to self.name after insert via after_insert
+			self.prompt_group = ""
+
+	def after_insert(self):
+		"""Finalise prompt_group for brand-new lineages (no previous_version)."""
+		if not self.prompt_group:
+			frappe.db.set_value(
+				"Agent Prompt", self.name, "prompt_group", self.name, update_modified=False
+			)
+			self.prompt_group = self.name

--- a/huf/huf/doctype/agent_prompt/test_agent_prompt.py
+++ b/huf/huf/doctype/agent_prompt/test_agent_prompt.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAgentPrompt(FrappeTestCase):
+	pass

--- a/huf/huf/doctype/agent_prompt_category/__init__.py
+++ b/huf/huf/doctype/agent_prompt_category/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt

--- a/huf/huf/doctype/agent_prompt_category/agent_prompt_category.json
+++ b/huf/huf/doctype/agent_prompt_category/agent_prompt_category.json
@@ -1,0 +1,78 @@
+{
+ "actions": [],
+ "autoname": "field:category_name",
+ "creation": "2026-02-20 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "category_name",
+  "description",
+  "column_break_main",
+  "icon",
+  "color",
+  "parent_category"
+ ],
+ "fields": [
+  {
+   "fieldname": "category_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Category Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "icon",
+   "fieldtype": "Data",
+   "label": "Icon"
+  },
+  {
+   "fieldname": "color",
+   "fieldtype": "Data",
+   "description": "Hex color code for the category badge, e.g. #6366F1",
+   "label": "Color"
+  },
+  {
+   "description": "Optional parent category for hierarchical grouping.",
+   "fieldname": "parent_category",
+   "fieldtype": "Link",
+   "label": "Parent Category",
+   "options": "Agent Prompt Category"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-02-20 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Agent Prompt Category",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/huf/huf/doctype/agent_prompt_category/agent_prompt_category.py
+++ b/huf/huf/doctype/agent_prompt_category/agent_prompt_category.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class AgentPromptCategory(Document):
+	def validate(self):
+		if self.parent_category and self.parent_category == self.name:
+			frappe.throw(_("A category cannot be its own parent."))

--- a/huf/huf/doctype/agent_prompt_category/test_agent_prompt_category.py
+++ b/huf/huf/doctype/agent_prompt_category/test_agent_prompt_category.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAgentPromptCategory(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Summary
Introduces a comprehensive prompt template management system for agents, enabling reusable prompt templates with versioning, forking, and flexible prompt mode switching between local and template-based approaches.

## Key Changes

### New DocTypes
- **Agent Prompt**: Immutable versioned prompt templates with support for:
  - Version history tracking via `previous_version` and `prompt_group` fields
  - Forking to create independent lineages
  - Visibility controls (Public/App/Private)
  - Category organization and tagging
  - System vs. user-managed prompts

- **Agent Prompt Category**: Hierarchical categorization for prompt templates with icon and color support

### Agent Enhancements
- Added `prompt_mode` field to switch between "Local" (inline instructions) and "Template" (linked prompt) modes
- Added template linking fields: `agent_prompt`, `prompt_version_locked`, `template_version_at_attach`, `copied_from_prompt`
- Updated validation to support both prompt modes
- Modified plan generation to use centralized prompt resolution

### New API Module (`huf/ai/prompt_api.py`)
Whitelisted server-side operations for prompt management:
- `create_new_version()`: Create immutable versions with automatic agent link updates for unlocked agents
- `fork_prompt()`: Create independent prompt lineages
- `detach_from_template()`: Convert template-mode agents to local mode with traceability
- `save_as_template()`: Save agent instructions as reusable templates
- `attach_template()`: Link agents to templates with optional version locking
- `get_version_history()`: Retrieve full version lineage

### Prompt Resolution (`huf/ai/prompt_resolver.py`)
Centralized `resolve_prompt()` function that:
- Handles both Local and Template modes transparently
- Supports version-locked agents (fixed to specific versions)
- Automatically uses latest versions for unlocked agents
- Provides consistent prompt resolution across sync runs, streaming, and orchestration

### Integration Updates
- Updated `agent_integration.py`, `agent_scheduler.py`, and `orchestrator.py` to use centralized prompt resolution instead of direct `instructions` field access

## Implementation Details
- Prompt versioning uses an immutable model where new versions create new documents rather than modifying existing ones
- `prompt_group` field ties all versions of a prompt together for efficient history queries
- Version locking allows agents to stay on specific prompt versions while others auto-upgrade
- Backward compatible: agents default to "Local" mode using existing `instructions` field
- System prompts are protected from user versioning

