### PR TITLE
fix: resolve setup wizard infinite redirect loop after completion

### DIFF
--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -6,8 +6,7 @@ app_email = "info@tridz.com"
 app_license = "agpl"
 source_link = "https://github.com/tridz-dev/huf.git"
 app_logo_url="/assets/huf/Images/huf.png"
-# for version 16+ this has to be /desk/huf, this is being updated in after_app_install hook
-app_url="huf"
+app_url="/huf"
 # Apps
 # ------------------
 


### PR DESCRIPTION
- Use absolute URL `/huf` instead of relative `huf` for `app_url` in `hooks.py`.
- This prevents `window.location.href` from resolving the relative path incorrectly when called from the setup wizard page (`/desk/setup-wizard/0`), which caused navigation to `/desk/setup-wizard/huf` instead of `/huf`.

**Test**

- ✔ Tested on Frappe v15
- ✔ Tested on Frappe v16
- ✔ Setup wizard completes successfully
- ✔ No infinite reload loop
- ✔ Redirects correctly to /huf
- ✔ No /desk/setup-wizard/undefined route observed