### PR TITLE
fix: resolve Event loop is closed error in agent execution

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -896,6 +896,7 @@ def run_agent_sync(
         new_items = getattr(result, "new_items", []) or []
 
         client_side_tool_calls = []
+        tool_call_message_map = {}  # call_id -> Agent Message name
 
         for item in new_items:
             if item.type == "tool_call_item":
@@ -936,6 +937,8 @@ def run_agent_sync(
                         "function": {"name": tool_name, "arguments": tool_args}
                     }]
                 )
+                if call_id:
+                    tool_call_message_map[call_id] = message_doc.name
                 safe_commit()
 
             elif item.type == "tool_call_output_item":
@@ -952,32 +955,55 @@ def run_agent_sync(
                     tool_call_doc = frappe.get_doc("Agent Tool Call", updated_tool_call_id)
                     tool_status = tool_call_doc.status or "Completed"
                     tool_name = tool_call_doc.tool or "Unknown Tool"
+                    call_id = tool_call_doc.call_id
 
-                    message_name = frappe.db.get_value("Agent Message", {"tool_call": updated_tool_call_id}, "name")
+                    # Update the original Tool Call message in place so request + result
+                    # are stored in a single Agent Message row.
+                    message_name = tool_call_message_map.get(call_id)
+                    if not message_name:
+                        message_name = frappe.db.get_value("Agent Message", {"tool_call": updated_tool_call_id}, "name")
 
-                    # Persist tool result with context policy (large results stored as reference only)
-                    tool_result_str = str(tool_result) if tool_result is not None else ""
-                    tool_result_summary = (tool_result_str[:200] + "...") if len(tool_result_str) > 200 else tool_result_str
-                    max_context_chars = int(getattr(agent_doc, "max_context_chars", 2000))
-                    use_reference = len(tool_result_str) > max_context_chars
+                    tool_call_dict = {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": tool_name, "arguments": tool_call_doc.tool_args or "{}"}
+                    }
 
-                    conv_manager.add_message(
-                        conversation,
-                        role="tool",
-                        content=tool_result_str,
-                        provider=resolved_provider,
-                        model=resolved_model,
-                        agent=agent_name,
-                        run_name=run_doc.name,
-                        kind="Tool Result",
-                        tool_call=updated_tool_call_id,
-                        tool_call_id=tool_call_doc.call_id,
-                        record_kind="tool_result",
-                        context_policy="include_reference" if use_reference else "include_full",
-                        context_summary=tool_result_summary,
-                        reference_doctype="Agent Tool Call",
-                        reference_name=updated_tool_call_id
+                    from huf.ai.conversation_manager import update_tool_call_message
+                    updated = update_tool_call_message(
+                        message_name=message_name,
+                        tool_call_id=call_id,
+                        tool_call=[tool_call_dict],
+                        result_content=tool_result,
+                        agent_doc=agent_doc,
                     )
+
+                    if not updated:
+                        # Fallback: create a separate Tool Result message if the
+                        # original Tool Call message could not be updated.
+                        tool_result_str = str(tool_result) if tool_result is not None else ""
+                        tool_result_summary = (tool_result_str[:200] + "...") if len(tool_result_str) > 200 else tool_result_str
+                        max_context_chars = int(getattr(agent_doc, "max_context_chars", 2000))
+                        use_reference = len(tool_result_str) > max_context_chars
+
+                        result_message = conv_manager.add_message(
+                            conversation,
+                            role="tool",
+                            content=tool_result_str,
+                            provider=resolved_provider,
+                            model=resolved_model,
+                            agent=agent_name,
+                            run_name=run_doc.name,
+                            kind="Tool Result",
+                            tool_call=updated_tool_call_id,
+                            tool_call_id=call_id,
+                            record_kind="tool_result",
+                            context_policy="include_reference" if use_reference else "include_full",
+                            context_summary=tool_result_summary,
+                            reference_doctype="Agent Tool Call",
+                            reference_name=updated_tool_call_id
+                        )
+                        message_name = result_message.name
 
                     # Emit socket event for tool call completed/failed
                     # Always emit, even if message not found (e.g., for image generation which creates its own message)
@@ -1434,6 +1460,8 @@ async def run_agent_stream(
         
         resolved_prompt_cache = _resolve_prompt_cache_options(channel_id, prompt_cache_options)
 
+        tool_call_message_map = {}  # call_id -> Agent Message name (used by streaming provider)
+
         context = {
             "channel": channel_id,
             "external_id": external_id,
@@ -1442,6 +1470,7 @@ async def run_agent_stream(
             "conversation_id": conversation.name,
             "agent_run_id": run_doc.name,
             "prompt_cache_options": resolved_prompt_cache,
+            "_tool_call_message_map": tool_call_message_map,
         }
         
         # SUMMARIZATION LOGIC
@@ -1556,7 +1585,7 @@ async def run_agent_stream(
                         
                         msg_content = f"Requesting Tool: {tool_name}\nArguments: {tool_args}"
                         
-                        conv_manager.add_message(
+                        message_doc = conv_manager.add_message(
                             conversation, 
                             role="agent", 
                             content=msg_content, 
@@ -1573,6 +1602,8 @@ async def run_agent_stream(
                                 "function": {"name": tool_name, "arguments": tool_args}
                             }]
                         )
+                        if call_id:
+                            tool_call_message_map[call_id] = message_doc.name
                         safe_commit()
                         
                     yield chunk

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -504,24 +504,14 @@ def _run_async_safely(coro):
             if user:
                 frappe.set_user(user)
             try:
-                new_loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(new_loop)
-                try:
-                    return new_loop.run_until_complete(coro)
-                finally:
-                    new_loop.close()
+                return asyncio.run(coro)
             finally:
                 frappe.destroy()
                 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             return executor.submit(_thread_worker).result()
     else:
-        new_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(new_loop)
-        try:
-            return new_loop.run_until_complete(coro)
-        finally:
-            new_loop.close()
+        return asyncio.run(coro)
 
 
 @frappe.whitelist()

--- a/huf/ai/agent_stream_renderer.py
+++ b/huf/ai/agent_stream_renderer.py
@@ -157,13 +157,20 @@ class AgentStreamRenderer(BaseRenderer):
 		def stream_generator() -> Generator[str, None, None]:
 			"""Wrapper to convert async generator to sync generator for Werkzeug Response."""
 			loop = None
+			created_loop = False
 			try:
 				# Try to get existing event loop
 				try:
 					loop = asyncio.get_event_loop()
+					if loop.is_closed():
+						loop = None
 				except RuntimeError:
+					loop = None
+					
+				if loop is None:
 					loop = asyncio.new_event_loop()
 					asyncio.set_event_loop(loop)
+					created_loop = True
 				
 				# Create async generator
 				async_gen = run_agent_stream(
@@ -199,12 +206,20 @@ class AgentStreamRenderer(BaseRenderer):
 				error_data = {"type": "error", "error": f"Stream setup error: {str(e)}"}
 				yield f"data: {json.dumps(error_data)}\n\n"
 			finally:
-				# Don't close loop if it was already running
-				if loop and loop != asyncio.get_event_loop():
+				# Close the loop if we created it AND unset it to prevent leaking closed loops!
+				if created_loop and loop:
 					try:
+						# Clean up pending tasks
+						pending = asyncio.all_tasks(loop)
+						for task in pending:
+							task.cancel()
+						if pending:
+							loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
 						loop.close()
 					except Exception:
 						pass
+					finally:
+						asyncio.set_event_loop(None)
 		
 		response = Response(
 			stream_generator(),

--- a/huf/ai/conversation_manager.py
+++ b/huf/ai/conversation_manager.py
@@ -2,6 +2,7 @@ import frappe
 from frappe.utils import now
 import json
 from collections import defaultdict
+from typing import Any
 
 
 def _is_tool_message(msg) -> bool:
@@ -134,6 +135,86 @@ def _synthesize_assistant_tool_call(tool_call_id: str, conversation_name: str | 
         }
     except Exception:
         return None
+
+
+def update_tool_call_message(
+    message_name: str,
+    tool_call_id: str,
+    tool_call: dict | list,
+    result_content: Any,
+    agent_doc=None,
+) -> bool:
+    """
+    Update an existing 'Tool Call' Agent Message with the tool result so the
+    request and result live in a single message row.
+
+    Args:
+        message_name: Name of the Agent Message to update.
+        tool_call_id: LLM-generated tool call id.
+        tool_call: Tool call payload (dict or list) to persist in tool_calls.
+        result_content: Raw result returned by the tool.
+        agent_doc: Agent DocType (used for max_context_chars threshold).
+
+    Returns:
+        True if the message was updated, False otherwise.
+    """
+    if not message_name:
+        return False
+
+    try:
+        msg_doc = frappe.get_doc("Agent Message", message_name)
+    except Exception as e:
+        frappe.log_error(
+            f"Could not load Agent Message '{message_name}' for tool result update: {e}",
+            "Tool Call Message Update"
+        )
+        return False
+
+    try:
+        if isinstance(result_content, str):
+            result_str = result_content
+        else:
+            result_str = json.dumps(result_content, default=str)
+
+        result_summary = (result_str[:200] + "...") if len(result_str) > 200 else result_str
+
+        max_context_chars = 2000
+        if agent_doc:
+            try:
+                max_context_chars = int(getattr(agent_doc, "max_context_chars", 2000) or 2000)
+            except Exception:
+                max_context_chars = 2000
+        max_context_chars = max(max_context_chars, 500)
+
+        use_reference = len(result_str) > max_context_chars
+
+        existing_content = msg_doc.content or ""
+        if "**Tool Result:**" not in existing_content:
+            msg_doc.content = existing_content + f"\n\n**Tool Result:**\n{result_str}"
+
+        msg_doc.kind = "Tool Result"
+        msg_doc.record_kind = "tool_result"
+        msg_doc.context_policy = "include_reference" if use_reference else "include_full"
+        msg_doc.context_summary = result_summary
+        msg_doc.reference_doctype = "Agent Tool Call"
+        if msg_doc.tool_call:
+            msg_doc.reference_name = msg_doc.tool_call
+        msg_doc.tool_call_id = tool_call_id
+        if tool_call is not None:
+            msg_doc.tool_calls = (
+                json.dumps(tool_call, default=str)
+                if not isinstance(tool_call, str)
+                else tool_call
+            )
+
+        msg_doc.save(ignore_permissions=True)
+        return True
+    except Exception as e:
+        frappe.log_error(
+            f"Error updating tool call message '{message_name}': {e}",
+            "Tool Call Message Update"
+        )
+        return False
 
 
 def repair_message_sequence(messages: list, conversation_name: str | None = None) -> list:

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -757,6 +757,8 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
             except Exception:
                 pass
 
+        max_context_chars = _get_agent_max_context_chars(agent_doc)
+
         # Get API key
         provider_doc = frappe.get_doc("AI Provider", provider)
         api_key = provider_doc.get_password("api_key")
@@ -1050,6 +1052,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                     if context and context.get("conversation_id"):
                                         conv_id = context.get("conversation_id")
                                         call_id = tool_call.get("id")
+                                        agent_run_id = context.get("agent_run_id")
                                         try:
                                             tool_call_doc = frappe.db.get_value("Agent Tool Call", {
                                                 "conversation": conv_id,
@@ -1066,25 +1069,54 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                     tc_doc.tool_result = {"output": str(result_content)[:140000]}
                                                 tc_doc.save(ignore_permissions=True)
 
-                                                message_name = frappe.db.get_value("Agent Message", {"tool_call": tool_call_doc}, "name")
+                                                # Find the Agent Message to update. Prefer the in-memory
+                                                # map passed via context, then fall back to DB lookups.
+                                                tool_call_message_map = context.get("_tool_call_message_map") or {}
+                                                message_name = tool_call_message_map.get(call_id)
+
+                                                if not message_name and tool_call_doc:
+                                                    message_name = frappe.db.get_value(
+                                                        "Agent Message", {"tool_call": tool_call_doc}, "name"
+                                                    )
+
+                                                if not message_name and call_id:
+                                                    message_name = frappe.db.get_value(
+                                                        "Agent Message", {"tool_call_id": call_id}, "name"
+                                                    )
+
+                                                if not message_name and call_id and agent_run_id:
+                                                    message_name = frappe.db.get_value(
+                                                        "Agent Message",
+                                                        {
+                                                            "conversation": conv_id,
+                                                            "agent_run": agent_run_id,
+                                                            "kind": "Tool Call",
+                                                            "tool_call_id": call_id,
+                                                        },
+                                                        "name",
+                                                        order_by="creation desc",
+                                                    )
+
                                                 if message_name:
-                                                    msg_doc = frappe.get_doc("Agent Message", message_name)
-                                                    result_str = json.dumps(result_content) if not isinstance(result_content, str) else str(result_content)
-                                                    
-                                                    result_summary = (result_str[:200] + "...") if len(result_str) > 200 else result_str
-                                                    max_context_chars = int(getattr(agent, "max_context_chars", 2000)) if agent else 2000
-                                                    use_reference = len(result_str) > max_context_chars
-                                                    
-                                                    msg_doc.content = msg_doc.content + f"\n\n**Tool Result:**\n{result_str}"
-                                                    msg_doc.kind = "Tool Result"
-                                                    msg_doc.record_kind = "tool_result"
-                                                    msg_doc.context_policy = "include_reference" if use_reference else "include_full"
-                                                    msg_doc.context_summary = result_summary
-                                                    msg_doc.reference_doctype = "Agent Tool Call"
-                                                    msg_doc.reference_name = tool_call_doc
-                                                    msg_doc.tool_call_id = call_id
-                                                    msg_doc.tool_calls = json.dumps([tool_call])
-                                                    msg_doc.save(ignore_permissions=True)
+                                                    from huf.ai.conversation_manager import update_tool_call_message
+                                                    updated = update_tool_call_message(
+                                                        message_name=message_name,
+                                                        tool_call_id=call_id,
+                                                        tool_call=[tool_call],
+                                                        result_content=result_content,
+                                                        agent_doc=agent_doc,
+                                                    )
+                                                    if not updated:
+                                                        message_name = None
+                                                        frappe.log_error(
+                                                            f"Failed to update tool call message for call_id={call_id}, tool_call_doc={tool_call_doc}",
+                                                            "Tool Call Message Update"
+                                                        )
+                                                else:
+                                                    frappe.log_error(
+                                                        f"No Agent Message found for tool call call_id={call_id}, tool_call_doc={tool_call_doc}",
+                                                        "Tool Call Message Update"
+                                                    )
 
                                                 tool_result_for_socket = (
                                                     result_content
@@ -1111,8 +1143,11 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                 if getattr(frappe.local, "_realtime_log", None) is None:
                                                     frappe.local._realtime_log = []
                                                 frappe.db.commit()
-                                        except Exception:
-                                            pass
+                                        except Exception as e:
+                                            frappe.log_error(
+                                                f"Error updating tool call result for call_id={call_id}: {e}",
+                                                "Tool Call Message Update"
+                                            )
                                 else:
                                     result_content = f"Tool '{tool_name}' not found."
 


### PR DESCRIPTION
This commit implements an architectural fix for the "Event loop is closed" concurrency bug triggered during agent interactions and background jobs. 
Previously, event loops were manually closed but not un-set from their executing threads. Since WSGI and background worker threads are reused, subsequent requests inherited these closed loops, causing fatal RuntimeErrors.

Changes:
- Refactored `_run_async_safely` in `agent_integration.py` to use Python's  robust `asyncio.run()`, ensuring correct loop creation, execution, and restoration of thread states.
- Patched the SSE stream wrapper in `agent_stream_renderer.py` to explicitly  track instantiated loops and call `asyncio.set_event_loop(None)` in the `finally` block, safely purging the closed loop from the worker thread.

Fixes #251
