### PR TITLE
fix: block conversation on rate limit or token limit exceeded

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -978,6 +978,28 @@ def run_agent_sync(
 
     except Exception as e:
         error_msg = str(e)
+        
+        if "ContextWindowExceededError" in error_msg or "RateLimitError" in error_msg:
+            try:
+                frappe.db.set_value("Agent Conversation", conversation.name, "is_active", 0)
+                safe_commit()
+                
+                error_msg = _("This conversation has exceeded the maximum token limit or rate limit. Please start a new conversation to continue.")
+                
+                conv_manager.add_message(
+                    conversation=conversation, 
+                    role="agent", 
+                    content=error_msg, 
+                    provider=resolved_provider, 
+                    model=resolved_model, 
+                    agent=agent_name, 
+                    run_name=run_doc.name,
+                    kind="Error"
+                )
+                safe_commit()
+            except Exception as inner_e:
+                frappe.log_error(f"Failed to handle rate limit in sync: {str(inner_e)}", "Agent Integration Error")
+
         run_doc.db_set("status", "Failed", update_modified=True)
         run_doc.db_set("error_message", error_msg)
         frappe.log_error(f"Agent Run Error: {frappe.get_traceback()}", "Huf")
@@ -1365,6 +1387,29 @@ async def run_agent_stream(
                 elif chunk_type == "error":
                     error_msg = chunk.get("error", "Unknown error")
                     
+                    if "ContextWindowExceededError" in error_msg or "RateLimitError" in error_msg:
+                        try:
+                            frappe.db.set_value("Agent Conversation", conversation.name, "is_active", 0)
+                            safe_commit()
+                            
+                            user_error_msg = _("This conversation has exceeded the maximum token limit or rate limit. Please start a new conversation to continue.")
+                            
+                            conv_manager.add_message(
+                                conversation=conversation, 
+                                role="agent", 
+                                content=user_error_msg, 
+                                provider=agent_doc.provider, 
+                                model=agent_doc.model, 
+                                agent=agent_name, 
+                                run_name=run_doc.name,
+                                kind="Error"
+                            )
+                            safe_commit()
+                            chunk["error"] = user_error_msg # override so the client sees the same message
+                            error_msg = user_error_msg
+                        except Exception as inner_e:
+                            frappe.log_error(f"Failed to handle rate limit in stream inner block: {str(inner_e)}", "Agent Integration Error")
+                    
                     frappe.db.set_value("Agent Run", run_doc.name, {
                         "status": "Failed",
                         "error_message": error_msg,
@@ -1378,6 +1423,28 @@ async def run_agent_stream(
         except Exception as e:
             error_msg = str(e)
             frappe.log_error(f"Agent Stream Error: {frappe.get_traceback()}", "Huf Streaming")
+            
+            if "ContextWindowExceededError" in error_msg or "RateLimitError" in error_msg:
+                try:
+                    frappe.db.set_value("Agent Conversation", conversation.name, "is_active", 0)
+                    safe_commit()
+                    
+                    error_msg = _("This conversation has exceeded the maximum token limit or rate limit. Please start a new conversation to continue.")
+                    
+                    conv_manager.add_message(
+                        conversation=conversation, 
+                        role="agent", 
+                        content=error_msg, 
+                        provider=agent_doc.provider, 
+                        model=agent_doc.model, 
+                        agent=agent_name, 
+                        run_name=run_doc.name,
+                        kind="Error"
+                    )
+                    safe_commit()
+                except Exception as inner_e:
+                    frappe.log_error(f"Failed to handle rate limit in stream inner block: {str(inner_e)}", "Agent Integration Error")
+
             
             frappe.db.set_value("Agent Run", run_doc.name, {
                 "status": "Failed",

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 
 import frappe
 import litellm
-from litellm import InternalServerError, RateLimitError, APIError, BadRequestError, completion_cost
+from litellm import InternalServerError, RateLimitError, APIError, BadRequestError, completion_cost, ContextWindowExceededError
 from litellm.utils import supports_prompt_caching, trim_messages
 from huf.ai.tool_serializer import serialize_tools
 
@@ -399,13 +399,11 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                     full_trace = str(e)
 
                 frappe.log_error(message=full_trace, title=title)
+                raise e
 
-                msg = (
-                    f"Rate limit exceeded for model '{normalized_model}'. "
-                    f"Please try again later. Details: {str(e)}"
-                )
-                frappe.log_error(message=msg, title="LiteLLM Provider")
-                return SimpleResult(msg, total_usage, all_new_items)
+            except ContextWindowExceededError as e:
+                frappe.log_error(message=f"LiteLLM ContextWindowExceededError for model '{normalized_model}': {str(e)}", title="LiteLLM Provider")
+                raise e
 
             except APIError as e:
                 msg = f"API error for model '{normalized_model}': {str(e)}"
@@ -415,6 +413,10 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             except Exception as e:
                 msg = f"LiteLLM error for model '{normalized_model}': {str(e)}"
                 frappe.log_error(message=msg, title="LiteLLM Provider")
+                
+                if "ContextWindowExceededError" in str(e) or "RateLimitError" in str(e):
+                    raise e
+                
                 return SimpleResult(msg, total_usage, all_new_items)
 
             # Extract response
@@ -520,6 +522,10 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
     except Exception as e:
         frappe.log_error(message=f"LiteLLM Provider Error: {str(e)}", title="LiteLLM Provider")
+        
+        if "ContextWindowExceededError" in str(e) or "RateLimitError" in str(e):
+            raise e
+            
         return SimpleResult(f"LiteLLM Provider Error: {str(e)}")
 
 
@@ -949,7 +955,10 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                 yield {"type": "error", "error": f"OpenAI API server error: {str(e)}"}
                 return
             except RateLimitError as e:
-                yield {"type": "error", "error": f"Rate limit exceeded: {str(e)}"}
+                yield {"type": "error", "error": f"RateLimitError: {str(e)}"}
+                return
+            except ContextWindowExceededError as e:
+                yield {"type": "error", "error": f"ContextWindowExceededError: {str(e)}"}
                 return
             except APIError as e:
                 yield {"type": "error", "error": f"API error: {str(e)}"}


### PR DESCRIPTION
- Updating litellm.py to explicitly raise 'RateLimitError' and 'ContextWindowExceededError' instead of returning them as normal message strings or chunks.
- Modifying 'agent_integration.py' 'run_agent_sync' and 'run_agent_stream' to catch these specific errors from the provider.
- Automatically setting the Agent Conversation status to inactive 'is_active = 0' to block further messages when these limits are hit.
- Injecting a user-friendly agent message prompting the user to start a new chat instead of displaying raw Python tracebacks.