### PR TITLE
chore(security): block compromised LiteLLM 1.82.7/1.82.8 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,19 @@ bench restart
 
 ---
 
+## Security Notice (LiteLLM)
+
+LiteLLM is a core dependency of Huf. On **March 24, 2026**, the LiteLLM team reported a supply-chain compromise affecting published releases (`1.82.7` and `1.82.8`) that included a malicious `.pth` startup payload.
+
+What Huf has done:
+- Blocked compromised versions in dependency constraints (`litellm>=1.0.0,!=1.82.7,!=1.82.8`).
+- Added install-time detection in `huf/install.py` to show a critical alert if a compromised LiteLLM version is already present in the environment.
+
+Upstream incident thread:
+- https://github.com/BerriAI/litellm/issues/24518
+
+---
+
 ## Documentation
 
 - [**Full Documentation**](https://docs.huf.ai/) — Guides, tutorials, and API reference

--- a/huf/install.py
+++ b/huf/install.py
@@ -74,7 +74,20 @@ def after_install():
     """
     try:
         import litellm
-        frappe.msgprint("✅ LiteLLM is installed and ready to use.")
+        from importlib.metadata import version as get_installed_version
+
+        litellm_version = get_installed_version("litellm")
+        compromised_versions = {"1.82.7", "1.82.8"}
+
+        if litellm_version in compromised_versions:
+            frappe.msgprint(
+                "🚨 Compromised LiteLLM version detected "
+                f"({litellm_version}). Rotate credentials and reinstall a safe version immediately.",
+                indicator="red",
+                title="Critical Security Alert",
+            )
+        else:
+            frappe.msgprint(f"✅ LiteLLM is installed and ready to use (v{litellm_version}).")
     except ImportError:
         frappe.msgprint(
             "⚠️ LiteLLM package not found. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
     "openai-agents",
-    "litellm>=1.0.0",
+    "litellm>=1.0.0,!=1.82.7,!=1.82.8",
     "llama-index-core>=0.10.0",
     "sqlite-vec",
     "pysqlite3-binary",


### PR DESCRIPTION
### Motivation
- A supply-chain compromise in LiteLLM releases allows execution via a malicious `litellm_init.pth`, so installs of affected versions must be prevented.
- The repository previously allowed unconstrained `litellm>=1.0.0`, which could resolve to compromised releases and expose secrets on affected hosts.
- Add runtime detection to surface a critical alert if a compromised version is already installed to prompt immediate operational response.

### Description
- Updated dependency constraints in `pyproject.toml` to exclude the compromised releases by adding `litellm>=1.0.0,!=1.82.7,!=1.82.8`.
- Added an install-time check in `huf/install.py` to read the installed `litellm` version using `importlib.metadata.version` and display a red critical alert when the version is `1.82.7` or `1.82.8`.
- The install hook still falls back to the existing message when `litellm` is not installed and preserves the existing `sqlite_vec` availability check.

### Testing
- Verified code references to LiteLLM with `rg -n "litellm|LiteLLM"` to confirm locations that depend on the package and to scope the change.
- Searched the workspace for any `litellm_init.pth` artifacts with `find /workspace -type f -name 'litellm_init.pth'` and found none in the repository workspace.
- Inspected the modified files (`pyproject.toml` and `huf/install.py`) to confirm the dependency exclusion and the runtime detection logic were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f908ad1c832192f5571ca093d65d)