### PR TITLE
Frontend UI Updates and new fields additions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,12 @@ const PreviewViewPage = lazy(() => import('./pages/PreviewViewPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 const DataRecordViewWrapper = lazy(() => import('./pages/DataRecordViewWrapper'));
 const ModelsPageWrapper = lazy(() => import('./pages/ModelsPageWrapper'));
+const IntegrationSettingsListingPageWrapper = lazy(
+  () => import('./pages/IntegrationSettingsListingPageWrapper'),
+);
+const IntegrationSettingsDetailsPageWrapper = lazy(
+  () => import('./pages/IntegrationSettingsDetailsPageWrapper'),
+);
 
 import { useEffect } from 'react';
 import { createFrappeSocket } from './utils/socket';
@@ -373,6 +379,26 @@ function App() {
               <ProtectedRoute>
                 <Suspense fallback={<PageLoader />}>
                   <KnowledgeSourceFormPageWrapper />
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/integrations"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<PageLoader />}>
+                  <IntegrationSettingsListingPageWrapper />
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/integrations/:settingId"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<PageLoader />}>
+                  <IntegrationSettingsDetailsPageWrapper />
                 </Suspense>
               </ProtectedRoute>
             }

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -6,6 +6,7 @@ import { Button } from './ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Label } from './ui/label';
 import { Combobox } from './ui/combobox';
+import { linkRoutes } from '@/lib/link-routes';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -523,6 +524,7 @@ export function RightSidebar({ onToggle }: RightSidebarProps) {
                         disabled={loadingAgents}
                         searchPlaceholder="Search agents..."
                         emptyText="No agent found."
+                        linkTo={linkRoutes.agent}
                       />
                     </div>
                     <div>
@@ -652,6 +654,7 @@ export function RightSidebar({ onToggle }: RightSidebarProps) {
                         disabled={loadingAgents}
                         searchPlaceholder="Search agents..."
                         emptyText="No agent found."
+                        linkTo={linkRoutes.agent}
                       />
                     </div>
                     <div>

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -75,9 +75,11 @@ export function RightSidebar({ onToggle }: RightSidebarProps) {
       .then((result) => {
         const items = Array.isArray(result) ? result : result.items;
         setAgents(
-          (items || []).map((a: { name: string; agent_name?: string }) => ({
+          (items || []).map((a: { name: string; agent_name?: string; model?: string }) => ({
             value: a.name,
-            label: a.agent_name || a.name,
+            label: a.model
+              ? `${a.agent_name || a.name} · ${a.model}`
+              : a.agent_name || a.name,
           }))
         );
       })

--- a/frontend/src/components/agent/AdvancedTab.tsx
+++ b/frontend/src/components/agent/AdvancedTab.tsx
@@ -1,6 +1,8 @@
 import { FormField, FormItem, FormLabel, FormControl, FormDescription, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { LinkFieldControl } from '@/components/ui/link-field-control';
+import { linkRoutes } from '@/lib/link-routes';
 import { Switch } from '@/components/ui/switch';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { UseFormReturn } from 'react-hook-form';
@@ -113,23 +115,25 @@ export function AdvancedTab({ form, allModels }: AdvancedTabProps) {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Summary Model</FormLabel>
-                  <Select
-                    onValueChange={(v) => field.onChange(v || undefined)}
-                    value={field.value || ''}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Default (main agent model)" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {allModels.map((m) => (
-                        <SelectItem key={m.name} value={m.name}>
-                          {m.model_name || m.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <FormControl>
+                    <LinkFieldControl value={field.value} linkTo={linkRoutes.aiModel}>
+                      <Select
+                        onValueChange={(v) => field.onChange(v || undefined)}
+                        value={field.value || ''}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Default (main agent model)" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {allModels.map((m) => (
+                            <SelectItem key={m.name} value={m.name}>
+                              {m.model_name || m.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </LinkFieldControl>
+                  </FormControl>
                   <FormDescription>
                     Optional lightweight model used only when compressing older messages (Summarize strategy).
                   </FormDescription>
@@ -386,23 +390,25 @@ export function AdvancedTab({ form, allModels }: AdvancedTabProps) {
             render={({ field }) => (
               <FormItem>
 								<FormLabel>{IMAGE_MODEL_LABEL}</FormLabel>
-                <Select
-                  onValueChange={(v) => field.onChange(v || undefined)}
-                  value={field.value || ''}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-											<SelectValue placeholder={IMAGE_MODEL_PLACEHOLDER} />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {imageModels.map((m) => (
-                      <SelectItem key={m.name} value={m.name}>
-                        {m.model_name || m.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <LinkFieldControl value={field.value} linkTo={linkRoutes.aiModel}>
+                    <Select
+                      onValueChange={(v) => field.onChange(v || undefined)}
+                      value={field.value || ''}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder={IMAGE_MODEL_PLACEHOLDER} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {imageModels.map((m) => (
+                          <SelectItem key={m.name} value={m.name}>
+                            {m.model_name || m.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </LinkFieldControl>
+                </FormControl>
 								<FormDescription>{IMAGE_MODEL_DESCRIPTION}</FormDescription>
                 <FormMessage />
               </FormItem>
@@ -415,23 +421,25 @@ export function AdvancedTab({ form, allModels }: AdvancedTabProps) {
             render={({ field }) => (
               <FormItem>
 								<FormLabel>{TTS_MODEL_LABEL}</FormLabel>
-                <Select
-                  onValueChange={(v) => field.onChange(v || undefined)}
-                  value={field.value || ''}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-											<SelectValue placeholder={TTS_MODEL_PLACEHOLDER} />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {ttsModels.map((m) => (
-                      <SelectItem key={m.name} value={m.name}>
-                        {m.model_name || m.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <LinkFieldControl value={field.value} linkTo={linkRoutes.aiModel}>
+                    <Select
+                      onValueChange={(v) => field.onChange(v || undefined)}
+                      value={field.value || ''}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder={TTS_MODEL_PLACEHOLDER} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ttsModels.map((m) => (
+                          <SelectItem key={m.name} value={m.name}>
+                            {m.model_name || m.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </LinkFieldControl>
+                </FormControl>
 								<FormDescription>{TTS_MODEL_DESCRIPTION}</FormDescription>
                 <FormMessage />
               </FormItem>
@@ -459,23 +467,25 @@ export function AdvancedTab({ form, allModels }: AdvancedTabProps) {
             render={({ field }) => (
               <FormItem>
 								<FormLabel>{STT_MODEL_LABEL}</FormLabel>
-                <Select
-                  onValueChange={(v) => field.onChange(v || undefined)}
-                  value={field.value || ''}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-											<SelectValue placeholder={STT_MODEL_PLACEHOLDER} />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {sttModels.map((m) => (
-                      <SelectItem key={m.name} value={m.name}>
-                        {m.model_name || m.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <LinkFieldControl value={field.value} linkTo={linkRoutes.aiModel}>
+                    <Select
+                      onValueChange={(v) => field.onChange(v || undefined)}
+                      value={field.value || ''}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder={STT_MODEL_PLACEHOLDER} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {sttModels.map((m) => (
+                          <SelectItem key={m.name} value={m.name}>
+                            {m.model_name || m.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </LinkFieldControl>
+                </FormControl>
 								<FormDescription>{STT_MODEL_DESCRIPTION}</FormDescription>
                 <FormMessage />
               </FormItem>

--- a/frontend/src/components/agent/AgentKnowledgeModal.tsx
+++ b/frontend/src/components/agent/AgentKnowledgeModal.tsx
@@ -23,6 +23,7 @@ import { knowledgeModes } from '@/data/knowledge';
 import { getKnowledgeSources } from '@/services/knowledgeApi';
 import type { AgentKnowledgeRow } from '@/types/agent.types';
 import type { ComboboxOption } from '@/components/ui/combobox';
+import { linkRoutes } from '@/lib/link-routes';
 
 interface AgentKnowledgeModalProps {
   open: boolean;
@@ -111,6 +112,7 @@ export function AgentKnowledgeModal({
               placeholder="Select knowledge source..."
               searchPlaceholder="Search knowledge sources..."
               emptyText="No knowledge sources found."
+              linkTo={linkRoutes.knowledgeSource}
             />
           </div>
 

--- a/frontend/src/components/agent/GeneralTab.tsx
+++ b/frontend/src/components/agent/GeneralTab.tsx
@@ -11,6 +11,8 @@ import type { AIProvider, AIModel } from '@/types/agent.types';
 import type { AgentFormValues } from './types';
 import { InstructionsTextarea } from './InstructionsTextarea';
 import { PromptTemplateSection, type AgentPromptOption } from './PromptTemplateSection';
+import { LinkFieldControl } from '@/components/ui/link-field-control';
+import { linkRoutes } from '@/lib/link-routes';
 
 interface GeneralTabProps {
   form: UseFormReturn<AgentFormValues>;
@@ -95,26 +97,28 @@ export function GeneralTab({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Provider</FormLabel>
-                <Select
-                  onValueChange={(value) => {
-                    field.onChange(value);
-                    form.setValue('model', '');
-                  }}
-                  value={field.value || undefined}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select provider" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {providers.map((provider) => (
-                      <SelectItem key={provider.name} value={provider.name}>
-                        {provider.provider_name || provider.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <LinkFieldControl value={field.value} linkTo={linkRoutes.aiProvider}>
+                    <Select
+                      onValueChange={(value) => {
+                        field.onChange(value);
+                        form.setValue('model', '');
+                      }}
+                      value={field.value || undefined}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select provider" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {providers.map((provider) => (
+                          <SelectItem key={provider.name} value={provider.name}>
+                            {provider.provider_name || provider.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </LinkFieldControl>
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}
@@ -126,22 +130,24 @@ export function GeneralTab({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Model</FormLabel>
-                <Select onValueChange={field.onChange} value={field.value || undefined} disabled={!watchProvider}>
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select model" />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {models
-                      .filter((model) => model.provider === watchProvider)
-                      .map((model) => (
-                        <SelectItem key={model.name} value={model.name}>
-                          {model.model_name || model.name}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
+                <FormControl>
+                  <LinkFieldControl value={field.value} linkTo={linkRoutes.aiModel} disabled={!watchProvider}>
+                    <Select onValueChange={field.onChange} value={field.value || undefined} disabled={!watchProvider}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select model" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {models
+                          .filter((model) => model.provider === watchProvider)
+                          .map((model) => (
+                            <SelectItem key={model.name} value={model.name}>
+                              {model.model_name || model.name}
+                            </SelectItem>
+                          ))}
+                      </SelectContent>
+                    </Select>
+                  </LinkFieldControl>
+                </FormControl>
                 <FormDescription>Filtered by selected provider</FormDescription>
                 <FormMessage />
               </FormItem>

--- a/frontend/src/components/agent/PromptTemplateSection.tsx
+++ b/frontend/src/components/agent/PromptTemplateSection.tsx
@@ -8,6 +8,7 @@ import type { AgentFormValues } from './types';
 import type { UseFormReturn } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Plus } from 'lucide-react';
+import { linkRoutes } from '@/lib/link-routes';
 
 export interface AgentPromptOption {
   value: string;
@@ -66,6 +67,7 @@ export function PromptTemplateSection({
                     disabled={loadingPrompts}
                     searchPlaceholder="Search templates..."
                     emptyText="No active prompt templates found."
+                    linkTo={linkRoutes.agentPrompt}
                   />
                 </FormControl>
                 {showAddNew ? (

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Home, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu } from "lucide-react"
+import { Home, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2 } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -75,6 +75,12 @@ const allNavItems = [
     url: "/mcp",
     icon: Server,
     capability: "system.mcp.manage",
+  },
+  {
+    title: "Integrations",
+    url: "/integrations",
+    icon: Link2,
+    capability: "system.integrations.manage",
   },
   {
     title: "AI Providers",

--- a/frontend/src/components/chat/AgentModelSelector.tsx
+++ b/frontend/src/components/chat/AgentModelSelector.tsx
@@ -136,8 +136,21 @@ export function AgentModelSelector({ value, onValueChange, disabled, showLabel =
                     }}
                     value={m.id}
                   >
-                    {m.chefSlug && <ModelSelectorLogo provider={m.chefSlug} />}
-                    <ModelSelectorName>{m.name}</ModelSelectorName>
+                    {m.agent_color ? (
+                      <span
+                        className="size-4 rounded-full shrink-0 border border-border"
+                        style={{ backgroundColor: m.agent_color }}
+                        aria-hidden
+                      />
+                    ) : m.chefSlug ? (
+                      <ModelSelectorLogo provider={m.chefSlug} />
+                    ) : null}
+                    <div className="flex flex-col min-w-0">
+                      <ModelSelectorName>{m.name}</ModelSelectorName>
+                      {m.model && (
+                        <span className="text-xs text-muted-foreground truncate">{m.model}</span>
+                      )}
+                    </div>
                     <ModelSelectorLogoGroup>
                       {m.providers.map((provider) => (
                         <ModelSelectorLogo key={provider} provider={provider} />

--- a/frontend/src/components/dashboard/cards/ItemCard.tsx
+++ b/frontend/src/components/dashboard/cards/ItemCard.tsx
@@ -26,11 +26,13 @@ interface ItemCardProps {
   title: string;
   description?: string;
   icon?: LucideIcon;
+  avatarColor?: string | null;
   status?: {
     label: string;
     variant?: BadgeVariant;
   };
   metadata?: MetadataItem[];
+  badges?: Array<{ label: string; variant?: BadgeVariant }>;
   actions?: ActionButton[];
   menuActions?: ActionButton[];
   menuIcon?: LucideIcon;
@@ -43,8 +45,10 @@ export function ItemCard({
   title,
   description,
   icon: TitleIcon,
+  avatarColor,
   status,
   metadata = [],
+  badges = [],
   actions = [],
   menuActions = [],
   menuIcon: MenuIcon = MoreVertical,
@@ -57,6 +61,13 @@ export function ItemCard({
       <div className="flex flex-col flex-1">
         <CardHeader className="pb-3">
           <CardTitle className="text-xl font-semibold line-clamp-1 flex items-center gap-2">
+            {avatarColor && (
+              <span
+                className="w-3 h-3 rounded-full shrink-0 border border-border"
+                style={{ backgroundColor: avatarColor }}
+                aria-hidden
+              />
+            )}
             {TitleIcon && <TitleIcon className="w-5 h-5 shrink-0 text-muted-foreground" />}
             {title}
           </CardTitle>
@@ -87,6 +98,16 @@ export function ItemCard({
                     </div>
                     <span className="font-medium">{item.value}</span>
                   </div>
+                ))}
+              </div>
+            )}
+
+            {badges.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-2">
+                {badges.map((badge) => (
+                  <Badge key={badge.label} variant={badge.variant || 'secondary'} className="text-xs">
+                    {badge.label}
+                  </Badge>
                 ))}
               </div>
             )}

--- a/frontend/src/components/dashboard/views/ActiveAgentsTab.tsx
+++ b/frontend/src/components/dashboard/views/ActiveAgentsTab.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getAgents } from '@/services/agentApi';
 import type { AgentDoc } from '@/types/agent.types';
 import { Loader2, Zap } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
 
 interface ActiveAgentsTabProps {
   agents?: AgentDoc[];
@@ -84,14 +85,33 @@ export function ActiveAgentsTab({ agents: providedAgents, loading: providedLoadi
                 className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors cursor-pointer"
                 onClick={() => handleAgentClick(agent.name)}
               >
-                <div className="flex-1 min-w-0">
-                  <div className="font-medium truncate">{agent.agent_name || agent.name}</div>
-                  <div className="text-sm text-muted-foreground flex items-center gap-2 mt-1">
-                    <span>{agent.model || 'Unknown'}</span>
-                    <span>•</span>
-                    <span className="flex items-center gap-1">
+                <div className="flex items-center gap-3 flex-1 min-w-0">
+                  {agent.agent_color && (
+                    <span
+                      className="w-2.5 h-2.5 rounded-full shrink-0 border border-border"
+                      style={{ backgroundColor: agent.agent_color }}
+                      aria-hidden
+                    />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium truncate flex items-center gap-2">
+                      {agent.agent_name || agent.name}
+                      {agent.allow_chat === 1 && (
+                        <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                          Chat
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="text-sm text-muted-foreground flex items-center gap-2 mt-1">
+                      <span>{agent.provider || 'Unknown provider'}</span>
+                      <span>•</span>
+                      <span>{agent.model || 'Unknown model'}</span>
+                      <span>•</span>
+                      <span className="flex items-center gap-1">
                         <Zap className="w-4 h-4" />
-                        {agent.total_run || 0}</span>
+                        {agent.total_run || 0}
+                      </span>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/dashboard/views/ActiveFlowsTab.tsx
+++ b/frontend/src/components/dashboard/views/ActiveFlowsTab.tsx
@@ -1,52 +1,106 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Sparkles } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
+import { getDashboardActiveFlows, type DashboardFlowItem } from '@/services/dashboardApi';
+import { formatTimeAgo } from '@/utils/time';
+import type { FlowStatus } from '@/types/flow.types';
 
-interface Flow {
-  id: string;
-  name: string;
-  status: 'active';
-  runs: number;
-  last_run: string;
+interface ActiveFlowsTabProps {
+  flows?: DashboardFlowItem[];
+  loading?: boolean;
 }
 
-const activeFlows: Flow[] = [
-  { id: '1', name: 'Webform Handler', status: 'active', runs: 523, last_run: '2 minutes ago' },
-  { id: '2', name: 'Email Automation', status: 'active', runs: 389, last_run: '5 minutes ago' },
-  { id: '3', name: 'Slack Notification', status: 'active', runs: 234, last_run: '12 minutes ago' },
-  { id: '4', name: 'Data Processing', status: 'active', runs: 156, last_run: '1 hour ago' },
-  { id: '5', name: 'Customer Onboarding', status: 'active', runs: 98, last_run: '3 hours ago' },
-];
+function getStatusVariant(status: FlowStatus): 'default' | 'secondary' | 'outline' {
+  switch (status) {
+    case 'active':
+      return 'default';
+    case 'paused':
+      return 'secondary';
+    default:
+      return 'outline';
+  }
+}
 
-export function ActiveFlowsTab() {
+function getStatusLabel(status: FlowStatus): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+export function ActiveFlowsTab({ flows: providedFlows, loading: providedLoading }: ActiveFlowsTabProps) {
+  const navigate = useNavigate();
+  const [flows, setFlows] = useState<DashboardFlowItem[]>(providedFlows || []);
+  const [loading, setLoading] = useState(providedLoading ?? true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (providedFlows !== undefined) {
+      setFlows(providedFlows);
+      setLoading(providedLoading ?? false);
+      return;
+    }
+
+    async function fetchActiveFlows() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getDashboardActiveFlows(10);
+        setFlows(data);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to fetch flows'));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchActiveFlows();
+  }, [providedFlows, providedLoading]);
+
+  const handleFlowClick = (flowId: string) => {
+    navigate(`/flows/${flowId}`);
+  };
+
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+      <CardHeader>
         <CardTitle>Active Flows</CardTitle>
-        <Badge variant="secondary" className="flex items-center gap-1.5">
-          <Sparkles className="w-3 h-3" />
-          Coming Soon
-        </Badge>
       </CardHeader>
       <CardContent>
-        <div className="space-y-3">
-          {activeFlows.map((flow) => (
-            <div
-              key={flow.id}
-              className="flex items-center justify-between p-3 rounded-lg border opacity-60"
-            >
-              <div className="flex-1">
-                <div className="font-medium">{flow.name}</div>
-                <div className="text-sm text-muted-foreground">
-                  {flow.runs} runs • Last run {flow.last_run}
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="text-center py-8 text-destructive">
+            <p>Failed to load flows</p>
+            <p className="text-sm text-muted-foreground mt-1">{error.message}</p>
+          </div>
+        ) : flows.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">
+            No active flows
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {flows.map((flow) => (
+              <div
+                key={flow.id}
+                className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors cursor-pointer"
+                onClick={() => handleFlowClick(flow.id)}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium truncate">{flow.name}</div>
+                  <div className="text-sm text-muted-foreground">
+                    {flow.runCount} runs • Last run {formatTimeAgo(flow.lastRunAt)}
+                  </div>
                 </div>
+                <Badge variant={getStatusVariant(flow.status)}>
+                  {getStatusLabel(flow.status)}
+                </Badge>
               </div>
-              <Badge variant="default">Active</Badge>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
       </CardContent>
     </Card>
   );
 }
-

--- a/frontend/src/components/integrations/CredentialsTab.tsx
+++ b/frontend/src/components/integrations/CredentialsTab.tsx
@@ -1,0 +1,64 @@
+import type { UseFormReturn } from 'react-hook-form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import type { CredentialSchemaItem } from '@/types/integration.types';
+import type { IntegrationFormValues } from './types';
+
+interface CredentialsTabProps {
+  form: UseFormReturn<IntegrationFormValues>;
+  schema: CredentialSchemaItem[];
+  isNew: boolean;
+}
+
+export function CredentialsTab({ form, schema, isNew }: CredentialsTabProps) {
+  if (schema.length === 0) {
+    return (
+      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
+        No credential schema defined for this service.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-6">
+      {!isNew && (
+        <p className="text-sm text-muted-foreground">
+          Leave credential fields blank to keep existing values unchanged.
+        </p>
+      )}
+      {schema.map((item) => (
+        <FormField
+          key={item.key}
+          control={form.control}
+          name={`credentialValues.${item.key}`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                {item.label}
+                {item.required && <span className="text-destructive ml-1">*</span>}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  type="password"
+                  autoComplete="off"
+                  placeholder={isNew ? `Enter ${item.label.toLowerCase()}` : '••••••••'}
+                  value={field.value ?? ''}
+                />
+              </FormControl>
+              {item.description && <FormDescription>{item.description}</FormDescription>}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/GeneralTab.tsx
+++ b/frontend/src/components/integrations/GeneralTab.tsx
@@ -1,0 +1,102 @@
+import type { UseFormReturn } from 'react-hook-form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import type { IntegrationFormValues } from './types';
+
+interface GeneralTabProps {
+  form: UseFormReturn<IntegrationFormValues>;
+  isNew: boolean;
+  serviceLabel?: string;
+  lastUsed?: string;
+  lastError?: string;
+}
+
+export function GeneralTab({
+  form,
+  isNew,
+  serviceLabel,
+  lastUsed,
+  lastError,
+}: GeneralTabProps) {
+  return (
+    <div className="space-y-6 rounded-lg border p-6">
+      <FormField
+        control={form.control}
+        name="service"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Integration Service</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                readOnly
+                className="capitalize bg-muted"
+                value={serviceLabel || field.value.replace(/_/g, ' ')}
+              />
+            </FormControl>
+            {!isNew && (
+              <FormDescription>Service cannot be changed after creation.</FormDescription>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="is_active"
+        render={({ field }) => (
+          <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+            <div className="space-y-0.5">
+              <FormLabel>Active</FormLabel>
+              <FormDescription>
+                Inactive integrations are ignored when agents resolve credentials.
+              </FormDescription>
+            </div>
+            <FormControl>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="is_default"
+        render={({ field }) => (
+          <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+            <div className="space-y-0.5">
+              <FormLabel>Default for this service</FormLabel>
+              <FormDescription>
+                When multiple configs exist for the same service, the default is preferred.
+              </FormDescription>
+            </div>
+            <FormControl>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+
+      {!isNew && (lastUsed || lastError) && (
+        <div className="space-y-3 rounded-lg border p-4 bg-muted/30">
+          <h3 className="text-sm font-medium">Usage Statistics</h3>
+          {lastUsed && (
+            <p className="text-sm text-muted-foreground">Last used: {new Date(lastUsed).toLocaleString()}</p>
+          )}
+          {lastError && (
+            <p className="text-sm text-destructive">Last error: {lastError}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/IntegrationHeader.tsx
+++ b/frontend/src/components/integrations/IntegrationHeader.tsx
@@ -1,0 +1,75 @@
+import { Save, Trash2, Link2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface IntegrationHeaderProps {
+  title: string;
+  service: string;
+  isActive: boolean;
+  isDefault: boolean;
+  isNew: boolean;
+  showSaveButton: boolean;
+  saving: boolean;
+  deleting?: boolean;
+  onSave: () => void;
+  onDelete?: () => void;
+}
+
+export function IntegrationHeader({
+  title,
+  service,
+  isActive,
+  isDefault,
+  isNew,
+  showSaveButton,
+  saving,
+  deleting = false,
+  onSave,
+  onDelete,
+}: IntegrationHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+      <div className="flex-1 space-y-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-2xl font-bold capitalize">
+            {isNew ? `New ${service.replace(/_/g, ' ')} Integration` : title}
+          </h1>
+          {!isNew && (
+            <>
+              <Badge variant={isActive ? 'default' : 'secondary'}>
+                {isActive ? 'Active' : 'Inactive'}
+              </Badge>
+              {isDefault && <Badge variant="outline">Default</Badge>}
+            </>
+          )}
+          <Badge variant="outline">
+            <Link2 className="w-3 h-3 mr-1" />
+            {service.replace(/_/g, ' ')}
+          </Badge>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {!isNew && onDelete && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDelete}
+            disabled={saving || deleting}
+            type="button"
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 className={cn('w-4 h-4 mr-2', deleting && 'animate-pulse')} />
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        )}
+        {showSaveButton && (
+          <Button size="sm" onClick={onSave} disabled={saving || deleting}>
+            <Save className="w-4 h-4 mr-2" />
+            {saving ? (isNew ? 'Creating...' : 'Saving...') : (isNew ? 'Create' : 'Save')}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/IntegrationSettingsHeaderActions.tsx
+++ b/frontend/src/components/integrations/IntegrationSettingsHeaderActions.tsx
@@ -1,0 +1,14 @@
+import { Plus } from 'lucide-react';
+import { Button } from '../ui/button';
+import { useIntegrationSettingsContext } from '@/contexts/IntegrationSettingsContext';
+
+export function IntegrationSettingsHeaderActions() {
+  const { onAddIntegration } = useIntegrationSettingsContext();
+
+  return (
+    <Button onClick={onAddIntegration} size="sm">
+      <Plus className="w-4 h-4 mr-2" />
+      Add Integration
+    </Button>
+  );
+}

--- a/frontend/src/components/integrations/RecipientsTab.tsx
+++ b/frontend/src/components/integrations/RecipientsTab.tsx
@@ -1,0 +1,111 @@
+import { Plus, Trash2 } from 'lucide-react';
+import type { UseFormReturn } from 'react-hook-form';
+import { useFieldArray } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import type { IntegrationFormValues } from './types';
+
+interface RecipientsTabProps {
+  form: UseFormReturn<IntegrationFormValues>;
+}
+
+export function RecipientsTab({ form }: RecipientsTabProps) {
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'recipients',
+  });
+
+  return (
+    <div className="space-y-4 rounded-lg border p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium">Named Recipients</h3>
+          <p className="text-sm text-muted-foreground mt-1">
+            Map friendly names to service-specific IDs (e.g. Telegram chat ID, Slack channel ID).
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            append({ recipient_name: '', recipient_id: '', user: '' })
+          }
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          Add Recipient
+        </Button>
+      </div>
+
+      {fields.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-8">
+          No recipients configured. Add one so agents can look up IDs by name.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {fields.map((field, index) => (
+            <div key={field.id} className="grid gap-4 rounded-lg border p-4 md:grid-cols-[1fr_1fr_1fr_auto]">
+              <FormField
+                control={form.control}
+                name={`recipients.${index}.recipient_name`}
+                render={({ field: f }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input {...f} placeholder="e.g. Sales Alerts" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`recipients.${index}.recipient_id`}
+                render={({ field: f }) => (
+                  <FormItem>
+                    <FormLabel>Recipient ID</FormLabel>
+                    <FormControl>
+                      <Input {...f} placeholder="Service-specific ID" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`recipients.${index}.user`}
+                render={({ field: f }) => (
+                  <FormItem>
+                    <FormLabel>User (optional)</FormLabel>
+                    <FormControl>
+                      <Input {...f} placeholder="Frappe user email" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex items-end">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => remove(index)}
+                  className="text-destructive hover:text-destructive"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/ServiceCatalogModal.tsx
+++ b/frontend/src/components/integrations/ServiceCatalogModal.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ExternalLink, Search } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { getIntegrationServices } from '@/services/integrationApi';
+import { parseRequiredCredentials } from '@/types/integration.types';
+import type { IntegrationServiceDoc } from '@/types/integration.types';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+import { toast } from 'sonner';
+
+interface ServiceCatalogModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalProps) {
+  const navigate = useNavigate();
+  const [services, setServices] = useState<IntegrationServiceDoc[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState('all');
+
+  useEffect(() => {
+    if (!open) return;
+
+    setLoading(true);
+    getIntegrationServices()
+      .then(setServices)
+      .catch((error) => {
+        toast.error(getFrappeErrorMessage(error) || 'Failed to load integration services');
+      })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  const categories = useMemo(() => {
+    const unique = new Set(services.map((s) => s.category).filter(Boolean));
+    return ['all', ...Array.from(unique).sort()];
+  }, [services]);
+
+  const filteredServices = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return services.filter((service) => {
+      const matchesCategory = category === 'all' || service.category === category;
+      const matchesSearch =
+        !query ||
+        service.service_name.toLowerCase().includes(query) ||
+        service.description?.toLowerCase().includes(query) ||
+        service.category?.toLowerCase().includes(query);
+      return matchesCategory && matchesSearch;
+    });
+  }, [services, search, category]);
+
+  const handleSelect = (serviceName: string) => {
+    onOpenChange(false);
+    setSearch('');
+    setCategory('all');
+    navigate(`/integrations/new?service=${encodeURIComponent(serviceName)}`);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Add Integration</DialogTitle>
+          <DialogDescription>
+            Choose a service to connect. Required credentials are shown for each integration.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input
+              placeholder="Search services..."
+              className="pl-9"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <select
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          >
+            {categories.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat === 'all' ? 'All categories' : cat}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex-1 overflow-y-auto min-h-0 py-2">
+          {loading ? (
+            <div className="text-center py-12 text-muted-foreground">Loading services...</div>
+          ) : filteredServices.length === 0 ? (
+            <div className="text-center py-12 text-muted-foreground">No services found.</div>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {filteredServices.map((service) => {
+                const credSchema = parseRequiredCredentials(service.required_credentials);
+                return (
+                  <Card
+                    key={service.name}
+                    className="cursor-pointer transition-colors hover:border-primary/50"
+                    onClick={() => handleSelect(service.service_name)}
+                  >
+                    <CardHeader className="pb-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <CardTitle className="text-base capitalize">
+                          {service.service_name.replace(/_/g, ' ')}
+                        </CardTitle>
+                        <Badge variant="outline">{service.category}</Badge>
+                      </div>
+                      {service.description && (
+                        <CardDescription className="line-clamp-2">{service.description}</CardDescription>
+                      )}
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                      {credSchema.length > 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          Requires: {credSchema.map((c) => c.label).join(', ')}
+                        </p>
+                      )}
+                      {service.documentation_url && (
+                        <a
+                          href={service.documentation_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center text-xs text-primary hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Documentation
+                          <ExternalLink className="w-3 h-3 ml-1" />
+                        </a>
+                      )}
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/integrations/TelegramTab.tsx
+++ b/frontend/src/components/integrations/TelegramTab.tsx
@@ -1,0 +1,138 @@
+import { RefreshCw } from 'lucide-react';
+import type { UseFormReturn } from 'react-hook-form';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
+import type { IntegrationFormValues } from './types';
+
+interface TelegramTabProps {
+  form: UseFormReturn<IntegrationFormValues>;
+  agents: Array<{ name: string; agent_name: string }>;
+  webhookUrl?: string;
+  webhookStatus?: string;
+  lastWebhookSetup?: string;
+  settingUpWebhook: boolean;
+  onSetupWebhook: () => void;
+}
+
+function getWebhookStatusVariant(status?: string): 'default' | 'secondary' | 'destructive' {
+  if (!status) return 'secondary';
+  const lower = status.toLowerCase();
+  if (lower.includes('fail') || lower.includes('error')) return 'destructive';
+  if (lower.includes('configured') || lower.includes('already')) return 'default';
+  return 'secondary';
+}
+
+export function TelegramTab({
+  form,
+  agents,
+  webhookUrl,
+  webhookStatus,
+  lastWebhookSetup,
+  settingUpWebhook,
+  onSetupWebhook,
+}: TelegramTabProps) {
+  const isHttps = webhookUrl?.startsWith('https://');
+
+  return (
+    <div className="space-y-6 rounded-lg border p-6">
+      <FormField
+        control={form.control}
+        name="telegram_agent"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Responding Agent</FormLabel>
+            <Select onValueChange={field.onChange} value={field.value || ''}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select an agent for incoming messages" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {agents.map((agent) => (
+                  <SelectItem key={agent.name} value={agent.name}>
+                    {agent.agent_name || agent.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormDescription>
+              The HUF agent that responds to messages received by this Telegram bot.
+            </FormDescription>
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="telegram_auto_setup_webhook"
+        render={({ field }) => (
+          <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+            <div className="space-y-0.5">
+              <FormLabel>Auto setup webhook on save</FormLabel>
+              <FormDescription>
+                Automatically register the webhook with Telegram when this integration is saved.
+              </FormDescription>
+            </div>
+            <FormControl>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+
+      <div className="space-y-4 rounded-lg border p-4 bg-muted/30">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <h3 className="text-sm font-medium">Webhook Configuration</h3>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onSetupWebhook}
+            disabled={settingUpWebhook}
+          >
+            <RefreshCw className={cn('w-4 h-4 mr-2', settingUpWebhook && 'animate-spin')} />
+            {settingUpWebhook ? 'Setting up...' : 'Setup Webhook'}
+          </Button>
+        </div>
+
+        {webhookStatus && (
+          <Badge variant={getWebhookStatusVariant(webhookStatus)}>{webhookStatus}</Badge>
+        )}
+
+        {!isHttps && webhookUrl && (
+          <p className="text-sm text-destructive">
+            Telegram requires a public HTTPS URL. The current webhook URL may not work on localhost.
+          </p>
+        )}
+
+        <div className="space-y-2">
+          <FormLabel>Webhook URL</FormLabel>
+          <Input readOnly value={webhookUrl || ''} className="bg-muted font-mono text-xs" />
+        </div>
+
+        {lastWebhookSetup && (
+          <p className="text-xs text-muted-foreground">
+            Last setup attempt: {new Date(lastWebhookSetup).toLocaleString()}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/TelegramTab.tsx
+++ b/frontend/src/components/integrations/TelegramTab.tsx
@@ -19,6 +19,8 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
+import { LinkFieldControl } from '@/components/ui/link-field-control';
+import { linkRoutes } from '@/lib/link-routes';
 import type { IntegrationFormValues } from './types';
 
 interface TelegramTabProps {
@@ -58,20 +60,22 @@ export function TelegramTab({
         render={({ field }) => (
           <FormItem>
             <FormLabel>Responding Agent</FormLabel>
-            <Select onValueChange={field.onChange} value={field.value || ''}>
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select an agent for incoming messages" />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                {agents.map((agent) => (
-                  <SelectItem key={agent.name} value={agent.name}>
-                    {agent.agent_name || agent.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <FormControl>
+              <LinkFieldControl value={field.value} linkTo={linkRoutes.agent}>
+                <Select onValueChange={field.onChange} value={field.value || ''}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select an agent for incoming messages" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {agents.map((agent) => (
+                      <SelectItem key={agent.name} value={agent.name}>
+                        {agent.agent_name || agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </LinkFieldControl>
+            </FormControl>
             <FormDescription>
               The HUF agent that responds to messages received by this Telegram bot.
             </FormDescription>

--- a/frontend/src/components/integrations/types.ts
+++ b/frontend/src/components/integrations/types.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const recipientRowSchema = z.object({
+  name: z.string().optional(),
+  recipient_name: z.string().min(1, 'Recipient name is required'),
+  recipient_id: z.string().min(1, 'Recipient ID is required'),
+  user: z.string().optional(),
+});
+
+export const integrationFormSchema = z.object({
+  service: z.string().min(1, 'Service is required'),
+  is_active: z.boolean(),
+  is_default: z.boolean(),
+  credentialValues: z.record(z.string(), z.string()),
+  recipients: z.array(recipientRowSchema),
+  telegram_agent: z.string().optional(),
+  telegram_auto_setup_webhook: z.boolean(),
+});
+
+export type IntegrationFormValues = z.infer<typeof integrationFormSchema>;
+export type RecipientFormRow = z.infer<typeof recipientRowSchema>;

--- a/frontend/src/components/knowledge/GeneralTab.tsx
+++ b/frontend/src/components/knowledge/GeneralTab.tsx
@@ -7,6 +7,7 @@ import { Combobox } from '@/components/ui/combobox';
 import { UseFormReturn } from 'react-hook-form';
 import { useMemo } from 'react';
 import { knowledgeTypes, knowledgeScopes, knowledgeStorageModes } from '@/data/knowledge';
+import { linkRoutes } from '@/lib/link-routes';
 import type { KnowledgeSourceFormValues } from './types';
 
 interface ProviderOption {
@@ -213,6 +214,7 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
                       placeholder="Select AI Provider..."
                       searchPlaceholder="Search providers..."
                       emptyText="No providers found."
+                      linkTo={linkRoutes.aiProvider}
                     />
                   </FormControl>
                   <FormDescription>AI Provider used for API key resolution (optional)</FormDescription>

--- a/frontend/src/components/modals/NodeSelectionModal.tsx
+++ b/frontend/src/components/modals/NodeSelectionModal.tsx
@@ -32,9 +32,8 @@ import {
 import { triggerOptions } from '../../data/triggers';
 import { actionOptions } from '../../data/actions';
 import { TriggerConfig, ActionConfig, ScheduleIntervalType, DocEventType } from '../../types/flow.types';
-import { Agent } from '../../types/agent.types';
 import { getAgents, getDocTypes } from '../../services/agentApi';
-import { AgentDoc } from '../../types/agent.types';
+import type { AgentDoc } from '../../types/agent.types';
 import { Combobox } from '../ui/combobox';
 import { toast } from 'sonner';
 
@@ -85,7 +84,7 @@ export function NodeSelectionModal({
   const [triggerConfig, setTriggerConfig] = useState<TriggerConfig>(
     initialTriggerConfig || { type: undefined }
   );
-  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agents, setAgents] = useState<AgentDoc[]>([]);
   const [loadingAgents, setLoadingAgents] = useState(false);
   const [docTypes, setDocTypes] = useState<Array<{ name: string }>>([]);
   const [loadingDocTypes, setLoadingDocTypes] = useState(false);
@@ -110,30 +109,7 @@ export function NodeSelectionModal({
       setLoadingAgents(true);
       getAgents().then((result) => {
         const agentDocs = Array.isArray(result) ? result : result.items;
-        // Map AgentDoc[] to Agent[] format expected by the component
-        const mappedAgents: Agent[] = agentDocs.map((doc: AgentDoc) => ({
-          name: doc.name,
-          agent_name: doc.agent_name || doc.name,
-          provider: '',
-          model: doc.model || '',
-          instructions: '',
-          temperature: 1,
-          top_p: 1,
-          disabled: doc.disabled === 1,
-          allow_chat: true,
-          persist_conversation: true,
-          triggers: [],
-          tags: [],
-          category: undefined,
-          visibility: 'Global',
-          environment: 'Prod',
-          status: (doc.disabled === 1 ? 'Disabled' : 'Active') as Agent['status'],
-          tools: [],
-          stats: { conversations: 0, lastRunAt: '', successRate: 0, avgCost: 0, avgLatencyMs: 0, token24h: { input: 0, output: 0, total: 0 } },
-          created_at: '',
-          updated_at: '',
-        }));
-        setAgents(mappedAgents);
+        setAgents(agentDocs);
         setLoadingAgents(false);
       }).catch(() => {
         setLoadingAgents(false);
@@ -533,10 +509,20 @@ export function NodeSelectionModal({
                           Available Agents
                         </h3>
                         <div className="space-y-2">
-                          {agents.filter((agent) =>
-                            agent.agent_name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                            agent.instructions.toLowerCase().includes(searchQuery.toLowerCase())
-                          ).map((agent) => (
+                          {agents.filter((agent) => {
+                            const query = searchQuery.toLowerCase();
+                            const summary = agent.description || '';
+                            return (
+                              (agent.agent_name || agent.name).toLowerCase().includes(query) ||
+                              summary.toLowerCase().includes(query) ||
+                              (agent.model || '').toLowerCase().includes(query) ||
+                              (agent.provider || '').toLowerCase().includes(query)
+                            );
+                          }).map((agent) => {
+                            const status = agent.disabled === 1 ? 'Disabled' : 'Active';
+                            const summary = agent.description?.slice(0, 120) || 'No description';
+
+                            return (
                             <button
                               key={agent.name}
                               className={`flex items-center gap-3 p-3 rounded-lg border w-full transition-all ${selectedItem === agent.name
@@ -549,31 +535,41 @@ export function NodeSelectionModal({
                                   type: 'app-trigger',
                                   integration: 'agent' as any,
                                   event: 'run_agent',
-                                  config: { agentId: agent.name, agentName: agent.agent_name }
+                                  config: { agentId: agent.name, agentName: agent.agent_name || agent.name }
                                 });
                               }}
                             >
                               <div className="w-8 h-8 rounded bg-primary/10 flex items-center justify-center flex-shrink-0">
-                                <Bot className="w-4 h-4 text-primary" />
+                                {agent.agent_color ? (
+                                  <span
+                                    className="w-4 h-4 rounded-full border border-border"
+                                    style={{ backgroundColor: agent.agent_color }}
+                                  />
+                                ) : (
+                                  <Bot className="w-4 h-4 text-primary" />
+                                )}
                               </div>
                               <div className="text-left flex-1 min-w-0">
-                                <div className="flex items-center gap-2">
-                                  <div className="text-sm font-medium">{agent.agent_name}</div>
-                                  {agent.status && (
-                                    <Badge variant={agent.status === 'Active' ? 'default' : 'secondary'} className="text-xs">
-                                      {agent.status}
-                                    </Badge>
+                                <div className="flex items-center gap-2 flex-wrap">
+                                  <div className="text-sm font-medium">{agent.agent_name || agent.name}</div>
+                                  <Badge variant={status === 'Active' ? 'default' : 'secondary'} className="text-xs">
+                                    {status}
+                                  </Badge>
+                                  {agent.allow_chat === 1 && (
+                                    <Badge variant="outline" className="text-xs">Chat</Badge>
                                   )}
                                 </div>
                                 <div className="text-xs text-muted-foreground line-clamp-1">
-                                  {agent.instructions}
+                                  {summary}
                                 </div>
                                 <div className="text-xs text-muted-foreground mt-1">
-                                  {agent.model} • {agent.category || 'General'}
+                                  {agent.provider || 'Unknown provider'} • {agent.model || 'Unknown model'}
+                                  {agent.prompt_mode === 'Template' ? ' • Template' : ''}
                                 </div>
                               </div>
                             </button>
-                          ))}
+                          );
+                          })}
                         </div>
                       </div>
                     )

--- a/frontend/src/components/tools/ToolCreationForm.tsx
+++ b/frontend/src/components/tools/ToolCreationForm.tsx
@@ -20,6 +20,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Combobox } from '@/components/ui/combobox';
+import { linkRoutes } from '@/lib/link-routes';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
@@ -575,6 +576,7 @@ export function ToolCreationForm({
                     searchPlaceholder="Search agents..."
                     emptyText="No agent found."
                     disabled={loading || loadingData}
+                    linkTo={linkRoutes.agent}
                   />
                 </FormControl>
                 <FormMessage />

--- a/frontend/src/components/tools/useToolCreationOptions.ts
+++ b/frontend/src/components/tools/useToolCreationOptions.ts
@@ -33,7 +33,9 @@ export function useToolCreationOptions() {
     () =>
       agents.map((agent) => ({
         value: agent.name,
-        label: agent.agent_name || agent.name,
+        label: agent.model
+          ? `${agent.agent_name || agent.name} · ${agent.model}`
+          : agent.agent_name || agent.name,
       })),
     [agents]
   );

--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -15,6 +15,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { LinkFieldAction } from '@/components/ui/link-field-control';
 
 export interface ComboboxOption {
   value: string;
@@ -30,6 +31,7 @@ export interface ComboboxProps {
   disabled?: boolean;
   emptyText?: string;
   searchPlaceholder?: string;
+  linkTo?: (value: string) => string | undefined;
 }
 
 export function Combobox({
@@ -40,10 +42,13 @@ export function Combobox({
   disabled = false,
   emptyText = 'No option found.',
   searchPlaceholder = 'Search...',
+  linkTo,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
 
   const selectedOption = options.find((option) => option.value === value);
+  const href = value && linkTo ? linkTo(value) : undefined;
+  const showLink = Boolean(href) && !disabled;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -52,17 +57,18 @@ export function Combobox({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-full justify-between"
+          className="h-9 w-full justify-between px-3 py-2"
           disabled={disabled}
         >
           {selectedOption ? (
-            <div className="flex min-w-0 flex-col items-start text-left">
-              <span className="truncate">{selectedOption.label}</span>
-            </div>
+            <span className="min-w-0 flex-1 truncate text-left">{selectedOption.label}</span>
           ) : (
-            placeholder
+            <span className="min-w-0 flex-1 truncate text-left text-muted-foreground">{placeholder}</span>
           )}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          <div className="flex shrink-0 items-center gap-0.5">
+            {showLink && href ? <LinkFieldAction href={href} /> : null}
+            <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
+          </div>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
@@ -101,4 +107,3 @@ export function Combobox({
     </Popover>
   );
 }
-

--- a/frontend/src/components/ui/link-field-control.tsx
+++ b/frontend/src/components/ui/link-field-control.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { ArrowUpRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+
+interface LinkFieldActionProps {
+	href: string;
+	className?: string;
+}
+
+export function LinkFieldAction({ href, className }: LinkFieldActionProps) {
+	const navigate = useNavigate();
+
+	return (
+		<button
+			type="button"
+			className={cn(
+				'inline-flex shrink-0 items-center justify-center rounded-sm p-0.5 text-muted-foreground/50 transition-colors hover:bg-muted/70 hover:text-foreground',
+				className
+			)}
+			title="Open record"
+			aria-label="Open record"
+			onClick={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				navigate(href);
+			}}
+		>
+			<ArrowUpRight className="h-3.5 w-3.5" />
+		</button>
+	);
+}
+
+export interface LinkFieldControlProps {
+	value?: string;
+	linkTo?: (value: string) => string | undefined;
+	disabled?: boolean;
+	children: React.ReactNode;
+	className?: string;
+}
+
+export function LinkFieldControl({
+	value,
+	linkTo,
+	disabled = false,
+	children,
+	className,
+}: LinkFieldControlProps) {
+	const href = value && linkTo ? linkTo(value) : undefined;
+	const showLink = Boolean(href) && !disabled;
+
+	return (
+		<div
+			className={cn(
+				'relative w-full',
+				showLink && '[&>button>span]:pr-5',
+				className
+			)}
+		>
+			{children}
+			{showLink && href ? (
+				<LinkFieldAction
+					href={href}
+					className="absolute right-8 top-1/2 z-10 -translate-y-1/2"
+				/>
+			) : null}
+		</div>
+	);
+}

--- a/frontend/src/contexts/IntegrationSettingsContext.tsx
+++ b/frontend/src/contexts/IntegrationSettingsContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react';
+
+interface IntegrationSettingsContextType {
+  onAddIntegration: () => void;
+}
+
+export const IntegrationSettingsContext = createContext<IntegrationSettingsContextType | undefined>(
+  undefined,
+);
+
+export function useIntegrationSettingsContext() {
+  const context = useContext(IntegrationSettingsContext);
+  if (!context) {
+    throw new Error('useIntegrationSettingsContext must be used within IntegrationSettingsProvider');
+  }
+  return context;
+}
+
+interface IntegrationSettingsProviderProps {
+  children: React.ReactNode;
+  onAddIntegration: () => void;
+}
+
+export function IntegrationSettingsProvider({
+  children,
+  onAddIntegration,
+}: IntegrationSettingsProviderProps) {
+  return (
+    <IntegrationSettingsContext.Provider value={{ onAddIntegration }}>
+      {children}
+    </IntegrationSettingsContext.Provider>
+  );
+}

--- a/frontend/src/data/doctypes.ts
+++ b/frontend/src/data/doctypes.ts
@@ -13,6 +13,8 @@ export const doctype = {
   "Agent Prompt": "Agent Prompt",
   "Agent Prompt Category": "Agent Prompt Category",
   "MCP Server": "MCP Server",
+  "Integration Settings": "Integration Settings",
+  "Integration Service": "Integration Service",
   "Flow Definition": "Flow Definition",
   "Flow Run": "Flow Run",
   "Knowledge Source": "Knowledge Source",

--- a/frontend/src/layouts/UnifiedHeader.tsx
+++ b/frontend/src/layouts/UnifiedHeader.tsx
@@ -25,6 +25,7 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
     if (path.startsWith('/flows')) return 'Flows';
     if (path.startsWith('/data')) return 'Data';
     if (path.startsWith('/providers')) return 'AI Providers';
+    if (path.startsWith('/integrations')) return 'Integrations';
     if (path.startsWith('/settings')) return 'Settings';
     if (path.startsWith('/help')) return 'Help';
     if (path.startsWith('/chat')) return 'Chat';

--- a/frontend/src/lib/link-routes.ts
+++ b/frontend/src/lib/link-routes.ts
@@ -1,0 +1,13 @@
+function encodeId(id: string): string {
+	return encodeURIComponent(id);
+}
+
+export const linkRoutes = {
+	agent: (id: string) => `/agents/${encodeId(id)}`,
+	agentPrompt: (id: string) => `/prompts/${encodeId(id)}`,
+	knowledgeSource: (id: string) => `/knowledge/${encodeId(id)}`,
+	aiModel: (id: string) => `/models?configure=${encodeId(id)}`,
+	aiProvider: (id: string) => `/providers?configure=${encodeId(id)}`,
+} as const;
+
+export type LinkRouteKey = keyof typeof linkRoutes;

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Calendar, Activity, Settings, Zap } from 'lucide-react';
+import { Calendar, Activity, Settings, Zap, Server } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
@@ -12,6 +12,12 @@ const statusOptions = [
   { label: 'All Status', value: 'all' },
   { label: 'Active', value: 'active' },
   { label: 'Disabled', value: 'disabled' },
+];
+
+const chatOptions = [
+  { label: 'All Agents', value: 'all' },
+  { label: 'Chat Enabled', value: 'chat' },
+  { label: 'Automation Only', value: 'no_chat' },
 ];
 
 function getStatusVariant(status: 'active' | 'disabled') {
@@ -27,6 +33,28 @@ function getStatusVariant(status: 'active' | 'disabled') {
 
 function getStatusLabel(agent: AgentDoc): 'active' | 'disabled' {
   return agent.disabled === 1 ? 'disabled' : 'active';
+}
+
+function getAgentBadges(agent: AgentDoc) {
+  const badges: Array<{ label: string; variant?: 'default' | 'secondary' | 'outline' }> = [];
+
+  if (agent.allow_chat === 1) {
+    badges.push({ label: 'Chat', variant: 'default' });
+  }
+  if (agent.prompt_mode === 'Template') {
+    badges.push({ label: 'Template', variant: 'secondary' });
+  }
+  if (agent.enable_multi_run === 1) {
+    badges.push({ label: 'Multi-run', variant: 'outline' });
+  }
+  if (agent.enable_prompt_caching === 1) {
+    badges.push({ label: 'Prompt cache', variant: 'outline' });
+  }
+  if (agent.allow_guest === 1) {
+    badges.push({ label: 'Guest', variant: 'outline' });
+  }
+
+  return badges;
 }
 
 export { AgentsPage };
@@ -48,7 +76,14 @@ function AgentsPage() {
     total,
     error,
   } = useInfiniteScroll<
-    { status?: 'active' | 'disabled' | 'all'; page?: number; limit?: number; start?: number; search?: string },
+    {
+      status?: 'active' | 'disabled' | 'all';
+      chat?: 'all' | 'chat' | 'no_chat';
+      page?: number;
+      limit?: number;
+      start?: number;
+      search?: string;
+    },
     AgentDoc
   >({
     fetchFn: async (params) => {
@@ -58,9 +93,9 @@ function AgentsPage() {
         start: params.start,
         search: params.search,
         status: params.status,
+        chat: params.chat,
       });
 
-      // Handle both old (array) and new (paginated) response formats
       if (Array.isArray(response)) {
         return {
           data: response,
@@ -69,7 +104,6 @@ function AgentsPage() {
         };
       }
 
-      // Convert PaginatedAgentsResponse to PaginatedResponse format
       return {
         data: response.items,
         hasMore: response.hasMore,
@@ -82,7 +116,6 @@ function AgentsPage() {
     autoLoad: true,
   });
 
-  // Show error toast when there's an error
   useEffect(() => {
     if (error) {
       toast.error('Failed to load agents', {
@@ -107,6 +140,12 @@ function AgentsPage() {
               options: statusOptions,
               onChange: (value) => setFilter('status', value),
             },
+            {
+              label: 'Chat',
+              value: filters.chat || 'all',
+              options: chatOptions,
+              onChange: (value) => setFilter('chat', value),
+            },
           ]}
         />
       }
@@ -128,19 +167,28 @@ function AgentsPage() {
         }
         renderItem={(agent) => {
           const status = getStatusLabel(agent);
+          const lastActivity = agent.last_run || agent.modified;
+
           return (
             <ItemCard
               title={agent.agent_name || agent.name}
               description={agent.description?.slice(0, 100) || 'No description'}
+              avatarColor={agent.agent_color}
               status={{
                 label: status,
                 variant: getStatusVariant(status),
               }}
               metadata={[
+                { label: 'Provider', value: agent.provider || 'Unknown', icon: Server },
                 { label: 'Model', value: agent.model || 'Unknown' },
                 { label: 'Runs', value: agent.total_run?.toString() || '0', icon: Zap },
-                { label: 'Last Run', value: formatTimeAgo(agent.last_run), icon: Calendar },
+                {
+                  label: agent.last_run ? 'Last Run' : 'Updated',
+                  value: formatTimeAgo(lastActivity),
+                  icon: Calendar,
+                },
               ]}
+              badges={getAgentBadges(agent)}
               actions={[
                 {
                   icon: Settings,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../com
 import { Button } from '../components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import { ActiveAgentsTab, ActiveFlowsTab, RecentExecutionsTab } from '../components/dashboard';
-import { getAgentRunsCountLast7Days, getAgentRunsForMetrics, getRecentAgentRuns, type AgentRunMetricsDoc } from '../services/dashboardApi';
+import { getAgentRunsCountLast7Days, getAgentRunsForMetrics, getRecentAgentRuns, getDashboardActiveFlows, type AgentRunMetricsDoc, type DashboardFlowItem } from '../services/dashboardApi';
 import type { AgentRunDoc } from '../services/agentRunApi';
 import { getAgents } from '../services/agentApi';
 import type { AgentDoc } from '../types/agent.types';
@@ -134,12 +134,14 @@ function HomePage() {
   const [agentsLoading, setAgentsLoading] = useState(true);
   const [agentRuns, setAgentRuns] = useState<AgentRunDoc[]>([]);
   const [agentRunsLoading, setAgentRunsLoading] = useState(true);
+  const [flows, setFlows] = useState<DashboardFlowItem[]>([]);
+  const [flowsLoading, setFlowsLoading] = useState(true);
 
   useEffect(() => {
     async function fetchAllData() {
       try {
         // Fetch all data in parallel
-        const [totalRuns, runsData, agentsData, recentRuns] = await Promise.all([
+        const [totalRuns, runsData, agentsData, recentRuns, flowsData] = await Promise.all([
           getAgentRunsCountLast7Days(),
           getAgentRunsForMetrics(),
           getAgents({
@@ -148,6 +150,7 @@ function HomePage() {
             page: 1,
           }),
           getRecentAgentRuns(),
+          getDashboardActiveFlows(10),
         ]);
 
         // Process metrics
@@ -169,12 +172,16 @@ function HomePage() {
 
         // Set agent runs
         setAgentRuns(recentRuns);
+
+        // Set flows
+        setFlows(flowsData);
       } catch (error) {
         console.error('Error fetching dashboard data:', error);
       } finally {
         setMetricsLoading(false);
         setAgentsLoading(false);
         setAgentRunsLoading(false);
+        setFlowsLoading(false);
       }
     }
 
@@ -274,6 +281,15 @@ function HomePage() {
                 Show More
               </Button>
             )}
+            {activeTab === 'flows' && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate('/flows')}
+              >
+                Show More
+              </Button>
+            )}
           </div>
 
           {/* Agents Tab */}
@@ -283,7 +299,7 @@ function HomePage() {
 
           {/* Flows Tab */}
           <TabsContent value="flows" className="space-y-4">
-            <ActiveFlowsTab />
+            <ActiveFlowsTab flows={flows} loading={flowsLoading} />
           </TabsContent>
 
           {/* Executions Tab */}

--- a/frontend/src/pages/IntegrationSettingsDetailsPage.tsx
+++ b/frontend/src/pages/IntegrationSettingsDetailsPage.tsx
@@ -1,0 +1,482 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Form } from '@/components/ui/form';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { IntegrationHeader } from '@/components/integrations/IntegrationHeader';
+import { GeneralTab } from '@/components/integrations/GeneralTab';
+import { CredentialsTab } from '@/components/integrations/CredentialsTab';
+import { RecipientsTab } from '@/components/integrations/RecipientsTab';
+import { TelegramTab } from '@/components/integrations/TelegramTab';
+import { integrationFormSchema, type IntegrationFormValues } from '@/components/integrations/types';
+import {
+  createIntegrationSetting,
+  deleteIntegrationSetting,
+  getIntegrationService,
+  getIntegrationSetting,
+  setupTelegramWebhook,
+  updateIntegrationSetting,
+} from '@/services/integrationApi';
+import { getAgents } from '@/services/agentApi';
+import {
+  buildCredentialsPayload,
+  parseRequiredCredentials,
+  type CredentialSchemaItem,
+  type IntegrationSettingsDoc,
+} from '@/types/integration.types';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+import { createFormSubmitHandler, type TabFieldMapping } from '@/utils/formValidation';
+
+export function IntegrationSettingsDetailsPage() {
+  const { settingId } = useParams<{ settingId: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const isNew = settingId === 'new';
+  const initialService = searchParams.get('service') || '';
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [settingUpWebhook, setSettingUpWebhook] = useState(false);
+  const [credentialSchema, setCredentialSchema] = useState<CredentialSchemaItem[]>([]);
+  const [agents, setAgents] = useState<Array<{ name: string; agent_name: string }>>([]);
+  const [docMeta, setDocMeta] = useState({
+    lastUsed: undefined as string | undefined,
+    lastError: undefined as string | undefined,
+    webhookUrl: undefined as string | undefined,
+    webhookStatus: undefined as string | undefined,
+    lastWebhookSetup: undefined as string | undefined,
+  });
+
+  const form = useForm<IntegrationFormValues>({
+    resolver: zodResolver(integrationFormSchema),
+    defaultValues: {
+      service: initialService,
+      is_active: true,
+      is_default: false,
+      credentialValues: {},
+      recipients: [],
+      telegram_agent: '',
+      telegram_auto_setup_webhook: true,
+    },
+  });
+
+  const watchService = form.watch('service');
+  const watchIsActive = form.watch('is_active');
+  const watchIsDefault = form.watch('is_default');
+  const isDirty = form.formState.isDirty;
+  const isTelegram = (isNew ? initialService : watchService) === 'telegram';
+
+  const tabConfig = useMemo(() => {
+    const base = {
+      general: {
+        label: 'General',
+        fields: ['service', 'is_active', 'is_default'],
+        default: true,
+        disabled: false,
+      },
+      credentials: {
+        label: 'Credentials',
+        fields: ['credentialValues'],
+        default: false,
+        disabled: false,
+      },
+      recipients: {
+        label: 'Recipients',
+        fields: ['recipients'],
+        default: false,
+        disabled: false,
+      },
+    };
+
+    if ((isNew ? initialService : watchService) === 'telegram') {
+      return {
+        ...base,
+        telegram: {
+          label: 'Telegram',
+          fields: ['telegram_agent', 'telegram_auto_setup_webhook'],
+          default: false,
+          disabled: isNew,
+        },
+      };
+    }
+
+    return base;
+  }, [isNew, initialService, watchService]);
+
+  const validTabs = useMemo(() => Object.keys(tabConfig), [tabConfig]);
+  const defaultTab = useMemo(
+    () => Object.entries(tabConfig).find(([, config]) => config.default)?.[0] || validTabs[0],
+    [tabConfig, validTabs],
+  );
+  const tabFieldMapping: TabFieldMapping = useMemo(
+    () => Object.fromEntries(
+      Object.entries(tabConfig).map(([key, config]) => [key, [...config.fields]]),
+    ),
+    [tabConfig],
+  );
+  const tabLabels = useMemo(
+    () => Object.fromEntries(
+      Object.entries(tabConfig).map(([key, config]) => [key, config.label]),
+    ),
+    [tabConfig],
+  );
+
+  const [activeTab, setActiveTab] = useState<string>(() => {
+    const hashFromUrl = window.location.hash.slice(1);
+    return hashFromUrl && validTabs.includes(hashFromUrl) ? hashFromUrl : defaultTab;
+  });
+
+  useEffect(() => {
+    if (!validTabs.includes(activeTab)) {
+      setActiveTab(defaultTab);
+    }
+  }, [validTabs, activeTab, defaultTab]);
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hashFromUrl = window.location.hash.slice(1);
+      const tab = hashFromUrl && validTabs.includes(hashFromUrl) ? hashFromUrl : defaultTab;
+      setActiveTab(tab);
+    };
+
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, [defaultTab, validTabs]);
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value);
+    if (value === defaultTab) {
+      window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    } else {
+      window.location.hash = value;
+    }
+  };
+
+  const loadServiceSchema = useCallback(async (serviceName: string) => {
+    if (!serviceName) return;
+    try {
+      const serviceDoc = await getIntegrationService(serviceName);
+      setCredentialSchema(parseRequiredCredentials(serviceDoc.required_credentials));
+    } catch (error) {
+      toast.error(getFrappeErrorMessage(error) || 'Failed to load service schema');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isNew) {
+      if (!initialService) {
+        toast.error('Please select a service from the catalog');
+        navigate('/integrations');
+        return;
+      }
+      form.reset({
+        service: initialService,
+        is_active: true,
+        is_default: false,
+        credentialValues: {},
+        recipients: [],
+        telegram_agent: '',
+        telegram_auto_setup_webhook: true,
+      });
+      loadServiceSchema(initialService).finally(() => setLoading(false));
+      return;
+    }
+
+    if (!settingId) return;
+
+    getIntegrationSetting(settingId)
+      .then((data) => {
+        const schemaPromise = loadServiceSchema(data.service);
+        const credValues: Record<string, string> = {};
+        for (const cred of data.credentials ?? []) {
+          credValues[cred.key] = '';
+        }
+
+        form.reset({
+          service: data.service,
+          is_active: data.is_active === 1,
+          is_default: data.is_default === 1,
+          credentialValues: credValues,
+          recipients: (data.recipients ?? []).map((r) => ({
+            name: r.name,
+            recipient_name: r.recipient_name,
+            recipient_id: r.recipient_id,
+            user: r.user || '',
+          })),
+          telegram_agent: data.telegram_agent || '',
+          telegram_auto_setup_webhook: data.telegram_auto_setup_webhook !== 0,
+        });
+
+        setDocMeta({
+          lastUsed: data.last_used,
+          lastError: data.last_error,
+          webhookUrl: data.telegram_webhook_url,
+          webhookStatus: data.telegram_webhook_status,
+          lastWebhookSetup: data.telegram_last_webhook_setup,
+        });
+
+        return schemaPromise;
+      })
+      .catch((error) => {
+        toast.error(getFrappeErrorMessage(error) || 'Failed to load integration');
+      })
+      .finally(() => setLoading(false));
+  }, [isNew, initialService, settingId, form, navigate, loadServiceSchema]);
+
+  useEffect(() => {
+    if (isTelegram) {
+      getAgents().then((result) => {
+        const list = Array.isArray(result) ? result : result.items;
+        setAgents(list.map((a) => ({ name: a.name, agent_name: a.agent_name || a.name })));
+      }).catch(() => {
+        // Agents optional for display
+      });
+    }
+  }, [isTelegram]);
+
+  const validateCredentials = (
+    values: IntegrationFormValues,
+    schema: CredentialSchemaItem[],
+    creating: boolean,
+  ): boolean => {
+    if (!creating) return true;
+
+    for (const item of schema) {
+      if (item.required && !values.credentialValues[item.key]?.trim()) {
+        toast.error(`${item.label} is required`);
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const onSubmit = useCallback(async (values: IntegrationFormValues) => {
+    if (!validateCredentials(values, credentialSchema, isNew)) {
+      return;
+    }
+
+    setSaving(true);
+    try {
+      let existingCredentials;
+      if (!isNew && settingId) {
+        const existing = await getIntegrationSetting(settingId);
+        existingCredentials = existing.credentials;
+      }
+
+      const credentials = buildCredentialsPayload(
+        credentialSchema,
+        values.credentialValues,
+        existingCredentials,
+        isNew,
+      );
+
+      const payload: Partial<IntegrationSettingsDoc> = {
+        service: values.service,
+        is_active: values.is_active ? 1 : 0,
+        is_default: values.is_default ? 1 : 0,
+        credentials,
+        recipients: values.recipients.map((r) => ({
+          ...(r.name ? { name: r.name } : {}),
+          recipient_name: r.recipient_name,
+          recipient_id: r.recipient_id,
+          user: r.user || undefined,
+        })),
+        ...(values.service === 'telegram'
+          ? {
+              telegram_agent: values.telegram_agent || undefined,
+              telegram_auto_setup_webhook: values.telegram_auto_setup_webhook ? 1 : 0,
+            }
+          : {}),
+      };
+
+      if (isNew) {
+        const created = await createIntegrationSetting(payload);
+        toast.success('Integration created successfully');
+        navigate(`/integrations/${encodeURIComponent(created.name)}`, { replace: true });
+      } else if (settingId) {
+        const updated = await updateIntegrationSetting(settingId, payload);
+        toast.success('Integration updated successfully');
+
+        const credValues: Record<string, string> = {};
+        for (const item of credentialSchema) {
+          credValues[item.key] = '';
+        }
+
+        form.reset({
+          ...values,
+          credentialValues: credValues,
+        });
+
+        setDocMeta({
+          lastUsed: updated.last_used,
+          lastError: updated.last_error,
+          webhookUrl: updated.telegram_webhook_url,
+          webhookStatus: updated.telegram_webhook_status,
+          lastWebhookSetup: updated.telegram_last_webhook_setup,
+        });
+      }
+    } catch (error) {
+      toast.error(getFrappeErrorMessage(error) || 'Failed to save integration');
+    } finally {
+      setSaving(false);
+    }
+  }, [credentialSchema, form, isNew, navigate, settingId]);
+
+  const handleFormSubmit = useMemo(
+    () => createFormSubmitHandler(form, activeTab, tabFieldMapping, tabLabels, onSubmit),
+    [form, activeTab, tabFieldMapping, tabLabels, onSubmit],
+  );
+
+  const handleDelete = async () => {
+    if (!settingId || isNew) return;
+
+    setDeleting(true);
+    try {
+      await deleteIntegrationSetting(settingId);
+      toast.success('Integration deleted');
+      navigate('/integrations');
+    } catch (error) {
+      toast.error(getFrappeErrorMessage(error) || 'Failed to delete integration');
+    } finally {
+      setDeleting(false);
+      setDeleteDialogOpen(false);
+    }
+  };
+
+  const handleSetupWebhook = async () => {
+    if (!settingId || isNew) {
+      toast.error('Save the integration before setting up the webhook');
+      return;
+    }
+
+    setSettingUpWebhook(true);
+    try {
+      const result = await setupTelegramWebhook(settingId);
+      toast.success(result.status || 'Webhook setup completed');
+      const refreshed = await getIntegrationSetting(settingId);
+      setDocMeta((prev) => ({
+        ...prev,
+        webhookUrl: refreshed.telegram_webhook_url,
+        webhookStatus: refreshed.telegram_webhook_status,
+        lastWebhookSetup: refreshed.telegram_last_webhook_setup,
+      }));
+    } catch (error) {
+      toast.error(getFrappeErrorMessage(error) || 'Failed to setup webhook');
+    } finally {
+      setSettingUpWebhook(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-muted-foreground">Loading integration...</div>
+      </div>
+    );
+  }
+
+  const displayService = watchService || initialService;
+  const tabCols = validTabs.length;
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="p-6 space-y-6 max-w-6xl mx-auto">
+        <IntegrationHeader
+          title={settingId && !isNew ? settingId : ''}
+          service={displayService}
+          isActive={watchIsActive}
+          isDefault={watchIsDefault}
+          isNew={isNew}
+          showSaveButton={isNew || isDirty}
+          saving={saving}
+          deleting={deleting}
+          onSave={handleFormSubmit}
+          onDelete={!isNew ? () => setDeleteDialogOpen(true) : undefined}
+        />
+
+        <Form {...form}>
+          <form onSubmit={handleFormSubmit} className="space-y-6">
+            <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
+              <TabsList className={`grid w-full grid-cols-${tabCols}`} style={{ gridTemplateColumns: `repeat(${tabCols}, minmax(0, 1fr))` }}>
+                {Object.entries(tabConfig).map(([tabKey, config]) => (
+                  <TabsTrigger key={tabKey} value={tabKey} disabled={config.disabled}>
+                    {config.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+
+              <TabsContent value="general" className="space-y-4">
+                <GeneralTab
+                  form={form}
+                  isNew={isNew}
+                  lastUsed={docMeta.lastUsed}
+                  lastError={docMeta.lastError}
+                />
+              </TabsContent>
+
+              <TabsContent value="credentials" className="space-y-4">
+                <CredentialsTab form={form} schema={credentialSchema} isNew={isNew} />
+              </TabsContent>
+
+              <TabsContent value="recipients" className="space-y-4">
+                <RecipientsTab form={form} />
+              </TabsContent>
+
+              {'telegram' in tabConfig && (
+                <TabsContent value="telegram" className="space-y-4">
+                  <TelegramTab
+                    form={form}
+                    agents={agents}
+                    webhookUrl={docMeta.webhookUrl}
+                    webhookStatus={docMeta.webhookStatus}
+                    lastWebhookSetup={docMeta.lastWebhookSetup}
+                    settingUpWebhook={settingUpWebhook}
+                    onSetupWebhook={handleSetupWebhook}
+                  />
+                </TabsContent>
+              )}
+            </Tabs>
+          </form>
+        </Form>
+      </div>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete integration?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove &quot;{settingId}&quot; and its stored credentials.
+              Agents using this integration may fail until a replacement is configured.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export default IntegrationSettingsDetailsPage;

--- a/frontend/src/pages/IntegrationSettingsDetailsPageWrapper.tsx
+++ b/frontend/src/pages/IntegrationSettingsDetailsPageWrapper.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { UnifiedLayout } from '@/layouts/UnifiedLayout';
+import { IntegrationSettingsDetailsPage } from './IntegrationSettingsDetailsPage';
+import { getIntegrationSetting } from '@/services/integrationApi';
+
+export { IntegrationSettingsDetailsPageWrapper };
+export default IntegrationSettingsDetailsPageWrapper;
+
+function IntegrationSettingsDetailsPageWrapper() {
+  const { settingId } = useParams<{ settingId: string }>();
+  const [title, setTitle] = useState('New Integration');
+  const isNew = settingId === 'new';
+
+  useEffect(() => {
+    if (settingId && !isNew) {
+      getIntegrationSetting(settingId)
+        .then((doc) => {
+          setTitle(doc.name);
+        })
+        .catch(() => {
+          setTitle('Integration');
+        });
+    } else {
+      setTitle('New Integration');
+    }
+  }, [settingId, isNew]);
+
+  const breadcrumbs = [
+    { label: 'Integrations', href: '/integrations' },
+    { label: title },
+  ];
+
+  return (
+    <UnifiedLayout breadcrumbs={breadcrumbs}>
+      <IntegrationSettingsDetailsPage />
+    </UnifiedLayout>
+  );
+}

--- a/frontend/src/pages/IntegrationSettingsListingPage.tsx
+++ b/frontend/src/pages/IntegrationSettingsListingPage.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AlertCircle, Settings, Star, Users } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '@/components/dashboard';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import {
+  getIntegrationSettings,
+  getIntegrationServices,
+} from '@/services/integrationApi';
+import { ServiceCatalogModal } from '@/components/integrations/ServiceCatalogModal';
+import type { IntegrationSettingsDoc, IntegrationServiceDoc } from '@/types/integration.types';
+import { formatTimeAgo } from '@/utils/time';
+
+interface IntegrationSettingsListingPageProps {
+  catalogOpenKey?: number;
+}
+
+export function IntegrationSettingsListingPage({
+  catalogOpenKey,
+}: IntegrationSettingsListingPageProps) {
+  const navigate = useNavigate();
+  const [catalogOpen, setCatalogOpen] = useState(false);
+  const [services, setServices] = useState<IntegrationServiceDoc[]>([]);
+  const [categoryFilter, setCategoryFilter] = useState('all');
+
+  useEffect(() => {
+    getIntegrationServices().then(setServices).catch(() => {
+      // Non-fatal; cards still render without category labels
+    });
+  }, []);
+
+  useEffect(() => {
+    if (catalogOpenKey && catalogOpenKey > 0) {
+      setCatalogOpen(true);
+    }
+  }, [catalogOpenKey]);
+
+  const serviceCategoryMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const service of services) {
+      map.set(service.service_name, service.category);
+    }
+    return map;
+  }, [services]);
+
+  const categories = useMemo(() => {
+    const unique = new Set(services.map((s) => s.category).filter(Boolean));
+    return [
+      { label: 'All categories', value: 'all' },
+      ...Array.from(unique).sort().map((c) => ({ label: c, value: c })),
+    ];
+  }, [services]);
+
+  const {
+    items: allSettings,
+    hasMore,
+    initialLoading,
+    loadingMore,
+    search,
+    setSearch,
+    loadMore,
+    total,
+    error,
+  } = useInfiniteScroll<
+    { page?: number; limit?: number; start?: number; search?: string },
+    IntegrationSettingsDoc
+  >({
+    fetchFn: async (params) => {
+      const response = await getIntegrationSettings({
+        page: params.page,
+        limit: params.limit,
+        start: params.start,
+        search: params.search,
+      });
+
+      if (Array.isArray(response)) {
+        return { data: response, hasMore: false, total: response.length };
+      }
+
+      return {
+        data: response.items,
+        hasMore: response.hasMore,
+        total: response.total,
+      };
+    },
+    initialParams: {},
+    pageSize: 20,
+    debounceMs: 300,
+    autoLoad: true,
+  });
+
+  const settings = useMemo(() => {
+    if (categoryFilter === 'all') return allSettings;
+    return allSettings.filter(
+      (item) => serviceCategoryMap.get(item.service) === categoryFilter,
+    );
+  }, [allSettings, categoryFilter, serviceCategoryMap]);
+
+  useEffect(() => {
+    if (error) {
+      toast.error('Failed to load integrations', {
+        description: error.message || 'An error occurred while fetching integrations.',
+      });
+    }
+  }, [error]);
+
+  return (
+    <PageLayout
+      subtitle="Connect external services like Slack, Telegram, GitHub, and Google Workspace"
+      filters={
+        <FilterBar
+          searchPlaceholder="Search integrations..."
+          searchValue={search}
+          onSearchChange={setSearch}
+          filters={[
+            {
+              label: 'Category',
+              value: categoryFilter,
+              placeholder: 'Category',
+              options: categories,
+              onChange: setCategoryFilter,
+            },
+          ]}
+        />
+      }
+    >
+      <ServiceCatalogModal open={catalogOpen} onOpenChange={setCatalogOpen} />
+
+      {error && !initialLoading && (
+        <div className="text-center py-12">
+          <p className="text-destructive mb-4">Failed to load integrations</p>
+          <p className="text-sm text-muted-foreground">{error.message}</p>
+        </div>
+      )}
+
+      <GridView
+        items={settings}
+        columns={{ sm: 1, md: 2, lg: 3 }}
+        loading={initialLoading}
+        emptyState={
+          <div className="text-center py-12">
+            <p className="text-muted-foreground mb-4">No integrations configured yet.</p>
+            <button
+              type="button"
+              className="text-sm text-primary hover:underline"
+              onClick={() => setCatalogOpen(true)}
+            >
+              Add your first integration
+            </button>
+          </div>
+        }
+        renderItem={(setting) => {
+          const category = serviceCategoryMap.get(setting.service);
+          const metadata = [
+            ...(category ? [{ label: 'Category', value: category }] : []),
+            ...(setting.is_default ? [{ label: 'Default', value: 'Yes', icon: Star }] : []),
+            ...(setting.last_used
+              ? [{ label: 'Last used', value: formatTimeAgo(setting.last_used) }]
+              : []),
+            ...(setting.last_error
+              ? [{ label: 'Error', value: setting.last_error.slice(0, 40), icon: AlertCircle }]
+              : []),
+          ];
+
+          return (
+            <ItemCard
+              title={setting.name}
+              description={`${setting.service.replace(/_/g, ' ')} integration`}
+              status={{
+                label: setting.is_active ? 'active' : 'inactive',
+                variant: setting.is_active ? 'default' : 'secondary',
+              }}
+              metadata={metadata}
+              actions={[
+                {
+                  icon: Settings,
+                  label: 'Configure',
+                  onClick: () => navigate(`/integrations/${encodeURIComponent(setting.name)}`),
+                },
+              ]}
+              onClick={() => navigate(`/integrations/${encodeURIComponent(setting.name)}`)}
+            />
+          );
+        }}
+        keyExtractor={(setting) => setting.name}
+      />
+
+      <LoadMoreButton
+        hasMore={hasMore}
+        loading={loadingMore}
+        onLoadMore={loadMore}
+        disabled={!!search || initialLoading || categoryFilter !== 'all'}
+      />
+
+      {!hasMore && settings.length > 0 && categoryFilter === 'all' && (
+        <div className="text-center py-4 text-sm text-muted-foreground">
+          {total !== undefined ? `Showing all ${total} integrations` : 'No more integrations to load'}
+        </div>
+      )}
+
+      {categoryFilter !== 'all' && settings.length > 0 && (
+        <div className="text-center py-4 text-sm text-muted-foreground flex items-center justify-center gap-1">
+          <Users className="w-4 h-4" />
+          {settings.length} integration{settings.length !== 1 ? 's' : ''} in this category
+        </div>
+      )}
+    </PageLayout>
+  );
+}
+
+export default IntegrationSettingsListingPage;

--- a/frontend/src/pages/IntegrationSettingsListingPageWrapper.tsx
+++ b/frontend/src/pages/IntegrationSettingsListingPageWrapper.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { IntegrationSettingsProvider } from '@/contexts/IntegrationSettingsContext';
+import { IntegrationSettingsListingPage } from './IntegrationSettingsListingPage';
+import { UnifiedLayout } from '@/layouts/UnifiedLayout';
+import { IntegrationSettingsHeaderActions } from '@/components/integrations/IntegrationSettingsHeaderActions';
+
+export { IntegrationSettingsListingPageWrapper };
+export default IntegrationSettingsListingPageWrapper;
+
+function IntegrationSettingsListingPageWrapper() {
+  const [catalogOpenKey, setCatalogOpenKey] = useState(0);
+
+  const handleAddIntegration = () => {
+    setCatalogOpenKey((prev) => prev + 1);
+  };
+
+  return (
+    <IntegrationSettingsProvider onAddIntegration={handleAddIntegration}>
+      <UnifiedLayout headerActions={<IntegrationSettingsHeaderActions />}>
+        <IntegrationSettingsListingPage catalogOpenKey={catalogOpenKey} />
+      </UnifiedLayout>
+    </IntegrationSettingsProvider>
+  );
+}

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -16,7 +16,8 @@ import { PageLayout, FilterBar, GridView, LoadMoreButton } from '../components/d
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getProviders, getProvider, updateProvider, createProvider } from '../services/providerApi';
 import { getModels } from '../services/providerApi';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import type { AIProvider, AIModel } from '../types/agent.types';
 
@@ -25,6 +26,8 @@ interface IntegrationsPageProps {
 }
 
 export function IntegrationsPage({ addProviderKey }: IntegrationsPageProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const configureHandledRef = useRef(false);
   const [models, setModels] = useState<AIModel[]>([]);
   const [configureModalOpen, setConfigureModalOpen] = useState(false);
   const [selectedProvider, setSelectedProvider] = useState<AIProvider | null>(null);
@@ -151,6 +154,44 @@ export function IntegrationsPage({ addProviderKey }: IntegrationsPageProps) {
       setLoadingProvider(false);
     }
   };
+
+  useEffect(() => {
+    const configureId = searchParams.get('configure');
+    if (!configureId || configureHandledRef.current) {
+      return;
+    }
+
+    configureHandledRef.current = true;
+    let cancelled = false;
+
+    const openFromDeepLink = async () => {
+      try {
+        const listMatch = providers.find((provider) => provider.name === configureId);
+        if (listMatch) {
+          await handleConfigure(listMatch);
+        } else {
+          const details = await getProvider(configureId);
+          await handleConfigure(details);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          toast.error('Failed to open provider configuration');
+          console.error(loadError);
+        }
+      } finally {
+        if (!cancelled) {
+          setSearchParams({}, { replace: true });
+        }
+      }
+    };
+
+    openFromDeepLink();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   const handleSave = async () => {
     // Validate provider name is required

--- a/frontend/src/pages/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage.tsx
@@ -248,6 +248,7 @@ export function IntegrationsPage({ addProviderKey }: IntegrationsPageProps) {
                     {providerModels.slice(0, 3).map(model => (
                       <Badge key={model.name} variant="secondary" className="text-xs">
                         {model.model_name}
+                        {model.modalities ? ` · ${model.modalities}` : ''}
                       </Badge>
                     ))}
                   </div>

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -32,9 +32,12 @@ import {
   buildProviderNameMap,
   resolveProviderName,
 } from '../services/providerApi';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import type { AIModel, AIProvider } from '../types/agent.types';
+import { LinkFieldControl } from '../components/ui/link-field-control';
+import { linkRoutes } from '../lib/link-routes';
 
 interface ModelsPageProps {
   addModelKey?: number;
@@ -77,6 +80,8 @@ function formatPricingSummary(model: AIModel): string | null {
 }
 
 export function ModelsPage({ addModelKey }: ModelsPageProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const configureHandledRef = useRef(false);
   const [providers, setProviders] = useState<AIProvider[]>([]);
   const [modalityOptions, setModalityOptions] = useState<string[]>([]);
   const [configureModalOpen, setConfigureModalOpen] = useState(false);
@@ -200,6 +205,44 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
       setLoadingModel(false);
     }
   };
+
+  useEffect(() => {
+    const configureId = searchParams.get('configure');
+    if (!configureId || configureHandledRef.current) {
+      return;
+    }
+
+    configureHandledRef.current = true;
+    let cancelled = false;
+
+    const openFromDeepLink = async () => {
+      try {
+        const listMatch = models.find((model) => model.name === configureId);
+        if (listMatch) {
+          await handleConfigure(listMatch);
+        } else {
+          const details = await getModel(configureId);
+          await handleConfigure(details);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          toast.error('Failed to open model configuration');
+          console.error(loadError);
+        }
+      } finally {
+        if (!cancelled) {
+          setSearchParams({}, { replace: true });
+        }
+      }
+    };
+
+    openFromDeepLink();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   const buildModelPayload = () => {
     const payload: Record<string, unknown> = {
@@ -378,21 +421,26 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
                 <Label htmlFor="provider">
                   Provider <span className="text-destructive">*</span>
                 </Label>
-                <Select
+                <LinkFieldControl
                   value={formData.provider}
-                  onValueChange={(value) => setFormData({ ...formData, provider: value })}
+                  linkTo={linkRoutes.aiProvider}
                 >
-                  <SelectTrigger id="provider">
-                    <SelectValue placeholder="Select a provider" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {providers.map((p) => (
-                      <SelectItem key={p.name} value={p.name}>
-                        {p.provider_name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  <Select
+                    value={formData.provider}
+                    onValueChange={(value) => setFormData({ ...formData, provider: value })}
+                  >
+                    <SelectTrigger id="provider">
+                      <SelectValue placeholder="Select a provider" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {providers.map((p) => (
+                        <SelectItem key={p.name} value={p.name}>
+                          {p.provider_name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </LinkFieldControl>
               </div>
 
               <div className="space-y-2">

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -1,4 +1,4 @@
-import { Cpu, Settings, Loader2 } from 'lucide-react';
+import { Cpu, Settings, Loader2, DollarSign } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
@@ -12,6 +12,7 @@ import {
 } from '../components/ui/dialog';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
+import { Switch } from '../components/ui/switch';
 import {
   Select,
   SelectContent,
@@ -21,13 +22,58 @@ import {
 } from '../components/ui/select';
 import { PageLayout, FilterBar, GridView, LoadMoreButton } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
-import { getModels, getModel, updateModel, createModel, getProviders, getModalityOptions } from '../services/providerApi';
-import { useEffect, useState } from 'react';
+import {
+  getModels,
+  getModel,
+  updateModel,
+  createModel,
+  getProviders,
+  getModalityOptions,
+  buildProviderNameMap,
+  resolveProviderName,
+} from '../services/providerApi';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import type { AIModel, AIProvider } from '../types/agent.types';
 
 interface ModelsPageProps {
   addModelKey?: number;
+}
+
+interface ModelFormData {
+  model_name: string;
+  provider: string;
+  modalities: string;
+  use_custom_pricing: boolean;
+  input_cost_per_1m_tokens: string;
+  output_cost_per_1m_tokens: string;
+  cached_input_cost_per_1m_tokens: string;
+}
+
+const emptyFormData: ModelFormData = {
+  model_name: '',
+  provider: '',
+  modalities: '',
+  use_custom_pricing: false,
+  input_cost_per_1m_tokens: '',
+  output_cost_per_1m_tokens: '',
+  cached_input_cost_per_1m_tokens: '',
+};
+
+function parseModalityBadges(modalities?: string): string[] {
+  if (!modalities?.trim()) return ['Text'];
+  return modalities.split(',').map((m) => m.trim()).filter(Boolean);
+}
+
+function formatPricingSummary(model: AIModel): string | null {
+  if (model.use_custom_pricing !== 1) return null;
+  const input = model.input_cost_per_1m_tokens;
+  const output = model.output_cost_per_1m_tokens;
+  if (input == null && output == null) return 'Custom pricing';
+  const parts: string[] = [];
+  if (input != null) parts.push(`In $${input}/1M`);
+  if (output != null) parts.push(`Out $${output}/1M`);
+  return parts.join(' · ');
 }
 
 export function ModelsPage({ addModelKey }: ModelsPageProps) {
@@ -38,11 +84,9 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [loadingModel, setLoadingModel] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [formData, setFormData] = useState({
-    model_name: '',
-    provider: '',
-    modalities: '',
-  });
+  const [formData, setFormData] = useState<ModelFormData>(emptyFormData);
+
+  const providerMap = useMemo(() => buildProviderNameMap(providers), [providers]);
 
   const {
     items: models,
@@ -87,7 +131,6 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
     autoLoad: true,
   });
 
-  // Fetch providers and modality options
   useEffect(() => {
     getProviders().then((data) => {
       if (Array.isArray(data)) {
@@ -95,18 +138,17 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
       } else {
         setProviders(data.items);
       }
-    }).catch((error) => {
-      console.error('Error fetching providers:', error);
+    }).catch((fetchError) => {
+      console.error('Error fetching providers:', fetchError);
     });
 
     getModalityOptions().then((options) => {
       setModalityOptions(options);
-    }).catch((error) => {
-      console.error('Error fetching modality options:', error);
+    }).catch((fetchError) => {
+      console.error('Error fetching modality options:', fetchError);
     });
   }, []);
 
-  // Show error toast when there's an error
   useEffect(() => {
     if (error) {
       toast.error('Failed to load models', {
@@ -119,15 +161,10 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
   const handleAddModel = () => {
     setSelectedModel(null);
     setIsEditing(false);
-    setFormData({
-      model_name: '',
-      provider: '',
-      modalities: '',
-    });
+    setFormData(emptyFormData);
     setConfigureModalOpen(true);
   };
 
-  // Listen for add model trigger from header
   useEffect(() => {
     if (addModelKey && addModelKey > 0) {
       handleAddModel();
@@ -146,13 +183,45 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         model_name: details.model_name || '',
         provider: details.provider || '',
         modalities: details.modalities || '',
+        use_custom_pricing: details.use_custom_pricing === 1,
+        input_cost_per_1m_tokens:
+          details.input_cost_per_1m_tokens != null ? String(details.input_cost_per_1m_tokens) : '',
+        output_cost_per_1m_tokens:
+          details.output_cost_per_1m_tokens != null ? String(details.output_cost_per_1m_tokens) : '',
+        cached_input_cost_per_1m_tokens:
+          details.cached_input_cost_per_1m_tokens != null
+            ? String(details.cached_input_cost_per_1m_tokens)
+            : '',
       });
-    } catch (error) {
+    } catch (loadError) {
       toast.error('Failed to load model details');
-      console.error(error);
+      console.error(loadError);
     } finally {
       setLoadingModel(false);
     }
+  };
+
+  const buildModelPayload = () => {
+    const payload: Record<string, unknown> = {
+      model_name: formData.model_name.trim(),
+      provider: formData.provider,
+      modalities: formData.modalities,
+      use_custom_pricing: formData.use_custom_pricing ? 1 : 0,
+    };
+
+    if (formData.use_custom_pricing) {
+      payload.input_cost_per_1m_tokens = formData.input_cost_per_1m_tokens
+        ? parseFloat(formData.input_cost_per_1m_tokens)
+        : 0;
+      payload.output_cost_per_1m_tokens = formData.output_cost_per_1m_tokens
+        ? parseFloat(formData.output_cost_per_1m_tokens)
+        : 0;
+      payload.cached_input_cost_per_1m_tokens = formData.cached_input_cost_per_1m_tokens
+        ? parseFloat(formData.cached_input_cost_per_1m_tokens)
+        : 0;
+    }
+
+    return payload;
   };
 
   const handleSave = async () => {
@@ -167,26 +236,19 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
 
     setSaving(true);
     try {
+      const payload = buildModelPayload();
       if (isEditing && selectedModel) {
-        await updateModel(selectedModel.name, {
-          model_name: formData.model_name.trim(),
-          provider: formData.provider,
-          modalities: formData.modalities,
-        });
+        await updateModel(selectedModel.name, payload);
         toast.success('Model updated successfully');
       } else {
-        await createModel({
-          model_name: formData.model_name.trim(),
-          provider: formData.provider,
-          modalities: formData.modalities,
-        });
+        await createModel(payload);
         toast.success('Model created successfully');
       }
       setConfigureModalOpen(false);
       reset();
-    } catch (error) {
+    } catch (saveError) {
       toast.error(`Failed to ${isEditing ? 'update' : 'create'} model`);
-      console.error(error);
+      console.error(saveError);
     } finally {
       setSaving(false);
     }
@@ -218,49 +280,55 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
             <p className="text-muted-foreground mb-4">No models found.</p>
           </div>
         }
-        renderItem={(model) => (
-          <Card key={model.name} className="h-full flex flex-col">
-            <CardHeader>
-              <div className="flex items-start justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                    <Cpu className="w-5 h-5 text-primary" />
-                  </div>
-                  <div>
-                    <CardTitle className="text-base">{model.model_name}</CardTitle>
-                    <CardDescription className="text-xs">
-                      {model.provider}
-                    </CardDescription>
+        renderItem={(model) => {
+          const pricingSummary = formatPricingSummary(model);
+
+          return (
+            <Card key={model.name} className="h-full flex flex-col">
+              <CardHeader>
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
+                      <Cpu className="w-5 h-5 text-primary" />
+                    </div>
+                    <div>
+                      <CardTitle className="text-base">{model.model_name}</CardTitle>
+                      <CardDescription className="text-xs">
+                        {resolveProviderName(model.provider, providerMap)}
+                      </CardDescription>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </CardHeader>
-            <CardContent className="flex-1">
-              <div className="flex flex-wrap gap-2">
-                {model.modalities ? (
-                  model.modalities.split(',').map(m => (
-                    <Badge key={m} variant="secondary" className="text-xs">
-                      {m.trim()}
+              </CardHeader>
+              <CardContent className="flex-1 space-y-2">
+                <div className="flex flex-wrap gap-2">
+                  {parseModalityBadges(model.modalities).map((modality) => (
+                    <Badge key={modality} variant="secondary" className="text-xs">
+                      {modality}
                     </Badge>
-                  ))
-                ) : (
-                  <Badge variant="outline" className="text-xs">Text</Badge>
+                  ))}
+                </div>
+                {model.use_custom_pricing === 1 && (
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <DollarSign className="w-3 h-3" />
+                    <span>{pricingSummary || 'Custom pricing'}</span>
+                  </div>
                 )}
-              </div>
-            </CardContent>
-            <CardFooter>
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1 gap-2"
-                onClick={() => handleConfigure(model)}
-              >
-                <Settings className="w-4 h-4" />
-                Configure
-              </Button>
-            </CardFooter>
-          </Card>
-        )}
+              </CardContent>
+              <CardFooter>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1 gap-2"
+                  onClick={() => handleConfigure(model)}
+                >
+                  <Settings className="w-4 h-4" />
+                  Configure
+                </Button>
+              </CardFooter>
+            </Card>
+          );
+        }}
         keyExtractor={(model) => model.name}
       />
       <LoadMoreButton
@@ -275,9 +343,8 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         </div>
       )}
 
-      {/* Configure Model Modal */}
       <Dialog open={configureModalOpen} onOpenChange={setConfigureModalOpen}>
-        <DialogContent className="sm:max-w-[500px]">
+        <DialogContent className="sm:max-w-[520px] max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>
               {isEditing ? `Configure ${selectedModel?.model_name || 'Model'}` : 'Add Model'}
@@ -345,6 +412,71 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+
+              <div className="border-t pt-4 space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="use_custom_pricing">Enable Custom Pricing</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Override LiteLLM automatic pricing (USD per 1M tokens)
+                    </p>
+                  </div>
+                  <Switch
+                    id="use_custom_pricing"
+                    checked={formData.use_custom_pricing}
+                    onCheckedChange={(checked) =>
+                      setFormData({ ...formData, use_custom_pricing: checked })
+                    }
+                  />
+                </div>
+
+                {formData.use_custom_pricing && (
+                  <div className="space-y-3">
+                    <div className="space-y-2">
+                      <Label htmlFor="input_cost">Input Cost per 1M Tokens (USD)</Label>
+                      <Input
+                        id="input_cost"
+                        type="number"
+                        min="0"
+                        step="0.00000001"
+                        placeholder="e.g. 2.50"
+                        value={formData.input_cost_per_1m_tokens}
+                        onChange={(e) =>
+                          setFormData({ ...formData, input_cost_per_1m_tokens: e.target.value })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="output_cost">Output Cost per 1M Tokens (USD)</Label>
+                      <Input
+                        id="output_cost"
+                        type="number"
+                        min="0"
+                        step="0.00000001"
+                        placeholder="e.g. 10.00"
+                        value={formData.output_cost_per_1m_tokens}
+                        onChange={(e) =>
+                          setFormData({ ...formData, output_cost_per_1m_tokens: e.target.value })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="cached_input_cost">Cached Input Cost per 1M Tokens (USD)</Label>
+                      <Input
+                        id="cached_input_cost"
+                        type="number"
+                        min="0"
+                        step="0.00000001"
+                        placeholder="Optional, e.g. 0.30"
+                        value={formData.cached_input_cost_per_1m_tokens}
+                        onChange={(e) =>
+                          setFormData({ ...formData, cached_input_cost_per_1m_tokens: e.target.value })
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/frontend/src/services/agentApi.ts
+++ b/frontend/src/services/agentApi.ts
@@ -32,11 +32,19 @@ const AGENT_LIST_FIELDS = [
   'name',
   'agent_name',
   'description',
+  'provider',
   'model',
   'disabled',
   'last_run',
   'total_run',
   'agent_color',
+  'allow_chat',
+  'prompt_mode',
+  'agent_prompt',
+  'enable_multi_run',
+  'enable_prompt_caching',
+  'allow_guest',
+  'modified',
 ];
 
 /**
@@ -47,6 +55,9 @@ const AGENT_MODEL_FIELDS = [
   'agent_name',
   'chef',
   'slug',
+  'model',
+  'agent_color',
+  'description',
 ];
 
 /**
@@ -96,6 +107,7 @@ export interface GetAgentsParams {
   start?: number;
   search?: string;
   status?: 'active' | 'disabled' | 'all';
+  chat?: 'all' | 'chat' | 'no_chat';
 }
 
 /**
@@ -130,6 +142,7 @@ export async function getAgents(
       start = (page - 1) * limit,
       search,
       status,
+      chat,
     } = params;
 
     // Build filters
@@ -137,6 +150,12 @@ export async function getAgents(
 
     if (status && status !== 'all' && (status === 'disabled' || status === 'active')) {
       filters.push(['disabled', '=', status === 'disabled' ? 1 : 0]);
+    }
+
+    if (chat === 'chat') {
+      filters.push(['allow_chat', '=', 1]);
+    } else if (chat === 'no_chat') {
+      filters.push(['allow_chat', '=', 0]);
     }
 
     // Build search filters if provided
@@ -345,6 +364,9 @@ export interface AgentModelItem {
   chef: string;
   chefSlug: string;
   providers: string[];
+  model?: string;
+  agent_color?: string | null;
+  description?: string | null;
 }
 
 /**
@@ -453,6 +475,9 @@ export async function getAgentModels(
       chef: agent.chef || '',
       chefSlug: agent.slug || '',
       providers: agent.slug ? [agent.slug] : [],
+      model: agent.model || '',
+      agent_color: agent.agent_color || null,
+      description: agent.description || null,
     }));
 
     const hasMore = mappedModels.length > limit;

--- a/frontend/src/services/chatApi.ts
+++ b/frontend/src/services/chatApi.ts
@@ -151,6 +151,9 @@ export interface AgentWithCount {
   conversationCount: number;
   last_updated?: string;
   agent_color?: string | null;
+  provider?: string;
+  model?: string;
+  allow_chat?: number;
 }
 
 /**
@@ -161,14 +164,23 @@ export async function getAgentsWithConversationCounts(): Promise<AgentWithCount[
   try {
     // Fetch all agents sorted by last updated (modified field)
     const agents = await db.getDocList(doctype.Agent, {
-      fields: ['name', 'agent_name', 'modified', 'agent_color'],
+      fields: ['name', 'agent_name', 'modified', 'agent_color', 'provider', 'model', 'allow_chat'],
+      filters: [['allow_chat', '=', 1]],
       orderBy: { field: 'modified', order: 'asc' },
       limit: 1000, // Reasonable limit for agents
     });
 
     // Fetch conversation count for each agent
     const agentsWithCounts: AgentWithCount[] = await Promise.all(
-      (agents as Array<{ name: string; agent_name: string; modified?: string }>).map(async (agent) => {
+      (agents as Array<{
+        name: string;
+        agent_name: string;
+        modified?: string;
+        agent_color?: string | null;
+        provider?: string;
+        model?: string;
+        allow_chat?: number;
+      }>).map(async (agent) => {
         const count = await fetchDocCount(doctype['Agent Conversation'], [
           ['agent', '=', agent.name],
           ['channel', '=', 'Chat'],
@@ -178,7 +190,10 @@ export async function getAgentsWithConversationCounts(): Promise<AgentWithCount[
           agent_name: agent.agent_name || agent.name,
           conversationCount: count || 0,
           last_updated: agent.modified,
-          agent_color: (agent as any).agent_color || null,
+          agent_color: agent.agent_color || null,
+          provider: agent.provider,
+          model: agent.model,
+          allow_chat: agent.allow_chat,
         };
       })
     );

--- a/frontend/src/services/dashboardApi.ts
+++ b/frontend/src/services/dashboardApi.ts
@@ -3,6 +3,17 @@ import { doctype } from '@/data/doctypes';
 import { handleFrappeError } from '@/lib/frappe-error';
 import { fetchDocCount } from './utilsApi';
 import { AgentRunDoc } from './agentRunApi';
+import { getFlowDefinitions, listFlowRuns } from './flowApi';
+import { mapBackendStatusToFrontend } from './flowSerializer';
+import type { FlowStatus } from '@/types/flow.types';
+
+export interface DashboardFlowItem {
+  id: string;
+  name: string;
+  status: FlowStatus;
+  runCount: number;
+  lastRunAt: string | null;
+}
 
 /**
  * Agent Run document for metrics calculation
@@ -90,5 +101,37 @@ export async function getRecentAgentRuns(): Promise<AgentRunDoc[]> {
     return runs as AgentRunDoc[];
   } catch (error) {
     handleFrappeError(error, 'Error fetching recent agent runs');
+  }
+}
+
+/**
+ * Fetch active flows with run stats for the dashboard preview
+ */
+export async function getDashboardActiveFlows(limit = 10): Promise<DashboardFlowItem[]> {
+  try {
+    const items = await getFlowDefinitions();
+    const active = items
+      .filter((f) => f.status === 'Active')
+      .slice(0, limit);
+
+    return Promise.all(
+      active.map(async (flow) => {
+        const [runCount, recentRuns] = await Promise.all([
+          fetchDocCount(doctype['Flow Run'], [['flow_id', '=', flow.flow_id]]),
+          listFlowRuns(flow.flow_id, undefined, 1),
+        ]);
+
+        return {
+          id: flow.flow_id,
+          name: flow.flow_name,
+          status: mapBackendStatusToFrontend(flow.status),
+          runCount: runCount ?? 0,
+          lastRunAt: recentRuns[0]?.started_at ?? null,
+        };
+      })
+    );
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching dashboard active flows');
+    return [];
   }
 }

--- a/frontend/src/services/integrationApi.ts
+++ b/frontend/src/services/integrationApi.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration Settings API functions
+ *
+ * Manages external service credentials (Slack, Telegram, GitHub, etc.)
+ */
+
+import { db, call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+import { fetchPaginatedCount } from './utilsApi';
+import { doctype } from '@/data/doctypes';
+import type {
+  IntegrationServiceDoc,
+  IntegrationSettingsDoc,
+} from '@/types/integration.types';
+
+export interface GetIntegrationSettingsParams {
+  page?: number;
+  limit?: number;
+  start?: number;
+  search?: string;
+  service?: string;
+  category?: string;
+}
+
+export interface PaginatedIntegrationSettingsResponse {
+  items: IntegrationSettingsDoc[];
+  hasMore: boolean;
+  total?: number;
+}
+
+const LIST_FIELDS = [
+  'name',
+  'service',
+  'is_active',
+  'is_default',
+  'last_used',
+  'last_error',
+  'modified',
+] as const;
+
+export async function getIntegrationServices(): Promise<IntegrationServiceDoc[]> {
+  try {
+    const response = await db.getDocList(doctype['Integration Service'], {
+      fields: [
+        'name',
+        'service_name',
+        'category',
+        'description',
+        'documentation_url',
+        'required_credentials',
+        'is_builtin',
+      ],
+      orderBy: { field: 'category', order: 'asc' },
+      limit: 100,
+    });
+    return response as IntegrationServiceDoc[];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching integration services');
+    return [];
+  }
+}
+
+export async function getIntegrationService(
+  serviceName: string,
+): Promise<IntegrationServiceDoc> {
+  try {
+    const response = await db.getDoc(doctype['Integration Service'], serviceName);
+    return response as IntegrationServiceDoc;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function getIntegrationSettings(
+  params?: GetIntegrationSettingsParams,
+): Promise<PaginatedIntegrationSettingsResponse | IntegrationSettingsDoc[]> {
+  try {
+    if (!params) {
+      const response = await db.getDocList(doctype['Integration Settings'], {
+        fields: [...LIST_FIELDS],
+        orderBy: { field: 'modified', order: 'desc' },
+        limit: 100,
+      });
+      return response as IntegrationSettingsDoc[];
+    }
+
+    const {
+      page = 1,
+      limit = 20,
+      start = (page - 1) * limit,
+      search,
+      service,
+    } = params;
+
+    const filters: Array<[string, string, unknown]> = [];
+
+    if (search?.trim()) {
+      filters.push(['name', 'like', `%${search.trim()}%`]);
+    }
+    if (service && service !== 'all') {
+      filters.push(['service', '=', service]);
+    }
+
+    const settings = await db.getDocList(doctype['Integration Settings'], {
+      fields: [...LIST_FIELDS],
+      filters: filters.length > 0 ? (filters as never) : undefined,
+      limit: limit + 1,
+      ...(start > 0 && { limit_start: start }),
+      orderBy: { field: 'modified', order: 'desc' },
+    });
+
+    const mapped = settings as IntegrationSettingsDoc[];
+    const hasMore = mapped.length > limit;
+    const items = hasMore ? mapped.slice(0, limit) : mapped;
+
+    const total = await fetchPaginatedCount(
+      page,
+      items.length,
+      doctype['Integration Settings'],
+      filters,
+    );
+
+    return { items, hasMore, total };
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching integration settings');
+    throw error;
+  }
+}
+
+export async function getIntegrationSetting(
+  name: string,
+): Promise<IntegrationSettingsDoc> {
+  try {
+    const response = await db.getDoc(doctype['Integration Settings'], name);
+    return response as IntegrationSettingsDoc;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function createIntegrationSetting(
+  data: Partial<IntegrationSettingsDoc>,
+): Promise<IntegrationSettingsDoc> {
+  try {
+    const response = await db.createDoc(doctype['Integration Settings'], data);
+    return response as IntegrationSettingsDoc;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function updateIntegrationSetting(
+  name: string,
+  data: Partial<IntegrationSettingsDoc>,
+): Promise<IntegrationSettingsDoc> {
+  try {
+    const response = await db.updateDoc(doctype['Integration Settings'], name, data);
+    return response as IntegrationSettingsDoc;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function deleteIntegrationSetting(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype['Integration Settings'], name);
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function setupTelegramWebhook(
+  name: string,
+): Promise<{ status?: string }> {
+  try {
+    const response = await call.post('frappe.client.run_doc_method', {
+      dt: doctype['Integration Settings'],
+      dn: name,
+      method: 'setup_telegram_webhook',
+    });
+    return (response.message ?? response) as { status?: string };
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}

--- a/frontend/src/services/providerApi.ts
+++ b/frontend/src/services/providerApi.ts
@@ -5,8 +5,47 @@ import { handleFrappeError } from '@/lib/frappe-error';
 import { fetchPaginatedCount } from './utilsApi';
 
 /**
- * Pagination parameters for fetching providers
+ * Fields needed for model listing pages
  */
+const MODEL_LIST_FIELDS = [
+  'name',
+  'model_name',
+  'provider',
+  'modalities',
+  'use_custom_pricing',
+  'input_cost_per_1m_tokens',
+  'output_cost_per_1m_tokens',
+  'cached_input_cost_per_1m_tokens',
+];
+
+function mapModelListItem(m: Record<string, unknown>): AIModel {
+  return {
+    name: m.name as string,
+    model_name: (m.model_name as string) || (m.name as string),
+    provider: m.provider as string,
+    modalities: m.modalities as string | undefined,
+    use_custom_pricing: m.use_custom_pricing as number | undefined,
+    input_cost_per_1m_tokens: m.input_cost_per_1m_tokens as number | null | undefined,
+    output_cost_per_1m_tokens: m.output_cost_per_1m_tokens as number | null | undefined,
+    cached_input_cost_per_1m_tokens: m.cached_input_cost_per_1m_tokens as number | null | undefined,
+  };
+}
+
+/**
+ * Build a provider doc name → display name map from provider list
+ */
+export function buildProviderNameMap(providers: AIProvider[]): Map<string, string> {
+  return new Map(providers.map((p) => [p.name, p.provider_name || p.name]));
+}
+
+export function resolveProviderName(
+  providerId: string | undefined,
+  providerMap: Map<string, string>,
+): string {
+  if (!providerId) return 'Unknown';
+  return providerMap.get(providerId) || providerId;
+}
+
 export interface GetProvidersParams {
   page?: number;
   limit?: number;
@@ -180,15 +219,11 @@ export async function getModels(
     if (typeof params === 'string' || !params) {
       const providerId = typeof params === 'string' ? params : undefined;
       const models = await db.getDocList(doctype['AI Model'], {
-        fields: ['name', 'model_name', 'provider'],
+        fields: MODEL_LIST_FIELDS,
         filters: providerId ? [['provider', '=', providerId]] : undefined,
         limit: 1000,
       });
-      return models.map((m: any) => ({
-        name: m.name,
-        model_name: m.model_name || m.name,
-        provider: m.provider,
-      })) as AIModel[];
+      return models.map((m: Record<string, unknown>) => mapModelListItem(m));
     }
 
     const {
@@ -212,18 +247,14 @@ export async function getModels(
 
     // Fetch data
     const models = await db.getDocList(doctype['AI Model'], {
-      fields: ['name', 'model_name', 'provider'],
+      fields: MODEL_LIST_FIELDS,
       filters: filters.length > 0 ? (filters as any) : undefined,
       limit: limit + 1,
       ...(start > 0 && { limit_start: start }),
       orderBy: { field: 'modified', order: 'desc' },
     });
 
-    const mappedModels = models.map((m: any) => ({
-      name: m.name,
-      model_name: m.model_name || m.name,
-      provider: m.provider,
-    })) as AIModel[];
+    const mappedModels = models.map((m: Record<string, unknown>) => mapModelListItem(m));
 
     const hasMore = mappedModels.length > limit;
     const items = hasMore ? mappedModels.slice(0, limit) : mappedModels;
@@ -258,6 +289,10 @@ export interface AIModelDoc {
   model_name: string;
   provider: string;
   modalities?: string;
+  use_custom_pricing?: number;
+  input_cost_per_1m_tokens?: number | null;
+  output_cost_per_1m_tokens?: number | null;
+  cached_input_cost_per_1m_tokens?: number | null;
 }
 
 /**

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -8,6 +8,10 @@ export type AIModel = {
   model_name: string;
   provider: string;
   modalities?: string;
+  use_custom_pricing?: number;
+  input_cost_per_1m_tokens?: number | null;
+  output_cost_per_1m_tokens?: number | null;
+  cached_input_cost_per_1m_tokens?: number | null;
 };
 
 export type ToolType =

--- a/frontend/src/types/integration.types.ts
+++ b/frontend/src/types/integration.types.ts
@@ -1,0 +1,104 @@
+export interface CredentialSchemaItem {
+  key: string;
+  label: string;
+  required?: boolean;
+  description?: string;
+}
+
+export interface IntegrationCredentialRow {
+  name?: string;
+  key: string;
+  value?: string;
+  description?: string;
+}
+
+export interface IntegrationRecipientRow {
+  name?: string;
+  recipient_name: string;
+  recipient_id: string;
+  user?: string;
+}
+
+export interface IntegrationServiceDoc {
+  name: string;
+  service_name: string;
+  category: string;
+  description?: string;
+  documentation_url?: string;
+  required_credentials?: string | CredentialSchemaItem[];
+  is_builtin?: 0 | 1;
+}
+
+export interface IntegrationSettingsDoc {
+  name: string;
+  service: string;
+  is_active: 0 | 1;
+  is_default: 0 | 1;
+  credentials?: IntegrationCredentialRow[];
+  recipients?: IntegrationRecipientRow[];
+  telegram_agent?: string;
+  telegram_auto_setup_webhook?: 0 | 1;
+  telegram_webhook_secret?: string;
+  telegram_webhook_url?: string;
+  telegram_webhook_status?: string;
+  telegram_last_webhook_setup?: string;
+  last_used?: string;
+  last_error?: string;
+  modified?: string;
+}
+
+export function parseRequiredCredentials(
+  json: string | CredentialSchemaItem[] | undefined | null,
+): CredentialSchemaItem[] {
+  if (!json) return [];
+  if (Array.isArray(json)) return json;
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function credentialsToMap(
+  credentials: IntegrationCredentialRow[] | undefined,
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const cred of credentials ?? []) {
+    if (cred.key) {
+      map[cred.key] = cred.value ?? '';
+    }
+  }
+  return map;
+}
+
+export function buildCredentialsPayload(
+  schema: CredentialSchemaItem[],
+  formValues: Record<string, string>,
+  existingCredentials: IntegrationCredentialRow[] | undefined,
+  isNew: boolean,
+): IntegrationCredentialRow[] {
+  const existingMap = credentialsToMap(existingCredentials);
+
+  return schema.map((item) => {
+    const formValue = formValues[item.key]?.trim() ?? '';
+    const existingRow = existingCredentials?.find((c) => c.key === item.key);
+
+    if (isNew) {
+      return {
+        key: item.key,
+        value: formValue,
+        description: item.label,
+      };
+    }
+
+    // On edit: blank field keeps existing value
+    const value = formValue || existingMap[item.key] || '';
+    return {
+      ...(existingRow?.name ? { name: existingRow.name } : {}),
+      key: item.key,
+      value,
+      description: item.label,
+    };
+  });
+}

--- a/huf/huf/doctype/huf_role_permission/huf_role_permission.json
+++ b/huf/huf/doctype/huf_role_permission/huf_role_permission.json
@@ -14,7 +14,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Capability",
-   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.settings.manage\nusers.invite\nusers.manage\nroles.manage",
+   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.integrations.manage\nsystem.settings.manage\nusers.invite\nusers.manage\nroles.manage",
    "reqd": 1
   },
   {

--- a/huf/permissions.py
+++ b/huf/permissions.py
@@ -54,6 +54,7 @@ CAPABILITIES: dict[str, str] = {
 	"system.providers.manage": "Manage AI Providers",
 	"system.models.manage": "Manage AI Models",
 	"system.mcp.manage": "Manage MCP Servers",
+	"system.integrations.manage": "Manage Integrations",
 	"system.settings.manage": "Manage Settings",
 	# --- Users & Roles ---
 	"users.invite": "Invite Users",


### PR DESCRIPTION
## Summary

Four frontend updates on `fix/updates-v2`: real dashboard flows, Integration Settings UI, richer Agents/Models listings, and inline link-field navigation.

**4 commits · 46 files · +2,753 / −317** vs `develop`

## What's in it

- **Dashboard flows** — Active flows tab uses real Flow Definition data (run counts, last run) instead of placeholders.
- **Integration Settings** — New `/integrations` listing + detail pages for external services (Slack, Telegram, GitHub, etc.), schema-driven tabs, service catalog, Telegram webhook setup. Gated by `system.integrations.manage`. (`/providers` stays for AI providers.)
- **Agents & Models** — Listings show DocType metadata (provider, model, modalities, pricing, badges/filters); Models configure modal expanded.
- **Link-field arrows** — Inline open-record links on selects/comboboxes; models/providers support `?configure=` deep-links to open Configure modals.

## Test plan

- [ ] Dashboard flows tab loads and links to flow canvas
- [ ] `/integrations` CRUD + permissions; distinct from `/providers`
- [ ] Agents/Models listings and configure modals
- [ ] Link arrows navigate correctly; `?configure=` opens modals
- [ ] `yarn typecheck`