### PR TITLE
feat: support dynamic model and provider override in run_agent_sync api

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -530,6 +530,9 @@ def run_agent_sync(
         channel_id = "api"
 
     agent_doc = frappe.get_doc("Agent", agent_name)
+    
+    resolved_provider = provider if provider else agent_doc.provider
+    resolved_model = model if model else agent_doc.model
 
     if frappe.session.user == "Guest" and not agent_doc.allow_guest:
         frappe.throw(_("Access denied. This agent does not allow guest access."), frappe.PermissionError)
@@ -564,7 +567,7 @@ def run_agent_sync(
     #          )
     # else:
     
-    frappe.db.set_value("Agent Conversation", conversation.name, "model", agent_doc.model)
+    frappe.db.set_value("Agent Conversation", conversation.name, "model", resolved_model)
 
 
     # Optimized history fetching with dynamic limit + buffer
@@ -576,14 +579,14 @@ def run_agent_sync(
         "status": "Queued",
         "conversation": conversation.name,
         "prompt": prompt,
-        "model": agent_doc.model,
-        "provider": agent_doc.provider,
+        "model": resolved_model,
+        "provider": resolved_provider,
         "parent_run": parent_run_id,
         "is_child": 1 if parent_run_id else 0,
         "agent_orchestration": orchestration_id
     })
     run_doc.insert(ignore_permissions=True)
-    conv_manager.add_message(conversation, "user", prompt, agent_doc.provider, agent_doc.model, agent_name, run_doc.name)
+    conv_manager.add_message(conversation, "user", prompt, resolved_provider, resolved_model, agent_name, run_doc.name)
     run_doc.db_set("start_time", now_datetime())
     safe_commit()
 
@@ -719,7 +722,7 @@ def run_agent_sync(
                 "conversation_id": conversation.name,
                 "agent_run_id": run_doc.name
             }
-            run = RunProvider.run(agent, enhanced_prompt, agent_doc.provider, agent_doc.model,context)
+            run = RunProvider.run(agent, enhanced_prompt, resolved_provider, resolved_model,context)
 
             result = loop.run_until_complete(run)
         finally:
@@ -754,8 +757,8 @@ def run_agent_sync(
                     conversation, 
                     role="agent", 
                     content=msg_content, 
-                    provider=agent_doc.provider, 
-                    model=agent_doc.model, 
+                    provider=resolved_provider, 
+                    model=resolved_model, 
                     agent=agent_name, 
                     run_name=run_doc.name,
                     kind="Tool Call",
@@ -873,14 +876,14 @@ def run_agent_sync(
                 "cost": cost
             })
 
-        conv_manager.add_message(conversation, "agent", final_output, agent_doc.provider, agent_doc.model, agent_name, run_doc.name)
+        conv_manager.add_message(conversation, "agent", final_output, resolved_provider, resolved_model, agent_name, run_doc.name)
 
         frappe.db.set_value("Agent Run", run_doc.name, {
             "status": "Success",
             "response": final_output,
             "prompt": prompt,
-            "model": agent_doc.model,
-            "provider": agent_doc.provider,
+            "model": resolved_model,
+            "provider": resolved_provider,
             "end_time": now_datetime()
         }, update_modified=True)
         safe_commit()
@@ -917,7 +920,7 @@ def run_agent_sync(
             "response": final_output,
             "client_side_tool_calls": client_side_tool_calls,
             "structured": structured,
-            "provider": manager.agent_doc.provider,
+            "provider": resolved_provider,
             "agent_run_id": run_doc.name,
             "conversation_id": conversation.name,
             "session_id": conv_manager.session_id


### PR DESCRIPTION
  - Allows overriding the default agent model and provider by passing 'provider' and model arguments directly to the run_agent_sync API.
  - The 'agent_doc' is now dynamically updated during execution so that all downstream tasks (logging, inference, conversation management) seamlessly use the overridden values.