### PR TITLE
refactor(agent-form): add section rail layout and memory placeholder

### DIFF
--- a/frontend/src/components/agent/BehaviorTab.tsx
+++ b/frontend/src/components/agent/BehaviorTab.tsx
@@ -1,9 +1,9 @@
 import { FormField, FormItem, FormLabel, FormControl, FormDescription } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { UseFormReturn } from 'react-hook-form';
 import type { AgentFormValues } from './types';
 import { toast } from 'sonner';
+import { SectionRailLayout, SectionBlock, type RailSection } from './form-base/SectionRailLayout';
 
 interface BehaviorTabProps {
   form: UseFormReturn<AgentFormValues>;
@@ -12,47 +12,68 @@ interface BehaviorTabProps {
 export function BehaviorTab({ form }: BehaviorTabProps) {
   const persistConversationEnabled = form.watch('persist_conversation');
   const enableMultiRun = form.watch('enable_multi_run');
+  const allowChat = form.watch('allow_chat');
+  const persistPerUser = form.watch('persist_user_history');
+
+  const sections: RailSection[] = [
+    {
+      id: 'chat',
+      label: 'Chat Access',
+      status: allowChat ? 'complete' : 'partial',
+      meta: allowChat ? 'Enabled' : 'Disabled',
+    },
+    {
+      id: 'history',
+      label: 'History',
+      status: persistConversationEnabled ? 'complete' : 'empty',
+      meta: persistConversationEnabled ? (persistPerUser ? 'Per user' : 'Shared') : 'Not persisted',
+    },
+    {
+      id: 'execution',
+      label: 'Execution',
+      status: enableMultiRun ? 'complete' : 'partial',
+      meta: enableMultiRun ? 'Multi run enabled' : 'Single run mode',
+    },
+  ];
 
   return (
-    <>
-      <Card>
-        <CardHeader>
-          <CardTitle>Conversation Settings</CardTitle>
-          <CardDescription>Configure conversation behavior</CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-4 sm:grid-cols-2">
-          <FormField
-            control={form.control}
-            name="allow_chat"
-            render={({ field }) => (
-              <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                <div className="space-y-0.5">
-                  <FormLabel className="text-base">Allow Chat</FormLabel>
-                  <FormDescription>
-                    If checked, this agent can be interacted with in the Agent Chat window.
-                  </FormDescription>
-                </div>
-                <FormControl>
-                  <Switch
-                    checked={field.value}
-                    disabled={enableMultiRun}
-                    onCheckedChange={(checked) => {
-                      if (enableMultiRun) {
-                        toast.warning('Chat is not available for multi run agents right now.');
-                        return;
-                      }
-                      if (checked && !persistConversationEnabled) {
-                        toast.warning('Turn on Persist History before enabling chat.');
-                        return;
-                      }
-                      field.onChange(checked);
-                    }}
-                  />
-                </FormControl>
-              </FormItem>
-            )}
-          />
+    <SectionRailLayout sections={sections}>
+      <SectionBlock id="chat" title="Chat Access" description="Control whether this agent is available in Agent Chat.">
+        <FormField
+          control={form.control}
+          name="allow_chat"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel className="text-base">Allow Chat</FormLabel>
+                <FormDescription>
+                  If checked, this agent can be interacted with in the Agent Chat window.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  disabled={enableMultiRun}
+                  onCheckedChange={(checked) => {
+                    if (enableMultiRun) {
+                      toast.warning('Chat is not available for multi run agents right now.');
+                      return;
+                    }
+                    if (checked && !persistConversationEnabled) {
+                      toast.warning('Turn on Persist History before enabling chat.');
+                      return;
+                    }
+                    field.onChange(checked);
+                  }}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </SectionBlock>
 
+      <SectionBlock id="history" title="History" description="Save and segment conversation history.">
+        <div className="grid gap-4 sm:grid-cols-2">
           <FormField
             control={form.control}
             name="persist_conversation"
@@ -61,7 +82,7 @@ export function BehaviorTab({ form }: BehaviorTabProps) {
                 <div className="space-y-0.5">
                   <FormLabel className="text-base">Persist History</FormLabel>
                   <FormDescription>
-                    If checked, the conversation history with this agent will be saved and loaded for future sessions.
+                    Save and load conversation history for future sessions.
                   </FormDescription>
                 </div>
                 <FormControl className="ml-1">
@@ -87,8 +108,7 @@ export function BehaviorTab({ form }: BehaviorTabProps) {
                 <div className="space-y-0.5">
                   <FormLabel className="text-base">Persist per User (Doc/Schedule)</FormLabel>
                   <FormDescription>
-                    When checked, Doc Event and Scheduled runs create / maintain conversation history per
-                    initiating user (or trigger owner). If unchecked, a single shared history is used.
+                    Keep histories isolated by initiating user (otherwise one shared history is used).
                   </FormDescription>
                 </div>
                 <FormControl>
@@ -97,39 +117,39 @@ export function BehaviorTab({ form }: BehaviorTabProps) {
               </FormItem>
             )}
           />
+        </div>
+      </SectionBlock>
 
-          <FormField
-            control={form.control}
-            name="enable_multi_run"
-            render={({ field }) => (
-              <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                <div className="space-y-0.5">
-                  <FormLabel className="text-base">Enable Multi Run</FormLabel>
-                  <FormDescription>
-                    When enabled, this agent can execute multiple runs.
-                  </FormDescription>
-                </div>
-                <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={(checked) => {
-                      field.onChange(checked);
-                      if (checked) {
-                        // Disable chat when multi run is enabled
-                        const currentChatValue = form.getValues('allow_chat');
-                        if (currentChatValue) {
-                          form.setValue('allow_chat', false, { shouldDirty: true });
-                        }
+      <SectionBlock id="execution" title="Execution" description="Multi-run mode settings.">
+        <FormField
+          control={form.control}
+          name="enable_multi_run"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <FormLabel className="text-base">Enable Multi Run</FormLabel>
+                <FormDescription>
+                  When enabled, this agent can execute multiple runs.
+                </FormDescription>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={(checked) => {
+                    field.onChange(checked);
+                    if (checked) {
+                      const currentChatValue = form.getValues('allow_chat');
+                      if (currentChatValue) {
+                        form.setValue('allow_chat', false, { shouldDirty: true });
                       }
-                    }}
-                  />
-                </FormControl>
-              </FormItem>
-            )}
-          />
-        </CardContent>
-      </Card>
-    </>
+                    }
+                  }}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </SectionBlock>
+    </SectionRailLayout>
   );
 }
-

--- a/frontend/src/components/agent/GeneralTab.tsx
+++ b/frontend/src/components/agent/GeneralTab.tsx
@@ -1,14 +1,13 @@
 import { FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { Slider } from '@/components/ui/slider';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { UseFormReturn } from 'react-hook-form';
+import { Badge } from '@/components/ui/badge';
 import type { AIProvider, AIModel } from '@/types/agent.types';
 import type { AgentFormValues } from './types';
 import { InstructionsTextarea } from './InstructionsTextarea';
+import { SectionRailLayout, SectionBlock, type RailSection } from './form-base/SectionRailLayout';
 
 interface GeneralTabProps {
   form: UseFormReturn<AgentFormValues>;
@@ -20,57 +19,72 @@ interface GeneralTabProps {
 }
 
 export function GeneralTab({ form, providers, models, watchProvider, optimizingPrompt, onOptimizePrompt }: GeneralTabProps) {
-  return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>LLM Configuration</CardTitle>
-          <CardDescription>Configure language model settings</CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-6 sm:grid-cols-2">
-          <div className="sm:col-span-2">
-            <FormField
-              control={form.control}
-              name="agent_name"
-              render={({ field }) => (
-                <FormItem className="sm:col-span-2">
-                  <FormLabel>Agent Name</FormLabel>
-                  <FormControl>
-                    <Input placeholder="my-agent" {...field} />
-                  </FormControl>
-                  <FormDescription>Unique agent name</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+  const agentName = form.watch('agent_name');
+  const provider = form.watch('provider');
+  const model = form.watch('model');
+  const instructions = form.watch('instructions');
 
-            <div className="sm:col-span-2">
-              <Accordion type="single" collapsible className="w-full">
-                <AccordionItem value="description">
-                  <AccordionTrigger>Description</AccordionTrigger>
-                  <AccordionContent>
-                    <FormField
-                      control={form.control}
-                      name="description"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormControl>
-                            <Textarea
-                              placeholder="A short summary describing what this agent does or is designed for."
-                              className="min-h-[80px] resize-y"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormDescription>A brief description of the agent's purpose</FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            </div>
-          </div>
+  const sections: RailSection[] = [
+    {
+      id: 'identity',
+      label: 'Identity',
+      status: agentName ? 'complete' : 'empty',
+      meta: agentName || 'Name required',
+    },
+    {
+      id: 'model',
+      label: 'Model',
+      status: provider && model ? 'complete' : provider ? 'partial' : 'empty',
+      meta: model || provider || 'Pick provider + model',
+    },
+    {
+      id: 'instructions',
+      label: 'Instructions',
+      status: instructions ? 'complete' : 'partial',
+      meta: instructions ? `${instructions.length} chars` : 'Add system prompt',
+    },
+  ];
+
+  return (
+    <SectionRailLayout sections={sections}>
+      <SectionBlock id="identity" title="Identity" description="Name and describe the agent's purpose.">
+        <FormField
+          control={form.control}
+          name="agent_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Agent Name</FormLabel>
+              <FormControl>
+                <Input placeholder="my-agent" {...field} />
+              </FormControl>
+              <FormDescription>Unique agent name</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="A short summary describing what this agent does."
+                  {...field}
+                  value={field.value ?? ''}
+                />
+              </FormControl>
+              <FormDescription>A concise summary shown in listings and docs.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </SectionBlock>
+
+      <SectionBlock id="model" title="Model" description="Provider, model, and response randomness.">
+        <div className="grid gap-4 sm:grid-cols-2">
           <FormField
             control={form.control}
             name="provider"
@@ -90,9 +104,9 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {providers.map((provider) => (
-                      <SelectItem key={provider.name} value={provider.name}>
-                        {provider.provider_name || provider.name}
+                    {providers.map((item) => (
+                      <SelectItem key={item.name} value={item.name}>
+                        {item.provider_name || item.name}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -108,11 +122,7 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Model</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={field.value}
-                  disabled={!watchProvider}
-                >
+                <Select onValueChange={field.onChange} value={field.value} disabled={!watchProvider}>
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Select model" />
@@ -120,10 +130,10 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
                   </FormControl>
                   <SelectContent>
                     {models
-                      .filter((model) => model.provider === watchProvider)
-                      .map((model) => (
-                        <SelectItem key={model.name} value={model.name}>
-                          {model.model_name || model.name}
+                      .filter((item) => item.provider === watchProvider)
+                      .map((item) => (
+                        <SelectItem key={item.name} value={item.name}>
+                          {item.model_name || item.name}
                         </SelectItem>
                       ))}
                   </SelectContent>
@@ -139,19 +149,14 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
             name="temperature"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Temperature: {field.value}</FormLabel>
+                <div className="flex items-center justify-between">
+                  <FormLabel>Temperature</FormLabel>
+                  <Badge variant="outline">{field.value}</Badge>
+                </div>
                 <FormControl>
-                  <Slider
-                    min={0}
-                    max={2}
-                    step={0.1}
-                    value={[field.value]}
-                    onValueChange={(vals) => field.onChange(vals[0])}
-                  />
+                  <Slider min={0} max={2} step={0.1} value={[field.value]} onValueChange={(vals) => field.onChange(vals[0])} />
                 </FormControl>
-                <FormDescription>
-                  Lower = focused, higher = creative
-                </FormDescription>
+                <FormDescription>Lower = focused, higher = creative</FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -162,52 +167,40 @@ export function GeneralTab({ form, providers, models, watchProvider, optimizingP
             name="top_p"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Top P: {field.value}</FormLabel>
+                <div className="flex items-center justify-between">
+                  <FormLabel>Top P</FormLabel>
+                  <Badge variant="outline">{field.value}</Badge>
+                </div>
                 <FormControl>
-                  <Slider
-                    min={0}
-                    max={1}
-                    step={0.05}
-                    value={[field.value]}
-                    onValueChange={(vals) => field.onChange(vals[0])}
-                  />
+                  <Slider min={0} max={1} step={0.05} value={[field.value]} onValueChange={(vals) => field.onChange(vals[0])} />
                 </FormControl>
-                <FormDescription>
-                  Nucleus sampling parameter
-                </FormDescription>
+                <FormDescription>Nucleus sampling parameter</FormDescription>
                 <FormMessage />
               </FormItem>
             )}
           />
-        </CardContent>
-      </Card>
+        </div>
+      </SectionBlock>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Instructions</CardTitle>
-          <CardDescription>Define system prompt, goals, and constraints</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <FormField
-            control={form.control}
-            name="instructions"
-            render={({ field }) => (
-              <FormItem>
-                <InstructionsTextarea
-                  form={form}
-                  field={field}
-                  optimizingPrompt={optimizingPrompt}
-                  onOptimizePrompt={onOptimizePrompt}
-                  showOptimize={true}
-                  showExpand={true}
-                />
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </CardContent>
-      </Card>
-    </div>
+      <SectionBlock id="instructions" title="Instructions" description="System prompt, goals, and constraints.">
+        <FormField
+          control={form.control}
+          name="instructions"
+          render={({ field }) => (
+            <FormItem>
+              <InstructionsTextarea
+                form={form}
+                field={field}
+                optimizingPrompt={optimizingPrompt}
+                onOptimizePrompt={onOptimizePrompt}
+                showOptimize={true}
+                showExpand={true}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </SectionBlock>
+    </SectionRailLayout>
   );
 }
-

--- a/frontend/src/components/agent/MemoryTab.tsx
+++ b/frontend/src/components/agent/MemoryTab.tsx
@@ -1,0 +1,43 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+
+export function MemoryTab() {
+  return (
+    <Card className="border-dashed">
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CardTitle>Memory</CardTitle>
+          <Badge variant="secondary">Coming Soon</Badge>
+        </div>
+        <CardDescription>
+          The memory system is being finalized. This preview keeps the future structure visible, but inputs are disabled until merge.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 opacity-60">
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border p-4">
+            <p className="text-sm font-medium">Enable agent memory</p>
+            <p className="mt-1 text-xs text-muted-foreground">Capture structured memories across sessions.</p>
+            <div className="mt-3">
+              <Switch checked={false} disabled aria-label="Enable memory (coming soon)" />
+            </div>
+          </div>
+
+          <div className="rounded-lg border p-4">
+            <p className="text-sm font-medium">Memory profile</p>
+            <p className="mt-1 text-xs text-muted-foreground">Choose default schema and extraction strategy.</p>
+            <Input className="mt-3" value="General" disabled readOnly />
+          </div>
+        </div>
+
+        <div className="rounded-lg border p-4">
+          <p className="text-sm font-medium">Retrieval mode</p>
+          <p className="mt-1 text-xs text-muted-foreground">Hybrid retrieval + tool access will be configurable here.</p>
+          <Input className="mt-3" value="Hybrid (preview)" disabled readOnly />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/agent/form-base/SectionRailLayout.tsx
+++ b/frontend/src/components/agent/form-base/SectionRailLayout.tsx
@@ -1,0 +1,89 @@
+import { type ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type SectionStatus = 'empty' | 'partial' | 'complete' | 'coming_soon';
+
+export interface RailSection {
+  id: string;
+  label: string;
+  status?: SectionStatus;
+  meta?: string;
+  badge?: string;
+}
+
+interface SectionRailLayoutProps {
+  sections: RailSection[];
+  children: ReactNode;
+  className?: string;
+}
+
+const statusClassMap: Record<SectionStatus, string> = {
+  complete: 'bg-emerald-500',
+  partial: 'bg-amber-400',
+  empty: 'bg-border border border-border',
+  coming_soon: 'bg-blue-400',
+};
+
+export function SectionRailLayout({ sections, children, className }: SectionRailLayoutProps) {
+  const scrollToSection = (sectionId: string) => {
+    const target = document.getElementById(`agent-section-${sectionId}`);
+    target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <div className={cn('grid gap-6 lg:grid-cols-[180px_1fr]', className)}>
+      <aside className="hidden lg:block lg:sticky lg:top-6 lg:self-start">
+        <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">Sections</p>
+        <div className="space-y-1 rounded-lg border bg-card p-2">
+          {sections.map((section) => {
+            const status = section.status ?? 'empty';
+            return (
+              <button
+                key={section.id}
+                type="button"
+                onClick={() => scrollToSection(section.id)}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted/50"
+              >
+                <span className={cn('h-2 w-2 shrink-0 rounded-full', statusClassMap[status])} />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs text-foreground">{section.label}</span>
+                  {section.meta ? <span className="block truncate text-[11px] text-muted-foreground">{section.meta}</span> : null}
+                </span>
+                {section.badge ? (
+                  <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                    {section.badge}
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </aside>
+
+      <div className="space-y-4">{children}</div>
+    </div>
+  );
+}
+
+interface SectionBlockProps {
+  id: string;
+  title: string;
+  description?: string;
+  badge?: ReactNode;
+  children: ReactNode;
+}
+
+export function SectionBlock({ id, title, description, badge, children }: SectionBlockProps) {
+  return (
+    <section id={`agent-section-${id}`} className="scroll-mt-6 rounded-lg border bg-card">
+      <div className="border-b px-5 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+          {badge}
+        </div>
+        {description ? <p className="mt-1 text-xs text-muted-foreground">{description}</p> : null}
+      </div>
+      <div className="space-y-4 p-5">{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -19,6 +19,7 @@ import { GeneralTab } from '../components/agent/GeneralTab';
 import { BehaviorTab } from '../components/agent/BehaviorTab';
 import { TriggersTab } from '../components/agent/TriggersTab';
 import { ToolsTab } from '../components/agent/ToolsTab';
+import { MemoryTab } from '../components/agent/MemoryTab';
 import { agentFormSchema, type AgentFormValues } from '../components/agent/types';
 import { syncMCPTools, getMCPServer, type MCPServerRef } from '../services/mcpApi';
 import type { MCPServerDoc } from '../services/mcpApi';
@@ -56,12 +57,18 @@ export function AgentFormPage() {
       default: false,
       disabled: false,
     },
+    memory: {
+      label: 'Memory',
+      fields: [], // Placeholder tab until memory feature is merged
+      default: false,
+      disabled: false,
+    },
   } as const;
 
   // Extract derived values from tab config (memoized to avoid recreating on every render)
   const validTabs = useMemo(() => Object.keys(tabConfig), []);
   const defaultTab = useMemo(
-    () => Object.entries(tabConfig).find(([_, config]) => config.default)?.[0] || validTabs[0],
+    () => Object.entries(tabConfig).find(([, config]) => config.default)?.[0] || validTabs[0],
     [validTabs]
   );
   const tabFieldMapping: TabFieldMapping = useMemo(
@@ -800,7 +807,7 @@ export function AgentFormPage() {
         <Form {...form}>
           <form onSubmit={handleFormSubmit} className="space-y-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <TabsList className="grid w-full grid-cols-4">
+              <TabsList className="grid w-full grid-cols-5">
                 {Object.entries(tabConfig).map(([tabKey, config]) => (
                   <TabsTrigger key={tabKey} value={tabKey} disabled={config.disabled}>
                     {config.label}
@@ -851,6 +858,10 @@ export function AgentFormPage() {
                   onSyncMCP={handleSyncMCPServer}
                   mcpLoading={mcpLoading}
                 />
+              </TabsContent>
+
+              <TabsContent value="memory" className="space-y-4">
+                <MemoryTab />
               </TabsContent>
             </Tabs>
           </form>


### PR DESCRIPTION
### Motivation
- Provide a reusable, future-proof base for the Agent form UI so tabs can be composed from smaller sections and the form surface scales without becoming a god-component.
- Surface the forthcoming Memory tab in the UI as a disabled/coming-soon preview while preventing use until backend integration is merged.
- Preserve existing behavior, validation and provider/model wiring while making layout and section metadata reusable across tabs.

### Description
- Added a small form-base component set: `SectionRailLayout` and `SectionBlock` to render a left-side section rail with status dots and anchor navigation (`frontend/src/components/agent/form-base/SectionRailLayout.tsx`).
- Refactored `GeneralTab` to the new section-rail layout and split it into `Identity`, `Model`, and `Instructions` sections while keeping provider/model filtering, sliders and the instructions textarea (`frontend/src/components/agent/GeneralTab.tsx`).
- Refactored `BehaviorTab` to the section-rail pattern and split it into `Chat Access`, `History`, and `Execution` sections while keeping the existing cross-field logic and toasts (`frontend/src/components/agent/BehaviorTab.tsx`).
- Added a non-interactive `Memory` tab placeholder marked “Coming Soon” so the structure is visible but inputs are disabled until the feature is merged (`frontend/src/components/agent/MemoryTab.tsx`) and wired the tab into `AgentFormPage` (updated tab config and tab bar columns) (`frontend/src/pages/AgentFormPage.tsx`).

### Testing
- Ran ESLint for the new/updated files with `npx eslint src/components/agent/GeneralTab.tsx src/components/agent/BehaviorTab.tsx src/components/agent/MemoryTab.tsx src/components/agent/form-base/SectionRailLayout.tsx` and the checked files passed without errors.
- Ran type checking with `npm run typecheck` and it failed due to a pre-existing, unrelated TypeScript type mismatch in `src/components/agent/TriggerModal.tsx`; the type error is not introduced by these changes and requires a separate fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c760fb86c483218139a31a348c7601)