### PR TITLE
fix: add create_new support for sync chat API

### DIFF
--- a/huf/ai/chat_api.py
+++ b/huf/ai/chat_api.py
@@ -1,0 +1,100 @@
+import json
+
+import frappe
+from frappe import _
+
+from .agent_integration import run_agent_sync, _is_user_allowed
+from .conversation_manager import ConversationManager
+
+
+def _as_bool(value) -> bool:
+    """Parse Frappe/API boolean values consistently."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return False
+
+
+@frappe.whitelist(allow_guest=True)
+def run_agent_sync_chat(
+    agent_name: str,
+    prompt: str = None,
+    provider: str = None,
+    model: str = None,
+    channel_id: str = None,
+    external_id: str = None,
+    conversation_id: str = None,
+    create_new=False,
+    parent_run_id: str = None,
+    orchestration_id: str = None,
+    response_format=None,
+    flow_run_id: str = None,
+    flow_node_id: str = None,
+    run_kind: str = None,
+    prompt_template: str = None,
+    prompt_version=None,
+    parent_conversation_id: str = None,
+    invoked_by_agent: str = None,
+    prompt_cache_options=None,
+):
+    """Sync chat API with explicit new-conversation support.
+
+    Existing ``run_agent_sync`` reuses the latest active conversation for the
+    same agent + session when ``conversation_id`` is omitted. That behavior is
+    useful for simple integrations but ambiguous for ChatGPT-style UIs where a
+    logged-in user can create and switch between multiple chats.
+
+    Set ``create_new=true`` to force a fresh Agent Conversation, then run the
+    first message inside that new conversation. Subsequent turns should pass the
+    returned ``conversation_id``.
+    """
+    if not agent_name:
+        frappe.throw(_("Agent Name is required"))
+
+    if not channel_id:
+        channel_id = "api"
+
+    if _as_bool(create_new):
+        agent_doc = frappe.get_doc("Agent", agent_name)
+
+        if frappe.session.user == "Guest" and not agent_doc.allow_guest:
+            frappe.throw(_("Access denied. This agent does not allow guest access."), frappe.PermissionError)
+
+        if not _is_user_allowed(agent_doc, frappe.session.user):
+            frappe.throw(_("You are not authorized to use this agent."), frappe.PermissionError)
+
+        conv_manager = ConversationManager(
+            agent_name=agent_name,
+            channel=channel_id,
+            external_id=external_id,
+        )
+        conversation = conv_manager.create_new_conversation(
+            title=f"Chat with {agent_name}"
+        )
+        conversation_id = conversation.name
+
+    return run_agent_sync(
+        agent_name=agent_name,
+        prompt=prompt,
+        provider=provider,
+        model=model,
+        channel_id=channel_id,
+        external_id=external_id,
+        conversation_id=conversation_id,
+        parent_run_id=parent_run_id,
+        orchestration_id=orchestration_id,
+        response_format=response_format,
+        flow_run_id=flow_run_id,
+        flow_node_id=flow_node_id,
+        run_kind=run_kind,
+        prompt_template=prompt_template,
+        prompt_version=prompt_version,
+        parent_conversation_id=parent_conversation_id,
+        invoked_by_agent=invoked_by_agent,
+        prompt_cache_options=prompt_cache_options,
+    )


### PR DESCRIPTION
## Summary

Adds a sync chat API wrapper with an explicit `create_new` boolean so ChatGPT-style UIs can force a fresh conversation without relying on frontend-generated `external_id` thread keys.

New endpoint:

```http
POST /api/method/huf.ai.chat_api.run_agent_sync_chat
```

When `create_new=true`, the wrapper creates a fresh `Agent Conversation` using the same `ConversationManager.create_new_conversation()` path used by streaming, then delegates to the existing `run_agent_sync()` with the new `conversation_id`.

## Why

Current `run_agent_sync()` reuses the latest active conversation for the same `agent + session_id` when `conversation_id` is omitted. That behavior is expected, but it is ambiguous for logged-in chat applications where users need to create multiple independent chats.

## Usage

Create a new chat:

```json
{
  "agent_name": "Hoppily Trip Agent",
  "prompt": "Start a new trip search",
  "channel_id": "web",
  "create_new": true
}
```

Continue the returned conversation:

```json
{
  "agent_name": "Hoppily Trip Agent",
  "prompt": "Both",
  "channel_id": "web",
  "conversation_id": "<returned conversation_id>"
}
```

## Notes

- Existing `run_agent_sync()` behavior remains unchanged for backward compatibility.
- Boolean parsing accepts common API values: `true`, `1`, `yes`, `on`.
- Permission checks mirror the existing sync endpoint before creating the conversation.