### PR TITLE
Detect and block compromised LiteLLM releases (1.82.7, 1.82.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ HUF sits at the intersection of knowledge, automation, and tools—enabling AI t
 
 [**Documentation**](https://docs.huf.ai/) | [**Report Issue**](https://github.com/tridz-dev/huf/issues) | [**Discussions**](https://github.com/tridz-dev/huf/discussions)
 
+> ⚠️ **Security notice (LiteLLM):** LiteLLM (a HUF dependency) reported compromised PyPI releases `1.82.7` and `1.82.8` on **March 24, 2026**. HUF blocks these versions and shows an install-time alert if detected. Incident: https://github.com/BerriAI/litellm/issues/24518
+
 <br/>
 
 <img width="1905" height="928" alt="HUF Dashboard" src="https://github.com/user-attachments/assets/61a8511b-80cc-4843-a90c-bfcfc4a45c97" />

--- a/huf/install.py
+++ b/huf/install.py
@@ -74,7 +74,20 @@ def after_install():
     """
     try:
         import litellm
-        frappe.msgprint("✅ LiteLLM is installed and ready to use.")
+        from importlib.metadata import version as get_installed_version
+
+        litellm_version = get_installed_version("litellm")
+        compromised_versions = {"1.82.7", "1.82.8"}
+
+        if litellm_version in compromised_versions:
+            frappe.msgprint(
+                "🚨 Compromised LiteLLM version detected "
+                f"({litellm_version}). Rotate credentials and reinstall a safe version immediately.",
+                indicator="red",
+                title="Critical Security Alert",
+            )
+        else:
+            frappe.msgprint(f"✅ LiteLLM is installed and ready to use (v{litellm_version}).")
     except ImportError:
         frappe.msgprint(
             "⚠️ LiteLLM package not found. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
     "openai-agents",
-    "litellm>=1.0.0",
+    "litellm>=1.0.0,!=1.82.7,!=1.82.8",
     "llama-index-core>=0.10.0",
     "sqlite-vec",
     "pysqlite3-binary",


### PR DESCRIPTION
### Motivation
- Respond to a security incident where LiteLLM PyPI releases `1.82.7` and `1.82.8` were reported compromised and prevent those versions from being used by HUF.
- Provide clear, install-time alerts to operators so they can rotate credentials and install a safe `litellm` version.

### Description
- Add a README security notice calling out the compromised `litellm` releases and linking to the incident report in the README.
- Enhance `after_install` to detect the installed `litellm` version using `importlib.metadata.version` and surface a critical alert via `frappe.msgprint` when a compromised version is present, otherwise confirm the installed version.
- Update `pyproject.toml` dependency constraints to include `!=1.82.7,!=1.82.8` so those versions are excluded from installation.
- Preserve existing dependency and environment checks (for example `sqlite_vec`) and non-fatal handling when unavailable.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f908ad1c832192f5571ca093d65d)