### PR TITLE
feat: implement Google Meet integration

### DIFF
--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -625,6 +625,32 @@ GOOGLE_DRIVE_TOOLS = [
 ]
 
 
+GOOGLE_MEET_TOOLS = [
+	{
+		"tool_name": "google_meet_create_space",
+		"description": "Create a Google Meet meeting space and return a joinable link. Requires Google OAuth credentials with Meet scope.",
+		"function_path": "huf.ai.tools.google_meet.handle_create_meet_space",
+		"category": "Google Tools",
+		"parameters": [
+			_p("access_type", description="Access level: OPEN, TRUSTED, or RESTRICTED (default: OPEN)"),
+		],
+	},
+	{
+		"tool_name": "google_meet_create_event",
+		"description": "Create a Google Calendar event with an auto-generated Google Meet conference. Requires Google OAuth credentials with Calendar scope.",
+		"function_path": "huf.ai.tools.google_meet.handle_create_meet_event",
+		"category": "Google Tools",
+		"parameters": [
+			_p("title", required=True, description="Meeting title"),
+			_p("start_date", required=True, description="Start datetime (ISO 8601)"),
+			_p("end_date", required=True, description="End datetime (ISO 8601)"),
+			_p("description", description="Event description"),
+			_p("timezone", description="Timezone (default: UTC)"),
+		],
+	},
+]
+
+
 # ---------------------------------------------------------------------------
 # Master list
 # ---------------------------------------------------------------------------
@@ -647,4 +673,5 @@ ALL_INTEGRATION_TOOLS = (
 	+ GOOGLE_CALENDAR_TOOLS
 	+ GOOGLE_MAPS_TOOLS
 	+ GOOGLE_DRIVE_TOOLS
+	+ GOOGLE_MEET_TOOLS
 )

--- a/huf/ai/tools/google_meet.py
+++ b/huf/ai/tools/google_meet.py
@@ -1,0 +1,132 @@
+import json
+import frappe
+import requests
+from huf.ai.tools.credentials import require_credential, update_last_error
+
+MEET_BASE = "https://meet.googleapis.com/v2"
+CALENDAR_BASE = "https://www.googleapis.com/calendar/v3"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+
+def _get_access_token():
+	service_name = "google_meet"
+	client_id = require_credential(service_name, "client_id")
+	client_secret = require_credential(service_name, "client_secret")
+	refresh_token = require_credential(service_name, "refresh_token")
+
+	resp = requests.post(TOKEN_URL, data={
+		"client_id": client_id,
+		"client_secret": client_secret,
+		"refresh_token": refresh_token,
+		"grant_type": "refresh_token",
+	}, timeout=15)
+	resp.raise_for_status()
+	return resp.json()["access_token"]
+
+
+def _headers():
+	return {"Authorization": f"Bearer {_get_access_token()}", "Content-Type": "application/json"}
+
+
+def handle_create_meet_space(**kwargs):
+	"""Create a Google Meet meeting space and return a joinable link."""
+	service_name = "google_meet"
+	try:
+		access_type = kwargs.get("access_type", "OPEN")
+		if access_type not in ("OPEN", "TRUSTED", "RESTRICTED"):
+			return json.dumps({"success": False, "error": "access_type must be OPEN, TRUSTED, or RESTRICTED"})
+
+		body = {
+			"config": {
+				"accessType": access_type,
+			}
+		}
+
+		resp = requests.post(
+			f"{MEET_BASE}/spaces",
+			headers=_headers(),
+			json=body,
+			timeout=30,
+		)
+		try:
+			resp.raise_for_status()
+		except requests.exceptions.HTTPError as e:
+			error_details = resp.text
+			frappe.log_error(title="Google Meet Tool API Error", message=f"Status: {e}, Details: {error_details}")
+			raise Exception(f"Google API Error: {resp.status_code} - {error_details}")
+
+		data = resp.json()
+
+		return json.dumps({
+			"success": True,
+			"results": {
+				"space_name": data.get("name"),
+				"meeting_code": data.get("meetingCode"),
+				"meet_url": data.get("meetingUri"),
+				"access_type": data.get("config", {}).get("accessType"),
+			}
+		})
+	except Exception as e:
+		frappe.log_error(title="Google Meet Tool", message=f"Google Meet Error (Create Space): {str(e)}")
+		update_last_error(service_name, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def handle_create_meet_event(**kwargs):
+	"""Create a Google Calendar event with an auto-generated Google Meet conference."""
+	service_name = "google_meet"
+	try:
+		title = kwargs.get("title")
+		start_date = kwargs.get("start_date")
+		end_date = kwargs.get("end_date")
+		if not all([title, start_date, end_date]):
+			return json.dumps({"success": False, "error": "title, start_date, and end_date are required"})
+
+		event = {
+			"summary": title,
+			"start": {"dateTime": start_date, "timeZone": kwargs.get("timezone", "UTC")},
+			"end": {"dateTime": end_date, "timeZone": kwargs.get("timezone", "UTC")},
+			"conferenceData": {
+				"createRequest": {
+					"requestId": frappe.generate_hash(length=12),
+					"conferenceSolutionKey": {"type": "hangoutsMeet"},
+				}
+			},
+		}
+		if "description" in kwargs:
+			event["description"] = kwargs["description"]
+
+		resp = requests.post(
+			f"{CALENDAR_BASE}/calendars/primary/events?conferenceDataVersion=1",
+			headers=_headers(),
+			json=event,
+			timeout=30,
+		)
+		try:
+			resp.raise_for_status()
+		except requests.exceptions.HTTPError as e:
+			error_details = resp.text
+			frappe.log_error(title="Google Meet Tool API Error", message=f"Status: {e}, Details: {error_details}")
+			raise Exception(f"Google API Error: {resp.status_code} - {error_details}")
+
+		data = resp.json()
+
+		meet_url = None
+		for ep in data.get("conferenceData", {}).get("entryPoints", []):
+			if ep.get("entryPointType") == "video":
+				meet_url = ep.get("uri")
+				break
+
+		return json.dumps({
+			"success": True,
+			"results": {
+				"event_id": data.get("id"),
+				"summary": data.get("summary"),
+				"html_link": data.get("htmlLink"),
+				"meet_url": meet_url,
+			}
+		})
+	except Exception as e:
+		frappe.log_error(title="Google Meet Tool", message=f"Google Meet Error (Create Event): {str(e)}")
+		update_last_error(service_name, str(e))
+		return json.dumps({"success": False, "error": str(e)})

--- a/huf/install.py
+++ b/huf/install.py
@@ -855,6 +855,16 @@ def register_integration_services():
 				{"key": "api_key", "label": "Google Maps API Key", "required": True}
 			]
 		},
+		{
+			"service_name": "google_meet",
+			"category": "Google",
+			"description": "Google Meet meeting space creation",
+			"required_credentials": [
+				{"key": "client_id", "label": "Google Client ID", "required": True},
+				{"key": "client_secret", "label": "Google Client Secret", "required": True},
+				{"key": "refresh_token", "label": "OAuth Refresh Token", "required": True}
+			]
+		},
 	]
 	
 	# Create or update each service


### PR DESCRIPTION
- Add `google_meet.py` tool handlers (`handle_create_meet_space` and `handle_create_meet_event`) to allow AI agents to generate Meet links and schedule Google Calendar events.
- Implement detailed `HTTPError` exception catching in the Google Meet tool to extract and log exact Google API JSON payloads, preventing generic "403 Forbidden" crashes and improving OAuth scope debugging.
- Register `google_meet_create_space` and `google_meet_create_event` in the central tool registry (`huf/ai/tools/_registry.py`).
- Add Google Meet OAuth2 credential requirements (`client_id`, `client_secret`, `refresh_token`) to the default `Integration Settings` setup in `huf/install.py`.
