### PR TITLE
feat: implement conversation data APIs and revamp advanced settings UI

### DIFF
--- a/huf/ai/conversation_data_tools.py
+++ b/huf/ai/conversation_data_tools.py
@@ -141,3 +141,49 @@ def handle_load_conversation_data(conversation_id: str = None, **kwargs):
         return {"success": True, "data": state}
     except Exception as e:
         return {"success": False, "error": str(e)}
+
+@frappe.whitelist()
+def api_get_conversation_data(conversation_id: str, name: str = None):
+    """API endpoint to read conversation data."""
+    if not frappe.has_permission("Agent Conversation", "read", conversation_id):
+        frappe.throw("Not permitted to read Agent Conversation", frappe.PermissionError)
+    
+    agent = frappe.db.get_value("Agent Conversation", conversation_id, "agent")
+    if not agent:
+        return {"success": False, "error": "Agent Conversation not found"}
+        
+    api_permission = frappe.db.get_value("Agent", agent, "conversation_data_api_permission")
+    if api_permission not in ("Read", "Write"):
+        frappe.throw("Agent does not allow reading conversation data via API", frappe.PermissionError)
+        
+    if name:
+        return handle_get_conversation_data(name=name, conversation_id=conversation_id)
+    else:
+        return handle_load_conversation_data(conversation_id=conversation_id)
+
+@frappe.whitelist()
+def api_set_conversation_data(conversation_id: str, name: str, value: Any, value_type: str = None, auto_inject: bool = None, inject_mode: str = None):
+    """API endpoint to write conversation data."""
+    if not frappe.has_permission("Agent Conversation", "write", conversation_id):
+        frappe.throw("Not permitted to write to Agent Conversation", frappe.PermissionError)
+        
+    agent = frappe.db.get_value("Agent Conversation", conversation_id, "agent")
+    if not agent:
+        return {"success": False, "error": "Agent Conversation not found"}
+        
+    api_permission = frappe.db.get_value("Agent", agent, "conversation_data_api_permission")
+    if api_permission != "Write":
+        frappe.throw("Agent does not allow writing conversation data via API", frappe.PermissionError)
+        
+    if isinstance(auto_inject, str):
+        auto_inject = frappe.utils.cint(auto_inject) == 1 or auto_inject.lower() in ("true", "yes", "1")
+        
+    return handle_set_conversation_data(
+        name=name, 
+        value=value, 
+        value_type=value_type, 
+        source="api", 
+        conversation_id=conversation_id, 
+        auto_inject=auto_inject, 
+        inject_mode=inject_mode
+    )

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -54,24 +54,33 @@
   "context_settings_section",
   "context_strategy",
   "history_limit",
-  "enable_conversation_data",
-  "inject_conversation_data",
-  "autonaming_of_conversation_title",
-  "column_break_ctx",
-  "summary_ratio",
-  "summary_model",
-  "max_knowledge_tokens",
-  "max_context_chars",
+  "column_break_9svx",
   "max_turns",
+  "summarisation_engine_section",
+  "summary_ratio",
+  "column_break_5vwr",
+  "summary_model",
+  "knowledge_and_tools_section",
+  "max_knowledge_tokens",
+  "column_break_3mhl",
+  "max_context_chars",
+  "agent_behaviors_section",
+  "autonaming_of_conversation_title",
+  "enable_conversation_data",
+  "column_break_g3a9",
+  "inject_conversation_data",
+  "conversation_data_api_permission",
   "image_generation_section",
   "image_generation_model",
   "audio_generation_section",
   "tts_model",
+  "column_break_mwgf",
   "tts_voice",
   "audio_transcription_section",
   "stt_model",
   "huf_ui_section",
   "agent_color",
+  "column_break_fl05",
   "show_tool_execution_details",
   "permissions_tab",
   "allow_guest",
@@ -83,7 +92,11 @@
   "total_run",
   "seeding_metadata_section",
   "source_app",
-  "source_file"
+  "source_file",
+  "column_break_summary_model",
+  "compression_instructions_section",
+  "use_external_template",
+  "summary_local_prompt"
  ],
  "fields": [
   {
@@ -297,14 +310,14 @@
    "label": "Advanced Settings"
   },
   {
-   "description": "Configure advanced context and memory settings",
+   "description": "Define the rules for how the agent manages its memory window when a conversation grows long and approaches token limits.",
    "fieldname": "context_settings_section",
    "fieldtype": "Section Break",
-   "label": "Context Settings"
+   "label": "Conversation Strategy"
   },
   {
    "default": "Summarize",
-   "description": "How to handle conversation history when it exceeds the limit. 'Summarize' compresses old messages, 'FIFO' drops them.",
+   "description": "Choose 'Summarize' to compress old messages via an LLM, or 'FIFO' to simply drop the oldest messages.",
    "fieldname": "context_strategy",
    "fieldtype": "Select",
    "label": "Context Strategy",
@@ -312,19 +325,15 @@
   },
   {
    "default": "20",
-   "description": "Maximum number of messages to keep in active context before applying strategy.",
+   "description": "Max messages before strategy triggers.",
    "fieldname": "history_limit",
    "fieldtype": "Int",
    "label": "History Limit",
    "non_negative": 1
   },
   {
-   "fieldname": "column_break_ctx",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "0.7",
-   "description": "Ratio of history to summarize effectively. 0.7 means 70% of oldest messages.",
+   "description": "Fraction of history to compress (e.g., 0.7 = 70%).",
    "fieldname": "summary_ratio",
    "fieldtype": "Float",
    "label": "Summary Ratio",
@@ -332,7 +341,7 @@
    "precision": "2"
   },
   {
-   "description": "Optional: Lightweight model to use specifically for summarization tasks.",
+   "description": "Dedicated lightweight model for this task.",
    "fieldname": "summary_model",
    "fieldtype": "Link",
    "label": "Summary Model",
@@ -348,7 +357,7 @@
   },
   {
    "default": "20",
-   "description": "Maximum consecutive turns/steps the agent can take in a single run.",
+   "description": "Consecutive actions in a single run.",
    "fieldname": "max_turns",
    "fieldtype": "Int",
    "label": "Max Turns",
@@ -519,6 +528,14 @@
    "label": "Inject Conversation Data into Prompt"
   },
   {
+   "depends_on": "eval:doc.enable_conversation_data==1",
+   "description": "Select API access level. 'Read' allows reading only. 'Write' allows reading and writing.",
+   "fieldname": "conversation_data_api_permission",
+   "fieldtype": "Select",
+   "label": "Conversation Data API Permission",
+   "options": "\nRead\nWrite"
+  },
+  {
    "fieldname": "image_generation_section",
    "fieldtype": "Section Break",
    "label": "Image Generation"
@@ -603,12 +620,77 @@
    "hidden": 1,
    "label": "Source File",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_9svx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Configure the model and prompts used to compress conversation history. These settings are only active when using the Summarize strategy.",
+   "fieldname": "summarisation_engine_section",
+   "fieldtype": "Section Break",
+   "label": "Summarisation Engine"
+  },
+  {
+   "fieldname": "column_break_summary_model",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Control how the model summarizes the context.",
+   "fieldname": "compression_instructions_section",
+   "fieldtype": "Section Break",
+   "label": "Compression Instructions"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_external_template",
+   "fieldtype": "Check",
+   "label": "Use external template"
+  },
+  {
+   "depends_on": "eval:doc.use_external_template==0",
+   "description": "Write custom instructions here... e.g., 'Summarize the conversation but strictly retain all mentioned dates and action items.'",
+   "fieldname": "summary_local_prompt",
+   "fieldtype": "Code",
+   "label": "LOCAL PROMPT"
+  },
+  {
+   "fieldname": "column_break_5vwr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Set strict boundaries on how much external data the agent can pull into its context window at once.",
+   "fieldname": "knowledge_and_tools_section",
+   "fieldtype": "Section Break",
+   "label": "Knowledge and Tools"
+  },
+  {
+   "description": "Enable or disable background tasks and auxiliary capabilities related to context management.",
+   "fieldname": "agent_behaviors_section",
+   "fieldtype": "Section Break",
+   "label": "Agent Behaviors"
+  },
+  {
+   "fieldname": "column_break_3mhl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_g3a9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_mwgf",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_fl05",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-12 11:10:42.372998",
+ "modified": "2026-06-24 16:17:35.737691",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent",


### PR DESCRIPTION
- Agent DocType: Restructured 'Advanced Settings' layout natively using section and column breaks to logically group Context Strategy, Summarisation Engine, and API settings.
- API Endpoints: Added `@frappe.whitelist()` endpoints `api_get_conversation_data` and `api_set_conversation_data` with strict document-level and agent-level permission enforcement.
