### PR TITLE
Fix/tts model selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,8 @@ The main DocType for creating an AI agent.
 | **Disabled**      | `disabled`      | Check     | If checked, this agent will be disabled and will not run.                                               |
 | **Chef**          | `chef`         | Data      | Provider standard name (fetched from provider, hidden).                                                   |
 | **Slug**          | `slug`         | Data      | Provider slug (fetched from provider, hidden).                                                          |
+| **TTS Model**    | `tts_model`    | Link (AI Model) | Dedicated model for the `generate_audio` tool. When set, the API key is sourced from the *TTS model's own provider* (`AI Model → AI Provider`), enabling cross-provider TTS (e.g. main agent on OpenAI, TTS on ElevenLabs). Falls back to the main provider's default TTS model when unset. |
+| **TTS Voice**    | `tts_voice`    | Data      | Default voice identifier for the configured TTS model (e.g. `alloy`, `nova`, `21m00Tcm4TlvDq8ikWAM`). Overridden by a `voice` argument passed directly to the `generate_audio` tool call. |
 
 **Note**: The `condition` field has been removed from Agent DocType. Conditional triggering is now handled via the `Agent Trigger` DocType.
 
@@ -433,6 +435,29 @@ Generate an image from a text description using AI.
     -   `size` (string): Image dimensions (default '1024x1024').
     -   `quality` (string): Image quality (default 'standard').
     -   `n` (integer): Number of images to generate (default 1).
+
+#### 3. generate_audio
+
+Generate audio (speech) from text using LiteLLM's `speech()` function. Supports OpenAI, Gemini, ElevenLabs, Minimax, AWS Polly, and any LiteLLM-supported TTS provider.
+
+-   **Function**: `huf.ai.sdk_tools.handle_generate_audio`
+-   **Helper**: `huf.ai.sdk_tools._resolve_tts_config` (three-tier resolution, see below)
+-   **Parameters**:
+    -   `input` (string, required): Text to convert to speech.
+    -   `voice` (string): Voice identifier. Provider-specific (e.g. `alloy`, `nova` for OpenAI; `21m00Tcm4TlvDq8ikWAM` for ElevenLabs; `Puck` for Gemini).
+    -   `model` (string): Optional TTS model override (e.g. `tts-1-hd`, `elevenlabs/eleven_multilingual_v2`).
+    -   `speed` (number): Speech speed 0.25–4.0 (default 1.0).
+    -   `response_format` (string): Audio format — `mp3` (default), `opus`, `aac`, `flac`, `wav`, `pcm`.
+
+**TTS Model / Voice Resolution (three-tier priority):**
+
+| Priority | Condition | Model source | API key source |
+| :------- | :-------- | :----------- | :------------- |
+| 1 | `model` param passed to tool call | `model` param directly | Agent's **main** provider |
+| 2 | `agent.tts_model` field is set | `AI Model.model_name` via link | `AI Model → AI Provider → api_key` (may be a **different** provider) |
+| 3 | Fallback | `_get_default_tts_model(main_provider)` | Agent's **main** provider |
+
+This enables fully cross-provider TTS: an agent using `OpenAI / gpt-4o` for conversation can use `ElevenLabs / eleven_multilingual_v2` for audio generation by simply setting `tts_model` and `tts_voice` on the Agent document (Advanced Settings → Audio Generation tab).
 
 ### Core Classes and Methods
 

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -2203,14 +2203,25 @@ async def handle_generate_audio(
                     "agent_run": kwargs.get("agent_run_id"),
                     "conversation_index": conversation_index,
                     "is_agent_message": 1,
-                    "user": "Agent"
+                    "user": "Agent",
+                    "tts_voice": voice
                 })
                 message_doc.insert(ignore_permissions=True)
+
+                if tts_source == "agent_config" and getattr(agent_doc, "tts_model", None):
+                    frappe.db.set_value(
+                        "Agent Message", message_doc.name,
+                        "tts_model", agent_doc.tts_model,
+                        update_modified=False
+                    )
+                    message_doc.tts_model = agent_doc.tts_model
+
             except Exception as e:
                 frappe.log_error(
                     f"Error creating Agent Message for generated audio: {str(e)}",
                     "Audio Generation Message Creation"
                 )
+                message_doc = None
         
         # Save file attached to the Agent Message
         if message_doc:

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -1928,6 +1928,147 @@ def _get_default_tts_model(provider_name: str) -> str:
     
     return defaults.get(provider_name.lower())
 
+_TTS_ENV_VAR_PROVIDERS: dict[str, str] = {
+    "google":     "GEMINI_API_KEY",
+    "gemini":     "GEMINI_API_KEY",
+    "vertex_ai":  "GEMINI_API_KEY",
+    "elevenlabs": "ELEVENLABS_API_KEY",
+    "minimax":    "MINIMAX_API_KEY",
+}
+
+
+def _resolve_tts_config(
+    agent_doc,
+    tool_model: str | None = None,
+    tool_voice: str | None = None,
+) -> dict:
+    """
+    Resolve the TTS model, voice, API key, and provider for audio generation.
+
+    Priority (highest → lowest):
+
+    1. **Tool-call parameter** - ``model`` / ``voice`` values passed by the
+       agent at runtime (highest precedence; lets individual calls override).
+    2. **Agent-level TTS configuration** - ``agent.tts_model`` / ``agent.tts_voice``
+       fields set on the Agent DocType.  The API key is fetched from the *TTS
+       model's own provider* (``AI Model → AI Provider``), which may be a
+       completely different provider from the agent's main conversational model.
+    3. **Provider default** - ``_get_default_tts_model`` / ``_get_default_voice``
+       derived from the agent's main provider (fallback when nothing else is set).
+
+    Args:
+        agent_doc:   Loaded ``Agent`` Frappe document.
+        tool_model:  Optional model name supplied by the tool call at runtime.
+        tool_voice:  Optional voice name supplied by the tool call at runtime.
+
+    Returns:
+        dict:
+            - ``tts_model``     - Normalised LiteLLM model string.
+            - ``voice``         - Voice identifier for the TTS provider.
+            - ``api_key``       - Decrypted API key for the TTS provider.
+            - ``provider_name`` - Lowercase provider name (used for env-var routing).
+            - ``provider_doc``  - Loaded ``AI Provider`` document for the TTS provider.
+            - ``source``        - How the model was resolved: ``"tool_param"``,
+                                  ``"agent_config"``, or ``"provider_default"``.
+
+    Raises:
+        ValueError: If no TTS model can be determined and the provider does not
+                    natively support TTS.
+    """
+    from huf.ai.providers.litellm import _normalize_model_name
+
+    if tool_model:
+        provider_doc = frappe.get_doc("AI Provider", agent_doc.provider)
+        api_key = provider_doc.get_password("api_key")
+        if not api_key:
+            raise ValueError(
+                f"API key is not configured for provider "
+                f"'{provider_doc.provider_name}'. Please add it to the AI Provider document."
+            )
+        provider_name = provider_doc.provider_name.lower()
+        voice = tool_voice or _get_default_voice(provider_name)
+        normalized = _normalize_model_name(tool_model, agent_doc.provider)
+        return {
+            "tts_model":     normalized,
+            "voice":         voice,
+            "api_key":       api_key,
+            "provider_name": provider_name,
+            "provider_doc":  provider_doc,
+            "source":        "tool_param",
+        }
+
+    if getattr(agent_doc, "tts_model", None):
+        tts_model_doc = frappe.get_doc("AI Model", agent_doc.tts_model)
+
+        if not tts_model_doc.provider:
+            raise ValueError(
+                f"TTS model '{agent_doc.tts_model}' has no provider linked. "
+                f"Please set a provider on the AI Model document."
+            )
+
+        tts_provider_doc = frappe.get_doc("AI Provider", tts_model_doc.provider)
+        api_key = tts_provider_doc.get_password("api_key")
+
+        if not api_key:
+            raise ValueError(
+                f"API key is not configured for TTS provider "
+                f"'{tts_provider_doc.provider_name}'. "
+                f"Please add the API key to that AI Provider document."
+            )
+
+        provider_name = tts_provider_doc.provider_name.lower()
+
+        voice = (
+            getattr(agent_doc, "tts_voice", None)
+            or _get_default_voice(provider_name)
+            or tool_voice
+        )
+
+        normalized = _normalize_model_name(
+            tts_model_doc.model_name, tts_model_doc.provider
+        )
+        return {
+            "tts_model":     normalized,
+            "voice":         voice,
+            "api_key":       api_key,
+            "provider_name": provider_name,
+            "provider_doc":  tts_provider_doc,
+            "source":        "agent_config",
+        }
+
+    provider_doc = frappe.get_doc("AI Provider", agent_doc.provider)
+    api_key = provider_doc.get_password("api_key")
+
+    if not api_key:
+        raise ValueError(
+            f"API key is not configured for provider "
+            f"'{provider_doc.provider_name}'. Please add it to the AI Provider document."
+        )
+
+    provider_name = provider_doc.provider_name.lower()
+    tts_model = _get_default_tts_model(provider_name)
+
+    if not tts_model:
+        raise ValueError(
+            f"Text-to-speech is not natively supported by provider "
+            f"'{provider_doc.provider_name}'. Please either:\n"
+            f"  \u2022 Set a dedicated 'TTS Model' on the Agent "
+            f"(Advanced Settings \u2192 Audio Generation), or\n"
+            f"  \u2022 Pass a 'model' parameter directly to the generate_audio tool."
+        )
+
+    voice = tool_voice or _get_default_voice(provider_name)
+    normalized = _normalize_model_name(tts_model, agent_doc.provider)
+    return {
+        "tts_model":     normalized,
+        "voice":         voice,
+        "api_key":       api_key,
+        "provider_name": provider_name,
+        "provider_doc":  provider_doc,
+        "source":        "provider_default",
+    }
+
+
 @frappe.whitelist()
 async def handle_generate_audio(
     input: str,
@@ -1967,6 +2108,8 @@ async def handle_generate_audio(
                 "speed": float,
                 "format": str,
                 "model": str
+                "model_source": str,
+                "tts_provider": str,
             },
             "message": str,
             "conversation_id": str
@@ -1976,77 +2119,42 @@ async def handle_generate_audio(
         # Get agent configuration from context
         if not agent_name:
             return {"success": False, "error": "Agent name not found in context"}
-        
-        agent_doc = frappe.get_doc("Agent", agent_name)
-        provider_doc = frappe.get_doc("AI Provider", agent_doc.provider)
-        api_key = provider_doc.get_password("api_key")
-        
-        if not api_key:
-            return {"success": False, "error": "API key not configured for provider"}
-        
-        # Determine TTS model
-        tts_model = None
-        
-        if model:
-            # Use explicitly provided model
-            tts_model = model
 
-            # If model is provided but voice isn't, determine default voice based on provider
-            if not voice:
-                voice = _get_default_voice(provider_doc.provider_name.lower())
-        else:
-            # Auto-detect suitable TTS model based on provider
-            provider_name = provider_doc.provider_name.lower()
-            tts_model = _get_default_tts_model(provider_name)
-            
-            # If voice not provided, get default for this provider
-            if not voice:
-                voice = _get_default_voice(provider_name)
-        
-        if not tts_model:
-            return {
-                "success": False,
-                "error": f"Text-to-speech not supported for provider '{provider_doc.provider_name}'. Please provide a model parameter."
-            }
-        
-        # Determine Voice if not provided
-        if not voice:
-            voice = _get_default_voice(provider_doc.provider_name.lower())
-        
-        # Normalize to LiteLLM format
-        from huf.ai.providers.litellm import _normalize_model_name
-        normalized_model = _normalize_model_name(tts_model, agent_doc.provider)
-        
-        # Call LiteLLM speech generation
+        agent_doc = frappe.get_doc("Agent", agent_name)
+
+        try:
+            tts_config = _resolve_tts_config(
+                agent_doc, tool_model=model, tool_voice=voice
+            )
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+
+        normalized_model = tts_config["tts_model"]
+        voice            = tts_config["voice"]
+        api_key          = tts_config["api_key"]
+        provider_name    = tts_config["provider_name"]
+        tts_source       = tts_config["source"]
+        tts_provider_doc = tts_config["provider_doc"]
+
         import litellm
-        
-        # Build parameters for speech generation
-        speech_params = {
+
+        speech_params: dict = {
             "model": normalized_model,
             "input": input,
-            "voice": voice
+            "voice": voice,
         }
-        
-        env_var_providers = {
-            "google": "GEMINI_API_KEY",
-            "vertex_ai": "GEMINI_API_KEY",
-            "gemini": "GEMINI_API_KEY",
-        }
-        
-        provider_key = provider_doc.provider_name.lower()
-        if provider_key in env_var_providers:
+
+        if provider_name in _TTS_ENV_VAR_PROVIDERS:
             import os
-            os.environ[env_var_providers[provider_key]] = api_key
+            os.environ[_TTS_ENV_VAR_PROVIDERS[provider_name]] = api_key
         else:
             speech_params["api_key"] = api_key
-        
-        # Add optional parameters
-        # LiteLLM forwards provider-specific params automatically
+
         if speed != 1.0:
             speech_params["speed"] = speed
         if response_format != "mp3":
             speech_params["response_format"] = response_format
-        
+
         # Call LiteLLM speech (returns HttpxBinaryResponseContent)
         response = await asyncio.to_thread(
             litellm.speech,
@@ -2183,7 +2291,9 @@ async def handle_generate_audio(
                 "voice": voice,
                 "speed": speed,
                 "format": response_format,
-                "model": normalized_model
+                "model": normalized_model,
+                "model_source": tts_source,
+                "tts_provider": tts_provider_doc.provider_name,
             },
             "message": "Generated audio successfully",
             "conversation_id": conversation_id

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -63,6 +63,9 @@
   "max_turns",
   "image_generation_section",
   "image_generation_model",
+  "audio_generation_section",
+  "tts_model",
+  "tts_voice",
   "huf_ui_section",
   "agent_color",
   "permissions_tab",
@@ -108,6 +111,19 @@
    "label": "Model",
    "options": "AI Model",
    "reqd": 1
+  },
+  {
+   "description": "Specific model for Text-to-Speech (Audio Generation). If unset, defaults to the provider's default TTS model.",
+   "fieldname": "tts_model",
+   "fieldtype": "Link",
+   "label": "TTS Model",
+   "options": "AI Model"
+  },
+  {
+   "description": "Voice to use for TTS (e.g. alloy, echo, onyx).",
+   "fieldname": "tts_voice",
+   "fieldtype": "Data",
+   "label": "TTS Voice"
   },
   {
    "default": "Local",
@@ -520,12 +536,17 @@
    "fieldname": "instruction_section",
    "fieldtype": "Section Break",
    "label": "Instruction"
+  },
+  {
+   "fieldname": "audio_generation_section",
+   "fieldtype": "Section Break",
+   "label": "Audio Generation"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-25 19:41:57.703300",
+ "modified": "2026-03-02 14:44:50.227984",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent",

--- a/huf/huf/doctype/agent_message/agent_message.json
+++ b/huf/huf/doctype/agent_message/agent_message.json
@@ -17,6 +17,8 @@
   "generated_image",
   "generated_audio",
   "voice_message",
+  "tts_model",
+  "tts_voice",
   "column_break_asyu",
   "session_id",
   "user",
@@ -186,6 +188,22 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.kind == \"Audio\";",
+   "description": "AI Model used for Text-to-Speech in this audio message.",
+   "fieldname": "tts_model",
+   "fieldtype": "Link",
+   "label": "TTS Model",
+   "options": "AI Model",
+   "read_only": 1
+  },
+  {
+   "description": "Voice to use for TTS (e.g. alloy, echo, onyx).",
+   "fieldname": "tts_voice",
+   "fieldtype": "Data",
+   "label": "TTS Voice",
+   "read_only": 1
+  },
+  {
    "fieldname": "voice_message",
    "fieldtype": "Attach",
    "label": "Voice Message",
@@ -195,7 +213,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-18 13:37:33.353103",
+ "modified": "2026-03-02 18:23:04.656369",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Message",

--- a/huf/install.py
+++ b/huf/install.py
@@ -340,6 +340,9 @@ def create_generate_audio_tool():
         tool_doc.description = "Generate audio (speech) from text using AI text-to-speech. Use this when the user asks to convert text to speech, create voice narration, or generate audio. Supports multiple providers via LiteLLM (OpenAI, Gemini, ElevenLabs, etc.)."
         tool_doc.function_path = "huf.ai.sdk_tools.handle_generate_audio"
         tool_doc.tool_type = "Audio Generation"
+        tool_doc.set("parameters", [])
+        for p in parameters:
+            tool_doc.append("parameters", p)
         try:
             tool_doc.save()
         except Exception as e:
@@ -359,22 +362,27 @@ def create_generate_audio_tool():
                 "fieldname": "voice",
                 "type": "string",
                 "required": 0,
-                "description": "Voice to use for speech generation. Options vary by provider. OpenAI: alloy, echo, fable, onyx, nova, shimmer. Default: 'alloy'.",
-                "options": "alloy\necho\nfable\nonyx\nnova\nshimmer"
+                "description": (
+                    "Voice identifier for the TTS provider. "
+                    "IMPORTANT: Leave this blank - the voice is automatically determined by the agent's TTS configuration (tts_voice field). Only set this if the user has explicitly asked for a specific voice AND provided the exact voice ID for the active TTS provider."
+                )
             },
             {
                 "label": "Model",
                 "fieldname": "model",
                 "type": "string",
                 "required": 0,
-                "description": "Optional TTS model override. Defaults based on provider: OpenAI (tts-1), Gemini (gemini-2.5-flash-preview-tts), ElevenLabs (eleven_multilingual_v2)."
+                "description": (
+                    "TTS model override."
+                    "IMPORTANT: Leave this blank — the model is automatically determined by the agent's TTS configuration (tts_model field). Only set this if the user has explicitly asked to use a specific TTS model."
+                )
             },
             {
                 "label": "Speed",
                 "fieldname": "speed",
                 "type": "number",
                 "required": 0,
-                "description": "Speech speed from 0.25 to 4.0. Default: 1.0. Supported by OpenAI and some other providers."
+                "description": "Speech speed from 0.25 to 4.0. Default: 1.0."
             },
             {
                 "label": "Response Format",


### PR DESCRIPTION
### Description
This PR introduces the ability to configure dedicated Text-to-Speech (TTS) models and voices at the Agent level, decoupling audio generation from the agent's main  model. It implements a robust, priority-based resolution system for handling TTS parameters—supporting cross-provider functionality out of the box—and adds auditing capabilities for generated audio messages.

### Motivation and Context
Previously, agents were limited to or biased towards the provider or specific voices of their main model (e.g., OpenAI voices). This update allows an agent to use an LLM from one provider (like Anthropic) while using a specialized TTS model from another (like ElevenLabs or Google). It also ensures that the voices and models used for audio generation are accurately tracked in the resulting `Agent Message` documents for observability.

### Highlights & Key Changes

####  Backend & Core Logic (`huf/ai/sdk_tools.py` & `huf/install.py`)
- **Cross-Provider TTS Resolution:**
  Introduced a 3-tier priority chain for resolving TTS config in the `generate_audio` tool:
  1. *Tool Arguments:* Explicit runtime overrides requested by the LLM.
  2. *Agent Configuration:* The agent's dedicated `tts_model` and `tts_voice` (with API keys sourced automatically for the specific TTS model's AI Provider).
  3. *Provider Defaults:* Fallback default models/voices based on the provider.
- **Provider-Neutral Parameters:** Removed OpenAI-specific voice dropdowns (alloy, echo, etc.) from `generate_audio` tool parameters in `huf/install.py` to prevent LLM hallucination/bias, instructing the LLM to leave these blank unless an explicit override is required.
- **Improved Audio Tracking:** Extended the `handle_generate_audio` return dictionary with `model_source` and `tts_provider` for better observability. `Agent Message` inserts now dynamically populate `tts_voice` and `tts_model` to track exactly what was used to generate an audio payload.

####  Database & DocTypes (`agent.json`, `agent_message.json`)
- **Agent Config:** Added `tts_model` (Link to AI Model) and `tts_voice` (Data) fields under a new "Audio Generation" section in the Advanced Settings tab.
- **Message Auditing:** Added `tts_model` and `tts_voice` tracking fields to the `Agent Message` doctype. Frappe Link validation is bypassed for runtime parameters containing slashes (unless using an explicitly linked model from `agent_config`).

####  Documentation (`AGENTS.md`)
- Documented the new `tts_model` and `tts_voice` fields in the Agent fields reference.
- Detailed the `generate_audio` tool (Standard Tool #3) parameters and explicitly explained the three-tier model/voice resolution priority system.

### How to Test
1. **Agent Setup:** Go to any Agent's Advanced Settings tab > Audio Generation section.
2. Set a different `tts_model` (e.g., ElevenLabs) and `tts_voice` than the agent's primary  model (e.g., OpenAI or Anthropic).
3. **Execution:** Ask the agent to generate an audio clip.
4. **Validation:** Check the resulting `Agent Message` to verify that the `tts_voice` and `tts_model` fields accurately reflect the fallback/configured parameters and that the audio successfully plays. Ensure `bench migrate` correctly updates the `generate_audio` tool parameter descriptions in the database.
