### PR TITLE
build: update dependencies for vector storage, document parsing, and compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,13 @@ dependencies = [
     "litellm>=1.0.0,!=1.82.7,!=1.82.8",
     "llama-index-core>=0.10.0",
     "sqlite-vec",
-    "pysqlite3-binary",
+    "pysqlite3-binary; platform_machine == 'x86_64' and python_version < '3.14'",
+    "chromadb",
+    "llama-index-vector-stores-chroma",
+    "pypdf",
+    "python-docx",
+    "beautifulsoup4",
+    "aiohttp",
 ]
 
 [build-system]


### PR DESCRIPTION
This commit introduces several new dependencies and refines existing ones to support extended vector database backends, document processing, and web integrations:

- Add environment markers to `pysqlite3-binary` restricting its installation to x86_64 architectures and Python versions < 3.14.
- Add `chromadb` and `llama-index-vector-stores-chroma` to support  Chroma vector storage integration.
- Add `pypdf` for extracting text from PDF documents.
- Add `python-docx` for processing Microsoft Word documents.
- Add `beautifulsoup4` and `aiohttp` for asynchronous web requests and HTML scraping capabilities.
