### PR TITLE
fix: comprehensive HTTP tool security hardening & review

### DIFF
--- a/frontend/src/components/tools/toolCreationForm.utils.ts
+++ b/frontend/src/components/tools/toolCreationForm.utils.ts
@@ -35,12 +35,24 @@ export const createToolFormSchema = (availableToolTypes: ToolType[]) => {
     function_name: z.string().optional(),
     pass_parameters_as_json: z.boolean().optional(),
     provider_app: z.string().optional(),
-    base_url: z.string().optional(),
+    base_url: z
+      .string()
+      .refine((val) => !val || /^https?:\/\/.+/.test(val), {
+        message: 'Must be a valid URL starting with http:// or https://',
+      })
+      .optional(),
     required_permission: z.enum(['read', 'write', 'create', 'delete', 'submit', 'cancel']).optional(),
     is_read_only: z.boolean().optional(),
     allowed_for_guest: z.boolean().optional(),
     parameters: z.array(z.any()).optional(),
-    http_headers: z.array(z.any()).optional(),
+    http_headers: z
+      .array(
+        z.object({
+          key: z.string(),
+          value: z.string(),
+        })
+      )
+      .optional(),
   });
 };
 

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -127,7 +127,16 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 		# Make the request
 		response = requests.request(method, final_url, **request_kwargs)
 
-		# Check response size before parsing
+		# Check response size — pre-check via Content-Length header, then verify actual content
+		content_length = response.headers.get("Content-Length")
+		if content_length and content_length.isdigit() and int(content_length) > MAX_RESPONSE_SIZE:
+			return {
+				"success": False,
+				"error": "Response too large (Content-Length exceeds 10MB limit)",
+				"status_code": response.status_code,
+				"suggestion": "The API indicates a response larger than 10MB. Try requesting less data.",
+			}
+
 		if len(response.content) > MAX_RESPONSE_SIZE:
 			return {
 				"success": False,

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -1,177 +1,207 @@
+import json
+import re
+import socket
+from urllib.parse import urlparse
+
 import frappe
 import requests
 from requests.exceptions import RequestException
-import json
-from urllib.parse import urlparse
+
+ALLOWED_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"}
+MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10MB
+
+_PRIVATE_IP_PATTERN = re.compile(
+	r"^(127\.|10\.|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[0-1]\.|192\.168\.|0\.|169\.254\.)"
+)
 
 
-def validate_url(url, tool_name=None):
-    """
-    Validate URL to prevent SSRF and other attacks
-    """
-    from urllib.parse import urlparse
-    import re
-    
-    # Parse the URL
-    parsed = urlparse(url)
-    
-    # If tool has a base URL, validate against it
-    if tool_name:
-        tool_doc = frappe.get_doc("Agent Tool Function", tool_name)
-        if tool_doc.base_url:
-            tool_parsed = urlparse(tool_doc.base_url)
-            if parsed.netloc != tool_parsed.netloc:
-                return False
-    
-    # Block private IP addresses
-    if parsed.hostname:
-        # Regex to match private IPs
-        private_ip_pattern = re.compile(
-            r'^(127\.|10\.|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[0-1]\.|192\.168\.)'
-        )
-        
-        if private_ip_pattern.match(parsed.hostname):
-            return False
-            
-        if parsed.hostname in ['localhost', '127.0.0.1', '::1']:
-            return False
-    
-    # Allow only HTTP and HTTPS
-    if parsed.scheme not in ['http', 'https']:
-        return False
-        
-    
-    return True
+def validate_url(url):
+	"""
+	Validate URL to prevent SSRF and other attacks.
+
+	Returns a tuple (is_valid, error_message).
+	"""
+	parsed = urlparse(url)
+
+	# Allow only HTTP and HTTPS
+	if parsed.scheme not in ("http", "https"):
+		return False, "Only HTTP and HTTPS schemes are allowed"
+
+	if not parsed.hostname:
+		return False, "Invalid URL: no hostname"
+
+	# Resolve hostname to check actual IP addresses (prevents DNS rebinding)
+	try:
+		addr_info = socket.getaddrinfo(parsed.hostname, None)
+		ips = {info[4][0] for info in addr_info}
+	except socket.gaierror:
+		return False, f"Cannot resolve hostname: {parsed.hostname}"
+
+	for ip in ips:
+		if _PRIVATE_IP_PATTERN.match(ip) or ip in ("::1", "0.0.0.0"):
+			return False, "Requests to private/internal addresses are not allowed"
+
+	return True, None
 
 
 @frappe.whitelist(allow_guest=True)
 def handle_http_request(method, url, headers=None, params=None, data=None, json_data=None, tool_name=None):
-    """
-    Generic HTTP request handler with support for tool-defined headers
-    """
-    try:
-        tool_info = {}
-        tool_allowed_for_guest = False
-        
-        if tool_name:
-            try:
-                tool_doc = frappe.get_doc("Agent Tool Function", tool_name)
-                # Extract headers from tool's http_headers child table
-                tool_headers = {}
-                if hasattr(tool_doc, 'http_headers') and tool_doc.http_headers:
-                    for header in tool_doc.http_headers:
-                        if header.key and header.value:
-                            tool_headers[header.key] = header.value
-                
-                tool_info = {
-                    "base_url": tool_doc.base_url,
-                    "headers": tool_headers
-                }
-                tool_allowed_for_guest = bool(tool_doc.allowed_for_guest)
-            except frappe.DoesNotExistError:
-                return {
-                    "success": False,
-                    "error": f"Tool '{tool_name}' not found"
-                }
-        
-        # Check if guest user is trying to use a tool that doesn't allow guest access
-        if frappe.session.user == "Guest" and not tool_allowed_for_guest:
-            return {
-                "success": False,
-                "error": "This tool does not allow guest access. Please log in or enable 'Allowed for Guest' on the tool.",
-                "status_code": 403
-            }
-        
-        # Apply base URL if specified in tool
-        final_url = url
-        if tool_info.get("base_url"):
-            # If the provided URL is relative, combine with base URL
-            if not url.startswith(('http://', 'https://')):
-                final_url = tool_info["base_url"].rstrip('/') + '/' + url.lstrip('/')
-        
-        # Merge tool headers with request headers
-        # Tool headers come first, then request headers can override them
-        tool_headers = tool_info.get("headers", {}) or {}
-        request_headers = headers or {}
-        final_headers = {**tool_headers, **request_headers}
-        
-        # Prepare request parameters
-        request_kwargs = {
-            'headers': final_headers,
-            'params': params or {},
-            'timeout': 30
-        }
-        
-        # Add data or json based on what's provided
-        if data is not None:
-            request_kwargs['data'] = data
-        if json_data is not None:
-            request_kwargs['json'] = json_data
-            
-        # Make the request
-        response = requests.request(method, final_url, **request_kwargs)
-        
-        # Try to parse JSON response, fall back to text
-        try:
-            response_data = response.json()
-        except ValueError:
-            response_data = response.text
-            
-        # Return standardized response
-        result = {
-            "success": True,
-            "status_code": response.status_code,
-            "headers": dict(response.headers),
-            "data": response_data,
-            "final_url": final_url
-        }
-        
-        # Add guidance for the AI if it's an error
-        if response.status_code >= 400:
-            result["suggestion"] = "Check if the URL is correct and if you need to include authentication headers."
-            
-        return result
-        
-    except RequestException as e:
-        frappe.log_error(f"HTTP Request Error: {str(e)}", "HTTP Handler")
-        return {
-            "success": False,
-            "error": str(e),
-            "suggestion": "Check the URL and network connection.",
-            "status_code": getattr(e.response, 'status_code', None) if hasattr(e, 'response') else None
-        }
+	"""
+	Generic HTTP request handler with support for tool-defined headers
+	"""
+	# Validate HTTP method
+	if method.upper() not in ALLOWED_METHODS:
+		return {
+			"success": False,
+			"error": f"HTTP method '{method}' is not allowed. Allowed methods: {', '.join(sorted(ALLOWED_METHODS))}",
+		}
+
+	try:
+		tool_info = {}
+		tool_allowed_for_guest = False
+
+		if tool_name:
+			try:
+				tool_doc = frappe.get_doc("Agent Tool Function", tool_name)
+				# Extract headers from tool's http_headers child table
+				tool_headers = {}
+				if hasattr(tool_doc, "http_headers") and tool_doc.http_headers:
+					for header in tool_doc.http_headers:
+						if header.key and header.value:
+							tool_headers[header.key] = header.value
+
+				tool_info = {
+					"base_url": tool_doc.base_url,
+					"headers": tool_headers,
+				}
+				tool_allowed_for_guest = bool(tool_doc.allowed_for_guest)
+			except frappe.DoesNotExistError:
+				return {
+					"success": False,
+					"error": f"Tool '{tool_name}' not found",
+				}
+
+		# Check if guest user is trying to use a tool that doesn't allow guest access
+		if frappe.session.user == "Guest" and not tool_allowed_for_guest:
+			return {
+				"success": False,
+				"error": "This tool does not allow guest access. Please log in or enable 'Allowed for Guest' on the tool.",
+				"status_code": 403,
+			}
+
+		# Apply base URL if specified in tool
+		final_url = url
+		if tool_info.get("base_url"):
+			# If the provided URL is relative, combine with base URL
+			if not url.startswith(("http://", "https://")):
+				final_url = tool_info["base_url"].rstrip("/") + "/" + url.lstrip("/")
+
+		# Validate URL to prevent SSRF
+		is_valid, error_msg = validate_url(final_url)
+		if not is_valid:
+			return {
+				"success": False,
+				"error": error_msg,
+				"suggestion": "Ensure the URL points to a public, external service.",
+			}
+
+		# Merge tool headers with request headers
+		# Tool headers come first, then request headers can override them
+		tool_headers = tool_info.get("headers", {}) or {}
+		request_headers = headers or {}
+		final_headers = {**tool_headers, **request_headers}
+
+		# Prepare request parameters
+		request_kwargs = {
+			"headers": final_headers,
+			"params": params or {},
+			"timeout": 30,
+		}
+
+		# Add data or json based on what's provided
+		if data is not None:
+			request_kwargs["data"] = data
+		if json_data is not None:
+			request_kwargs["json"] = json_data
+
+		# Make the request
+		response = requests.request(method, final_url, **request_kwargs)
+
+		# Check response size before parsing
+		if len(response.content) > MAX_RESPONSE_SIZE:
+			return {
+				"success": False,
+				"error": "Response too large",
+				"status_code": response.status_code,
+				"suggestion": "The API response exceeds the 10MB size limit. Try requesting less data.",
+			}
+
+		# Try to parse JSON response, fall back to text
+		try:
+			response_data = response.json()
+		except ValueError:
+			response_data = response.text
+
+		# Return standardized response
+		result = {
+			"success": True,
+			"status_code": response.status_code,
+			"headers": dict(response.headers),
+			"data": response_data,
+			"final_url": final_url,
+		}
+
+		# Add guidance for the AI if it's an error
+		if response.status_code >= 400:
+			result["suggestion"] = (
+				"Check if the URL is correct and if you need to include authentication headers."
+			)
+
+		return result
+
+	except RequestException as e:
+		frappe.log_error(f"HTTP Request Error: {e!s}", "HTTP Handler")
+		return {
+			"success": False,
+			"error": str(e),
+			"suggestion": "Check the URL and network connection.",
+			"status_code": getattr(e.response, "status_code", None) if hasattr(e, "response") else None,
+		}
+
 
 @frappe.whitelist(allow_guest=True)
 def handle_get_request(url, headers=None, params=None, tool_name=None):
-    """
-    Handle GET requests with tool-defined headers
-    """
-    return handle_http_request('GET', url, headers=headers, params=params, tool_name=tool_name)
+	"""
+	Handle GET requests with tool-defined headers
+	"""
+	return handle_http_request("GET", url, headers=headers, params=params, tool_name=tool_name)
 
 
 @frappe.whitelist(allow_guest=True)
 def handle_post_request(url, headers=None, data=None, json_data=None, tool_name=None):
-    """
-    Handle POST requests with JSON data support
-    """
-    # Convert string JSON to dict if needed
-    if isinstance(json_data, str):
-        try:
-            json_data = json.loads(json_data)
-        except json.JSONDecodeError:
-            return {
-                "success": False,
-                "error": "Invalid JSON data provided"
-            }
-    
-    # If data is provided but json_data is not, try to parse data as JSON
-    if data is not None and json_data is None:
-        if isinstance(data, str):
-            try:
-                json_data = json.loads(data)
-                data = None  # Clear data since we're using json_data now
-            except json.JSONDecodeError:
-                # If it's not JSON, keep it as form data
-                pass
-    
-    return handle_http_request('POST', url, headers=headers, data=data, json_data=json_data, tool_name=tool_name)
+	"""
+	Handle POST requests with JSON data support
+	"""
+	# Convert string JSON to dict if needed
+	if isinstance(json_data, str):
+		try:
+			json_data = json.loads(json_data)
+		except json.JSONDecodeError:
+			return {
+				"success": False,
+				"error": "Invalid JSON data provided",
+			}
+
+	# If data is provided but json_data is not, try to parse data as JSON
+	if data is not None and json_data is None:
+		if isinstance(data, str):
+			try:
+				json_data = json.loads(data)
+				data = None  # Clear data since we're using json_data now
+			except json.JSONDecodeError:
+				# If it's not JSON, keep it as form data
+				pass
+
+	return handle_http_request(
+		"POST", url, headers=headers, data=data, json_data=json_data, tool_name=tool_name
+	)

--- a/huf/ai/knowledge/extractors/url.py
+++ b/huf/ai/knowledge/extractors/url.py
@@ -1,14 +1,16 @@
 """URL content extractor using requests and BeautifulSoup."""
 
+from urllib.parse import urlparse
+
 import requests
 from bs4 import BeautifulSoup
-from urllib.parse import urlparse
-from . import TextExtractor, ExtractedText
+
+from . import ExtractedText, TextExtractor
 
 
 class URLExtractor(TextExtractor):
 	"""Extractor for URL content."""
-	
+
 	def extract(self, url: str) -> ExtractedText:
 		"""Extract text from URL."""
 		try:
@@ -16,43 +18,49 @@ class URLExtractor(TextExtractor):
 			headers = {
 				"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
 			}
+			from huf.ai.http_handler import validate_url
+
+			is_valid, error_msg = validate_url(url)
+			if not is_valid:
+				raise ValueError(f"URL blocked: {error_msg}")
+
 			response = requests.get(url, headers=headers, timeout=30)
 			response.raise_for_status()
-			
+
 			# Parse HTML
 			soup = BeautifulSoup(response.content, "html.parser")
-			
+
 			# Remove script and style elements
 			for script in soup(["script", "style"]):
 				script.decompose()
-			
+
 			# Extract title
 			title_tag = soup.find("title")
 			title = title_tag.get_text().strip() if title_tag else None
-			
+
 			# Extract main content (prefer article, main, or body)
 			content_selectors = ["article", "main", "[role='main']", "body"]
 			content = None
-			
+
 			for selector in content_selectors:
 				element = soup.select_one(selector)
 				if element:
 					content = element.get_text(separator="\n", strip=True)
 					break
-			
+
 			if not content:
 				# Fallback to all text
 				content = soup.get_text(separator="\n", strip=True)
-			
+
 			# Clean up whitespace
 			lines = [line.strip() for line in content.split("\n") if line.strip()]
 			text = "\n".join(lines)
-			
+
 			# Use URL domain as title if no title found
 			if not title:
 				parsed_url = urlparse(url)
 				title = parsed_url.netloc or url
-			
+
 			return ExtractedText(
 				text=text,
 				title=title,
@@ -62,8 +70,8 @@ class URLExtractor(TextExtractor):
 					"status_code": response.status_code,
 				},
 			)
-			
+
 		except requests.exceptions.RequestException as e:
-			raise ValueError(f"Failed to fetch URL: {str(e)}")
+			raise ValueError(f"Failed to fetch URL: {e!s}")
 		except Exception as e:
-			raise ValueError(f"Error extracting text from URL: {str(e)}")
+			raise ValueError(f"Error extracting text from URL: {e!s}")

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -1,47 +1,51 @@
-import inspect
-import json
-from typing import Any, Callable
-from frappe.utils.background_jobs import enqueue
-import base64
-from frappe.utils.file_manager import save_file
 import asyncio
-import frappe
-import io
-import requests
 import base64
-from frappe.utils.file_manager import save_file
-from frappe import _
+import hashlib
+import inspect
+import io
+import json
+import re
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from typing import Any
+
+import frappe
+import requests
 from agents import FunctionTool
-from frappe import client
+from frappe import _, client
+from frappe.utils.background_jobs import enqueue
+from frappe.utils.file_manager import save_file
 
 from .tool_functions import (
-    create_documents,update_documents,
-    delete_documents,submit_document, cancel_document,
-    get_value, set_value, get_report_result,attach_file_to_document
+    attach_file_to_document,
+    cancel_document,
+    create_documents,
+    delete_documents,
+    get_report_result,
+    get_value,
+    set_value,
+    submit_document,
+    update_documents,
 )
-import re
-import hashlib
-from datetime import datetime, timedelta
-
-
 from .tool_registry import PermissionAwareToolRegistry
+
 MUTATING_TOOL_TYPES = PermissionAwareToolRegistry.MUTATING_TOOL_TYPES
 
 def _check_tool_permission(tool_type: str, context: dict = None, allowed_for_guest: bool = False):
     """Guard function to block dangerous tools for Guest users"""
     user = frappe.session.user
-    
+
     #Guest cannot use mutating tools unless explicitly allowed
     if user == "Guest":
         if allowed_for_guest:
             return {"allowed": True}
-             
+
         if tool_type in MUTATING_TOOL_TYPES:
             return {
                 "allowed": False,
                 "error": f"Guest users cannot use {tool_type} tools. Please log in."
             }
-    
+
     return {"allowed": True}
 
 def create_agent_tools(agent) -> list[FunctionTool]:
@@ -53,7 +57,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
     2. Native tools from Agent Tool Function documents
     """
     tools = []
-    
+
     # Load MCP tools from linked MCP servers
     if hasattr(agent, "agent_mcp_server") and agent.agent_mcp_server:
         try:
@@ -62,14 +66,14 @@ def create_agent_tools(agent) -> list[FunctionTool]:
             tools.extend(mcp_tools)
         except Exception as e:
             frappe.log_error(
-                f"Error loading MCP tools for agent: {str(e)}",
+                f"Error loading MCP tools for agent: {e!s}",
                 "MCP Tool Loading Error"
             )
-    
+
     # Load native tools from Agent Tool Function documents
 
     from huf.ai.tool_registry import PermissionAwareToolRegistry
-    
+
     allowed_tool_docs = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
 
     for function_doc in allowed_tool_docs:
@@ -139,7 +143,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         except Exception as e:
                             frappe.log_error(
                                 "SDK Functions Debug",
-                                f"Error parsing params for {function_doc.name}: {str(e)}"
+                                f"Error parsing params for {function_doc.name}: {e!s}"
                             )
 
                     if "additionalProperties" in params:
@@ -161,7 +165,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         and function_doc.reference_doctype
                     ):
                         extra_args["reference_doctype"] = function_doc.reference_doctype
-                    
+
                     elif function_doc.types == "Client Side Tool":
                         if function_doc.function_name:
                             extra_args["function_name"] = function_doc.function_name
@@ -186,13 +190,13 @@ def create_agent_tools(agent) -> list[FunctionTool]:
             except Exception as e:
                 frappe.log_error(
                     "SDK Functions Debug",
-                    f"Error processing function {function_doc.name}: {str(e)}"
+                    f"Error processing function {function_doc.name}: {e!s}"
                 )
 
-    
+
     if hasattr(agent, "enable_conversation_data") and agent.enable_conversation_data:
         existing_types = [t.name for t in tools]
-        
+
         # Get Conversation Data
         if "get_conversation_data" not in existing_types:
             tool = create_function_tool(
@@ -305,7 +309,7 @@ def create_function_tool(
 
                 if "ignore_permissions" in args_dict:
                     del args_dict["ignore_permissions"]
-                
+
                 if allowed_for_guest and frappe.session.user == "Guest":
                     args_dict["ignore_permissions"] = True
 
@@ -315,20 +319,20 @@ def create_function_tool(
 
                 sig = inspect.signature(_function)
                 accepts_kwargs = any(
-                    p.kind == inspect.Parameter.VAR_KEYWORD 
+                    p.kind == inspect.Parameter.VAR_KEYWORD
                     for p in sig.parameters.values()
                 )
                 if accepts_kwargs:
                     result = _function(**args_dict)
                 else:
                     valid_params = set(sig.parameters.keys())
-                    
+
                     filtered_args = {
-                        k: v for k, v in args_dict.items() 
+                        k: v for k, v in args_dict.items()
                         if k in valid_params
                     }
                     result = _function(**filtered_args)
-                
+
                 # Handle async functions
                 if asyncio.iscoroutine(result):
                     result = await result
@@ -339,7 +343,7 @@ def create_function_tool(
                 return json.dumps(result, default=str) if isinstance(result, (dict, list)) else str(result)
 
             except Exception as e:
-                frappe.log_error(f"Error in on_invoke_tool for tool '{name}': {str(e)}", "SDK Functions Debug")
+                frappe.log_error(f"Error in on_invoke_tool for tool '{name}': {e!s}", "SDK Functions Debug")
                 return json.dumps({"error": str(e)})
 
         safe_name = re.sub(r'[^a-zA-Z0-9_-]', '_', (name or ""))
@@ -360,7 +364,7 @@ def create_function_tool(
         return tool
 
     except Exception as e:
-        frappe.log_error(f"Error creating FunctionTool for {name}: {str(e)}", "SDK Functions Debug")
+        frappe.log_error(f"Error creating FunctionTool for {name}: {e!s}", "SDK Functions Debug")
         return None
 
 
@@ -378,7 +382,7 @@ def get_function_from_name(tool_name: str) -> Callable:
 	try:
 		try:
 			module_name, func_name = tool_name.rsplit(".", 1)
-		except ValueError as ve:
+		except ValueError:
 			frappe.log_error(
 				"SDK Functions Debug",
 				f"Invalid function name format: {tool_name}. Should be 'module.function'",
@@ -388,18 +392,18 @@ def get_function_from_name(tool_name: str) -> Callable:
 		try:
 			module = __import__(module_name, fromlist=[func_name])
 		except ImportError as ie:
-			frappe.log_error("SDK Functions Debug", f"Module import error: {str(ie)}")
+			frappe.log_error("SDK Functions Debug", f"Module import error: {ie!s}")
 			return None
 
 		try:
 			available_attrs = dir(module)
 		except Exception as e:
-			frappe.log_error("SDK Functions Debug", f"Error getting module attributes: {str(e)}")
+			frappe.log_error("SDK Functions Debug", f"Error getting module attributes: {e!s}")
 
 		try:
 			function = getattr(module, func_name)
 		except AttributeError as ae:
-			frappe.log_error("SDK Functions Debug", f"Function not found in module: {str(ae)}")
+			frappe.log_error("SDK Functions Debug", f"Function not found in module: {ae!s}")
 			return None
 
 		if not callable(function):
@@ -409,7 +413,7 @@ def get_function_from_name(tool_name: str) -> Callable:
 
 	except Exception as e:
 		frappe.log_error(
-			"SDK Functions Debug", f"Unexpected error getting function {tool_name}: {str(e)}"
+			"SDK Functions Debug", f"Unexpected error getting function {tool_name}: {e!s}"
 		)
 		return None
 
@@ -456,22 +460,22 @@ def _sanitize_for_doctype(doctype: str, data: dict) -> dict:
         meta = frappe.get_meta(doctype)
         valid_fields = {df.fieldname for df in meta.fields}
         cleaned = {}
-        
+
         for key, value in (data or {}).items():
             if key not in valid_fields:
                 continue
-                
+
             df = meta.get_field(key)
             if df.fieldtype == "Table":
                 if isinstance(value, list):
                     cleaned[key] = [
-                        _sanitize_for_doctype(df.options, row) 
-                        for row in value 
+                        _sanitize_for_doctype(df.options, row)
+                        for row in value
                         if isinstance(row, dict)
                     ]
             else:
                 cleaned[key] = value
-                
+
         return cleaned
     except Exception:
         return data or {}
@@ -691,7 +695,7 @@ def handle_create_document(reference_doctype=None, ignore_permissions=False, **k
 
         return {"success": True, "result": doc_dict, "message": f"{reference_doctype} created"}
     except Exception as e:
-        frappe.log_error("SDK Functions Debug", f"Error in handle_create_document: {str(e)}")
+        frappe.log_error("SDK Functions Debug", f"Error in handle_create_document: {e!s}")
         return {"success": False, "error": str(e)}
 
 
@@ -729,7 +733,7 @@ def handle_delete_document(document_id=None, reference_doctype=None, ignore_perm
 
         return {"success": True, "message": f"{reference_doctype} {document_id} deleted"}
     except Exception as e:
-        frappe.log_error("SDK Functions Debug", f"Error in handle_delete_document: {str(e)}")
+        frappe.log_error("SDK Functions Debug", f"Error in handle_delete_document: {e!s}")
         return {"success": False, "error": str(e)}
 
 
@@ -841,13 +845,13 @@ def handle_get_list(
 			response["warning"] = warning
 
 
-		response["valid_fields"] = valid_fields[:20]  
+		response["valid_fields"] = valid_fields[:20]
 		if len(valid_fields) > 20:
 			response["valid_fields_note"] = f"Showing first 20 of {len(valid_fields)} available fields"
 
 		return response
 	except Exception as e:
-		frappe.log_error("SDK Functions Debug", f"Error in handle_get_list: {str(e)}")
+		frappe.log_error("SDK Functions Debug", f"Error in handle_get_list: {e!s}")
 		return {"success": False, "error": str(e)}
 
 
@@ -884,7 +888,7 @@ def handle_update_document(document_id=None, data=None, reference_doctype=None, 
             doc.set(field, value)
 
         doc.save(ignore_permissions=ignore_permissions)
-        frappe.db.commit() 
+        frappe.db.commit()
 
         return {
             "success": True,
@@ -892,7 +896,7 @@ def handle_update_document(document_id=None, data=None, reference_doctype=None, 
             "message": f"{reference_doctype} {document_id} updated successfully.",
         }
     except Exception as e:
-        frappe.log_error("SDK Functions Debug", f"Error in handle_update_document: {str(e)}")
+        frappe.log_error("SDK Functions Debug", f"Error in handle_update_document: {e!s}")
         return {"success": False, "error": str(e)}
 
 
@@ -943,7 +947,7 @@ def handle_get_document(document_id=None, reference_doctype=None, **filters):
         }
 
     except Exception as e:
-        frappe.log_error(f"Error in handle_get_document: {str(e)}", "SDK Functions Debug")
+        frappe.log_error(f"Error in handle_get_document: {e!s}", "SDK Functions Debug")
         return {"success": False, "error": str(e)}
 
 def handle_create_documents(reference_doctype: str, documents: list = None, data: list = None, **kwargs):
@@ -981,7 +985,7 @@ def handle_delete_documents(reference_doctype: str, document_ids: list, **kwargs
 def handle_submit_document(reference_doctype: str, document_id: str, ignore_permissions=False, **kwargs):
     if not ignore_permissions and not frappe.has_permission(reference_doctype, "submit", doc=document_id):
         return {"success": False, "error": "No permission to submit"}
-    
+
     doc = frappe.get_doc(reference_doctype, document_id)
     doc.submit()
     return {"success": True, "message": "Submitted"}
@@ -1094,7 +1098,7 @@ def handle_attach_file_to_document(reference_doctype, document_id, **kwargs):
         if k in ["file_path", "file_url"]:
             normalized_kwargs[k] = v
             continue
-            
+
         if isinstance(v, str):
             normalized_kwargs[k] = v
 
@@ -1128,7 +1132,7 @@ def _load_state(state_json: str | None | dict) -> dict:
                 except: pass
         except (json.JSONDecodeError, TypeError):
              return {"version": 1, "scope": {}, "items": []}
-             
+
     if "items" not in data or not isinstance(data["items"], list):
         data["items"] = []
     if "version" not in data:
@@ -1139,34 +1143,34 @@ def handle_get_conversation_data(name: str, default: Any = None, conversation_id
     """Get a value from conversation data."""
     if not conversation_id:
         return {"success": False, "error": "No conversation context provided"}
-    
+
     try:
         data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
         state = _load_state(data_json)
-        
+
         value = default
         for item in state["items"]:
             if item.get("name") == name:
                 value = item.get("value", default)
                 break
-                
+
         return {"success": True, "value": value}
     except Exception as e:
-        frappe.log_error(f"Error getting conversation data: {str(e)}", "Conversation Data")
+        frappe.log_error(f"Error getting conversation data: {e!s}", "Conversation Data")
         return {"success": False, "error": str(e)}
 
 def handle_set_conversation_data(
-    name: str, 
-    value: Any, 
-    value_type: str = None, 
-    source: str = "agent", 
-    conversation_id: str = None, 
+    name: str,
+    value: Any,
+    value_type: str = None,
+    source: str = "agent",
+    conversation_id: str = None,
     **kwargs
 ):
     """Set a value in conversation data."""
     if not conversation_id:
         return {"success": False, "error": "No conversation context provided"}
-    
+
     try:
         # Debug Log
         frappe.logger().info(f"[Conversation Data] Setting {name} for {conversation_id}")
@@ -1201,19 +1205,19 @@ def handle_set_conversation_data(
                 state["items"][i] = updated_item
                 found = True
                 break
-        
+
         if not found:
             state["items"].append(updated_item)
 
         new_json = json.dumps(state, ensure_ascii=False, indent=2)
-        
+
         frappe.db.set_value("Agent Conversation", conversation_id, "conversation_data", new_json)
         frappe.db.commit() # Persist changes immediately
-        
+
         return {"success": True, "message": f"Set '{name}' match successfully"}
-    
+
     except Exception as e:
-        frappe.log_error(f"Error setting conversation data: {str(e)}", "Conversation Data")
+        frappe.log_error(f"Error setting conversation data: {e!s}", "Conversation Data")
         return {"success": False, "error": str(e)}
 
 def handle_load_conversation_data(conversation_id: str = None, **kwargs):
@@ -1249,7 +1253,7 @@ def _get_default_image_model(provider_name: str) -> str:
         "bedrock": "bedrock/stability.stable-diffusion-xl-v0",
         "recraft": "recraft/recraftv3",
     }
-    
+
     return defaults.get(provider_name.lower())
 
 @frappe.whitelist()
@@ -1288,17 +1292,17 @@ async def handle_generate_image(
         # Get agent configuration from context
         if not agent_name:
             return {"success": False, "error": "Agent name not found in context"}
-        
+
         agent_doc = frappe.get_doc("Agent", agent_name)
         provider_doc = frappe.get_doc("AI Provider", agent_doc.provider)
         api_key = provider_doc.get_password("api_key")
-        
+
         if not api_key:
             return {"success": False, "error": "API key not configured for provider"}
-        
+
         # Determine image generation model
         image_model = None
-        
+
         if hasattr(agent_doc, "image_generation_model") and agent_doc.image_generation_model:
             # Use explicitly configured image model
             model_doc = frappe.get_doc("AI Model", agent_doc.image_generation_model)
@@ -1307,21 +1311,21 @@ async def handle_generate_image(
             # Auto-detect suitable image model based on provider
             provider_name = provider_doc.provider_name.lower()
             image_model = _get_default_image_model(provider_name)
-        
+
         if not image_model:
             return {
                 "success": False,
                 "error": f"Image generation not supported for provider '{provider_doc.provider_name}'. Please configure an image_generation_model in agent settings."
             }
-        
+
         # Normalize to LiteLLM format
         from huf.ai.providers.litellm import _normalize_model_name
         normalized_model = _normalize_model_name(image_model, agent_doc.provider)
-        
+
         # Call LiteLLM image generation
         import litellm
-        litellm.drop_params = True 
-        
+        litellm.drop_params = True
+
         response = await asyncio.to_thread(
             litellm.image_generation,
             prompt=prompt,
@@ -1331,7 +1335,7 @@ async def handle_generate_image(
             quality=quality,
             api_key=api_key
         )
-        
+
         # Get conversation_index once if conversation_id exists
         # Each Agent Message needs a unique, sequential conversation_index to maintain order.
         conversation_index = None
@@ -1342,11 +1346,11 @@ async def handle_generate_image(
                     FROM `tabAgent Message`
                     WHERE conversation = %s
                 """, (conversation_id,), as_dict=1)
-                
+
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
             except Exception:
                 conversation_index = 1
-        
+
         # Process response and save images
         images = []
         if hasattr(response, 'data') and response.data:
@@ -1354,27 +1358,32 @@ async def handle_generate_image(
                 # Get image URL or base64
                 image_url = None
                 image_b64 = None
-                
+
                 # Handle Pydantic model / Object access
                 if hasattr(image_data, 'url'):
                     image_url = image_data.url
                 if hasattr(image_data, 'b64_json'):
                     image_b64 = image_data.b64_json
-                
+
                 # Handle Dictionary access (if not an object)
                 if not image_url and not image_b64 and isinstance(image_data, dict):
                     image_url = image_data.get('url')
                     image_b64 = image_data.get('b64_json')
-                
+
                 if not image_url and not image_b64:
                     continue
-                
+
                 # Download and save image
                 image_bytes = None
                 filename = f"generated_image_{idx + 1}.png"
-                
+
                 if image_url and image_url.startswith('http'):
-                    # Download from URL
+                    # Download from URL (with SSRF protection)
+                    from huf.ai.http_handler import validate_url
+                    is_valid, _err = validate_url(image_url)
+                    if not is_valid:
+                        frappe.log_error(f"Image URL blocked by SSRF filter: {image_url}", "Image Generation")
+                        continue
                     img_response = requests.get(image_url, timeout=30)
                     img_response.raise_for_status()
                     image_bytes = img_response.content
@@ -1385,10 +1394,10 @@ async def handle_generate_image(
                     # Local file path or other format
                     frappe.log_error(f"Unsupported image URL format: {image_url}", "Image Generation")
                     continue
-                
+
                 if not image_bytes:
                     continue
-                
+
                 # Create Agent Message first (we'll attach the file to it)
                 message_doc = None
                 if conversation_id and conversation_index is not None:
@@ -1396,7 +1405,7 @@ async def handle_generate_image(
                         # Get provider and model from agent
                         provider = agent_doc.provider
                         model = agent_doc.model
-                        
+
                         # Create Agent Message with kind "Image" first (without image)
                         message_doc = frappe.get_doc({
                             "doctype": "Agent Message",
@@ -1415,11 +1424,11 @@ async def handle_generate_image(
                         message_doc.insert(ignore_permissions=True)
                     except Exception as e:
                         frappe.log_error(
-                            f"Error creating Agent Message for generated image: {str(e)}",
+                            f"Error creating Agent Message for generated image: {e!s}",
                             "Image Generation Message Creation"
                         )
                         # Continue even if message creation fails
-                
+
                 # Save file attached to the Agent Message (or conversation if message creation failed)
                 if message_doc:
                     saved_file = save_file(
@@ -1439,21 +1448,21 @@ async def handle_generate_image(
                         conversation_id or "Unknown",
                         is_private=False
                     )
-                
+
                 # save_file returns a File document object
                 file_url = getattr(saved_file, 'file_url', None)
                 file_id = getattr(saved_file, 'name', None)
-                
+
                 # Ensure we have a file_url
                 if not file_url:
                     file_url = f"/files/{getattr(saved_file, 'file_name', filename)}"
-                
+
                 # Update the message with the file URL if message was created
                 # This ensures the Attach Image field displays the image correctly
                 if message_doc and file_url:
                     message_doc.db_set("generated_image", file_url)
                     frappe.db.commit()
-                    
+
                     # Emit socket event for new agent message (Image)
                     try:
                         frappe.publish_realtime(
@@ -1473,15 +1482,15 @@ async def handle_generate_image(
                         )
                     except Exception as e:
                         frappe.log_error(
-                            f"Error emitting new_agent_message socket event: {str(e)}",
+                            f"Error emitting new_agent_message socket event: {e!s}",
                             "Image Generation Socket Event"
                         )
-                
+
                 images.append({
                     "url": file_url or f"/files/{filename}",
                     "file_id": file_id
                 })
-        
+
         # Update conversation total_messages once after all images are created
         if conversation_id and conversation_index is not None and images:
             try:
@@ -1493,25 +1502,25 @@ async def handle_generate_image(
                 """, (final_index, conversation_id))
             except Exception as e:
                 frappe.log_error(
-                    f"Error updating conversation total_messages: {str(e)}",
+                    f"Error updating conversation total_messages: {e!s}",
                     "Image Generation Message Creation"
                 )
-        
+
         if not images:
             return {
                 "success": False,
                 "error": "Image generation succeeded but no images were returned"
             }
-        
+
         print("Returned images: ", images)
         return {
             "success": True,
             "images": images,
             "message": f"Generated {len(images)} image(s) successfully"
         }
-        
+
     except Exception as e:
-        frappe.log_error(f"Image generation error: {str(e)}", "Image Generation Tool")
+        frappe.log_error(f"Image generation error: {e!s}", "Image Generation Tool")
         return {"success": False, "error": str(e)}
 
 
@@ -1519,15 +1528,15 @@ def _determine_ocr_strategy(file_path: str, file_type: str) -> str:
     """Determine OCR strategy based on file type."""
     # Check file extension if type not clear
     ext = file_path.lower().split('.')[-1] if '.' in file_path else ""
-    
+
     # PDF and documents - use OCR endpoint
     if file_type in ["pdf", "application/pdf"] or ext == "pdf":
         return "ocr"
-    
+
     # Images - use vision models
     if file_type.startswith("image/") or ext in ["jpg", "jpeg", "png", "webp", "gif"]:
         return "vision"
-    
+
     # Default to vision for unknown types
     return "vision"
 
@@ -1551,7 +1560,7 @@ def _get_default_ocr_model(provider_name: str, strategy: str) -> str:
             "gemini": "gemini/gemini-2.5-flash",
             "anthropic": "claude-3-5-sonnet-20241022",
         }
-    
+
     return defaults.get(provider_name.lower())
 
 
@@ -1563,19 +1572,20 @@ async def _process_with_ocr_endpoint(
     include_images: bool = False
 ):
     """Process document using LiteLLM OCR endpoint."""
-    import litellm
     import base64
-    
+
+    import litellm
+
     try:
         # Read file and encode to base64
         with open(file_path, "rb") as f:
             file_content = f.read()
             base64_content = base64.b64encode(file_content).decode('utf-8')
-        
+
         # Determine document type
         ext = file_path.lower().split('.')[-1]
         mime_type = "application/pdf" if ext == "pdf" else f"image/{ext}"
-        
+
         # Build OCR parameters
         ocr_params = {
             "model": model,
@@ -1585,26 +1595,26 @@ async def _process_with_ocr_endpoint(
             },
             "api_key": api_key
         }
-        
+
         # Add optional parameters
         if pages:
             # Convert comma-separated string to list of integers
             page_list = [int(p.strip()) for p in pages.split(",")]
             ocr_params["pages"] = page_list
-        
+
         if include_images:
             ocr_params["include_image_base64"] = True
-        
+
         # Call LiteLLM OCR
         response = await asyncio.to_thread(
             litellm.ocr,
             **ocr_params
         )
-        
+
         # Extract text from all pages
         all_text = []
         pages_data = []
-        
+
         for page in response.pages:
             all_text.append(f"## Page {page.index + 1}\n\n{page.markdown}")
             pages_data.append({
@@ -1612,15 +1622,15 @@ async def _process_with_ocr_endpoint(
                 "text": page.markdown,
                 "dimensions": page.dimensions if hasattr(page, 'dimensions') else None
             })
-        
+
         combined_text = "\n\n".join(all_text)
-        
+
         return {
             "success": True,
             "text": combined_text,
             "pages": pages_data
         }
-        
+
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -1631,25 +1641,26 @@ async def _process_with_vision_model(
     api_key: str
 ):
     """Process image using LiteLLM vision models."""
-    import litellm
     import base64
-    
+
+    import litellm
+
     try:
         # Read file and encode to base64
         with open(file_path, "rb") as f:
             file_content = f.read()
             base64_image = base64.b64encode(file_content).decode('utf-8')
-        
+
         # Determine image type
         ext = file_path.lower().split('.')[-1]
-        
+
         if ext == "pdf":
             mime_type = "application/pdf"
         elif ext in ["jpg", "jpeg", "png", "webp", "gif"]:
             mime_type = f"image/{ext}"
         else:
             mime_type = "image/jpeg"
-        
+
         # Build vision request
         messages = [
             {
@@ -1666,7 +1677,7 @@ async def _process_with_vision_model(
                 ]
             }
         ]
-        
+
         # Call LiteLLM completion with vision
         response = await asyncio.to_thread(
             litellm.completion,
@@ -1674,15 +1685,15 @@ async def _process_with_vision_model(
             messages=messages,
             api_key=api_key
         )
-        
+
         extracted_text = response.choices[0].message.content
-        
+
         return {
             "success": True,
             "text": extracted_text,
             "pages": [{"index": 0, "text": extracted_text}]
         }
-        
+
     except Exception as e:
         return {"success": False, "error": str(e)}
 
@@ -1728,53 +1739,53 @@ async def handle_ocr_document(
         # Get agent configuration from context
         if not agent_name:
             return {"success": False, "error": "Agent name not found in context"}
-        
+
         agent_doc = frappe.get_doc("Agent", agent_name)
         provider_doc = frappe.get_doc("AI Provider", agent_doc.provider)
         api_key = provider_doc.get_password("api_key")
-        
+
         if not api_key:
             return {"success": False, "error": "API key not configured for provider"}
-        
+
         # Get file
         file_doc = None
         if file_id:
             try:
                 file_doc = frappe.get_doc("File", file_id)
             except Exception as e:
-                return {"success": False, "error": f"File not found: {str(e)}"}
+                return {"success": False, "error": f"File not found: {e!s}"}
         elif file_url:
             # Try to find file by URL
             file_path = file_url.replace("/files/", "")
-            file_doc = frappe.db.get_value("File", 
-                {"file_url": file_url}, 
+            file_doc = frappe.db.get_value("File",
+                {"file_url": file_url},
                 ["name"], as_dict=True)
             if file_doc:
                 file_doc = frappe.get_doc("File", file_doc.name)
             else:
                 # Try by file name
-                file_doc = frappe.db.get_value("File", 
-                    {"file_name": file_path}, 
+                file_doc = frappe.db.get_value("File",
+                    {"file_name": file_path},
                     ["name"], as_dict=True)
                 if file_doc:
                     file_doc = frappe.get_doc("File", file_doc.name)
-        
+
         if not file_doc:
             return {"success": False, "error": "Either file_id or file_url is required"}
-        
+
         # Get file path and type
         file_path = file_doc.get_full_path()
         file_type = file_doc.file_type or ""
         file_name = file_doc.file_name or ""
-        
+
         # Determine strategy
         strategy = _determine_ocr_strategy(file_path, file_type)
-        
+
         # Override strategy for Google/Gemini: Use Vision (Multimodal) for PDFs too
         provider_name = provider_doc.provider_name.lower()
         if provider_name in ["google", "gemini"] and (strategy == "ocr" or file_path.lower().endswith(".pdf")):
             strategy = "vision"
-        
+
         # Determine model
         ocr_model = None
         if model:
@@ -1782,17 +1793,17 @@ async def handle_ocr_document(
         else:
             provider_name = provider_doc.provider_name.lower()
             ocr_model = _get_default_ocr_model(provider_name, strategy)
-        
+
         if not ocr_model:
             return {
                 "success": False,
                 "error": f"OCR not supported for provider '{provider_doc.provider_name}' with strategy '{strategy}'. Please provide a model parameter."
             }
-        
+
         # Normalize model name
         from huf.ai.providers.litellm import _normalize_model_name
         normalized_model = _normalize_model_name(ocr_model, agent_doc.provider)
-        
+
         # Route to appropriate method
         if strategy == "ocr":
             result = await _process_with_ocr_endpoint(
@@ -1802,13 +1813,13 @@ async def handle_ocr_document(
             result = await _process_with_vision_model(
                 file_path, normalized_model, api_key
             )
-        
+
         if not result["success"]:
             return result
-        
+
         extracted_text = result["text"]
         pages_data = result.get("pages", [])
-        
+
         # Create Agent Message with extracted text
         message_doc = None
         if conversation_id:
@@ -1819,9 +1830,9 @@ async def handle_ocr_document(
                     FROM `tabAgent Message`
                     WHERE conversation = %s
                 """, (conversation_id,), as_dict=1)
-                
+
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
-                
+
                 # Create Agent Message
                 message_doc = frappe.get_doc({
                     "doctype": "Agent Message",
@@ -1838,16 +1849,16 @@ async def handle_ocr_document(
                     "user": "Agent"
                 })
                 message_doc.insert(ignore_permissions=True)
-                
+
                 # Update conversation
                 frappe.db.sql("""
                     UPDATE `tabAgent Conversation`
                     SET total_messages = %s, last_activity = NOW()
                     WHERE name = %s
                 """, (conversation_index, conversation_id))
-                
+
                 frappe.db.commit()
-                
+
                 # Emit socket event
                 try:
                     frappe.publish_realtime(
@@ -1865,15 +1876,15 @@ async def handle_ocr_document(
                     )
                 except Exception as e:
                     frappe.log_error(
-                        f"Error emitting new_agent_message socket event: {str(e)}",
+                        f"Error emitting new_agent_message socket event: {e!s}",
                         "OCR Socket Event"
                     )
             except Exception as e:
                 frappe.log_error(
-                    f"Error creating Agent Message for OCR: {str(e)}",
+                    f"Error creating Agent Message for OCR: {e!s}",
                     "OCR Message Creation"
                 )
-        
+
         return {
             "success": True,
             "text": extracted_text,
@@ -1885,9 +1896,9 @@ async def handle_ocr_document(
             "model": normalized_model,
             "conversation_id": conversation_id
         }
-        
+
     except Exception as e:
-        frappe.log_error(f"OCR error: {str(e)}", "OCR Tool")
+        frappe.log_error(f"OCR error: {e!s}", "OCR Tool")
         return {"success": False, "error": str(e)}
 
 def _get_default_voice(provider_name: str) -> str:
@@ -1925,7 +1936,7 @@ def _get_default_tts_model(provider_name: str) -> str:
         "aws": "aws/polly",
         "minimax": "minimax/speech-01",
     }
-    
+
     return defaults.get(provider_name.lower())
 
 _TTS_ENV_VAR_PROVIDERS: dict[str, str] = {
@@ -2098,7 +2109,7 @@ def _resolve_stt_config(
         search_model = tool_model
         if "/" in search_model:
             search_model = search_model.split("/")[-1]
-            
+
         model_doc = frappe.get_all("AI Model", filters={"name": search_model}, fields=["provider"])
         if model_doc:
             stt_provider_name = model_doc[0].provider
@@ -2107,7 +2118,7 @@ def _resolve_stt_config(
             provs = frappe.get_all("AI Provider", filters={"slug": provider_slug}, fields=["name"])
             if provs:
                 stt_provider_name = provs[0].name
-                
+
         if not stt_provider_name:
             stt_provider_name = agent_doc.provider
 
@@ -2115,7 +2126,7 @@ def _resolve_stt_config(
         api_key = provider_doc.get_password("api_key")
         if not api_key:
             raise ValueError(f"API key is not configured for provider '{provider_doc.provider_name}'.")
-            
+
         provider_name = provider_doc.provider_name.lower()
         normalized = _normalize_model_name(tool_model, stt_provider_name)
         return {
@@ -2156,7 +2167,7 @@ def _resolve_stt_config(
 
     if not stt_model:
         stt_model = "whisper-1" # Safe ultimate fallback
-        
+
     normalized = _normalize_model_name(stt_model, agent_doc.provider)
     return {
         "stt_model":     normalized,
@@ -2258,11 +2269,11 @@ async def handle_generate_audio(
             litellm.speech,
             **speech_params
         )
-        
+
         # Get audio content from response
         # LiteLLM speech() returns HttpxBinaryResponseContent
         audio_bytes = response.content
-        
+
         # Get conversation_index for message ordering
         conversation_index = None
         if conversation_id:
@@ -2272,14 +2283,14 @@ async def handle_generate_audio(
                     FROM `tabAgent Message`
                     WHERE conversation = %s
                 """, (conversation_id,), as_dict=1)
-                
+
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
             except Exception:
                 conversation_index = 1
-        
+
         # Generate filename
         filename = f"generated_audio_{conversation_index}.{response_format}"
-        
+
         # Create Agent Message first (we'll attach the file to it)
         message_doc = None
         if conversation_id and conversation_index is not None:
@@ -2287,7 +2298,7 @@ async def handle_generate_audio(
                 # Get provider and model from agent
                 provider = agent_doc.provider
                 model_name = agent_doc.model
-                
+
                 # Create Agent Message with kind "Audio"
                 message_doc = frappe.get_doc({
                     "doctype": "Agent Message",
@@ -2316,11 +2327,11 @@ async def handle_generate_audio(
 
             except Exception as e:
                 frappe.log_error(
-                    f"Error creating Agent Message for generated audio: {str(e)}",
+                    f"Error creating Agent Message for generated audio: {e!s}",
                     "Audio Generation Message Creation"
                 )
                 message_doc = None
-        
+
         # Save file attached to the Agent Message
         if message_doc:
             saved_file = save_file(
@@ -2340,19 +2351,19 @@ async def handle_generate_audio(
                 conversation_id or "Unknown",
                 is_private=False
             )
-        
+
         # Get file URL
         file_url = getattr(saved_file, 'file_url', None)
         file_id = getattr(saved_file, 'name', None)
-        
+
         if not file_url:
             file_url = f"/files/{getattr(saved_file, 'file_name', filename)}"
-        
+
         # Update the message with the file URL
         if message_doc and file_url:
             message_doc.db_set("generated_audio", file_url)
             frappe.db.commit()
-            
+
             # Emit socket event for new agent message (Audio)
             try:
                 frappe.publish_realtime(
@@ -2372,10 +2383,10 @@ async def handle_generate_audio(
                 )
             except Exception as e:
                 frappe.log_error(
-                    f"Error emitting new_agent_message socket event: {str(e)}",
+                    f"Error emitting new_agent_message socket event: {e!s}",
                     "Audio Generation Socket Event"
                 )
-        
+
         # Update conversation total_messages
         if conversation_id and conversation_index is not None:
             try:
@@ -2386,10 +2397,10 @@ async def handle_generate_audio(
                 """, (conversation_index, conversation_id))
             except Exception as e:
                 frappe.log_error(
-                    f"Error updating conversation total_messages: {str(e)}",
+                    f"Error updating conversation total_messages: {e!s}",
                     "Audio Generation Message Creation"
                 )
-        
+
         return {
             "success": True,
             "audio": {
@@ -2407,9 +2418,9 @@ async def handle_generate_audio(
             "message": "Generated audio successfully",
             "conversation_id": conversation_id
         }
-        
+
     except Exception as e:
-        frappe.log_error(title="Audio Generation Tool", message=f"Audio generation error: {str(e)}")
+        frappe.log_error(title="Audio Generation Tool", message=f"Audio generation error: {e!s}")
         return {"success": False, "error": str(e)}
 
 @frappe.whitelist()
@@ -2450,20 +2461,20 @@ async def handle_transcribe_audio(
     try:
         # Get message_id for upsert logic
         message_id = kwargs.get("message_id")
-        
+
         # Get agent configuration from context
         if not agent_name:
             return {"success": False, "error": "Agent name not found in context"}
-        
+
         agent_doc = frappe.get_doc("Agent", agent_name)
-        
+
         # Get audio file
         file_doc = None
         if file_id:
             try:
                 file_doc = frappe.get_doc("File", file_id)
             except Exception as e:
-                return {"success": False, "error": f"File not found: {str(e)}"}
+                return {"success": False, "error": f"File not found: {e!s}"}
         elif file_url:
             # Try to find file by URL
             try:
@@ -2472,19 +2483,19 @@ async def handle_transcribe_audio(
                 # Try alternative lookup
                 file_name = file_url.replace("/files/", "")
                 file_doc = frappe.get_doc("File", {"file_name": file_name})
-            
+
             if not file_doc:
                 return {"success": False, "error": f"File not found at URL: {file_url}"}
         else:
             return {"success": False, "error": "Either file_id or file_url is required"}
-        
+
         # Get file path for LiteLLM
         # LiteLLM transcription accepts file path or file-like object
         try:
             file_path = file_doc.get_full_path()
         except Exception as e:
-            return {"success": False, "error": f"Error getting file path: {str(e)}"}
-        
+            return {"success": False, "error": f"Error getting file path: {e!s}"}
+
         # Determine transcription model
         try:
             stt_config = _resolve_stt_config(agent_doc, tool_model=model)
@@ -2496,27 +2507,27 @@ async def handle_transcribe_audio(
         provider_name    = stt_config["provider_name"]
         stt_source       = stt_config["source"]
         stt_provider_doc = stt_config["provider_doc"]
-        
+
         # Call LiteLLM transcription
         import litellm
-        
+
         if provider_name in ["google", "gemini", "vertex_ai"]:
             import base64
             import mimetypes
-            
+
             with open(file_path, "rb") as audio_file:
                 audio_data = audio_file.read()
-                
+
             mime_type, _ = mimetypes.guess_type(file_path)
             if not mime_type:
                 mime_type = "audio/mp3"
-                
+
             if file_path.lower().endswith(".webm") or mime_type == "video/webm":
                 mime_type = "audio/webm"
-                
+
             base64_audio = base64.b64encode(audio_data).decode('utf-8')
             audio_url = f"data:{mime_type};base64,{base64_audio}"
-            
+
             messages = [
                 {
                     "role": "user",
@@ -2526,22 +2537,22 @@ async def handle_transcribe_audio(
                     ]
                 }
             ]
-            
+
             import os
             env_var = _TTS_ENV_VAR_PROVIDERS.get(provider_name, "GEMINI_API_KEY")
             os.environ[env_var] = api_key
-                
+
             try:
                 response = await asyncio.to_thread(
                     litellm.completion,
                     model=normalized_model,
                     messages=messages,
-                    api_key=api_key 
+                    api_key=api_key
                 )
                 transcribed_text = response.choices[0].message.content
             except Exception as e:
-                return {"success": False, "error": f"Transcription failed: {str(e)}"}
-                
+                return {"success": False, "error": f"Transcription failed: {e!s}"}
+
         else:
             # Standard transcription handling (OpenAI, Deepgram, Groq, etc.)
             transcription_params = {
@@ -2549,11 +2560,11 @@ async def handle_transcribe_audio(
                 "file": file_path,
                 "api_key": api_key
             }
-            
+
             # Add optional parameters
             if language:
                 transcription_params["language"] = language
-            
+
             # Call LiteLLM transcription
             def _sync_transcribe(params):
                 with open(file_path, "rb") as audio_file:
@@ -2563,8 +2574,8 @@ async def handle_transcribe_audio(
             try:
                 response = await asyncio.to_thread(_sync_transcribe, transcription_params)
             except Exception as e:
-                return {"success": False, "error": f"Transcription failed: {str(e)}"}
-            
+                return {"success": False, "error": f"Transcription failed: {e!s}"}
+
             # Extract text from response
             # LiteLLM transcription returns a dict with 'text' key or object
             if hasattr(response, "text"):
@@ -2573,10 +2584,10 @@ async def handle_transcribe_audio(
                 transcribed_text = response.get("text", "")
             else:
                  transcribed_text = str(response)
-        
+
         if not transcribed_text:
             return {"success": False, "error": "Transcription returned empty result"}
-        
+
         # Create Agent Message with transcription result
         message_doc = None
         if conversation_id:
@@ -2587,9 +2598,9 @@ async def handle_transcribe_audio(
                     FROM `tabAgent Message`
                     WHERE conversation = %s
                 """, (conversation_id,), as_dict=1)
-                
+
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
-                
+
                 # Create or Update Agent Message
                 if message_id and frappe.db.exists("Agent Message", message_id):
                     message_doc = frappe.get_doc("Agent Message", message_id)
@@ -2598,7 +2609,7 @@ async def handle_transcribe_audio(
                     if stt_source == "agent_config" and getattr(agent_doc, "stt_model", None):
                         message_doc.stt_model = agent_doc.stt_model
                     message_doc.save(ignore_permissions=True)
-                    
+
                 else:
                     message_doc = frappe.get_doc({
                         "doctype": "Agent Message",
@@ -2617,7 +2628,7 @@ async def handle_transcribe_audio(
                     if stt_source == "agent_config" and getattr(agent_doc, "stt_model", None):
                         message_doc.stt_model = agent_doc.stt_model
                     message_doc.insert(ignore_permissions=True)
-                
+
                 # Check if file is already attached to this message
                 if file_doc and message_doc:
                     if not file_doc.attached_to_name:
@@ -2634,9 +2645,9 @@ async def handle_transcribe_audio(
                     """, (conversation_index, conversation_id))
                 else:
                     frappe.db.set_value("Agent Conversation", conversation_id, "last_activity", frappe.utils.now())
-                
+
                 frappe.db.commit()
-                
+
                 # Emit socket event for new message
                 try:
                     frappe.publish_realtime(
@@ -2649,7 +2660,7 @@ async def handle_transcribe_audio(
                             "kind": "Audio",
                             "file": {
                                 "file_name": file_doc.file_name,
-                                "file_url": file_doc.file_url 
+                                "file_url": file_doc.file_url
                             } if file_doc else None,
                             "conversation_index": conversation_index,
                         },
@@ -2658,16 +2669,16 @@ async def handle_transcribe_audio(
                     )
                 except Exception as e:
                     frappe.log_error(
-                        f"Error emitting new_user_message socket event: {str(e)}",
+                        f"Error emitting new_user_message socket event: {e!s}",
                         "Audio Transcription Socket Event"
                     )
-                    
+
             except Exception as e:
                 frappe.log_error(
-                    f"Error creating Agent Message for transcription: {str(e)}",
+                    f"Error creating Agent Message for transcription: {e!s}",
                     "Audio Transcription Message Creation"
                 )
-        
+
         return {
             "success": True,
             "text": transcribed_text,
@@ -2676,7 +2687,7 @@ async def handle_transcribe_audio(
             "language": language or "auto-detected",
             "model": normalized_model
         }
-        
+
     except Exception as e:
-        frappe.log_error(f"Audio transcription error: {str(e)}", "Audio Transcription Tool")
+        frappe.log_error(f"Audio transcription error: {e!s}", "Audio Transcription Tool")
         return {"success": False, "error": str(e)}

--- a/huf/ai/tool_functions.py
+++ b/huf/ai/tool_functions.py
@@ -1,14 +1,14 @@
-import frappe
-from frappe import _, client
-from frappe.utils.file_manager import save_file
 import os
 from urllib.parse import urlparse
-import requests
 
+import frappe
+import requests
+from frappe import _, client
+from frappe.utils.file_manager import save_file
 
 
 def get_document(doctype: str, document_id: str):
-	
+
 	"""
 	Get a document from the database
 	"""
@@ -17,7 +17,7 @@ def get_document(doctype: str, document_id: str):
 
 
 def get_documents(doctype: str, document_ids: list):
-	
+
 	"""
 	Get documents from the database
 	"""
@@ -97,10 +97,10 @@ def update_document(doctype: str, document_id: str, data: dict, tool=None):
     try:
         if not doctype or not document_id:
             return {"success": False, "error": "Doctype and document_id are required"}
-            
+
         if not frappe.db.exists(doctype, document_id):
             return {"success": False, "error": f"{doctype} {document_id} not found"}
-            
+
         if not frappe.has_permission(doctype, "write", doc=document_id):
             return {
                 "success": False,
@@ -108,25 +108,25 @@ def update_document(doctype: str, document_id: str, data: dict, tool=None):
                 "permission_denied": True
             }
 
-            
+
         doc = frappe.get_doc(doctype, document_id)
-        
+
         # Apply default values from tool if available
         if tool:
             for param in tool.parameters:
                 if param.default_value and not data.get(param.fieldname):
                     data[param.fieldname] = param.default_value
-        
+
         doc.update(data)
         doc.save()
-        
+
         return {
             "success": True,
             "message": f"{doctype} {document_id} updated successfully",
             "document": doc.as_dict()
         }
     except Exception as e:
-        frappe.log_error(f"Error updating {doctype} {document_id}: {str(e)}")
+        frappe.log_error(f"Error updating {doctype} {document_id}: {e!s}")
         return {"success": False, "error": str(e)}
 
 def update_documents(doctype: str, data: list, function=None):
@@ -172,10 +172,10 @@ def delete_document(doctype: str, document_id: str):
     try:
         if not doctype or not document_id:
             return {"success": False, "error": "Doctype and document_id are required"}
-            
+
         if not frappe.db.exists(doctype, document_id):
             return {"success": False, "error": f"{doctype} {document_id} not found"}
-            
+
         #Pre-check delete permission
         if not frappe.has_permission(doctype, "delete", doc=document_id):
             return {
@@ -187,7 +187,7 @@ def delete_document(doctype: str, document_id: str):
         frappe.delete_doc(doctype, document_id)
         return {"success": True, "message": f"{doctype} {document_id} deleted successfully"}
     except Exception as e:
-        frappe.log_error(f"Error deleting {doctype} {document_id}: {str(e)}")
+        frappe.log_error(f"Error deleting {doctype} {document_id}: {e!s}")
         return {"success": False, "error": str(e)}
 
 def delete_documents(doctype: str, document_ids: list):
@@ -204,10 +204,10 @@ def submit_document(doctype: str, document_id: str):
 	Submit a document in the database
 	"""
 	doc = frappe.get_doc(doctype, document_id)
-	
+
 	if not frappe.has_permission(doctype, "submit", doc=document_id):
 		return {
-			"success": False, 
+			"success": False,
 			"error": f"You do not have submit permission on {doctype} {document_id}",
 			"permission_denied": True
 		}
@@ -228,7 +228,7 @@ def cancel_document(doctype: str, document_id: str):
 
 	if not frappe.has_permission(doctype, "cancel", doc=document_id):
 		return {
-			"success": False, 
+			"success": False,
 			"error": f"You do not have cancel permission on {doctype} {document_id}",
 			"permission_denied": True
 		}
@@ -389,6 +389,11 @@ def attach_file_to_document(doctype: str, document_id: str, file_path: str):
 
 def _download_content(url: str, timeout: int = 30) -> bytes:
     """Download bytes from an http/https url."""
+    from huf.ai.http_handler import validate_url
+
+    is_valid, error_msg = validate_url(url)
+    if not is_valid:
+        raise ValueError(f"URL blocked: {error_msg}")
 
     resp = requests.get(url, timeout=timeout)
     resp.raise_for_status()
@@ -433,11 +438,11 @@ def _process_single_attachment(doctype, document_id, file_path):
             else:
                 filename = os.path.basename(file_path)
                 file_doc = _create_file_doc_for_local_path(file_path, filename)
-        
+
         clean_url = getattr(file_doc, "file_url", None)
         if not clean_url:
             clean_url = getattr(file_doc, "file_name", file_path)
-            
+
         attached_name = frappe.db.get_value("File", {
             "attached_to_doctype": doctype,
             "attached_to_name": document_id,
@@ -454,7 +459,7 @@ def _process_single_attachment(doctype, document_id, file_path):
         return clean_url
 
     except Exception as e:
-        frappe.log_error(f"Attachment failed for {file_path}: {str(e)}")
+        frappe.log_error(f"Attachment failed for {file_path}: {e!s}")
         return None
 
 
@@ -476,7 +481,7 @@ def attach_file_to_document(doctype: str, document_id: str, **kwargs):
     updates = {}
     attached_files = []
     meta = frappe.get_meta(doctype)
-    
+
     generic_file = kwargs.pop('file_path', None) or kwargs.pop('file_url', None)
     if generic_file:
          url = _process_single_attachment(doctype, document_id, generic_file)
@@ -499,8 +504,8 @@ def attach_file_to_document(doctype: str, document_id: str, **kwargs):
             frappe.db.commit()
         except Exception as e:
             return {
-                "success": True, 
-                "message": "Files attached but field update failed", 
+                "success": True,
+                "message": "Files attached but field update failed",
                 "error": str(e),
                 "attached": attached_files
             }

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -1,23 +1,23 @@
 # Copyright (c) 2025, Tridz Technologies Pvt Ltd and contributors
 # For license information, please see license.txt
 
+import inspect
 import json
+import re
+import typing
 
 import frappe
 from frappe import _, is_whitelisted
-
 from frappe.model.document import Document
 
-import inspect 
-
-import typing
-
-import re
 
 class AgentToolFunction(Document):
 	def before_validate(self):
 		self.validate_reference_doctype()
 		self.validate_fields_for_doctype()
+		self.validate_base_url()
+		self.validate_http_headers()
+		self.validate_http_parameter_names()
 		self.prepare_function_params()
 		self.validate_json()
 		self.validate_tool_name()
@@ -29,6 +29,40 @@ class AgentToolFunction(Document):
 				"and be at most 128 characters long.")
 			)
 
+
+	def validate_base_url(self):
+		"""Validate that base_url is a proper HTTP(S) URL when set."""
+		if self.types in ("GET", "POST") and self.base_url:
+			from urllib.parse import urlparse
+
+			parsed = urlparse(self.base_url)
+			if parsed.scheme not in ("http", "https"):
+				frappe.throw(_("Base URL must start with http:// or https://"))
+			if not parsed.hostname:
+				frappe.throw(_("Base URL must contain a valid hostname"))
+
+	def validate_http_headers(self):
+		"""Reject HTTP headers containing CRLF characters (header injection prevention)."""
+		if not hasattr(self, "http_headers") or not self.http_headers:
+			return
+		for header in self.http_headers:
+			if header.key and ("\r" in header.key or "\n" in header.key):
+				frappe.throw(_("HTTP header key contains invalid characters: {0}").format(header.key))
+			if header.value and ("\r" in header.value or "\n" in header.value):
+				frappe.throw(_("HTTP header value for '{0}' contains invalid characters").format(header.key))
+
+	def validate_http_parameter_names(self):
+		"""Reject parameter names that collide with reserved HTTP schema keys."""
+		if self.types not in ("GET", "POST"):
+			return
+		reserved = frozenset({"url", "params", "headers", "json_data", "data", "tool_name", "method"})
+		for param in self.parameters:
+			if param.fieldname in reserved:
+				frappe.throw(
+					_("Parameter name '{0}' is reserved for HTTP tools. Choose a different name.").format(
+						param.fieldname
+					)
+				)
 
 	def validate_reference_doctype(self):
 		if not self.reference_doctype:
@@ -230,7 +264,7 @@ class AgentToolFunction(Document):
 			else:
 				params = self.get_params_as_dict()
 		elif self.types == "Get List":
-			
+
 			filter_properties = {}
 			for param in self.parameters:
 				filter_properties[param.fieldname] = {
@@ -244,8 +278,8 @@ class AgentToolFunction(Document):
 					"filters": {
 						"type": "object",
 						"description": "Dictionary of filters. Example: {'status': 'New', 'first_name': 'John Doe'}.",
-						"properties": filter_properties, 
-						"additionalProperties": True 
+						"properties": filter_properties,
+						"additionalProperties": True
 					},
 					"fields": {
 						"type": "array",
@@ -485,7 +519,7 @@ class AgentToolFunction(Document):
 				"required": [],
 				"additionalProperties": False
 			}
-		
+
 		elif self.types == "Run Agent":
 			params = {
 				"type": "object",
@@ -498,7 +532,7 @@ class AgentToolFunction(Document):
 				"required": ["prompt"],
 				"additionalProperties": False
 			}
-					
+
 		else:
 			params = self.build_params_json_from_table()
 
@@ -561,13 +595,13 @@ class AgentToolFunction(Document):
 					child_tables[param.child_table_name]["items"]["required"].append(param.fieldname)
 
 		for child_table_name, child_table in child_tables.items():
-		
+
 			if self.reference_doctype:
 				try:
 					doctype_meta = frappe.get_meta(self.reference_doctype)
 					table_field = doctype_meta.get_field(child_table_name)
 				except Exception:
-					pass 
+					pass
 
 			properties[child_table_name] = child_table
 
@@ -583,7 +617,7 @@ class AgentToolFunction(Document):
 					},
 				}
 			}
-			
+
 		else:
 			params["properties"] = properties
 			params["required"] = required
@@ -694,7 +728,7 @@ class AgentToolFunction(Document):
 		for name, param in sig.parameters.items():
 			if name in ["self", "cls"]:
 				continue
-			
+
 			param_type = "string"
 			if param.annotation != inspect.Parameter.empty:
 				if param.annotation == int:
@@ -703,11 +737,11 @@ class AgentToolFunction(Document):
 					param_type = "boolean"
 				elif param.annotation == float:
 					param_type = "number"
-				elif param.annotation == dict or param.annotation == typing.Dict:
+				elif param.annotation == dict or param.annotation == dict:
 					param_type = "object"
-				elif param.annotation == list or param.annotation == typing.List:
+				elif param.annotation == list or param.annotation == list:
 					param_type = "array"
-			
+
 			reqd = 1
 			if param.default != inspect.Parameter.empty:
 				reqd = 0


### PR DESCRIPTION
## Summary

Full security review and hardening of the HTTP tool ecosystem. Two commits:

### Commit 1: Activate SSRF protection in `http_handler.py`
- **`validate_url()` was defined but never called** — agents could freely hit internal IPs, localhost, cloud metadata (`169.254.169.254`)
- Now called before every outbound request
- DNS rebinding protection via `socket.getaddrinfo()` (hostname → IP check)
- Blocks `169.254.x.x`, `0.0.0.0`, `::1`, all RFC 1918 ranges
- HTTP method whitelist: only GET/POST/PUT/PATCH/DELETE/HEAD
- 10MB response size limit

### Commit 2: Harden the broader HTTP tool ecosystem

**Security fixes across 6 files:**

| Fix | File | Detail |
|-----|------|--------|
| SSRF in `_download_content()` | `tool_functions.py` | Raw `requests.get(url)` with zero protection — now calls `validate_url()` |
| SSRF in URL knowledge extractor | `knowledge/extractors/url.py` | User-provided knowledge source URLs now validated |
| SSRF in image download | `sdk_tools.py` | Agent-provided image URLs now validated |
| CRLF header injection | `agent_tool_function.py` | Header key/value pairs checked for `\r` and `\n` characters |
| Reserved param name collision | `agent_tool_function.py` | Parameters named `url`, `params`, `json_data`, `headers`, `data`, `tool_name`, `method` rejected for HTTP tools |
| Base URL format validation | `agent_tool_function.py` | Must be valid `http://` or `https://` URL with hostname |
| Content-Length pre-check | `http_handler.py` | Checks `Content-Length` header before downloading full body |
| Frontend type safety | `toolCreationForm.utils.ts` | `base_url` validated as URL, `http_headers` typed as `{key, value}[]` |

## Files changed

- `huf/ai/http_handler.py` — SSRF activation, method whitelist, response limits, Content-Length pre-check
- `huf/ai/tool_functions.py` — SSRF protection for `_download_content()`
- `huf/ai/sdk_tools.py` — SSRF protection for image URL downloads
- `huf/ai/knowledge/extractors/url.py` — SSRF protection for knowledge URL extraction
- `huf/huf/doctype/agent_tool_function/agent_tool_function.py` — base_url, CRLF, reserved param validations
- `frontend/src/components/tools/toolCreationForm.utils.ts` — Zod schema improvements

## Full review document

A comprehensive review document covering the entire HTTP tool ecosystem (architecture, execution flow, all remaining issues, prioritized improvement plan) is available in the plan file. Key remaining items for future work:

- Configurable timeout per tool (currently hardcoded 30s)
- Request audit logging / Agent Tool Call records for HTTP tools
- Rate limiting per tool per user
- Backend unit tests (`test_agent_tool_function.py` is currently empty)
- HTTP handler integration tests
- Frontend: header value masking for secrets, common header autocomplete

## Test plan

- [ ] Create a GET tool with `base_url = https://httpbin.org` — verify requests work
- [ ] Try creating a tool with parameter named `url` — verify rejection
- [ ] Try setting `base_url` to `ftp://invalid` — verify rejection
- [ ] Try header with `\r\n` in value — verify rejection
- [ ] Verify agents cannot request `127.0.0.1`, `10.x.x.x`, `192.168.x.x`, `169.254.169.254`
- [ ] Verify agents can still make requests to public external APIs
- [ ] Verify GET and POST tool types work end-to-end with base_url and headers
- [ ] Verify unsupported HTTP methods (e.g. TRACE) are rejected
- [ ] Verify responses larger than 10MB return a structured error
- [ ] Verify `_download_content` blocks private IPs for file attachments
- [ ] Verify knowledge URL extractor blocks private IPs
- [ ] Frontend: verify base_url validation shows error for invalid URLs
- [ ] Frontend: verify TypeScript compiles cleanly

https://claude.ai/code/session_0185G6EwYpV4GTgKkvJNmCRk