### PR TITLE
fix: resolve UnboundLocalError for user_content in litellm provider

### DIFF
--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -258,9 +258,8 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             messages.extend(context["conversation_history"])
         
         # Add user message with cache_control if conversation history caching is enabled
-        if not (enable_prompt_caching and model_supports_caching and cache_conversation_history):
-            user_content = enhanced_prompt
-        else:
+        user_content = enhanced_prompt
+        if enable_prompt_caching and model_supports_caching and cache_conversation_history:
             if provider_name == "anthropic" or "anthropic" in normalized_model:
                 # Anthropic: content array with cache_control
                 user_content = [


### PR DESCRIPTION
  - Correctly initialize `user_content` with a default value before the prompt caching block in `providers/litellm.py`. 
  - This prevents `UnboundLocalError` from occurring when prompt caching is enabled for models that don't fall into the specialized Anthropic/OpenAI array formats (like Gemini).
