### PR TITLE
fix: add ChromaDB server mode support

### DIFF
--- a/huf/ai/knowledge/backends/chroma_backend.py
+++ b/huf/ai/knowledge/backends/chroma_backend.py
@@ -14,7 +14,6 @@ try:
 	from llama_index.vector_stores.chroma import ChromaVectorStore
 	from llama_index.core import VectorStoreIndex, StorageContext, Document
 	import chromadb
-	from chromadb.config import Settings
 	LLAMAINDEX_AVAILABLE = True
 except ImportError:
 	LLAMAINDEX_AVAILABLE = False
@@ -63,9 +62,6 @@ class ChromaBackend(KnowledgeBackend):
 			# File-based persistent client
 			self.client = chromadb.PersistentClient(
 				path=persist_directory,
-				settings=Settings(
-					anonymized_telemetry=False,
-				)
 			)
 		else:
 			# HTTP client for Chroma server
@@ -77,9 +73,6 @@ class ChromaBackend(KnowledgeBackend):
 				host=host,
 				port=port,
 				ssl=ssl,
-				settings=Settings(
-					anonymized_telemetry=False,
-				)
 			)
 		
 		# Get or create collection

--- a/huf/ai/knowledge/indexer.py
+++ b/huf/ai/knowledge/indexer.py
@@ -27,10 +27,17 @@ def _build_backend_config(source) -> dict:
 		config["embedding_provider"] = getattr(source, "embedding_provider", None)
 
 	if source.knowledge_type == "chroma":
-		from frappe.utils import get_files_path
-		files_path = get_files_path(is_private=True)
-		safe_name = frappe.scrub(source.name)
-		config["persist_directory"] = os.path.join(files_path, "knowledge", f"{safe_name}_chroma")
+		chroma_mode = getattr(source, "chroma_mode", "File") or "File"
+		if chroma_mode == "Server":
+			config["host"] = getattr(source, "chroma_host", None) or "localhost"
+			config["port"] = int(getattr(source, "chroma_port", None) or 8000)
+			config["ssl"] = bool(getattr(source, "chroma_ssl", False))
+			
+		else:
+			from frappe.utils import get_files_path
+			files_path = get_files_path(is_private=True)
+			safe_name = frappe.scrub(source.name)
+			config["persist_directory"] = os.path.join(files_path, "knowledge", f"{safe_name}_chroma")
 
 	return config
 

--- a/huf/huf/doctype/knowledge_source/knowledge_source.json
+++ b/huf/huf/doctype/knowledge_source/knowledge_source.json
@@ -17,6 +17,12 @@
         "vector_dimension",
         "column_break_vector",
         "embedding_provider",
+        "chroma_server_section",
+        "chroma_mode",
+        "chroma_host",
+        "column_break_chroma",
+        "chroma_port",
+        "chroma_ssl",
         "storage_settings_section",
         "storage_mode",
         "sqlite_file",
@@ -207,11 +213,54 @@
             "options": "AI Provider",
             "description": "AI Provider for API key resolution",
             "depends_on": "eval:['sqlite_vec', 'chroma'].includes(doc.knowledge_type)"
+        },
+        {
+            "fieldname": "chroma_server_section",
+            "fieldtype": "Section Break",
+            "label": "Chroma Connection Settings",
+            "depends_on": "eval:doc.knowledge_type === 'chroma'"
+        },
+        {
+            "fieldname": "chroma_mode",
+            "fieldtype": "Select",
+            "label": "Chroma Mode",
+            "options": "File\nServer",
+            "default": "File",
+            "description": "File: store on disk. Server: connect to a running Chroma server.",
+            "depends_on": "eval:doc.knowledge_type === 'chroma'"
+        },
+        {
+            "fieldname": "chroma_host",
+            "fieldtype": "Data",
+            "label": "Chroma Host",
+            "default": "localhost",
+            "description": "Hostname or IP of the Chroma server (only used in Server mode)",
+            "depends_on": "eval:doc.knowledge_type === 'chroma' && doc.chroma_mode === 'Server'"
+        },
+        {
+            "fieldname": "column_break_chroma",
+            "fieldtype": "Column Break"
+        },
+        {
+            "fieldname": "chroma_port",
+            "fieldtype": "Int",
+            "label": "Chroma Port",
+            "default": 8000,
+            "description": "Port of the Chroma server (only used in Server mode)",
+            "depends_on": "eval:doc.knowledge_type === 'chroma' && doc.chroma_mode === 'Server'"
+        },
+        {
+            "fieldname": "chroma_ssl",
+            "fieldtype": "Check",
+            "label": "Use SSL (HTTPS)",
+            "default": 0,
+            "description": "Enable if your Chroma server uses HTTPS",
+            "depends_on": "eval:doc.knowledge_type === 'chroma' && doc.chroma_mode === 'Server'"
         }
     ],
     "index_web_pages_for_search": 1,
     "links": [],
-    "modified": "2026-01-10 00:00:00.000000",
+    "modified": "2026-05-18 10:30:10.000000",
     "modified_by": "Administrator",
     "module": "Huf",
     "name": "Knowledge Source",


### PR DESCRIPTION
- knowledge_source.json: add Chroma Connection Settings section with chroma_mode (File/Server), chroma_host, chroma_port, chroma_ssl fields
- indexer.py : branch on chroma_mode - Server mode passes host/port/ssl to backend; File mode retains existing persist_directory behaviour
- chroma_backend.py: remove chromadb.config.Settings import and drop anonymized_telemetry kwarg from both PersistentClient and HttpClient calls for compatibility