### PR TITLE
Add "Show Tool Execution Details" toggle

### DIFF
--- a/frontend/src/components/agent/AdvancedTab.tsx
+++ b/frontend/src/components/agent/AdvancedTab.tsx
@@ -318,6 +318,27 @@ export function AdvancedTab({ form, allModels }: AdvancedTabProps) {
               </FormItem>
             )}
           />
+
+          <FormField
+            control={form.control}
+            name="show_tool_execution_details"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4 sm:col-span-2">
+                <div className="space-y-0.5">
+                  <FormLabel className="text-base">Show Tool Execution Details</FormLabel>
+                  <FormDescription>
+                    Enable to display tool execution status and responses in the agent output. This includes whether each tool call is completed and its corresponding result.
+                  </FormDescription>
+                </div>
+                <FormControl>
+                  <Switch
+                    checked={field.value ?? false}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
         </CardContent>
       </Card>
 

--- a/frontend/src/components/agent/types.ts
+++ b/frontend/src/components/agent/types.ts
@@ -52,6 +52,7 @@ export const agentFormSchema = z.object({
       (v) => v === undefined || v === '' || /^#[0-9A-Fa-f]{6}$/.test(v),
       { message: 'Use a hex color including #, e.g. #6366F1' },
     ),
+  show_tool_execution_details: z.boolean().optional(),
 
   // Advanced model overrides
   image_generation_model: z.string().optional(),

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -37,6 +37,7 @@ interface ChatMessageProps {
     message: MessageType;
     agentName: string;
     agentColor: string | null;
+    showToolExecutionDetails?: boolean;
     status: 'submitted' | 'streaming' | 'ready' | 'error';
     loadingType?: LoadingType;
     onFeedback: (feedback: 'Thumbs Up' | 'Thumbs Down', options?: { agentMessageId?: string; comments?: string }) => void;
@@ -47,6 +48,7 @@ export function ChatMessage({
     message, 
     agentName,
     agentColor,
+    showToolExecutionDetails = true,
     status,
     loadingType = 'default',
     onFeedback,
@@ -57,6 +59,21 @@ export function ChatMessage({
     const timestamp = message.versions[0]?.id ? undefined : undefined; // We'll get timestamp from message if available
     const timeDisplay = timestamp ? formatTime(timestamp) : '';
     const userInitials = user?.full_name ? getInitials(user.full_name) : 'You';
+
+    // Skip rendering ALL tool-related messages when tool execution details are hidden
+    if (!showToolExecutionDetails) {
+        // Hide messages with tool-related kinds (stored in DB as text)
+        const kind = message.kind;
+        if (kind === 'Tool Call' || kind === 'Tool Result') {
+            return null;
+        }
+        // Hide messages that only contain Tool UI components (from socket events)
+        const hasToolsOnly = message.tools && message.tools.length > 0 &&
+            (!message.versions[0]?.content || message.versions[0].content.trim() === '');
+        if (hasToolsOnly) {
+            return null;
+        }
+    }
 
     return (
         <div className={cn("flex gap-3 group relative", isUser ? "flex-row" : "flex-row")}>
@@ -78,7 +95,7 @@ export function ChatMessage({
                     )}
                 </div>
                 
-                {message.tools && message.tools.length > 0 ? (
+                {showToolExecutionDetails && message.tools && message.tools.length > 0 ? (
                     message.tools.map((tool, toolIndex) => (
                         <Tool key={`${message.key}-tool-${toolIndex}`}>
                             <ToolHeader
@@ -103,9 +120,9 @@ export function ChatMessage({
                              message.from === 'assistant' && 
                              (!message.versions[0]?.content || message.versions[0].content.trim() === '') && (
                                 <MessageLoadingState
-                                    type={message.tools?.length ? 'tool-execution' : loadingType}
-                                    hasTools={!!message.tools && message.tools.length > 0}
-                                    toolName={message.tools?.[0]?.name}
+                                    type={showToolExecutionDetails && message.tools?.length ? 'tool-execution' : loadingType}
+                                    hasTools={showToolExecutionDetails && !!message.tools && message.tools.length > 0}
+                                    toolName={showToolExecutionDetails ? message.tools?.[0]?.name : undefined}
                                 />
                             )}
                             {message.generatedAudio && message.from === 'assistant' ? (
@@ -153,7 +170,7 @@ export function ChatMessage({
                             )}
                         </MessageContent>
                         {/* Actions for assistant messages */}
-                        {message.from === 'assistant' && message.versions[0]?.content && !message.tools && (
+                        {message.from === 'assistant' && message.versions[0]?.content && (!message.tools || !showToolExecutionDetails) && (
                             <div className="opacity-0 transition-opacity group-hover:opacity-100">
                                 <MessageActions
                                     content={message.versions[0].content}

--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -40,7 +40,7 @@ export function ChatMessageList({
     const [isModelMismatch, setIsModelMismatch] = useState(false);
     const [isTransitioningToNewConversation, setIsTransitioningToNewConversation] = useState(false);
 
-    const { agentName, agentColor } = useChatAgentIdentity(chatId, searchParams);
+    const { agentName, agentColor, showToolExecutionDetails } = useChatAgentIdentity(chatId, searchParams);
 
     // Check for model mismatch between conversation and agent
     useEffect(() => {
@@ -305,6 +305,7 @@ export function ChatMessageList({
                                     message={message} 
                                     agentName={agentName}
                                     agentColor={agentColor}
+                                    showToolExecutionDetails={showToolExecutionDetails}
                                     status={status}
                                     loadingType={loadingType}
                                     onFeedback={handleFeedback}

--- a/frontend/src/components/chat/useChatAgentIdentity.ts
+++ b/frontend/src/components/chat/useChatAgentIdentity.ts
@@ -1,11 +1,37 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 import { getConversation } from '@/services/chatApi';
 import { getAgent } from '@/services/agentApi';
 
+/** localStorage key for cross-tab sync of the tool-execution-details toggle */
+function toolDetailsKey(agent: string): string {
+  return `huf:agent:${agent}:show_tool_execution_details`;
+}
+
+/** Write the setting to localStorage so other tabs can pick it up via the `storage` event. */
+export function writeToolDetailsSetting(agent: string, enabled: boolean): void {
+  try {
+    localStorage.setItem(toolDetailsKey(agent), enabled ? '1' : '0');
+  } catch {
+    // Storage full or unavailable – non-critical
+  }
+}
+
 export function useChatAgentIdentity(chatId: string | null, searchParams: URLSearchParams) {
   const [agentName, setAgentName] = useState<string>('');
   const [agentColor, setAgentColor] = useState<string | null>(null);
+  const [showToolExecutionDetails, setShowToolExecutionDetails] = useState<boolean>(true);
+  const agentNameRef = useRef<string>('');
+
+  // Keep ref in sync so async callbacks see the latest value
+  agentNameRef.current = agentName;
+
+  /** Apply the value from the API and cache it in localStorage */
+  const applyToolDetails = useCallback((agent: string, value: 0 | 1 | undefined) => {
+    const enabled = value === 1;
+    setShowToolExecutionDetails(enabled);
+    writeToolDetailsSetting(agent, enabled);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -19,10 +45,16 @@ export function useChatAgentIdentity(chatId: string | null, searchParams: URLSea
 
         try {
           const agentData = await getAgent(conversation.agent);
-          if (!cancelled) setAgentColor(agentData.agent_color || null);
+          if (!cancelled) {
+            setAgentColor(agentData.agent_color || null);
+            applyToolDetails(conversation.agent, agentData.show_tool_execution_details);
+          }
         } catch (error) {
           console.error('Failed to load agent color', error);
-          if (!cancelled) setAgentColor(null);
+          if (!cancelled) {
+            setAgentColor(null);
+            setShowToolExecutionDetails(true);
+          }
         }
       } catch (error) {
         console.error('Failed to load conversation agent', error);
@@ -34,16 +66,25 @@ export function useChatAgentIdentity(chatId: string | null, searchParams: URLSea
       if (!cancelled) setAgentName(agentFromQuery);
 
       if (!agentFromQuery) {
-        if (!cancelled) setAgentColor(null);
+        if (!cancelled) {
+          setAgentColor(null);
+          setShowToolExecutionDetails(true);
+        }
         return;
       }
 
       try {
         const agentData = await getAgent(agentFromQuery);
-        if (!cancelled) setAgentColor(agentData.agent_color || null);
+        if (!cancelled) {
+          setAgentColor(agentData.agent_color || null);
+          applyToolDetails(agentFromQuery, agentData.show_tool_execution_details);
+        }
       } catch (error) {
         console.error('Failed to load agent color', error);
-        if (!cancelled) setAgentColor(null);
+        if (!cancelled) {
+          setAgentColor(null);
+          setShowToolExecutionDetails(true);
+        }
       }
     }
 
@@ -53,8 +94,53 @@ export function useChatAgentIdentity(chatId: string | null, searchParams: URLSea
     return () => {
       cancelled = true;
     };
-  }, [chatId, searchParams]);
+  }, [chatId, searchParams, applyToolDetails]);
 
-  return { agentName, agentColor };
+  // ── Cross-tab sync via localStorage `storage` event ──────────────
+  // Instant sync when another tab in the SAME React SPA writes to localStorage
+  useEffect(() => {
+    if (!agentName) return;
+
+    const expectedKey = toolDetailsKey(agentName);
+
+    function handleStorageChange(event: StorageEvent) {
+      if (event.key !== expectedKey) return;
+      if (event.newValue === '1') setShowToolExecutionDetails(true);
+      else if (event.newValue === '0') setShowToolExecutionDetails(false);
+    }
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, [agentName]);
+
+  // ── Re-fetch from API when tab regains focus ─────────────────────
+  // Handles ALL save methods: React SPA, Frappe desk form, API/scripts
+  useEffect(() => {
+    if (!agentName) return;
+    let cancelled = false;
+
+    function handleVisibilityChange() {
+      if (document.visibilityState !== 'visible') return;
+      const currentAgent = agentNameRef.current;
+      if (!currentAgent) return;
+
+      // Re-fetch the authoritative value from the server
+      getAgent(currentAgent)
+        .then((agentData) => {
+          if (cancelled) return;
+          applyToolDetails(currentAgent, agentData.show_tool_execution_details);
+        })
+        .catch(() => {
+          // Non-critical – keep existing value
+        });
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [agentName, applyToolDetails]);
+
+  return { agentName, agentColor, showToolExecutionDetails };
 }
-

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -98,6 +98,7 @@ function mapAgentDocToFormValues(agent: Partial<AgentDoc>): AgentFormValues {
     enable_conversation_data: agent.enable_conversation_data === 1,
     autonaming_of_conversation_title: agent.autonaming_of_conversation_title === 1,
     agent_color: agent.agent_color?.trim() || '',
+    show_tool_execution_details: agent.show_tool_execution_details === 1,
     image_generation_model: agent.image_generation_model || undefined,
     tts_model: agent.tts_model || undefined,
     tts_voice: agent.tts_voice || '',
@@ -165,6 +166,7 @@ export function AgentFormPage() {
         'enable_conversation_data',
         'autonaming_of_conversation_title',
         'agent_color',
+        'show_tool_execution_details',
         'image_generation_model',
         'tts_model',
         'tts_voice',
@@ -288,6 +290,7 @@ export function AgentFormPage() {
         enable_conversation_data: false,
         autonaming_of_conversation_title: false,
         agent_color: '',
+        show_tool_execution_details: false,
         image_generation_model: undefined,
         tts_model: undefined,
         tts_voice: '',
@@ -671,6 +674,7 @@ export function AgentFormPage() {
             enable_conversation_data: data.enable_conversation_data === 1,
             autonaming_of_conversation_title: data.autonaming_of_conversation_title === 1,
             agent_color: data.agent_color?.trim() || '',
+            show_tool_execution_details: data.show_tool_execution_details === 1,
   
             image_generation_model: data.image_generation_model || undefined,
             tts_model: data.tts_model || undefined,
@@ -832,6 +836,7 @@ export function AgentFormPage() {
         enable_conversation_data: values.enable_conversation_data ? 1 : 0,
         autonaming_of_conversation_title: values.autonaming_of_conversation_title ? 1 : 0,
         agent_color: values.agent_color?.trim() || undefined,
+        show_tool_execution_details: values.show_tool_execution_details ? 1 : 0,
 
         image_generation_model: values.image_generation_model || undefined,
         tts_model: values.tts_model || undefined,
@@ -896,6 +901,7 @@ export function AgentFormPage() {
           enable_conversation_data: newAgent.enable_conversation_data === 1,
           autonaming_of_conversation_title: newAgent.autonaming_of_conversation_title === 1,
           agent_color: newAgent.agent_color?.trim() || '',
+          show_tool_execution_details: newAgent.show_tool_execution_details === 1,
 
           image_generation_model: newAgent.image_generation_model || undefined,
           tts_model: newAgent.tts_model || undefined,
@@ -947,6 +953,7 @@ form.reset({
   enable_conversation_data: values.enable_conversation_data,
   autonaming_of_conversation_title: values.autonaming_of_conversation_title,
   agent_color: values.agent_color,
+  show_tool_execution_details: values.show_tool_execution_details,
 
   image_generation_model: values.image_generation_model,
   tts_model: values.tts_model,

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -33,6 +33,7 @@ import { syncMCPTools, getMCPServer, type MCPServerRef } from '../services/mcpAp
 import type { MCPServerDoc } from '../services/mcpApi';
 import type { AgentKnowledgeRow } from '../types/agent.types';
 import { createFormSubmitHandler, type TabFieldMapping } from '../utils/formValidation';
+import { writeToolDetailsSetting } from '../components/chat/useChatAgentIdentity';
 
 type PromptListRow = {
   name: string;
@@ -912,12 +913,16 @@ export function AgentFormPage() {
         setAllowChat(newAgent.allow_chat === 1);
         setInitialKnowledgeSources([...knowledgeSources]);
         setAgentStats({ last_run: newAgent.last_run ?? null, total_run: newAgent.total_run ?? null });
+        // Sync tool-details setting to other tabs via localStorage
+        writeToolDetailsSetting(newAgent.name, newAgent.show_tool_execution_details === 1);
         // Navigate to the edit page with the new agent's ID
         navigate(`/agents/${newAgent.name}`);
       } else if (id) {
         // Update existing agent
         await updateAgent(id, agentData as unknown as Partial<AgentDoc>);
         toast.success('Agent updated successfully!');
+        // Sync tool-details setting to other tabs via localStorage
+        writeToolDetailsSetting(id, !!values.show_tool_execution_details);
 // Reset form state with the updated values to mark form as clean
 form.reset({
   agent_name: values.agent_name,

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -230,6 +230,7 @@ export interface AgentDoc {
   last_run?: string | null; // Last execution timestamp
   total_run?: number; // Total number of runs
   agent_color?: string | null; // Hex color code for agent background
+  show_tool_execution_details?: 0 | 1; // 0 or 1
   allow_guest?: number; // 0 or 1
   allowed_users?: AgentPermissionUserRow[];
   allowed_roles?: AgentPermissionRoleRow[];

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -70,6 +70,7 @@
   "stt_model",
   "huf_ui_section",
   "agent_color",
+  "show_tool_execution_details",
   "permissions_tab",
   "allow_guest",
   "allowed_users",
@@ -555,12 +556,19 @@
    "fieldname": "audio_transcription_section",
    "fieldtype": "Section Break",
    "label": "Audio Transcription"
+  },
+  {
+   "default": "1",
+   "description": "Enable to display tool execution status and responses in the agent output.\nThis includes whether each tool call is completed and its corresponding result.",
+   "fieldname": "show_tool_execution_details",
+   "fieldtype": "Check",
+   "label": "Show Tool Execution Details"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-11 12:59:21.085509",
+ "modified": "2026-04-20 16:43:49.008915",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent",


### PR DESCRIPTION
### What

New per-agent toggle in **Advanced Settings → Huf UI** that controls whether tool execution logs (tool name, status, arguments, results) are displayed in the chat interface. Default: **enabled** (no behavior change for existing agents).

### Why

End-user-facing agents show verbose tool logs like `"create_todo ✅ Completed"` and `"Requesting Tool: ..."` which clutter the conversation. This toggle lets admins hide these details per-agent for a cleaner chat experience.

### How

**Frontend-only rendering filter** — no backend changes to streaming or socket logic.

- Added `show_tool_execution_details` (`Check`, default `1`) to Agent DocType
- Chat UI fetches the setting via `getAgent()` and filters tool messages at render time
- Messages with `kind="Tool Call"` / `kind="Tool Result"` and `<Tool>` UI components are hidden when disabled
- Cross-tab sync via `localStorage` + `visibilitychange` API re-fetch

> Tool executions still happen and are recorded in the DB — only the display is filtered.

### Files Changed

| File | What |
|------|------|
| `agent.json` | New `Check` field |
| `useChatAgentIdentity.ts` | Fetch setting + cross-tab sync |
| `ChatMessage.tsx` | Filter tool messages by `kind` and `tools[]` |
| `ChatMessageList.tsx` | Pass setting as prop |
| `AgentFormPage.tsx` | Sync to localStorage on save |

### Testing

1. Enable toggle → chat with tool → tool details visible ✅
2. Disable toggle → chat with tool → only text response shown ✅
3. Disable → check old chat → historical tool messages hidden ✅
4. Re-enable → old messages reappear ✅

### Migration

```bash
bench migrate
bench build --app huf
```

Defaults to enabled — **zero impact on existing agents**.

### Compatibility

✅ Tested with Frappe v15 and Frappe v16 — no issues.