### PR TITLE
fix: allow portal doc-event trigger lookup

### DIFF
--- a/huf/ai/agent_hooks.py
+++ b/huf/ai/agent_hooks.py
@@ -18,7 +18,7 @@ def get_doc_event_agents(event: str):
     if cached:
         return frappe.parse_json(cached)
 
-    triggers = frappe.get_list(
+    triggers = frappe.get_all(
         "Agent Trigger",
         filters={
             "trigger_type": "Doc Event",


### PR DESCRIPTION
## Summary
- Allow HUF doc-event trigger lookup to read `Agent Trigger` rows without using the current portal user's permissions.
- Prevent Supplier portal actions, such as RFQ quote submission and Purchase Invoice creation/review, from failing with `Insufficient Permission for Agent Trigger`.

## Root Cause
HUF registers doc-event hooks globally. When a website Supplier user created or updated a procurement document through the ERPNext portal, the hook attempted to read `Agent Trigger` with that Supplier user's permissions. Supplier users should not have access to AI trigger configuration, so the document action failed before the portal workflow could complete.

## Validation
- Ran `python3 -m py_compile huf/ai/agent_hooks.py`.
- Migrated and restarted `property.localhost` bench.
- Verified vendor RFQ quote submission in browser created a Supplier Quotation without the Agent Trigger permission error.
- Verified vendor Purchase Invoice portal page loads without permission errors.