### PR TITLE
Add Agent Prompt Template UI and fix template_version_at_attach mapping

### DIFF
--- a/frontend/src/components/agent/GeneralTab.tsx
+++ b/frontend/src/components/agent/GeneralTab.tsx
@@ -10,6 +10,7 @@ import { UseFormReturn } from 'react-hook-form';
 import type { AIProvider, AIModel } from '@/types/agent.types';
 import type { AgentFormValues } from './types';
 import { InstructionsTextarea } from './InstructionsTextarea';
+import { PromptTemplateSection, type AgentPromptOption } from './PromptTemplateSection';
 
 interface GeneralTabProps {
   form: UseFormReturn<AgentFormValues>;
@@ -18,10 +19,23 @@ interface GeneralTabProps {
   watchProvider: string;
   optimizingPrompt: boolean;
   onOptimizePrompt: () => void;
+  promptOptions: AgentPromptOption[];
+  loadingPrompts: boolean;
 }
 
-export function GeneralTab({ form, providers, models, watchProvider, optimizingPrompt, onOptimizePrompt }: GeneralTabProps) {
-  const watchEnablePromptCaching = form.watch("enable_prompt_caching");
+export function GeneralTab({
+  form,
+  providers,
+  models,
+  watchProvider,
+  optimizingPrompt,
+  onOptimizePrompt,
+  promptOptions,
+  loadingPrompts,
+}: GeneralTabProps) {
+  const watchEnablePromptCaching = form.watch('enable_prompt_caching');
+  const promptMode = form.watch('prompt_mode');
+
   return (
     <div className="space-y-6">
       <Card>
@@ -110,11 +124,7 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Model</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={field.value}
-                  disabled={!watchProvider}
-                >
+                <Select onValueChange={field.onChange} value={field.value} disabled={!watchProvider}>
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Select model" />
@@ -143,17 +153,9 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
               <FormItem>
                 <FormLabel>Temperature: {field.value}</FormLabel>
                 <FormControl>
-                  <Slider
-                    min={0}
-                    max={2}
-                    step={0.1}
-                    value={[field.value]}
-                    onValueChange={(vals) => field.onChange(vals[0])}
-                  />
+                  <Slider min={0} max={2} step={0.1} value={[field.value]} onValueChange={(vals) => field.onChange(vals[0])} />
                 </FormControl>
-                <FormDescription>
-                  Lower = focused, higher = creative
-                </FormDescription>
+                <FormDescription>Lower = focused, higher = creative</FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -166,26 +168,50 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
               <FormItem>
                 <FormLabel>Top P: {field.value}</FormLabel>
                 <FormControl>
-                  <Slider
-                    min={0}
-                    max={1}
-                    step={0.05}
-                    value={[field.value]}
-                    onValueChange={(vals) => field.onChange(vals[0])}
-                  />
+                  <Slider min={0} max={1} step={0.05} value={[field.value]} onValueChange={(vals) => field.onChange(vals[0])} />
                 </FormControl>
+                <FormDescription>Nucleus sampling parameter</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Prompt Source</CardTitle>
+          <CardDescription>Choose whether this agent uses inline instructions or a reusable prompt template.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6 sm:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="prompt_mode"
+            render={({ field }) => (
+              <FormItem className="sm:col-span-2">
+                <FormLabel>Prompt Mode</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select prompt mode" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="Local">Local</SelectItem>
+                    <SelectItem value="Template">Template</SelectItem>
+                  </SelectContent>
+                </Select>
                 <FormDescription>
-                  Nucleus sampling parameter
+                  Local mode stores instructions directly on the agent. Template mode links to a reusable Agent Prompt from the library.
                 </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
           />
-
         </CardContent>
       </Card>
 
-      {form.watch("prompt_mode") === "Local" && (
+      {promptMode === 'Local' ? (
         <Card>
           <CardHeader>
             <CardTitle>Instructions</CardTitle>
@@ -211,6 +237,8 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
             />
           </CardContent>
         </Card>
+      ) : (
+        <PromptTemplateSection form={form} promptOptions={promptOptions} loadingPrompts={loadingPrompts} />
       )}
 
       <Card>
@@ -229,8 +257,7 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
                 <div className="space-y-0.5">
                   <FormLabel className="text-base">Enable Prompt Caching</FormLabel>
                   <FormDescription>
-                    Enable prompt caching to cache repeated prompt content and reduce token costs. Only
-                    works with supported providers (OpenAI, Anthropic, Bedrock, Deepseek).
+                    Enable prompt caching to cache repeated prompt content and reduce token costs. Only works with supported providers (OpenAI, Anthropic, Bedrock, Deepseek).
                   </FormDescription>
                 </div>
                 <FormControl>
@@ -259,8 +286,7 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
                     </SelectContent>
                   </Select>
                   <FormDescription>
-                    Cache control type: &apos;ephemeral&apos; for Anthropic (charges for cache writes),
-                    &apos;auto&apos; for OpenAI/Deepseek (automatic caching).
+                    Cache control type: &apos;ephemeral&apos; for Anthropic (charges for cache writes), &apos;auto&apos; for OpenAI/Deepseek (automatic caching).
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -297,8 +323,7 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
                   <div className="space-y-0.5">
                     <FormLabel className="text-base">Cache Conversation History</FormLabel>
                     <FormDescription>
-                      Cache conversation history messages to reduce token usage in multi-turn
-                      conversations.
+                      Cache conversation history messages to reduce token usage in multi-turn conversations.
                     </FormDescription>
                   </div>
                   <FormControl>
@@ -313,4 +338,3 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
     </div>
   );
 }
-

--- a/frontend/src/components/agent/PromptTemplateSection.tsx
+++ b/frontend/src/components/agent/PromptTemplateSection.tsx
@@ -1,0 +1,121 @@
+import { Badge } from '@/components/ui/badge';
+import { Combobox } from '@/components/ui/combobox';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Switch } from '@/components/ui/switch';
+import type { AgentFormValues } from './types';
+import type { UseFormReturn } from 'react-hook-form';
+
+export interface AgentPromptOption {
+  value: string;
+  label: string;
+  description?: string;
+  version?: number | null;
+  isLatest?: boolean;
+}
+
+interface PromptTemplateSectionProps {
+  form: UseFormReturn<AgentFormValues>;
+  promptOptions: AgentPromptOption[];
+  loadingPrompts?: boolean;
+}
+
+export function PromptTemplateSection({
+  form,
+  promptOptions,
+  loadingPrompts = false,
+}: PromptTemplateSectionProps) {
+  const selectedPrompt = promptOptions.find((option) => option.value === form.watch('agent_prompt'));
+  const attachedVersion = form.watch('template_version_at_attach');
+  const isLocked = form.watch('prompt_version_locked');
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Prompt Template</CardTitle>
+        <CardDescription>
+          Reuse a managed Agent Prompt template instead of local instructions. Version locking keeps the
+          agent pinned to the attached template revision.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-6 sm:grid-cols-2">
+        <FormField
+          control={form.control}
+          name="agent_prompt"
+          render={({ field }) => (
+            <FormItem className="sm:col-span-2">
+              <FormLabel>Agent Prompt</FormLabel>
+              <FormControl>
+                <Combobox
+                  options={promptOptions}
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  placeholder={loadingPrompts ? 'Loading templates...' : 'Select an Agent Prompt'}
+                  disabled={loadingPrompts}
+                  searchPlaceholder="Search templates..."
+                  emptyText="No active prompt templates found."
+                />
+              </FormControl>
+              <FormDescription>
+                Pick an active prompt from the shared template library. The backend records the current
+                version when you attach it.
+              </FormDescription>
+              {selectedPrompt && (
+                <div className="flex flex-wrap items-center gap-2 pt-2">
+                  {selectedPrompt.version ? (
+                    <Badge variant="outline">Current template v{selectedPrompt.version}</Badge>
+                  ) : null}
+                  {selectedPrompt.isLatest ? <Badge variant="secondary">Latest</Badge> : null}
+                  {selectedPrompt.description ? (
+                    <span className="text-sm text-muted-foreground">{selectedPrompt.description}</span>
+                  ) : null}
+                </div>
+              )}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="prompt_version_locked"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4 sm:col-span-2">
+              <div className="space-y-0.5 pr-4">
+                <FormLabel className="text-base">Lock Template Version</FormLabel>
+                <FormDescription>
+                  Keep this agent pinned to the attached version instead of following the latest template
+                  updates automatically.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="template_version_at_attach"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Attached at Version</FormLabel>
+              <FormControl>
+                <div className="flex min-h-10 items-center rounded-md border bg-muted/40 px-3 text-sm text-muted-foreground">
+                  {field.value ?? 'Will be recorded after template attachment'}
+                </div>
+              </FormControl>
+              <FormDescription>
+                {isLocked && attachedVersion
+                  ? `This agent is locked to version ${attachedVersion}.`
+                  : 'Read-only snapshot captured by the backend when a template is attached or changed.'}
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/agent/types.ts
+++ b/frontend/src/components/agent/types.ts
@@ -24,10 +24,10 @@ export const agentFormSchema = z.object({
     })
   ).default([]),
 
-  prompt_mode: z.string().default("Local"),
+  prompt_mode: z.enum(["Local", "Template"]).default("Local"),
   agent_prompt: z.string().optional(),
   prompt_version_locked: z.boolean().optional(),
-  attached_at_version: z.number().optional(),
+  template_version_at_attach: z.number().optional(),
   copied_from_prompt: z.string().nullable().optional(),
   enable_prompt_caching: z.boolean().optional(),
   cache_control_type: z.string().optional(),
@@ -46,7 +46,14 @@ export const agentFormSchema = z.object({
   tts_model: z.string().optional(),
   tts_voice: z.string().optional(),
   stt_model: z.string().optional(),
+}).superRefine((values, ctx) => {
+  if (values.prompt_mode === "Template" && !values.agent_prompt?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["agent_prompt"],
+      message: 'Select an Agent Prompt when using Template mode',
+    });
+  }
 });
 
 export type AgentFormValues = z.infer<typeof agentFormSchema>;
-

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Form } from '../components/ui/form';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { toast } from 'sonner';
-import { AIProvider, AIModel, AgentToolFunctionRef } from '../types/agent.types';
+import { AIProvider, AIModel, AgentToolFunctionRef, type ToolType } from '../types/agent.types';
 import { getAgent, updateAgent, createAgent, getAgentTriggers, getAgentTrigger, createAgentTrigger, updateAgentTrigger, getDocTypes, getTriggerTypes, type AgentTriggerListItem, type AgentTriggerDoc, type TriggerTypeOption, deleteAgentTrigger, runAgentTest } from '../services/agentApi';
 import { getProviders, getModels } from '../services/providerApi';
 import { getToolTypes, getToolFunction, updateToolFunction, getToolFunctionsByName } from '../services/toolApi';
@@ -22,10 +22,74 @@ import { BehaviorTab } from '../components/agent/BehaviorTab';
 import { TriggersTab } from '../components/agent/TriggersTab';
 import { ToolsTab } from '../components/agent/ToolsTab';
 import { AdvancedTab } from '../components/agent/AdvancedTab';
+import type { AgentPromptOption } from '../components/agent/PromptTemplateSection';
 import { agentFormSchema, type AgentFormValues } from '../components/agent/types';
 import { syncMCPTools, getMCPServer, type MCPServerRef } from '../services/mcpApi';
 import type { MCPServerDoc } from '../services/mcpApi';
 import { createFormSubmitHandler, type TabFieldMapping } from '../utils/formValidation';
+import { db } from '../lib/frappe-sdk';
+
+type PromptListRow = {
+  name: string;
+  title?: string | null;
+  version?: number | null;
+  is_latest?: 0 | 1;
+  description?: string | null;
+};
+
+type AgentToolRow = {
+  tool?: string | null;
+};
+
+type AgentMcpServerRow = {
+  name?: string | null;
+  mcp_server: string;
+  server_url?: string | null;
+  enabled?: 0 | 1 | boolean;
+  tool_count?: number | null;
+  server_name?: string | null;
+  description?: string | null;
+};
+
+function mapAgentDocToFormValues(agent: Partial<AgentDoc>): AgentFormValues {
+  return {
+    agent_name: agent.agent_name || '',
+    provider: agent.provider || '',
+    model: agent.model || '',
+    temperature: agent.temperature ?? 1,
+    top_p: agent.top_p ?? 1,
+    disabled: agent.disabled === 1,
+    allow_chat: agent.allow_chat === 1,
+    persist_conversation: agent.persist_conversation === 1,
+    persist_user_history: agent.persist_user_history === 1,
+    enable_multi_run: agent.enable_multi_run === 1,
+    description: agent.description || '',
+    instructions: agent.instructions || '',
+    default_plan: agent.default_plan || [],
+    prompt_mode: agent.prompt_mode || 'Local',
+    agent_prompt: agent.agent_prompt || '',
+    prompt_version_locked: agent.prompt_version_locked === 1,
+    template_version_at_attach:
+      agent.template_version_at_attach !== undefined ? agent.template_version_at_attach : undefined,
+    copied_from_prompt: agent.copied_from_prompt ?? undefined,
+    enable_prompt_caching: agent.enable_prompt_caching === 1,
+    cache_control_type: agent.cache_control_type || '',
+    cache_system_message: agent.cache_system_message === 1,
+    cache_conversation_history: agent.cache_conversation_history === 1,
+    context_strategy: agent.context_strategy || undefined,
+    summary_ratio: agent.summary_ratio !== undefined && agent.summary_ratio !== null ? agent.summary_ratio : undefined,
+    history_limit: agent.history_limit !== undefined && agent.history_limit !== null ? agent.history_limit : undefined,
+    max_knowledge_tokens:
+      agent.max_knowledge_tokens !== undefined && agent.max_knowledge_tokens !== null ? agent.max_knowledge_tokens : undefined,
+    max_turns: agent.max_turns !== undefined && agent.max_turns !== null ? agent.max_turns : undefined,
+    enable_conversation_data: agent.enable_conversation_data === 1,
+    autonaming_of_conversation_title: agent.autonaming_of_conversation_title === 1,
+    image_generation_model: agent.image_generation_model || undefined,
+    tts_model: agent.tts_model || undefined,
+    tts_voice: agent.tts_voice || '',
+    stt_model: agent.stt_model || undefined,
+  };
+}
 
 export function AgentFormPage() {
   const { id } = useParams<{ id: string }>();
@@ -36,7 +100,7 @@ export function AgentFormPage() {
   const tabConfig = {
     general: {
       label: 'General',
-      fields: ['agent_name', 'provider', 'model', 'temperature', 'top_p', 'description', 'instructions', 'enable_prompt_caching', 'cache_control_type', 'cache_system_message', 'cache_conversation_history', 'prompt_mode', 'agent_prompt', 'prompt_version_locked', 'attached_at_version'],
+      fields: ['agent_name', 'provider', 'model', 'temperature', 'top_p', 'description', 'instructions', 'enable_prompt_caching', 'cache_control_type', 'cache_system_message', 'cache_conversation_history', 'prompt_mode', 'agent_prompt', 'prompt_version_locked', 'template_version_at_attach'],
       default: true,
       disabled: false,
     },
@@ -79,22 +143,13 @@ export function AgentFormPage() {
   } as const;
 
   // Extract derived values from tab config (memoized to avoid recreating on every render)
-  const validTabs = useMemo(() => Object.keys(tabConfig), []);
-  const defaultTab = useMemo(
-    () => Object.entries(tabConfig).find(([_, config]) => config.default)?.[0] || validTabs[0],
-    [validTabs]
+  const validTabs = Object.keys(tabConfig);
+  const defaultTab = Object.entries(tabConfig).find(([, config]) => config.default)?.[0] || validTabs[0];
+  const tabFieldMapping: TabFieldMapping = Object.fromEntries(
+    Object.entries(tabConfig).map(([key, config]) => [key, [...config.fields]])
   );
-  const tabFieldMapping: TabFieldMapping = useMemo(
-    () => Object.fromEntries(
-      Object.entries(tabConfig).map(([key, config]) => [key, [...config.fields]])
-    ),
-    []
-  );
-  const tabLabels = useMemo(
-    () => Object.fromEntries(
-      Object.entries(tabConfig).map(([key, config]) => [key, config.label])
-    ),
-    []
+  const tabLabels = Object.fromEntries(
+    Object.entries(tabConfig).map(([key, config]) => [key, config.label])
   );
   
   // State to track active tab from URL hash
@@ -133,6 +188,8 @@ export function AgentFormPage() {
   const [providers, setProviders] = useState<AIProvider[]>([]);
   const [models, setModels] = useState<AIModel[]>([]);
   const [allModels, setAllModels] = useState<AIModel[]>([]);
+  const [promptOptions, setPromptOptions] = useState<AgentPromptOption[]>([]);
+  const [loadingPrompts, setLoadingPrompts] = useState(false);
   const [triggers, setTriggers] = useState<AgentTriggerListItem[]>([]);
   const [showTriggerModal, setShowTriggerModal] = useState(false);
   const [editingTrigger, setEditingTrigger] = useState<AgentTriggerDoc | null>(null);
@@ -174,7 +231,7 @@ export function AgentFormPage() {
         prompt_mode: "Local",
         agent_prompt: '',
         prompt_version_locked: false,
-        attached_at_version: undefined,
+        template_version_at_attach: undefined,
         enable_prompt_caching: false,
         cache_control_type: "",
         cache_system_message: false,
@@ -304,6 +361,52 @@ export function AgentFormPage() {
     });
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadPromptOptions = async () => {
+      setLoadingPrompts(true);
+      try {
+        const prompts = await db.getDocList('Agent Prompt', {
+          fields: ['name', 'title', 'version', 'is_latest', 'description'],
+          filters: [['is_active', '=', 1]],
+          limit: 500,
+          orderBy: { field: 'modified', order: 'desc' },
+        }) as PromptListRow[];
+
+        if (cancelled) {
+          return;
+        }
+
+        setPromptOptions(
+          prompts.map((prompt) => ({
+            value: prompt.name,
+            label: prompt.title || prompt.name,
+            description: prompt.description || undefined,
+            version: typeof prompt.version === 'number' ? prompt.version : undefined,
+            isLatest: prompt.is_latest === 1,
+          }))
+        );
+      } catch (error) {
+        console.error('Error loading prompt templates:', error);
+        if (!cancelled) {
+          setPromptOptions([]);
+          toast.error('Failed to load Agent Prompt templates');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingPrompts(false);
+        }
+      }
+    };
+
+    loadPromptOptions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Load models when provider changes
   useEffect(() => {
     if (watchProvider) {
@@ -322,45 +425,28 @@ export function AgentFormPage() {
     }
   }, [watchProvider, form]);
 
+  const watchPromptMode = form.watch('prompt_mode');
+  const watchAgentPrompt = form.watch('agent_prompt');
+
+  useEffect(() => {
+    if (watchPromptMode === 'Local') {
+      form.setValue('agent_prompt', '', { shouldDirty: false });
+      form.setValue('prompt_version_locked', false, { shouldDirty: false });
+      form.setValue('template_version_at_attach', undefined, { shouldDirty: false });
+      return;
+    }
+
+    if (watchPromptMode === 'Template' && !watchAgentPrompt) {
+      form.setValue('prompt_version_locked', false, { shouldDirty: false });
+      form.setValue('template_version_at_attach', undefined, { shouldDirty: false });
+    }
+  }, [watchPromptMode, watchAgentPrompt, form]);
+
   // Load agent data when id is available (only for edit mode)
   useEffect(() => {
     if (id && !isNew) {
       getAgent(id).then((data: AgentDoc) => {
-        form.reset({
-          agent_name: data.agent_name || '',
-          provider: data.provider || '',
-          model: data.model || '',
-          temperature: data.temperature ?? 1,
-          top_p: data.top_p ?? 1,
-          disabled: data.disabled === 1,
-          allow_chat: data.allow_chat === 1,
-          persist_conversation: data.persist_conversation === 1,
-          persist_user_history: data.persist_user_history === 1,
-          enable_multi_run: data.enable_multi_run === 1,
-          description: data.description || '',
-          instructions: data.instructions || '',
-          default_plan: data.default_plan || [],
-          prompt_mode: data.prompt_mode || 'Local',
-          agent_prompt: data.agent_prompt || '',
-          prompt_version_locked: data.prompt_version_locked === 1,
-          attached_at_version: data.attached_at_version !== undefined ? data.attached_at_version : undefined,
-          enable_prompt_caching: data.enable_prompt_caching === 1,
-          cache_control_type: data.cache_control_type || '',
-          cache_system_message: data.cache_system_message === 1,
-          cache_conversation_history: data.cache_conversation_history === 1,
-          context_strategy: data.context_strategy || undefined,
-          summary_ratio: data.summary_ratio !== undefined && data.summary_ratio !== null ? data.summary_ratio : undefined,
-          history_limit: data.history_limit !== undefined && data.history_limit !== null ? data.history_limit : undefined,
-          max_knowledge_tokens: data.max_knowledge_tokens !== undefined && data.max_knowledge_tokens !== null ? data.max_knowledge_tokens : undefined,
-          max_turns: data.max_turns !== undefined && data.max_turns !== null ? data.max_turns : undefined,
-          enable_conversation_data: data.enable_conversation_data === 1,
-          autonaming_of_conversation_title: data.autonaming_of_conversation_title === 1,
-
-          image_generation_model: data.image_generation_model || undefined,
-          tts_model: data.tts_model || undefined,
-          tts_voice: data.tts_voice || '',
-          stt_model: data.stt_model || undefined,
-        });
+        form.reset(mapAgentDocToFormValues(data));
         // Track initial disabled state and persisted allow_chat
         setInitialDisabled(data.disabled === 1);
         setAllowChat(data.allow_chat === 1);
@@ -368,7 +454,7 @@ export function AgentFormPage() {
         // agent_tool is a child table with format: [{ tool: "tool-name" }, ...]
         if (data.agent_tool && Array.isArray(data.agent_tool) && data.agent_tool.length > 0) {
           // Fetch full tool details for each tool reference
-          const toolNames = data.agent_tool.map((item: any) => item.tool).filter(Boolean);
+          const toolNames = (data.agent_tool as AgentToolRow[]).map((item) => item.tool).filter(Boolean) as string[];
           if (toolNames.length > 0) {
             getToolFunctionsByName(toolNames)
               .then((tools) => {
@@ -399,7 +485,7 @@ export function AgentFormPage() {
         // Load MCP servers from agent_mcp_server child table (already in agent document)
         if (data.agent_mcp_server && Array.isArray(data.agent_mcp_server) && data.agent_mcp_server.length > 0) {
           // First, map child table data to MCPServerRef format
-          const childTableServers: MCPServerRef[] = data.agent_mcp_server.map((item: any) => ({
+          const childTableServers: MCPServerRef[] = (data.agent_mcp_server as AgentMcpServerRow[]).map((item) => ({
             name: item.name || '', // Child table row name
             mcp_server: item.mcp_server, // Link to MCP Server DocType
             server_url: item.server_url || '',
@@ -456,7 +542,7 @@ export function AgentFormPage() {
     }
   }, [id, isNew, form]);
 
-  const onSubmit = async (values: AgentFormValues) => {
+  const onSubmit = useCallback(async (values: AgentFormValues) => {
     setSaving(true);
     try {
       // Convert form values (booleans) to AgentDoc format (numbers 0/1)
@@ -477,7 +563,7 @@ export function AgentFormPage() {
         prompt_mode: values.prompt_mode || 'Local',
         agent_prompt: values.agent_prompt || '',
         prompt_version_locked: values.prompt_version_locked ? 1 : 0,
-        attached_at_version: values.attached_at_version !== undefined ? values.attached_at_version : undefined,
+        template_version_at_attach: values.template_version_at_attach !== undefined ? values.template_version_at_attach : undefined,
         enable_prompt_caching: values.enable_prompt_caching ? 1 : 0,
         cache_control_type: values.cache_control_type || '',
         cache_system_message: values.cache_system_message ? 1 : 0,
@@ -497,7 +583,7 @@ export function AgentFormPage() {
         // Include tools - Frappe child table format: array of objects with 'tool' field pointing to Agent Tool Function name
         agent_tool: selectedTools.map((tool) => ({
           tool: tool.name,
-        })) as any,
+        })),
         // Include MCP servers - Frappe child table format: array of objects with 'mcp_server' field and 'enabled' field
         agent_mcp_server: mcpServers.map((server) => ({
           mcp_server: server.mcp_server, // This is the link field to MCP Server DocType
@@ -510,41 +596,7 @@ export function AgentFormPage() {
         const newAgent = await createAgent(agentData);
         toast.success('Agent created successfully!');
         // Reset form state with the created agent's values
-        form.reset({
-          agent_name: newAgent.agent_name || '',
-          provider: newAgent.provider || '',
-          model: newAgent.model || '',
-          temperature: newAgent.temperature ?? 1,
-          top_p: newAgent.top_p ?? 1,
-          disabled: newAgent.disabled === 1,
-          allow_chat: newAgent.allow_chat === 1,
-          persist_conversation: newAgent.persist_conversation === 1,
-          persist_user_history: newAgent.persist_user_history === 1,
-          enable_multi_run: newAgent.enable_multi_run === 1,
-          description: newAgent.description || '',
-          instructions: newAgent.instructions || '',
-          default_plan: newAgent.default_plan || [],
-          prompt_mode: newAgent.prompt_mode || 'Local',
-          agent_prompt: newAgent.agent_prompt || '',
-          prompt_version_locked: newAgent.prompt_version_locked === 1,
-          attached_at_version: newAgent.attached_at_version !== undefined ? newAgent.attached_at_version : undefined,
-          enable_prompt_caching: newAgent.enable_prompt_caching === 1,
-          cache_control_type: newAgent.cache_control_type || '',
-          cache_system_message: newAgent.cache_system_message === 1,
-          cache_conversation_history: newAgent.cache_conversation_history === 1,
-          context_strategy: newAgent.context_strategy || undefined,
-          summary_ratio: newAgent.summary_ratio !== undefined && newAgent.summary_ratio !== null ? newAgent.summary_ratio : undefined,
-          history_limit: newAgent.history_limit !== undefined && newAgent.history_limit !== null ? newAgent.history_limit : undefined,
-          max_knowledge_tokens: newAgent.max_knowledge_tokens !== undefined && newAgent.max_knowledge_tokens !== null ? newAgent.max_knowledge_tokens : undefined,
-          max_turns: newAgent.max_turns !== undefined && newAgent.max_turns !== null ? newAgent.max_turns : undefined,
-          enable_conversation_data: newAgent.enable_conversation_data === 1,
-          autonaming_of_conversation_title: newAgent.autonaming_of_conversation_title === 1,
-
-          image_generation_model: newAgent.image_generation_model || undefined,
-          tts_model: newAgent.tts_model || undefined,
-          tts_voice: newAgent.tts_voice || '',
-          stt_model: newAgent.stt_model || undefined,
-        });
+        form.reset(mapAgentDocToFormValues(newAgent));
         setInitialDisabled(newAgent.disabled === 1);
         setAllowChat(newAgent.allow_chat === 1);
         // Navigate to the edit page with the new agent's ID
@@ -553,52 +605,16 @@ export function AgentFormPage() {
         // Update existing agent
         await updateAgent(id, agentData);
         toast.success('Agent updated successfully!');
-        // Reset form state with the updated values to mark form as clean
-        form.reset({
-          agent_name: values.agent_name,
-          provider: values.provider,
-          model: values.model,
-          temperature: values.temperature,
-          top_p: values.top_p,
-          disabled: values.disabled,
-          allow_chat: values.allow_chat,
-          persist_conversation: values.persist_conversation,
-          persist_user_history: values.persist_user_history,
-          enable_multi_run: values.enable_multi_run,
-          description: values.description,
-          instructions: values.instructions,
-          default_plan: values.default_plan || [],
-          prompt_mode: values.prompt_mode,
-          agent_prompt: values.agent_prompt,
-          prompt_version_locked: values.prompt_version_locked,
-          attached_at_version: values.attached_at_version,
-          enable_prompt_caching: values.enable_prompt_caching,
-          cache_control_type: values.cache_control_type,
-          cache_system_message: values.cache_system_message,
-          cache_conversation_history: values.cache_conversation_history,
-          context_strategy: values.context_strategy,
-          summary_ratio: values.summary_ratio,
-          history_limit: values.history_limit,
-          max_knowledge_tokens: values.max_knowledge_tokens,
-          max_turns: values.max_turns,
-          enable_conversation_data: values.enable_conversation_data,
-          autonaming_of_conversation_title: values.autonaming_of_conversation_title,
-
-          image_generation_model: values.image_generation_model,
-          tts_model: values.tts_model,
-          tts_voice: values.tts_voice,
-          stt_model: values.stt_model,
-        });
-        // Reset tools, disabled state, and persisted allow_chat after successful update
-        setInitialTools([...selectedTools]);
-        setInitialDisabled(values.disabled);
-        setAllowChat(values.allow_chat);
-        // Reload agent to get updated MCP servers from the agent document
         if (id) {
           getAgent(id).then((updatedData: AgentDoc) => {
+            form.reset(mapAgentDocToFormValues(updatedData));
+            // Reset tools, disabled state, and persisted allow_chat after successful update
+            setInitialTools([...selectedTools]);
+            setInitialDisabled(updatedData.disabled === 1);
+            setAllowChat(updatedData.allow_chat === 1);
             // Reload MCP servers from updated agent document
             if (updatedData.agent_mcp_server && Array.isArray(updatedData.agent_mcp_server) && updatedData.agent_mcp_server.length > 0) {
-              const childTableServers: MCPServerRef[] = updatedData.agent_mcp_server.map((item: any) => ({
+              const childTableServers: MCPServerRef[] = (updatedData.agent_mcp_server as AgentMcpServerRow[]).map((item) => ({
                 name: item.name || '',
                 mcp_server: item.mcp_server,
                 server_url: item.server_url || '',
@@ -648,7 +664,7 @@ export function AgentFormPage() {
     } finally {
       setSaving(false);
     }
-  };
+  }, [form, id, isNew, mcpServers, navigate, selectedTools]);
 
   // Memoize the form submit handler to avoid recreating it on every render
   const handleFormSubmit = useMemo(
@@ -749,7 +765,7 @@ export function AgentFormPage() {
         setToolFormData({
           tool_name: tool.tool_name,
           tool_type: tool.tool_type,
-          types: tool.types as any,
+          types: tool.types as ToolType,
           description: tool.description,
           reference_doctype: tool.reference_doctype,
           agent: tool.agent,
@@ -1031,6 +1047,8 @@ export function AgentFormPage() {
                   watchProvider={watchProvider}
                   optimizingPrompt={optimizingPrompt}
                   onOptimizePrompt={handleOptimizePrompt}
+                  promptOptions={promptOptions}
+                  loadingPrompts={loadingPrompts}
                 />
               </TabsContent>
 

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -212,10 +212,10 @@ export interface AgentDoc {
   total_run?: number; // Total number of runs
   agent_color?: string | null; // Hex color code for agent background
   default_plan: AgentOrchestrationPlanRow[];
-  prompt_mode: string; // 'local' or 'template'
+  prompt_mode: 'Local' | 'Template';
   agent_prompt?: string;
   prompt_version_locked?: number; // 0 or 1
-  attached_at_version?: number; // Version number when prompt was attached
+  template_version_at_attach?: number; // Version number when prompt was attached
   copied_from_prompt?: string | null; // Name of the prompt this agent was copied from, if any
   enable_prompt_caching?: number; // 0 or 1
   cache_control_type?: string | null; // ephemeral or persistent


### PR DESCRIPTION
### Motivation
- Provide frontend parity for Agent Prompt Template mode so agents can use reusable prompts and version locking as implemented on the backend. 
- Correct the field-name mismatch (`attached_at_version` → `template_version_at_attach`) that prevented template attach versions from loading/saving correctly. 

### Description
- Add a reusable `PromptTemplateSection` component to select an `Agent Prompt`, toggle version-locking, and show the read-only attached version. 
- Expose a Prompt Mode selector in the General tab and switch between inline `instructions` (Local) and `PromptTemplateSection` (Template). 
- Load active Agent Prompt options from the backend (`db.getDocList('Agent Prompt', ...)`) and surface them in a searchable `Combobox`. 
- Fix frontend/backend mapping: unify on `template_version_at_attach` across form schema, types, load/save mapping and added `mapAgentDocToFormValues` to centralize conversion. 
- Update Zod form schema to require an `agent_prompt` when `prompt_mode === 'Template'` and add small type fixes (Tool type casting and AgentDoc prompt_mode/type adjustments). 
- Reset dependent prompt-template fields when switching modes and refresh form state from backend after save so attached-version is accurate.

### Testing
- Ran ESLint for affected files: `npx eslint -c frontend/eslint.config.js frontend/src/components/agent/types.ts frontend/src/types/agent.types.ts frontend/src/components/agent/PromptTemplateSection.tsx frontend/src/components/agent/GeneralTab.tsx frontend/src/pages/AgentFormPage.tsx` and resolved issues; lint passed for the changes. (Passed)
- Performed `git diff --check` to ensure there are no whitespace/diff errors. (Passed)
- Ran TypeScript typecheck with `npx tsc --noEmit -p frontend/tsconfig.app.json` in the environment; typecheck completed for the modified files after fixes. (Completed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb6915e5c08321846ddce7c22b3d21)