### PR TITLE
Add runtime prompt-cache controls across API and streaming paths

### DIFF
--- a/PROMPT_CACHING_RUNTIME_GUIDE.md
+++ b/PROMPT_CACHING_RUNTIME_GUIDE.md
@@ -1,0 +1,363 @@
+# Huf Runtime Prompt Caching Guide (Static + Dynamic Mix)
+
+This document explains, in plain language, what was added in this PR, what was missing before, what is now possible, and how to use it in real Huf scenarios (API, streaming chat, and trigger-driven runs).
+
+---
+
+## 1) Why this PR exists
+
+Huf already had agent-level prompt caching toggles in the Agent DocType (UI), but that was not enough for teams that need:
+
+- different caching behavior by **channel/trigger** (`api`, `chat`, `doc_event`, `schedule`, `flow`, `sse_stream`, etc.)
+- **static vs dynamic** segmentation for better cache hit rates
+- provider-specific controls like:
+  - OpenAI/Deepseek `prompt_cache_retention`
+  - Gemini explicit `cached_content` reuse
+- the same behavior in **streaming** and non-streaming paths without adding new UI fields
+
+In short: teams needed backend/runtime control for cost optimization across trigger types.
+
+---
+
+## 2) What was missing before
+
+Before this PR:
+
+1. `run_agent_sync` and `run_agent_stream` did not support passing a runtime cache policy payload.
+2. There was no central way to set channel-level cache defaults from site config.
+3. Provider execution did not support explicit runtime static/dynamic segmentation controls.
+4. SSE endpoint (`/huf/stream/<agent_name>`) did not pass prompt-cache options down to `run_agent_stream`.
+
+---
+
+## 3) What changed in Huf
+
+## 3.1 Runtime cache options in `agent_integration.py`
+
+Added:
+
+- `_parse_prompt_cache_options(...)`
+- `_resolve_prompt_cache_options(channel_id, prompt_cache_options=None)`
+
+These functions:
+
+- accept dict or JSON string input
+- merge runtime options on top of site defaults from `huf_prompt_cache_defaults`
+- support per-channel defaults (`default` + `channels.<channel_id>`)
+
+Both of these APIs now accept `prompt_cache_options`:
+
+- `run_agent_sync(...)`
+- `run_agent_stream(...)`
+
+Resolved options are injected into provider context as:
+
+```python
+context["prompt_cache_options"] = {...}
+```
+
+So every path that uses these functions can leverage it.
+
+---
+
+## 3.2 Provider behavior in `huf/ai/providers/litellm.py`
+
+Added runtime-aware handling for:
+
+- `static_prefix`
+- `dynamic_suffix`
+- `cache_static_prefix`
+- `cache_dynamic_content`
+- `openai_prompt_cache_retention`
+- `gemini_cached_content`
+
+Also added helper `_build_text_content(...)` to normalize provider message payload format.
+
+### Behavior summary
+
+- If `static_prefix` is set, it is injected as a **system** block before user content.
+- If `dynamic_suffix` is set, it becomes the dynamic user part; otherwise it falls back to `enhanced_prompt`.
+- `cache_static_prefix` and `cache_dynamic_content` can override what is marked cacheable (subject to provider/model support).
+- For OpenAI/Deepseek, `prompt_cache_retention` is forwarded.
+- For Gemini/Google, `cached_content` is forwarded for explicit cache object reuse.
+
+---
+
+## 3.3 Streaming endpoint wiring (`huf/ai/agent_stream_renderer.py`)
+
+The SSE renderer now accepts and forwards `prompt_cache_options` from:
+
+- query/form data
+- JSON POST body
+
+and passes it into:
+
+```python
+run_agent_stream(..., prompt_cache_options=prompt_cache_options)
+```
+
+This closes the gap so streaming can use the same runtime controls.
+
+---
+
+## 4) What is now possible
+
+You can now do cost-saving strategies like:
+
+1. Keep a large, stable corpus in `static_prefix` (hotel list, policy text, product catalog slice).
+2. Send only changing request data in `dynamic_suffix` (dates, budget, user preference, event payload).
+3. Set defaults globally/per-channel in site config, then override per-call only where needed.
+4. Use the same approach in:
+   - direct API calls
+   - chat
+   - streaming SSE
+   - doc-event/scheduled/flow runs (because they go through `run_agent_sync`)
+
+---
+
+## 5) Runtime option contract
+
+`prompt_cache_options` supports:
+
+```json
+{
+  "static_prefix": "stable content...",
+  "dynamic_suffix": "request-specific content...",
+  "cache_static_prefix": true,
+  "cache_dynamic_content": false,
+  "openai_prompt_cache_retention": "24h",
+  "gemini_cached_content": "cachedContents/abc123"
+}
+```
+
+Notes:
+
+- Unknown keys are ignored.
+- Provider/model must still support caching.
+- Existing agent-level toggles still apply; these options are runtime overrides/enhancements.
+
+---
+
+## 6) Site-wide/channel defaults (non-UI control)
+
+Add this to site config (`site_config.json`) if desired:
+
+```json
+{
+  "huf_prompt_cache_defaults": {
+    "default": {
+      "cache_static_prefix": true,
+      "cache_dynamic_content": false
+    },
+    "channels": {
+      "api": {
+        "openai_prompt_cache_retention": "6h"
+      },
+      "doc_event": {
+        "openai_prompt_cache_retention": "24h"
+      },
+      "sse_stream": {
+        "openai_prompt_cache_retention": "24h"
+      }
+    }
+  }
+}
+```
+
+Runtime call options always override these defaults.
+
+---
+
+## 7) Example: Python API call (sync) with static+dynamic mix
+
+```python
+import frappe
+import json
+
+HOTEL_STATIC = """
+You are a hotel recommendation assistant.
+Rank hotels for business travelers.
+Prefer metro access, strong wifi, clean modern rooms.
+
+Hotels in Dubai:
+1. Jumeirah Emirates Towers | DIFC | AED 980
+2. Conrad Dubai | Sheikh Zayed Road | AED 860
+3. Rove Trade Centre | Trade Centre | AED 520
+"""
+
+dynamic = """
+User trip dates: 2026-05-10 to 2026-05-14
+Budget: AED 700-1000
+Preference: near DIFC/Sheikh Zayed + strong wifi + metro
+Return top 3 with one-line reason each.
+"""
+
+result = frappe.call(
+    "huf.ai.agent_integration.run_agent_sync",
+    agent_name="Dubai Hotel Agent",
+    channel_id="api",
+    prompt="Use the provided criteria and answer.",
+    prompt_cache_options={
+        "static_prefix": HOTEL_STATIC,
+        "dynamic_suffix": dynamic,
+        "cache_static_prefix": True,
+        "cache_dynamic_content": False,
+        "openai_prompt_cache_retention": "24h"
+    }
+)
+
+print(json.dumps(result, indent=2))
+```
+
+---
+
+## 8) Example: SSE streaming with prompt cache options
+
+### GET style (query param)
+
+```javascript
+const options = {
+  static_prefix: "Stable domain rules and hotel corpus...",
+  dynamic_suffix: "Trip dates, budget, and user prefs...",
+  cache_static_prefix: true,
+  cache_dynamic_content: false,
+  openai_prompt_cache_retention: "24h"
+};
+
+const url = `/huf/stream/${encodeURIComponent("Dubai Hotel Agent")}`
+  + `?prompt=${encodeURIComponent("Recommend best hotels")}`
+  + `&prompt_cache_options=${encodeURIComponent(JSON.stringify(options))}`;
+
+const es = new EventSource(url);
+es.onmessage = (evt) => console.log(JSON.parse(evt.data));
+```
+
+### POST style
+
+```javascript
+await fetch(`/huf/stream/${encodeURIComponent("Dubai Hotel Agent")}`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    prompt: "Recommend best hotels",
+    prompt_cache_options: {
+      static_prefix: "Stable domain rules and hotel corpus...",
+      dynamic_suffix: "Trip dates, budget, and user prefs...",
+      cache_static_prefix: true,
+      cache_dynamic_content: false,
+      openai_prompt_cache_retention: "24h"
+    }
+  })
+});
+```
+
+---
+
+## 9) Example: Huf Agent + trigger combination (doc event + chat)
+
+Imagine one agent:
+
+- Agent name: `Travel Procurement Assistant`
+- Used by:
+  - **Doc Event trigger** on `Travel Request` submission
+  - **Chat** for employee follow-up questions
+
+Use one stable static block (policy + preferred hotels), and dynamic content per channel:
+
+### A) Doc Event hook path (dynamic from document)
+
+```python
+# in your custom hook / server logic
+from huf.ai.agent_integration import run_agent_sync
+
+static_policy = """
+Company travel policy for Dubai:
+- Prefer approved hotels list first
+- Require metro access and stable wifi for business trips
+- Budget bracket rules...
+"""
+
+def on_travel_request_submit(doc, method=None):
+    dynamic = f"""
+Travel Request: {doc.name}
+Employee: {doc.employee}
+Dates: {doc.from_date} to {doc.to_date}
+Budget: {doc.budget}
+Special requirements: {doc.special_requirements or "None"}
+"""
+
+    run_agent_sync(
+        agent_name="Travel Procurement Assistant",
+        prompt="Recommend approved hotel options and rationale.",
+        channel_id="doc_event",
+        prompt_cache_options={
+            "static_prefix": static_policy,
+            "dynamic_suffix": dynamic,
+            "cache_static_prefix": True,
+            "cache_dynamic_content": False,
+            "openai_prompt_cache_retention": "24h"
+        }
+    )
+```
+
+### B) Chat path (dynamic from live user query)
+
+```python
+run_agent_sync(
+    agent_name="Travel Procurement Assistant",
+    prompt="I need options closer to DIFC this time.",
+    channel_id="chat",
+    prompt_cache_options={
+        "static_prefix": static_policy,
+        "dynamic_suffix": "User follow-up: closer to DIFC, same budget and dates.",
+        "cache_static_prefix": True,
+        "cache_dynamic_content": False
+    }
+)
+```
+
+Result: same stable policy block reused, dynamic asks remain small and change per interaction.
+
+---
+
+## 10) Reasoning behind design
+
+Why this approach:
+
+1. **No schema/UI migration required** for immediate adoption.
+2. Keeps compatibility with existing Agent toggles.
+3. Provides a pragmatic backend escape hatch for advanced cost optimization.
+4. Works with existing execution architecture (`run_agent_sync` / `run_agent_stream`), so it naturally spans trigger types.
+
+---
+
+## 11) Known limits / what can be improved next
+
+Good next steps:
+
+1. **UI support (optional)**  
+   Add advanced panel to define per-channel runtime caching templates directly in Desk.
+
+2. **Validation + typing**  
+   Add strict schema validation for `prompt_cache_options` and descriptive errors.
+
+3. **Observability**  
+   Persist effective cache options + retention/cached-content refs into `Agent Run` for auditing.
+
+4. **Provider-specific adapters**  
+   Add richer Gemini cache lifecycle helpers (create/list/expire) and explicit cache object management APIs.
+
+5. **Policy presets**  
+   Allow reusable named cache policies (e.g., `travel_policy_v3`) with role-based access.
+
+---
+
+## 12) Quick checklist for production usage
+
+- Keep `static_prefix` byte-stable whenever possible.
+- Keep dynamic details out of static block.
+- Start with `cache_dynamic_content=false` for best static hit ratio.
+- Use channel defaults in site config for consistency.
+- Add per-call overrides only for special cases.
+- Monitor cached token usage in run telemetry.
+

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -314,6 +314,63 @@ def safe_commit():
         else:
             raise
 
+
+def _parse_prompt_cache_options(prompt_cache_options):
+    """Parse prompt caching options passed via API/runtime and return a dict."""
+    if not prompt_cache_options:
+        return {}
+
+    if isinstance(prompt_cache_options, dict):
+        return prompt_cache_options
+
+    if isinstance(prompt_cache_options, str):
+        try:
+            parsed = json.loads(prompt_cache_options)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+
+    return {}
+
+
+def _resolve_prompt_cache_options(channel_id: str, prompt_cache_options=None) -> dict:
+    """
+    Resolve prompt-cache controls from runtime overrides + site config defaults.
+
+    Site config (non-UI) format:
+    {
+      "default": {"openai_prompt_cache_retention": "24h"},
+      "channels": {
+        "api": {"openai_prompt_cache_retention": "6h"},
+        "doc_event": {"openai_prompt_cache_retention": "24h"},
+        "sse_stream": {"openai_prompt_cache_retention": "24h"}
+      }
+    }
+    """
+    resolved = {}
+    site_defaults = frappe.conf.get("huf_prompt_cache_defaults")
+
+    if isinstance(site_defaults, str):
+        try:
+            site_defaults = json.loads(site_defaults)
+        except Exception:
+            site_defaults = {}
+
+    if isinstance(site_defaults, dict):
+        default_opts = site_defaults.get("default")
+        if isinstance(default_opts, dict):
+            resolved.update(default_opts)
+
+        channel_opts = (site_defaults.get("channels") or {}).get((channel_id or "").lower())
+        if isinstance(channel_opts, dict):
+            resolved.update(channel_opts)
+
+    runtime_opts = _parse_prompt_cache_options(prompt_cache_options)
+    if runtime_opts:
+        resolved.update(runtime_opts)
+
+    return resolved
+
 def process_tool_call(agent_run, conversation, name=None, args=None, result=None, error=None, is_output=False, tool_call_id=None):
     """Process tool call - handle requests (insert) and outputs (update) separately"""
     try:
@@ -580,6 +637,7 @@ def run_agent_sync(
     run_kind: str = None,
     prompt_template: str = None,
     prompt_version = None,
+    prompt_cache_options=None,
 ):
 
     if not agent_name:
@@ -747,6 +805,8 @@ def run_agent_sync(
             except Exception:
                 pass
 
+        resolved_prompt_cache = _resolve_prompt_cache_options(channel_id, prompt_cache_options)
+
         context = {
             "channel": channel_id,
             "external_id": external_id,
@@ -754,7 +814,8 @@ def run_agent_sync(
             "agent_name": agent_name,
             "response_format": response_format,
             "conversation_id": conversation.name,
-            "agent_run_id": run_doc.name
+            "agent_run_id": run_doc.name,
+            "prompt_cache_options": resolved_prompt_cache,
         }
 
         context_strategy = agent_doc.context_strategy or "Summarize"
@@ -809,7 +870,8 @@ def run_agent_sync(
             "agent_name": agent_name,
             "response_format": response_format,
             "conversation_id": conversation.name,
-            "agent_run_id": run_doc.name
+            "agent_run_id": run_doc.name,
+            "prompt_cache_options": resolved_prompt_cache,
         }
         run = RunProvider.run(agent, enhanced_prompt, resolved_provider, resolved_model, context)
         result = _run_async_safely(run)
@@ -1086,7 +1148,8 @@ async def run_agent_stream(
     conversation_id: str = None,
     create_new: bool = False,
     prompt_template: str = None,
-    prompt_version = None
+    prompt_version = None,
+    prompt_cache_options=None,
 ):
     """
     Streaming version of run_agent_sync.
@@ -1233,13 +1296,16 @@ async def run_agent_stream(
             
         agent = manager.create_agent()
         
+        resolved_prompt_cache = _resolve_prompt_cache_options(channel_id, prompt_cache_options)
+
         context = {
             "channel": channel_id,
             "external_id": external_id,
             "conversation_history": history,
             "agent_name": agent_name,
             "conversation_id": conversation.name,
-            "agent_run_id": run_doc.name
+            "agent_run_id": run_doc.name,
+            "prompt_cache_options": resolved_prompt_cache,
         }
         
         # SUMMARIZATION LOGIC

--- a/huf/ai/agent_stream_renderer.py
+++ b/huf/ai/agent_stream_renderer.py
@@ -68,6 +68,7 @@ class AgentStreamRenderer(BaseRenderer):
 		model = frappe.form_dict.get("model")
 		prompt_template = frappe.form_dict.get("prompt_template")
 		prompt_version = frappe.form_dict.get("prompt_version")
+		prompt_cache_options = frappe.form_dict.get("prompt_cache_options")
 		
 		if not prompt:
 			# Try to get from POST body
@@ -79,6 +80,7 @@ class AgentStreamRenderer(BaseRenderer):
 					if not model: model = body.get("model")
 					if not prompt_template: prompt_template = body.get("prompt_template")
 					if not prompt_version: prompt_version = body.get("prompt_version")
+					if not prompt_cache_options: prompt_cache_options = body.get("prompt_cache_options")
 			except Exception:
 				pass
 		
@@ -174,7 +176,8 @@ class AgentStreamRenderer(BaseRenderer):
 					conversation_id=None if create_new else conversation_id,
 					create_new=create_new,
 					prompt_template=prompt_template,
-					prompt_version=prompt_version
+					prompt_version=prompt_version,
+					prompt_cache_options=prompt_cache_options
 				)
 				
 				# Convert async generator to sync
@@ -445,4 +448,3 @@ class AgentStreamRenderer(BaseRenderer):
 
 		headers = {"Content-Type": "text/html; charset=utf-8"}
 		return self.build_response(html_content, headers=headers)
-

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -43,6 +43,27 @@ class SimpleResult:
 _L1_CAPABILITY_CACHE = {}
 
 
+def _get_prompt_cache_options(context: dict | None) -> dict:
+    if not isinstance(context, dict):
+        return {}
+    options = context.get("prompt_cache_options")
+    return options if isinstance(options, dict) else {}
+
+
+def _build_text_content(text: str, provider_name: str, cache_enabled: bool, cache_control_type: str):
+    """Build provider-compatible message content payload with optional cache marker."""
+    if not cache_enabled:
+        return text
+
+    if provider_name == "anthropic":
+        return [{"type": "text", "text": text, "cache_control": {"type": cache_control_type}}]
+
+    if provider_name in ("openai", "deepseek", "gemini", "google"):
+        return [{"type": "text", "text": text}]
+
+    return [{"type": "text", "text": text}]
+
+
 async def _execute_tool_call(tool, args_json, context=None, tool_call_id=None):
     """Execute a tool call and return the result.
 
@@ -202,6 +223,13 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
         cache_control_type = "ephemeral"
         cache_system_message = False
         cache_conversation_history = False
+        prompt_cache_options = _get_prompt_cache_options(context)
+        static_prefix = (prompt_cache_options.get("static_prefix") or "").strip()
+        dynamic_suffix = prompt_cache_options.get("dynamic_suffix")
+        openai_prompt_cache_retention = prompt_cache_options.get("openai_prompt_cache_retention")
+        gemini_cached_content = prompt_cache_options.get("gemini_cached_content")
+        cache_static_prefix = bool(prompt_cache_options.get("cache_static_prefix", True))
+        cache_dynamic_content_override = prompt_cache_options.get("cache_dynamic_content")
         
         if agent_doc:
             enable_prompt_caching = bool(agent_doc.get("enable_prompt_caching", 0))
@@ -221,36 +249,33 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                     "LiteLLM Prompt Caching"
                 )
 
-        # Prepare messages with cache_control if enabled
+        if not isinstance(dynamic_suffix, str):
+            dynamic_suffix = enhanced_prompt
+
+        # Prepare messages with cache control/static-vs-dynamic segmentation
         messages = []
         provider_name = normalized_model.split("/")[0]
+
+        if static_prefix:
+            static_cache_enabled = (
+                enable_prompt_caching and model_supports_caching and cache_static_prefix
+            )
+            messages.append(
+                {
+                    "role": "system",
+                    "content": _build_text_content(
+                        static_prefix, provider_name, static_cache_enabled, cache_control_type
+                    ),
+                }
+            )
         
         if agent.instructions:
-            if not (enable_prompt_caching and model_supports_caching and cache_system_message):
-                system_content = agent.instructions
-            else:
-                if provider_name == "anthropic" or "anthropic" in normalized_model:
-                    # Anthropic: content array with cache_control
-                    system_content = [
-                        {
-                            "type": "text",
-                            "text": agent.instructions,
-                            "cache_control": {"type": cache_control_type}
-                        }
-                    ]
-                elif provider_name in ("openai", "deepseek"):
-                    # OpenAI/Deepseek: content array format (LiteLLM handles cache_control)
-                    system_content = [
-                        {
-                            "type": "text",
-                            "text": agent.instructions
-                        }
-                    ]
-                    # Note: OpenAI requires messages to be marked for caching
-                    # LiteLLM handles this automatically when content is an array
-                else:
-                    system_content = [{"type": "text", "text": agent.instructions}]
-            
+            system_cache_enabled = (
+                enable_prompt_caching and model_supports_caching and cache_system_message
+            )
+            system_content = _build_text_content(
+                agent.instructions, provider_name, system_cache_enabled, cache_control_type
+            )
             messages.append({"role": "system", "content": system_content})
         
         # Insert Conversation History if available
@@ -258,25 +283,16 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             messages.extend(context["conversation_history"])
         
         # Add user message with cache_control if conversation history caching is enabled
-        user_content = enhanced_prompt
-        if enable_prompt_caching and model_supports_caching and cache_conversation_history:
-            if provider_name == "anthropic" or "anthropic" in normalized_model:
-                # Anthropic: content array with cache_control
-                user_content = [
-                    {
-                        "type": "text",
-                        "text": enhanced_prompt,
-                        "cache_control": {"type": cache_control_type}
-                    }
-                ]
-            elif provider_name in ("openai", "deepseek"):
-                # OpenAI/Deepseek: content array format
-                user_content = [
-                    {
-                        "type": "text",
-                        "text": enhanced_prompt
-                    }
-                ]
+        cache_dynamic_content = cache_conversation_history
+        if isinstance(cache_dynamic_content_override, bool):
+            cache_dynamic_content = cache_dynamic_content_override
+
+        user_content = _build_text_content(
+            dynamic_suffix,
+            provider_name,
+            enable_prompt_caching and model_supports_caching and cache_dynamic_content,
+            cache_control_type,
+        )
         
         messages.append({"role": "user", "content": user_content})
 
@@ -330,6 +346,15 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
             if context and context.get("response_format"):
                 completion_kwargs["response_format"] = context.get("response_format")
+
+            if (
+                provider_name in ("openai", "deepseek")
+                and openai_prompt_cache_retention
+            ):
+                completion_kwargs["prompt_cache_retention"] = openai_prompt_cache_retention
+
+            if provider_name in ("gemini", "google") and gemini_cached_content:
+                completion_kwargs["cached_content"] = gemini_cached_content
 
             if top_p:
                 completion_kwargs["top_p"] = top_p
@@ -642,6 +667,13 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         cache_control_type = "ephemeral"
         cache_system_message = False
         cache_conversation_history = False
+        prompt_cache_options = _get_prompt_cache_options(context)
+        static_prefix = (prompt_cache_options.get("static_prefix") or "").strip()
+        dynamic_suffix = prompt_cache_options.get("dynamic_suffix")
+        openai_prompt_cache_retention = prompt_cache_options.get("openai_prompt_cache_retention")
+        gemini_cached_content = prompt_cache_options.get("gemini_cached_content")
+        cache_static_prefix = bool(prompt_cache_options.get("cache_static_prefix", True))
+        cache_dynamic_content_override = prompt_cache_options.get("cache_dynamic_content")
         
         if agent_doc:
             enable_prompt_caching = bool(agent_doc.get("enable_prompt_caching", 0))
@@ -661,53 +693,49 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                     title="LiteLLM Prompt Caching"
                 )
 
-        # Prepare messages with cache_control if enabled
+        if not isinstance(dynamic_suffix, str):
+            dynamic_suffix = enhanced_prompt
+
+        # Prepare messages with cache control/static-vs-dynamic segmentation
         messages = []
         provider_name = normalized_model.split("/")[0]
+
+        if static_prefix:
+            static_cache_enabled = (
+                enable_prompt_caching and model_supports_caching and cache_static_prefix
+            )
+            messages.append(
+                {
+                    "role": "system",
+                    "content": _build_text_content(
+                        static_prefix, provider_name, static_cache_enabled, cache_control_type
+                    ),
+                }
+            )
         
         if agent.instructions:
-            system_content = agent.instructions
-            
-            if enable_prompt_caching and model_supports_caching and cache_system_message:
-                if provider_name == "anthropic" or "anthropic" in normalized_model:
-                    system_content = [
-                        {
-                            "type": "text",
-                            "text": agent.instructions,
-                            "cache_control": {"type": cache_control_type}
-                        }
-                    ]
-                elif provider_name in ("openai", "deepseek"):
-                    system_content = [
-                        {
-                            "type": "text",
-                            "text": agent.instructions
-                        }
-                    ]
-            
+            system_cache_enabled = (
+                enable_prompt_caching and model_supports_caching and cache_system_message
+            )
+            system_content = _build_text_content(
+                agent.instructions, provider_name, system_cache_enabled, cache_control_type
+            )
             messages.append({"role": "system", "content": system_content})
         
         # Insert Conversation History if available
         if context and context.get("conversation_history"):
             messages.extend(context["conversation_history"])
         
-        user_content = enhanced_prompt
-        if enable_prompt_caching and model_supports_caching and cache_conversation_history:
-            if provider_name == "anthropic" or "anthropic" in normalized_model:
-                user_content = [
-                    {
-                        "type": "text",
-                        "text": enhanced_prompt,
-                        "cache_control": {"type": cache_control_type}
-                    }
-                ]
-            elif provider_name in ("openai", "deepseek"):
-                user_content = [
-                    {
-                        "type": "text",
-                        "text": enhanced_prompt
-                    }
-                ]
+        cache_dynamic_content = cache_conversation_history
+        if isinstance(cache_dynamic_content_override, bool):
+            cache_dynamic_content = cache_dynamic_content_override
+
+        user_content = _build_text_content(
+            dynamic_suffix,
+            provider_name,
+            enable_prompt_caching and model_supports_caching and cache_dynamic_content,
+            cache_control_type,
+        )
         
         messages.append({"role": "user", "content": user_content})
 
@@ -755,6 +783,15 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
 
         if top_p:
             completion_kwargs["top_p"] = top_p
+
+        if (
+            provider_name in ("openai", "deepseek")
+            and openai_prompt_cache_retention
+        ):
+            completion_kwargs["prompt_cache_retention"] = openai_prompt_cache_retention
+
+        if provider_name in ("gemini", "google") and gemini_cached_content:
+            completion_kwargs["cached_content"] = gemini_cached_content
 
         provider_name = normalized_model.split("/")[0]
         _setup_api_key(provider_name, api_key, completion_kwargs)

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -58,9 +58,6 @@ def _build_text_content(text: str, provider_name: str, cache_enabled: bool, cach
     if provider_name == "anthropic":
         return [{"type": "text", "text": text, "cache_control": {"type": cache_control_type}}]
 
-    if provider_name in ("openai", "deepseek", "gemini", "google"):
-        return [{"type": "text", "text": text}]
-
     return [{"type": "text", "text": text}]
 
 
@@ -347,13 +344,10 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             if context and context.get("response_format"):
                 completion_kwargs["response_format"] = context.get("response_format")
 
-            if (
-                provider_name in ("openai", "deepseek")
-                and openai_prompt_cache_retention
-            ):
+            if openai_prompt_cache_retention:
                 completion_kwargs["prompt_cache_retention"] = openai_prompt_cache_retention
 
-            if provider_name in ("gemini", "google") and gemini_cached_content:
+            if gemini_cached_content:
                 completion_kwargs["cached_content"] = gemini_cached_content
 
             if top_p:
@@ -784,13 +778,10 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         if top_p:
             completion_kwargs["top_p"] = top_p
 
-        if (
-            provider_name in ("openai", "deepseek")
-            and openai_prompt_cache_retention
-        ):
+        if openai_prompt_cache_retention:
             completion_kwargs["prompt_cache_retention"] = openai_prompt_cache_retention
 
-        if provider_name in ("gemini", "google") and gemini_cached_content:
+        if gemini_cached_content:
             completion_kwargs["cached_content"] = gemini_cached_content
 
         provider_name = normalized_model.split("/")[0]


### PR DESCRIPTION
### Motivation

- Enable static-vs-dynamic prompt-caching strategies (like Gemini explicit cache or OpenAI prefix caching) for all trigger channels and streaming without adding UI fields. 

### Description

- Added backend-only parsing/resolution helpers `
_parse_prompt_cache_options()` and `
resolve_prompt_cache_options()` and a site-config hook `huf_prompt_cache_defaults` to supply per-channel defaults for prompt-cache controls. 
- Propagated resolved cache options into execution context by adding a new `prompt_cache_options` parameter to `run_agent_sync()` and `run_agent_stream()` so API/chat/doc-event/schedule/flow/streaming runs can override caching at runtime. 
- Extended the LiteLLM provider (`huf/ai/providers/litellm.py`) to consume runtime options and implement static vs dynamic segmentation and provider-specific controls (`static_prefix`, `dynamic_suffix`, `cache_static_prefix`, `cache_dynamic_content`, `openai_prompt_cache_retention`, and `gemini_cached_content`) and added `_build_text_content()` to normalize provider-specific cache payloads. 
- Changes touch `huf/ai/agent_integration.py` and `huf/ai/providers/litellm.py` and preserve existing agent-level toggles (`enable_prompt_caching`, `cache_system_message`, `cache_conversation_history`) while allowing programmatic overrides. 

### Testing

- Ran `python -m py_compile huf/ai/agent_integration.py huf/ai/providers/litellm.py` and compilation succeeded. 
- Verified that sync and streaming code paths include `prompt_cache_options` in the `context` passed to the provider.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1f19af9f88321b9f940beb230e5ef)