### PR TITLE
fix: fallback to standard Frappe roles for app access

### DIFF
--- a/huf/permissions.py
+++ b/huf/permissions.py
@@ -137,14 +137,27 @@ def get_user_huf_role(user: str | None = None) -> str | None:
 	if not user:
 		user = frappe.session.user
 
-	if user == "Administrator":
+	if user == "Administrator" or _is_system_manager(user):
 		return "Huf Admin"
 
-	return frappe.db.get_value(
+	huf_role = frappe.db.get_value(
 		"Huf User Role",
 		{"user": user, "enabled": 1},
 		"huf_role",
 	)
+	if huf_role:
+		return huf_role
+
+	# Fallback: check standard Frappe Roles if no Huf User Role record exists
+	user_roles = frappe.get_roles(user)
+	if "Huf Manager" in user_roles:
+		return "Huf Manager"
+	if "Huf User" in user_roles:
+		return "Huf User"
+	if "Huf Viewer" in user_roles:
+		return "Huf Viewer"
+
+	return None
 
 
 def get_user_capabilities(user: str | None = None) -> list[str]:


### PR DESCRIPTION

- Implement a resilient fallback in `get_user_huf_role` to check standard Frappe user roles (Huf Manager, Huf User, Huf Viewer) when a custom `Huf User Role` record is missing. 

- This resolves an issue where users assigned roles directly via Frappe's core Roles & Permissions UI were denied access to the Huf workspace sidebar and frontend UI capabilities due to strict reliance on the bridge table. 

- This read-level fallback ensures system stability and avoids recursive database loops while granting proper authorization access.
