### PR TITLE
fix: Fix agent header stats alignment

### DIFF
--- a/frontend/src/components/agent/AgentHeader.tsx
+++ b/frontend/src/components/agent/AgentHeader.tsx
@@ -100,7 +100,7 @@ export function AgentHeader({
             </div>
           )}
           {!isNew && (lastRun !== undefined || totalRun !== undefined) && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 pl-0 sm:pl-6">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
               <span>Last run: {lastRun ? formatTimeAgo(lastRun) : 'Never'}</span>
               <span>Total runs: {totalRun ?? 0}</span>
             </div>


### PR DESCRIPTION
## Summary

Fixes the agent detail header stats row so `Last run` and `Total runs` align with the agent title/input and the rest of the header content.

## Root Cause

The stats row had a responsive `sm:pl-6` class, adding 24px of left padding on wider screens. That made the stats line visually drift right from the title and form content.

## Validation

- Verified `http://192.168.97.3:8001/huf/agents/huf_future_v2` is reachable in the browser; unauthenticated browser session redirects to Frappe login.
- Verified API access against `http://192.168.97.3:8001` with token auth.
- Ran `yarn build` successfully after rebasing onto current `upstream/develop`.
- Browser-rendered a local fixture using the updated `AgentHeader` class layout and generated stylesheet to confirm the stats row shares the same left edge as the title.