### PR TITLE
feat: implement agent summary prompt templates and configuration UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,21 @@ The main DocType for creating an AI agent.
 | **Slug**          | `slug`         | Data      | Provider slug (fetched from provider, hidden).                                                          |
 | **TTS Model**    | `tts_model`    | Link (AI Model) | Dedicated model for the `generate_audio` tool. When set, the API key is sourced from the *TTS model's own provider* (`AI Model → AI Provider`), enabling cross-provider TTS (e.g. main agent on OpenAI, TTS on ElevenLabs). Falls back to the main provider's default TTS model when unset. |
 | **TTS Voice**    | `tts_voice`    | Data      | Default voice identifier for the configured TTS model (e.g. `alloy`, `nova`, `21m00Tcm4TlvDq8ikWAM`). Overridden by a `voice` argument passed directly to the `generate_audio` tool call. |
+| **Context Strategy** | `context_strategy` | Select | How to handle conversation history when it exceeds the limit. `Summarize` compresses old messages, `FIFO` drops them, `None` keeps all. |
+| **History Limit** | `history_limit` | Int | Maximum number of messages to keep in active context before applying strategy. |
+| **Summary Ratio** | `summary_ratio` | Float | Ratio of history to summarize effectively. 0.7 means 70% of oldest messages. |
+| **Summary Model** | `summary_model` | Link | Optional lightweight `AI Model` used only when compressing older messages (Summarize strategy). |
+| **Summary Prompt Mode** | `summary_prompt_mode` | Select | `Local` uses the `summary_prompt` field. `Template` links to a reusable `Agent Summary Prompt` for conversation summarization. |
+| **Summary Prompt Template** | `summary_prompt_template` | Link | Reusable `Agent Summary Prompt` used for summarization when `summary_prompt_mode` is `Template`. |
+| **Lock Summary Prompt Version** | `summary_prompt_version_locked` | Check | Pins the agent to the attached summary prompt revision. |
+| **Summary Attached at Version** | `summary_template_version_at_attach` | Int | Read-only snapshot of the summary prompt version when attached. |
+| **Summary Prompt** | `summary_prompt` | Code | Local custom summary prompt. Supports `{summary_data}` placeholder. Falls back to a system default. |
+| **Max Knowledge Tokens** | `max_knowledge_tokens` | Int | Maximum tokens to use for injected knowledge context. |
+| **Max Context Characters** | `max_context_chars` | Int | Maximum characters allowed for tool results before truncating and applying `include_reference` context policy. |
+| **Max Turns** | `max_turns` | Int | Maximum consecutive turns/steps the agent can take in a single run. |
+| **Allow Conversation Data Management** | `enable_conversation_data` | Check | Enables key-value memory storage in the conversation context. |
+| **Inject Conversation Data into Prompt** | `inject_conversation_data` | Check | Auto-injects active memory items into the LLM system prompt on every turn. |
+| **Autonaming of Conversation Title** | `autonaming_of_conversation_title` | Check | Automatically updates the conversation title based on initial context. |
 
 **Note**: The `condition` field has been removed from Agent DocType. Conditional triggering is now handled via the `Agent Trigger` DocType.
 
@@ -483,7 +498,36 @@ Category classification for grouping and organizing prompt templates.
 -   **Python Class**: `AgentPromptCategory(Document)`
 -   **File**: `huf/huf/doctype/agent_prompt_category/agent_prompt_category.py`
 
-#### 20. Huf Data Table
+#### 20. Agent Summary Prompt
+
+Reusable summary prompt templates with version control, independent from `Agent Prompt`. Used by agents when the context strategy is `Summarize`.
+
+-   **Python Class**: `AgentSummaryPrompt(Document)`
+-   **File**: `huf/huf/doctype/agent_summary_prompt/agent_summary_prompt.py`
+
+**Fields:**
+
+| Label | Fieldname | Type | Description |
+| :--- | :--- | :--- | :--- |
+| **Title** | `title` | Data | Descriptive title of the summary prompt template. |
+| **Slug** | `slug` | Data | URL-friendly identifier, unique. |
+| **Category** | `category` | Link | Grouping category (`Agent Summary Prompt Category`). |
+| **Description** | `description` | Small Text | Internal description. |
+| **Is Active** | `is_active` | Check | Whether template is available. |
+| **Is System** | `is_system` | Check | System-shipped vs user-created. |
+| **Visibility** | `visibility` | Select | Public, App, or Private. |
+| **Prompt Body** | `prompt_body` | Code | The summary prompt template. Supports `{summary_data}` placeholder. |
+| **Version** | `version` | Int | Version number, auto-incremented. |
+| **Is Latest** | `is_latest` | Check | Marks the active latest version in prompt lineage. |
+
+#### 21. Agent Summary Prompt Category
+
+Category classification for grouping and organizing summary prompt templates.
+
+-   **Python Class**: `AgentSummaryPromptCategory(Document)`
+-   **File**: `huf/huf/doctype/agent_summary_prompt_category/agent_summary_prompt_category.py`
+
+#### 22. Huf Data Table
 
 Registry entry for custom, user-defined data tables. HUF allows dynamically creating database DocTypes (prefixed with `HF `) with custom schemas.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { McpHeaderActions } from './components/McpHeaderActions';
 import { FlowsListHeaderActions } from './components/FlowsListHeaderActions';
 import { KnowledgeHeaderActions } from './components/KnowledgeHeaderActions';
 import { AgentPromptsHeaderActions } from './components/AgentPromptsHeaderActions';
+import { AgentSummaryPromptsHeaderActions } from './components/AgentSummaryPromptsHeaderActions';
 import { UsersHeaderActions } from './components/UsersHeaderActions';
 import { PageLoader } from './components/PageLoader';
 import { DataHeaderActions } from './components/DataHeaderActions';
@@ -26,6 +27,8 @@ const AgentsPage = lazy(() => import('./pages/AgentsPage'));
 const AgentFormPageWrapper = lazy(() => import('./pages/AgentFormPageWrapper'));
 const AgentPromptsPage = lazy(() => import('./pages/AgentPromptsPage'));
 const AgentPromptFormPageWrapper = lazy(() => import('./pages/AgentPromptFormPageWrapper'));
+const AgentSummaryPromptsPage = lazy(() => import('./pages/AgentSummaryPromptsPage'));
+const AgentSummaryPromptFormPageWrapper = lazy(() => import('./pages/AgentSummaryPromptFormPageWrapper'));
 const FlowListPage = lazy(() => import('./pages/FlowListPage'));
 const FlowCanvasPageWrapper = lazy(() => import('./pages/FlowCanvasPageWrapper'));
 const DataPage = lazy(() => import('./pages/DataPage'));
@@ -191,6 +194,28 @@ function App() {
               <ProtectedRoute>
                 <Suspense fallback={<PageLoader />}>
                   <AgentPromptFormPageWrapper />
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/summary-prompts"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout headerActions={<AgentSummaryPromptsHeaderActions />}>
+                  <Suspense fallback={<PageLoader />}>
+                    <AgentSummaryPromptsPage />
+                  </Suspense>
+                </UnifiedLayout>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/summary-prompts/:id"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<PageLoader />}>
+                  <AgentSummaryPromptFormPageWrapper />
                 </Suspense>
               </ProtectedRoute>
             }

--- a/frontend/src/components/AgentSummaryPromptsHeaderActions.tsx
+++ b/frontend/src/components/AgentSummaryPromptsHeaderActions.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+export function AgentSummaryPromptsHeaderActions() {
+  const navigate = useNavigate();
+
+  const handleNewPrompt = () => {
+    navigate('/summary-prompts/new');
+  };
+
+  return (
+    <Button onClick={handleNewPrompt}>
+      <Plus className="mr-2 h-4 w-4" />
+      New Summary Prompt
+    </Button>
+  );
+}

--- a/frontend/src/components/agent/AdvancedTab.tsx
+++ b/frontend/src/components/agent/AdvancedTab.tsx
@@ -8,6 +8,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { UseFormReturn } from 'react-hook-form';
 import type { AgentFormValues } from './types';
 import type { AIModel } from '@/types/agent.types';
+import { Combobox } from '@/components/ui/combobox';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Plus } from 'lucide-react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import type { AgentPromptOption } from './PromptTemplateSection';
 import {
 	MODEL_MODALITY_IMAGE,
 	MODEL_MODALITY_TTS,
@@ -29,17 +35,32 @@ import {
 interface AdvancedTabProps {
   form: UseFormReturn<AgentFormValues>;
   allModels: AIModel[];
+  summaryPromptOptions: AgentPromptOption[];
+  loadingSummaryPrompts?: boolean;
 }
 
 function modelSupports(model: AIModel, required: string): boolean {
   return (model.modalities || '').trim() === required;
 }
 
-export function AdvancedTab({ form, allModels }: AdvancedTabProps) {
+export function AdvancedTab({
+  form,
+  allModels,
+  summaryPromptOptions,
+  loadingSummaryPrompts = false,
+}: AdvancedTabProps) {
 	const imageModels = allModels.filter((m) => modelSupports(m, MODEL_MODALITY_IMAGE));
 	const ttsModels = allModels.filter((m) => modelSupports(m, MODEL_MODALITY_TTS));
 	const sttModels = allModels.filter((m) => modelSupports(m, MODEL_MODALITY_STT));
 	const contextStrategy = form.watch('context_strategy');
+	const summaryPromptMode = form.watch('summary_prompt_mode');
+	const navigate = useNavigate();
+	const location = useLocation();
+	const selectedSummaryPrompt = summaryPromptOptions.find((option) => option.value === form.watch('summary_prompt_template'));
+	const summaryPromptComboboxOptions = summaryPromptOptions.map((option) => ({
+		...option,
+		subtitle: option.version ? `Version ${option.version}` : undefined,
+	}));
 
   return (
     <div className="space-y-6">
@@ -136,6 +157,170 @@ export function AdvancedTab({ form, allModels }: AdvancedTabProps) {
                   </FormControl>
                   <FormDescription>
                     Optional lightweight model used only when compressing older messages (Summarize strategy).
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          {contextStrategy === 'Summarize' && (
+            <FormField
+              control={form.control}
+              name="summary_prompt_mode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Summary Prompt Mode</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value || ''}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select mode" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="Local">Local</SelectItem>
+                      <SelectItem value="Template">Template</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Use a local summary prompt or link to a reusable Agent Summary Prompt template.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          {contextStrategy === 'Summarize' && summaryPromptMode === 'Template' && (
+            <FormField
+              control={form.control}
+              name="summary_prompt_template"
+              render={({ field }) => (
+                <FormItem id="summary-prompt-template-field" className="sm:col-span-2">
+                  <FormLabel>Summary Prompt Template</FormLabel>
+                  <div className="flex items-center gap-2">
+                    <FormControl>
+                      <Combobox
+                        options={summaryPromptComboboxOptions}
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder={loadingSummaryPrompts ? 'Loading templates...' : 'Select an Agent Summary Prompt'}
+                        disabled={loadingSummaryPrompts}
+                        searchPlaceholder="Search summary templates..."
+                        emptyText="No active summary prompt templates found."
+                        linkTo={linkRoutes.agentSummaryPrompt}
+                      />
+                    </FormControl>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() =>
+                        (() => {
+                          const returnTo = `${location.pathname}#advanced`;
+                          const selectedPromptField = 'summary_prompt_template';
+                          try {
+                            localStorage.setItem(
+                              'agentSummaryPromptCreateReturnTo',
+                              JSON.stringify({ returnTo, selectedPromptField })
+                            );
+                          } catch {
+                            // ignore storage failures
+                          }
+                          navigate('/summary-prompts/new', {
+                            state: {
+                              returnTo,
+                              selectedPromptField,
+                              showTab: 'advanced',
+                            },
+                          });
+                        })()
+                      }
+                    >
+                      <Plus className="w-4 h-4 mr-2" />
+                      New
+                    </Button>
+                  </div>
+                  <FormDescription>
+                    Pick an active summary prompt template from the shared library. The backend records the current
+                    version when you attach it.
+                  </FormDescription>
+                  {selectedSummaryPrompt && (
+                    <div className="flex flex-wrap items-center gap-2 pt-2">
+                      {selectedSummaryPrompt.version ? (
+                        <Badge variant="outline">Current template v{selectedSummaryPrompt.version}</Badge>
+                      ) : null}
+                      {selectedSummaryPrompt.isLatest ? <Badge variant="secondary">Latest</Badge> : null}
+                      {selectedSummaryPrompt.description ? (
+                        <span className="text-sm text-muted-foreground">{selectedSummaryPrompt.description}</span>
+                      ) : null}
+                    </div>
+                  )}
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          {contextStrategy === 'Summarize' && summaryPromptMode === 'Template' && (
+            <FormField
+              control={form.control}
+              name="summary_prompt_version_locked"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4 sm:col-span-2">
+                  <div className="space-y-0.5 pr-4">
+                    <FormLabel className="text-base">Lock Summary Prompt Version</FormLabel>
+                    <FormDescription>
+                      Keep this agent pinned to the attached summary prompt version instead of following the
+                      latest template updates automatically.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
+
+          {contextStrategy === 'Summarize' && summaryPromptMode === 'Template' && (
+            <FormField
+              control={form.control}
+              name="summary_template_version_at_attach"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Summary Attached at Version</FormLabel>
+                  <FormControl>
+                    <div className="flex min-h-10 items-center rounded-md border bg-muted/40 px-3 text-sm text-muted-foreground">
+                      {field.value ?? 'Will be recorded after template attachment'}
+                    </div>
+                  </FormControl>
+                  <FormDescription>
+                    Read-only snapshot captured by the backend when a summary prompt template is attached or changed.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          {contextStrategy === 'Summarize' && summaryPromptMode === 'Local' && (
+            <FormField
+              control={form.control}
+              name="summary_prompt"
+              render={({ field }) => (
+                <FormItem className="sm:col-span-2">
+                  <FormLabel>Summary Prompt</FormLabel>
+                  <FormControl>
+                    <textarea
+                      className="flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                      placeholder="Enter the prompt used to summarize conversation history..."
+                      {...field}
+                      value={field.value || ''}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Custom prompt for summarizing conversation history. Use {'{summary_data}'} as a placeholder
+                    for the JSON input containing existing_summary and new_messages_to_incorporate.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/frontend/src/components/agent/types.ts
+++ b/frontend/src/components/agent/types.ts
@@ -39,6 +39,11 @@ export const agentFormSchema = z.object({
   context_strategy: z.string().optional(),
   summary_model: z.string().optional(),
   summary_ratio: z.number().optional(),
+  summary_prompt_mode: z.enum(["Local", "Template"]).default("Local"),
+  summary_prompt_template: z.string().optional(),
+  summary_prompt_version_locked: z.boolean().optional(),
+  summary_template_version_at_attach: z.number().optional(),
+  summary_prompt: z.string().optional(),
   history_limit: z.number().optional(),
   max_knowledge_tokens: z.number().optional(),
   max_turns: z.number().optional(),
@@ -66,6 +71,13 @@ export const agentFormSchema = z.object({
       code: z.ZodIssueCode.custom,
       path: ["agent_prompt"],
       message: 'Select an Agent Prompt when using Template mode',
+    });
+  }
+  if (values.summary_prompt_mode === "Template" && !values.summary_prompt_template?.trim()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["summary_prompt_template"],
+      message: 'Select an Agent Summary Prompt when using Template mode for Summary Prompt',
     });
   }
 });

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -47,6 +47,12 @@ const allNavItems = [
     capability: "agent.use",
   },
   {
+    title: "Agent Summary Prompts",
+    url: "/summary-prompts",
+    icon: ScrollText,
+    capability: "agent.use",
+  },
+  {
     title: "Executions",
     url: "/executions",
     icon: Zap,

--- a/frontend/src/data/doctypes.ts
+++ b/frontend/src/data/doctypes.ts
@@ -12,6 +12,8 @@ export const doctype = {
   "Agent Run": "Agent Run",
   "Agent Prompt": "Agent Prompt",
   "Agent Prompt Category": "Agent Prompt Category",
+  "Agent Summary Prompt": "Agent Summary Prompt",
+  "Agent Summary Prompt Category": "Agent Summary Prompt Category",
   "MCP Server": "MCP Server",
   "Integration Settings": "Integration Settings",
   "Integration Service": "Integration Service",

--- a/frontend/src/lib/link-routes.ts
+++ b/frontend/src/lib/link-routes.ts
@@ -5,6 +5,7 @@ function encodeId(id: string): string {
 export const linkRoutes = {
 	agent: (id: string) => `/agents/${encodeId(id)}`,
 	agentPrompt: (id: string) => `/prompts/${encodeId(id)}`,
+	agentSummaryPrompt: (id: string) => `/summary-prompts/${encodeId(id)}`,
 	knowledgeSource: (id: string) => `/knowledge/${encodeId(id)}`,
 	aiModel: (id: string) => `/models?configure=${encodeId(id)}`,
 	aiProvider: (id: string) => `/providers?configure=${encodeId(id)}`,

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import { AIProvider, AIModel, AgentToolFunctionRef, type ToolType } from '../types/agent.types';
 import { getAgent, updateAgent, createAgent, getAgentTriggers, getAgentTrigger, createAgentTrigger, updateAgentTrigger, getDocTypes, getTriggerTypes, type AgentTriggerListItem, type AgentTriggerDoc, type TriggerTypeOption, deleteAgentTrigger, runAgentTest } from '../services/agentApi';
 import { getAgentPrompt } from '../services/agentPromptApi';
+import { getAgentSummaryPrompt } from '../services/agentSummaryPromptApi';
 import { getProviders, getModels } from '../services/providerApi';
 import { getToolTypes, getToolFunction, updateToolFunction, getToolFunctionsByName } from '../services/toolApi';
 import type { AgentDoc } from '../types/agent.types';
@@ -92,6 +93,11 @@ function mapAgentDocToFormValues(agent: Partial<AgentDoc>): AgentFormValues {
     context_strategy: agent.context_strategy || undefined,
     summary_model: agent.summary_model || undefined,
     summary_ratio: agent.summary_ratio !== undefined && agent.summary_ratio !== null ? agent.summary_ratio : undefined,
+    summary_prompt_mode: agent.summary_prompt_mode || 'Local',
+    summary_prompt_template: agent.summary_prompt_template || '',
+    summary_prompt_version_locked: agent.summary_prompt_version_locked === 1,
+    summary_template_version_at_attach: agent.summary_template_version_at_attach !== undefined ? agent.summary_template_version_at_attach : undefined,
+    summary_prompt: agent.summary_prompt || '',
     history_limit: agent.history_limit !== undefined && agent.history_limit !== null ? agent.history_limit : undefined,
     max_knowledge_tokens:
       agent.max_knowledge_tokens !== undefined && agent.max_knowledge_tokens !== null ? agent.max_knowledge_tokens : undefined,
@@ -162,6 +168,11 @@ export function AgentFormPage() {
        'context_strategy',
         'summary_model',
         'summary_ratio',
+        'summary_prompt_mode',
+        'summary_prompt_template',
+        'summary_prompt_version_locked',
+        'summary_template_version_at_attach',
+        'summary_prompt',
         'history_limit',
         'max_knowledge_tokens',
         'max_turns',
@@ -228,6 +239,8 @@ export function AgentFormPage() {
   const [allModels, setAllModels] = useState<AIModel[]>([]);
   const [promptOptions, setPromptOptions] = useState<AgentPromptOption[]>([]);
   const [loadingPrompts, setLoadingPrompts] = useState(false);
+  const [summaryPromptOptions, setSummaryPromptOptions] = useState<AgentPromptOption[]>([]);
+  const [loadingSummaryPrompts, setLoadingSummaryPrompts] = useState(false);
   const [triggers, setTriggers] = useState<AgentTriggerListItem[]>([]);
   const [showTriggerModal, setShowTriggerModal] = useState(false);
   const [editingTrigger, setEditingTrigger] = useState<AgentTriggerDoc | null>(null);
@@ -287,6 +300,11 @@ export function AgentFormPage() {
         context_strategy: undefined,
         summary_model: undefined,
         summary_ratio: undefined,
+        summary_prompt_mode: "Local",
+        summary_prompt_template: '',
+        summary_prompt_version_locked: false,
+        summary_template_version_at_attach: undefined,
+        summary_prompt: '',
         history_limit: undefined,
         max_knowledge_tokens: undefined,
         max_turns: undefined,
@@ -480,6 +498,52 @@ export function AgentFormPage() {
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
+
+    const loadSummaryPromptOptions = async () => {
+      setLoadingSummaryPrompts(true);
+      try {
+        const prompts = await db.getDocList('Agent Summary Prompt', {
+          fields: ['name', 'title', 'version', 'is_latest', 'description'],
+          filters: [['is_active', '=', 1]],
+          limit: 500,
+          orderBy: { field: 'modified', order: 'desc' },
+        }) as PromptListRow[];
+
+        if (cancelled) {
+          return;
+        }
+
+        setSummaryPromptOptions(
+          prompts.map((prompt) => ({
+            value: prompt.name,
+            label: prompt.title || prompt.name,
+            description: prompt.description || undefined,
+            version: typeof prompt.version === 'number' ? prompt.version : undefined,
+            isLatest: prompt.is_latest === 1,
+          }))
+        );
+      } catch (error) {
+        console.error('Error loading summary prompt templates:', error);
+        if (!cancelled) {
+          setSummaryPromptOptions([]);
+          toast.error('Failed to load Agent Summary Prompt templates');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingSummaryPrompts(false);
+        }
+      }
+    };
+
+    loadSummaryPromptOptions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
     const state = location.state as { selectedPrompt?: string; showTab?: string; selectedPromptField?: string } | null;
     if (state?.selectedPrompt) {
       setPendingSelectedPrompt(state.selectedPrompt);
@@ -500,11 +564,15 @@ export function AgentFormPage() {
     const run = async () => {
       setResolvingPendingPrompt(true);
       try {
-        const promptExists = promptOptions.some((option) => option.value === pendingSelectedPrompt);
+        const isSummaryPrompt = fieldName === 'summary_prompt_template';
+        const existingOptions = isSummaryPrompt ? summaryPromptOptions : promptOptions;
+        const promptExists = existingOptions.some((option) => option.value === pendingSelectedPrompt);
 
         // Ensure the selector's option list contains the newly created prompt.
         if (!promptExists) {
-          const promptDoc = await getAgentPrompt(pendingSelectedPrompt);
+          const promptDoc = isSummaryPrompt
+            ? await getAgentSummaryPrompt(pendingSelectedPrompt)
+            : await getAgentPrompt(pendingSelectedPrompt);
 
           if (promptDoc?.is_active === 1) {
             const option: AgentPromptOption = {
@@ -515,7 +583,8 @@ export function AgentFormPage() {
               isLatest: promptDoc.is_latest === 1,
             };
 
-            setPromptOptions((prev) => {
+            const setOptions = isSummaryPrompt ? setSummaryPromptOptions : setPromptOptions;
+            setOptions((prev) => {
               if (prev.some((p) => p.value === option.value)) return prev;
               return [option, ...prev];
             });
@@ -526,6 +595,9 @@ export function AgentFormPage() {
         if (fieldName === 'agent_prompt' && form.getValues('prompt_mode') !== 'Template') {
           form.setValue('prompt_mode', 'Template', { shouldDirty: true });
         }
+        if (fieldName === 'summary_prompt_template' && form.getValues('summary_prompt_mode') !== 'Template') {
+          form.setValue('summary_prompt_mode', 'Template', { shouldDirty: true });
+        }
 
         // Attach/select the created prompt in the form.
         form.setValue(fieldName as any, pendingSelectedPrompt as any, { shouldDirty: true });
@@ -533,7 +605,7 @@ export function AgentFormPage() {
         setPendingSelectedPrompt(null);
         setPendingSelectedPromptField(null);
 
-        if (fieldName === 'agent_prompt') {
+        if (fieldName === 'agent_prompt' || fieldName === 'summary_prompt_template') {
           setPendingScrollToPromptField(true);
         }
 
@@ -557,6 +629,7 @@ export function AgentFormPage() {
     pendingSelectedPromptField,
     resolvingPendingPrompt,
     promptOptions,
+    summaryPromptOptions,
     form,
     location.pathname,
     location.search,
@@ -585,6 +658,8 @@ export function AgentFormPage() {
 
   const watchPromptMode = form.watch('prompt_mode');
   const watchAgentPrompt = form.watch('agent_prompt');
+  const watchSummaryPromptMode = form.watch('summary_prompt_mode');
+  const watchSummaryPromptTemplate = form.watch('summary_prompt_template');
 
   useEffect(() => {
     // Don't clear prompt selection while we're applying an incoming selection from navigation.
@@ -601,6 +676,22 @@ export function AgentFormPage() {
       form.setValue('template_version_at_attach', undefined, { shouldDirty: false });
     }
   }, [watchPromptMode, watchAgentPrompt, form, pendingSelectedPrompt]);
+
+  useEffect(() => {
+    // Don't clear prompt selection while we're applying an incoming selection from navigation.
+    if (pendingSelectedPrompt) return;
+    if (watchSummaryPromptMode === 'Local') {
+      form.setValue('summary_prompt_template', '', { shouldDirty: false });
+      form.setValue('summary_prompt_version_locked', false, { shouldDirty: false });
+      form.setValue('summary_template_version_at_attach', undefined, { shouldDirty: false });
+      return;
+    }
+
+    if (watchSummaryPromptMode === 'Template' && !watchSummaryPromptTemplate) {
+      form.setValue('summary_prompt_version_locked', false, { shouldDirty: false });
+      form.setValue('summary_template_version_at_attach', undefined, { shouldDirty: false });
+    }
+  }, [watchSummaryPromptMode, watchSummaryPromptTemplate, form, pendingSelectedPrompt]);
 
   useEffect(() => {
     if (watchPromptMode !== 'Template' || !watchAgentPrompt) {
@@ -621,11 +712,33 @@ export function AgentFormPage() {
   }, [watchPromptMode, watchAgentPrompt, promptOptions, form]);
 
   useEffect(() => {
-    if (!pendingScrollToPromptField) return;
-    if (activeTab !== 'general') return;
-    if (watchPromptMode !== 'Template') return;
+    if (watchSummaryPromptMode !== 'Template' || !watchSummaryPromptTemplate) {
+      return;
+    }
 
-    const el = document.getElementById('agent-prompt-field');
+    const selectedPrompt = summaryPromptOptions.find((option) => option.value === watchSummaryPromptTemplate);
+    if (!selectedPrompt || typeof selectedPrompt.version !== 'number') {
+      return;
+    }
+
+    const currentVersion = form.getValues('summary_template_version_at_attach');
+    if (currentVersion === selectedPrompt.version) {
+      return;
+    }
+
+    form.setValue('summary_template_version_at_attach', selectedPrompt.version, { shouldDirty: true });
+  }, [watchSummaryPromptMode, watchSummaryPromptTemplate, summaryPromptOptions, form]);
+
+  useEffect(() => {
+    if (!pendingScrollToPromptField) return;
+
+    let el: HTMLElement | null = null;
+    if (activeTab === 'general' && watchPromptMode === 'Template') {
+      el = document.getElementById('agent-prompt-field');
+    } else if (activeTab === 'advanced' && watchSummaryPromptMode === 'Template') {
+      el = document.getElementById('summary-prompt-template-field');
+    }
+
     if (el) {
       // Wait a couple frames for the tab content to finish rendering.
       requestAnimationFrame(() => {
@@ -636,7 +749,7 @@ export function AgentFormPage() {
     }
 
     setPendingScrollToPromptField(false);
-  }, [pendingScrollToPromptField, activeTab, watchPromptMode]);
+  }, [pendingScrollToPromptField, activeTab, watchPromptMode, watchSummaryPromptMode]);
 
   // Load agent data when id is available (only for edit mode)
   useEffect(() => {
@@ -674,6 +787,11 @@ export function AgentFormPage() {
             context_strategy: data.context_strategy || undefined,
             summary_model: data.summary_model || undefined,
             summary_ratio: data.summary_ratio !== undefined && data.summary_ratio !== null ? data.summary_ratio : undefined,
+            summary_prompt_mode: data.summary_prompt_mode || 'Local',
+            summary_prompt_template: data.summary_prompt_template || '',
+            summary_prompt_version_locked: data.summary_prompt_version_locked === 1,
+            summary_template_version_at_attach: data.summary_template_version_at_attach !== undefined ? data.summary_template_version_at_attach : undefined,
+            summary_prompt: data.summary_prompt || '',
             history_limit: data.history_limit !== undefined && data.history_limit !== null ? data.history_limit : undefined,
             max_knowledge_tokens: data.max_knowledge_tokens !== undefined && data.max_knowledge_tokens !== null ? data.max_knowledge_tokens : undefined,
             max_turns: data.max_turns !== undefined && data.max_turns !== null ? data.max_turns : undefined,
@@ -837,6 +955,11 @@ export function AgentFormPage() {
         context_strategy: values.context_strategy || undefined,
         summary_model: values.summary_model || undefined,
         summary_ratio: values.summary_ratio !== undefined ? values.summary_ratio : undefined,
+        summary_prompt_mode: values.summary_prompt_mode || 'Local',
+        summary_prompt_template: values.summary_prompt_template || '',
+        summary_prompt_version_locked: values.summary_prompt_version_locked ? 1 : 0,
+        summary_template_version_at_attach: values.summary_template_version_at_attach !== undefined ? values.summary_template_version_at_attach : undefined,
+        summary_prompt: values.summary_prompt || '',
         history_limit: values.history_limit !== undefined ? values.history_limit : undefined,
         max_knowledge_tokens: values.max_knowledge_tokens !== undefined ? values.max_knowledge_tokens : undefined,
         max_turns: values.max_turns !== undefined ? values.max_turns : undefined,
@@ -903,6 +1026,11 @@ export function AgentFormPage() {
           context_strategy: newAgent.context_strategy || undefined,
           summary_model: newAgent.summary_model || undefined,
           summary_ratio: newAgent.summary_ratio !== undefined && newAgent.summary_ratio !== null ? newAgent.summary_ratio : undefined,
+          summary_prompt_mode: newAgent.summary_prompt_mode || 'Local',
+          summary_prompt_template: newAgent.summary_prompt_template || '',
+          summary_prompt_version_locked: newAgent.summary_prompt_version_locked === 1,
+          summary_template_version_at_attach: newAgent.summary_template_version_at_attach !== undefined ? newAgent.summary_template_version_at_attach : undefined,
+          summary_prompt: newAgent.summary_prompt || '',
           history_limit: newAgent.history_limit !== undefined && newAgent.history_limit !== null ? newAgent.history_limit : undefined,
           max_knowledge_tokens: newAgent.max_knowledge_tokens !== undefined && newAgent.max_knowledge_tokens !== null ? newAgent.max_knowledge_tokens : undefined,
           max_turns: newAgent.max_turns !== undefined && newAgent.max_turns !== null ? newAgent.max_turns : undefined,
@@ -960,6 +1088,11 @@ form.reset({
   context_strategy: values.context_strategy,
   summary_model: values.summary_model,
   summary_ratio: values.summary_ratio,
+  summary_prompt_mode: values.summary_prompt_mode,
+  summary_prompt_template: values.summary_prompt_template,
+  summary_prompt_version_locked: values.summary_prompt_version_locked,
+  summary_template_version_at_attach: values.summary_template_version_at_attach,
+  summary_prompt: values.summary_prompt,
   history_limit: values.history_limit,
   max_knowledge_tokens: values.max_knowledge_tokens,
   max_turns: values.max_turns,
@@ -1527,7 +1660,12 @@ setAllowChat(values.allow_chat);
               </TabsContent>
 
               <TabsContent value="advanced" className="space-y-4">
-                <AdvancedTab form={form} allModels={allModels} />
+                <AdvancedTab
+                  form={form}
+                  allModels={allModels}
+                  summaryPromptOptions={summaryPromptOptions}
+                  loadingSummaryPrompts={loadingSummaryPrompts}
+                />
               </TabsContent>
             </Tabs>
           </form>

--- a/frontend/src/pages/AgentSummaryPromptFormPage.tsx
+++ b/frontend/src/pages/AgentSummaryPromptFormPage.tsx
@@ -1,0 +1,594 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Form, FormField, FormItem, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { MoreVertical, Save, Trash2, Copy, GitFork } from 'lucide-react';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+import { InstructionsTextarea } from '@/components/agent/InstructionsTextarea';
+import { AgentPromptNewVersionDialog } from '@/components/agent/AgentPromptNewVersionDialog';
+import {
+  createAgentSummaryPrompt,
+  createAgentSummaryPromptNewVersion,
+  deleteAgentSummaryPrompt,
+  forkAgentSummaryPrompt,
+  getAgentSummaryPrompt,
+  getAgentSummaryPromptUsageCount,
+  getAgentsUsingSummaryPrompt,
+  updateAgentSummaryPrompt,
+  type AgentSummaryPromptDoc,
+  type AgentSummaryPromptUsageAgent,
+} from '@/services/agentSummaryPromptApi';
+
+const agentSummaryPromptFormSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  slug: z.string().optional(),
+  description: z.string().optional(),
+  is_active: z.boolean().default(true),
+  visibility: z.enum(['Public', 'App', 'Private']).default('Private'),
+  tags: z.string().optional(),
+  prompt_body: z.string().min(1, 'Prompt body is required'),
+});
+
+type AgentSummaryPromptFormValues = z.infer<typeof agentSummaryPromptFormSchema>;
+
+function mapDocToFormValues(doc: AgentSummaryPromptDoc): AgentSummaryPromptFormValues {
+  return {
+    title: doc.title || '',
+    slug: doc.slug || '',
+    description: doc.description || '',
+    is_active: doc.is_active === 1,
+    visibility: doc.visibility || 'Private',
+    tags: doc.tags || '',
+    prompt_body: doc.prompt_body || '',
+  };
+}
+
+export function AgentSummaryPromptFormPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isNew = id === 'new';
+  const [loading, setLoading] = useState(!isNew);
+  const [saving, setSaving] = useState(false);
+  const [usageCount, setUsageCount] = useState(0);
+  const [usageAgents, setUsageAgents] = useState<AgentSummaryPromptUsageAgent[]>([]);
+  const [docMeta, setDocMeta] = useState<Pick<
+    AgentSummaryPromptDoc,
+    'name' | 'version' | 'is_latest' | 'previous_version' | 'forked_from'
+  > | null>(null);
+  const [newVersionDialogOpen, setNewVersionDialogOpen] = useState(false);
+  const [newVersionTitle, setNewVersionTitle] = useState('');
+  const [newVersionDescription, setNewVersionDescription] = useState('');
+  const [dialogAction, setDialogAction] = useState<'new-version' | 'fork'>('new-version');
+
+  const form = useForm<AgentSummaryPromptFormValues>({
+    resolver: zodResolver(agentSummaryPromptFormSchema),
+    defaultValues: {
+      title: '',
+      slug: '',
+      description: '',
+      is_active: true,
+      visibility: 'Private',
+      tags: '',
+      prompt_body: '',
+    },
+  });
+
+  useEffect(() => {
+    if (!id || isNew) {
+      const state = location.state as {
+        prefill?: Partial<AgentSummaryPromptFormValues>;
+        previous_version?: string;
+        forked_from?: string;
+        current_version?: number;
+      } | null;
+
+      if (state?.prefill) {
+        form.reset({
+          ...form.getValues(),
+          ...state.prefill,
+        });
+      }
+      if (state?.previous_version || state?.forked_from) {
+        setDocMeta({
+          name: '',
+          version: state.previous_version && state.current_version ? state.current_version + 1 : 1,
+          is_latest: 1,
+          previous_version: state.previous_version,
+          forked_from: state.forked_from,
+        });
+      }
+
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const loadPrompt = async () => {
+      try {
+        const prompt = await getAgentSummaryPrompt(id);
+        if (cancelled) return;
+
+        form.reset(mapDocToFormValues(prompt));
+        setDocMeta({
+          name: prompt.name,
+          version: prompt.version,
+          is_latest: prompt.is_latest,
+          previous_version: prompt.previous_version,
+        });
+
+        const [count, agents] = await Promise.all([
+          getAgentSummaryPromptUsageCount(prompt.name),
+          getAgentsUsingSummaryPrompt(prompt.name),
+        ]);
+        if (cancelled) return;
+        setUsageCount(count);
+        setUsageAgents(agents);
+      } catch (error) {
+        toast.error('Failed to load Agent Summary Prompt', {
+          description: getFrappeErrorMessage(error),
+        });
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadPrompt();
+    return () => {
+      cancelled = true;
+    };
+  }, [id, isNew, form, location.state]);
+
+  const watchedTitle = form.watch('title');
+  useEffect(() => {
+    if (isNew && watchedTitle) {
+      const slug = watchedTitle
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+      form.setValue('slug', slug, { shouldDirty: true });
+    }
+  }, [watchedTitle, isNew, form]);
+
+  const handleSave = form.handleSubmit(
+    async (values) => {
+      setSaving(true);
+      try {
+        const payload: Partial<AgentSummaryPromptDoc> = {
+          title: values.title,
+          slug: values.slug || undefined,
+          description: values.description || undefined,
+          is_active: values.is_active ? 1 : 0,
+          visibility: values.visibility,
+          tags: values.tags || undefined,
+          prompt_body: values.prompt_body,
+        };
+
+        if (isNew && docMeta?.previous_version) {
+          payload.previous_version = docMeta.previous_version;
+        }
+        if (isNew && docMeta?.forked_from) {
+          payload.forked_from = docMeta.forked_from;
+        }
+
+        if (isNew) {
+          const created = await createAgentSummaryPrompt(payload);
+          toast.success('Agent Summary Prompt created');
+
+          const state = location.state as { returnTo?: string; selectedPromptField?: string } | null;
+          const fallbackRaw = (() => {
+            try {
+              return localStorage.getItem('agentSummaryPromptCreateReturnTo');
+            } catch {
+              return null;
+            }
+          })();
+          const fallback = fallbackRaw
+            ? (JSON.parse(fallbackRaw) as { returnTo?: string; selectedPromptField?: string })
+            : null;
+
+          const returnTo = state?.returnTo || fallback?.returnTo;
+          const selectedPromptField = state?.selectedPromptField || fallback?.selectedPromptField;
+
+          if (returnTo) {
+            navigate(returnTo, {
+              state: {
+                selectedPrompt: created.name,
+                showTab: 'advanced',
+                selectedPromptField,
+              },
+              replace: true,
+            });
+
+            try {
+              localStorage.removeItem('agentSummaryPromptCreateReturnTo');
+            } catch {
+              // ignore
+            }
+            return;
+          }
+
+          navigate(`/summary-prompts/${created.name}`);
+          return;
+        }
+
+        if (!id) return;
+        const updated = await updateAgentSummaryPrompt(id, payload);
+        form.reset(mapDocToFormValues(updated));
+        setDocMeta({
+          name: updated.name,
+          version: updated.version,
+          is_latest: updated.is_latest,
+          previous_version: updated.previous_version,
+        });
+        toast.success('Agent Summary Prompt saved');
+
+        const state = location.state as { returnTo?: string; selectedPromptField?: string } | null;
+        const fallbackRaw = (() => {
+          try {
+            return localStorage.getItem('agentSummaryPromptCreateReturnTo');
+          } catch {
+            return null;
+          }
+        })();
+        const fallback = fallbackRaw
+          ? (JSON.parse(fallbackRaw) as { returnTo?: string; selectedPromptField?: string })
+          : null;
+
+        const returnTo = state?.returnTo || fallback?.returnTo;
+        const selectedPromptField = state?.selectedPromptField || fallback?.selectedPromptField;
+
+        if (returnTo) {
+          navigate(returnTo, {
+            state: {
+              selectedPrompt: updated.name,
+              showTab: 'advanced',
+              selectedPromptField,
+            },
+            replace: true,
+          });
+
+          try {
+            localStorage.removeItem('agentSummaryPromptCreateReturnTo');
+          } catch {
+            // ignore
+          }
+          return;
+        }
+      } catch (error) {
+        toast.error('Failed to save Agent Summary Prompt', {
+          description: getFrappeErrorMessage(error),
+        });
+      } finally {
+        setSaving(false);
+      }
+    },
+    (errors) => {
+      if (errors.title) {
+        toast.error(errors.title.message || 'Title is required');
+      } else {
+        toast.error('Please check the form for errors');
+      }
+    }
+  );
+
+  const handleCreateNewVersion = () => {
+    const currentValues = form.getValues();
+    setDialogAction('new-version');
+    setNewVersionTitle(currentValues.title || '');
+    setNewVersionDescription(currentValues.description || '');
+    setNewVersionDialogOpen(true);
+  };
+
+  const handleConfirmCreateNewVersion = async () => {
+    if (!docMeta?.name) return;
+
+    const currentValues = form.getValues();
+    try {
+      setSaving(true);
+      const result = await createAgentSummaryPromptNewVersion(
+        docMeta.name,
+        currentValues.prompt_body,
+        newVersionTitle?.trim() || currentValues.title,
+        newVersionDescription?.trim() || undefined
+      );
+      toast.success(`Created version ${result.version}`);
+      setNewVersionDialogOpen(false);
+      navigate(`/summary-prompts/${result.name}`);
+    } catch (error) {
+      toast.error('Failed to create new version', {
+        description: getFrappeErrorMessage(error),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleForkPrompt = () => {
+    const currentValues = form.getValues();
+    setDialogAction('fork');
+    setNewVersionTitle(`Copy of ${currentValues.title}`);
+    setNewVersionDescription('');
+    setNewVersionDialogOpen(true);
+  };
+
+  const handleConfirmForkPrompt = async () => {
+    if (!docMeta?.name) return;
+    try {
+      setSaving(true);
+      const result = await forkAgentSummaryPrompt(docMeta.name, newVersionTitle?.trim() || undefined);
+      toast.success('Summary prompt forked successfully');
+      setNewVersionDialogOpen(false);
+      navigate(`/summary-prompts/${result.name}`);
+    } catch (error) {
+      toast.error('Failed to fork summary prompt', {
+        description: getFrappeErrorMessage(error),
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!id || isNew) return;
+    if (!window.confirm('Delete this Agent Summary Prompt?')) return;
+
+    try {
+      await deleteAgentSummaryPrompt(id);
+      toast.success('Agent Summary Prompt deleted');
+      navigate('/summary-prompts');
+    } catch (error) {
+      toast.error('Failed to delete Agent Summary Prompt', {
+        description: getFrappeErrorMessage(error),
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="text-muted-foreground">Loading Agent Summary Prompt...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="p-6 space-y-6 max-w-6xl mx-auto">
+        <Form {...form}>
+          <form onSubmit={handleSave} className="space-y-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-2">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem className="space-y-0">
+                      <FormControl>
+                        <Input
+                          {...field}
+                          className="text-2xl font-bold h-auto border-0 px-0 focus-visible:ring-0 max-w-2xl error:border-destructive"
+                          placeholder="Summary Prompt Title"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={form.watch('is_active') ? 'default' : 'secondary'}>
+                    {form.watch('is_active') ? 'Active' : 'Inactive'}
+                  </Badge>
+                  <Badge variant="outline">{form.watch('visibility')}</Badge>
+                  {!isNew ? (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant={form.watch('is_active') ? 'default' : 'secondary'}
+                          size="sm"
+                          className="h-6 rounded-full px-2 text-xs"
+                        >
+                          Used by {usageCount} {usageCount === 1 ? 'agent' : 'agents'}
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start" className="w-72">
+                        {usageAgents.length === 0 ? (
+                          <DropdownMenuItem disabled>No agents found.</DropdownMenuItem>
+                        ) : (
+                          usageAgents.map((agent) => (
+                            <DropdownMenuItem key={agent.name} onClick={() => navigate(`/agents/${agent.name}`)}>
+                              {agent.agent_name || agent.name}
+                            </DropdownMenuItem>
+                          ))
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button size="sm" type="submit" disabled={saving}>
+                  <Save className="mr-2 h-4 w-4" />
+                  {saving ? (isNew ? 'Creating...' : 'Saving...') : isNew ? 'Create' : 'Save'}
+                </Button>
+                {!isNew ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline" size="sm" type="button">
+                        <MoreVertical className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={handleCreateNewVersion}>
+                        <Copy className="mr-2 h-4 w-4" />
+                        Create New Version
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={handleForkPrompt}>
+                        <GitFork className="mr-2 h-4 w-4" />
+                        Fork Prompt
+                      </DropdownMenuItem>
+                      <DropdownMenuItem className="text-destructive" onClick={handleDelete}>
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : null}
+              </div>
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Summary Prompt Details</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem className="space-y-2 sm:col-span-2">
+                      <Label>Title</Label>
+                      <FormControl>
+                        <Input {...field} placeholder="Summary prompt title" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="space-y-2">
+                  <Label htmlFor="slug">Slug</Label>
+                  <Input
+                    id="slug"
+                    value={form.watch('slug') || ''}
+                    onChange={(event) => form.setValue('slug', event.target.value, { shouldDirty: true })}
+                    placeholder="Auto-generated from title"
+                    disabled={!isNew}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Visibility</Label>
+                  <Select
+                    value={form.watch('visibility')}
+                    onValueChange={(value) =>
+                      form.setValue('visibility', value as AgentSummaryPromptFormValues['visibility'], {
+                        shouldDirty: true,
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select visibility" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Private">Private</SelectItem>
+                      <SelectItem value="App">App</SelectItem>
+                      <SelectItem value="Public">Public</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="description">Description</Label>
+                  <Textarea
+                    id="description"
+                    value={form.watch('description') || ''}
+                    onChange={(event) => form.setValue('description', event.target.value, { shouldDirty: true })}
+                    placeholder="Describe what this summary prompt is for"
+                    rows={3}
+                  />
+                </div>
+                <div className="space-y-2 sm:col-span-2">
+                  <Label htmlFor="tags">Tags</Label>
+                  <Input
+                    id="tags"
+                    value={form.watch('tags') || ''}
+                    onChange={(event) => form.setValue('tags', event.target.value, { shouldDirty: true })}
+                    placeholder="Comma-separated tags"
+                  />
+                </div>
+                <div className="flex flex-row items-center justify-between rounded-lg border p-4 sm:col-span-2">
+                  <div className="space-y-0.5">
+                    <Label className="text-base">Active</Label>
+                  </div>
+                  <Switch
+                    checked={form.watch('is_active')}
+                    onCheckedChange={(checked) => form.setValue('is_active', checked, { shouldDirty: true })}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Prompt Body</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <InstructionsTextarea
+                  value={form.watch('prompt_body')}
+                  onChange={(value) => form.setValue('prompt_body', value, { shouldDirty: true })}
+                  placeholder="Write the summary prompt here. Use {summary_data} as a placeholder for the JSON input."
+                  className="min-h-[340px] font-mono resize-y"
+                  showOptimize={false}
+                  showExpand
+                />
+              </CardContent>
+            </Card>
+
+            {!isNew && docMeta ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Version Info</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-2">
+                  <Badge variant="outline">Version {docMeta.version ?? 1}</Badge>
+                  {docMeta.is_latest === 1 ? <Badge>Latest</Badge> : <Badge variant="secondary">Historical</Badge>}
+                  {docMeta.previous_version ? (
+                    <Button
+                      variant="link"
+                      className="h-auto p-0"
+                      onClick={() => navigate(`/summary-prompts/${docMeta.previous_version}`)}
+                    >
+                      Previous: {docMeta.previous_version}
+                    </Button>
+                  ) : null}
+                </CardContent>
+              </Card>
+            ) : null}
+          </form>
+          <AgentPromptNewVersionDialog
+            open={newVersionDialogOpen}
+            onOpenChange={setNewVersionDialogOpen}
+            dialogTitle={dialogAction === 'fork' ? 'Fork Summary Prompt' : 'Create New Version'}
+            title={newVersionTitle}
+            description={newVersionDescription}
+            showDescription={dialogAction !== 'fork'}
+            titleLabel={dialogAction === 'fork' ? 'Title for Fork' : 'Title (Optional)'}
+            onTitleChange={setNewVersionTitle}
+            onDescriptionChange={setNewVersionDescription}
+            onConfirm={dialogAction === 'fork' ? handleConfirmForkPrompt : handleConfirmCreateNewVersion}
+            confirmLabel={dialogAction === 'fork' ? 'Fork' : 'Create'}
+            saving={saving}
+          />
+        </Form>
+      </div>
+    </div>
+  );
+}
+
+export default AgentSummaryPromptFormPage;

--- a/frontend/src/pages/AgentSummaryPromptFormPageWrapper.tsx
+++ b/frontend/src/pages/AgentSummaryPromptFormPageWrapper.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { UnifiedLayout } from '../layouts/UnifiedLayout';
+import { AgentSummaryPromptFormPage } from './AgentSummaryPromptFormPage';
+import { getAgentSummaryPrompt } from '../services/agentSummaryPromptApi';
+
+export { AgentSummaryPromptFormPageWrapper };
+export default AgentSummaryPromptFormPageWrapper;
+
+function AgentSummaryPromptFormPageWrapper() {
+  const { id } = useParams<{ id: string }>();
+  const isNew = id === 'new';
+  const [promptTitle, setPromptTitle] = useState<string>('New Agent Summary Prompt');
+
+  useEffect(() => {
+    if (isNew) {
+      setPromptTitle('New Agent Summary Prompt');
+      return;
+    }
+
+    if (!id) return;
+    getAgentSummaryPrompt(id)
+      .then((doc) => {
+        setPromptTitle(doc.title || id);
+      })
+      .catch(() => {
+        setPromptTitle(id);
+      });
+  }, [id, isNew]);
+
+  const breadcrumbs = [
+    { label: 'Agent Summary Prompts', href: '/summary-prompts' },
+    { label: promptTitle },
+  ];
+
+  return (
+    <UnifiedLayout breadcrumbs={breadcrumbs}>
+      <AgentSummaryPromptFormPage />
+    </UnifiedLayout>
+  );
+}

--- a/frontend/src/pages/AgentSummaryPromptsPage.tsx
+++ b/frontend/src/pages/AgentSummaryPromptsPage.tsx
@@ -1,0 +1,247 @@
+import { useMemo, useState } from 'react';
+import { ArrowUpDown, Loader2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table';
+import { FilterBar, LoadMoreButton, PageLayout } from '@/components/dashboard';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Combobox } from '@/components/ui/combobox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import {
+  getAgentSummaryPrompts,
+  type AgentSummaryPromptDoc,
+  type GetAgentSummaryPromptsParams,
+} from '@/services/agentSummaryPromptApi';
+import { formatTimeAgo } from '@/utils/time';
+
+function getStatusVariant(enabled: 0 | 1): 'default' | 'secondary' {
+  return enabled === 1 ? 'default' : 'secondary';
+}
+
+export function AgentSummaryPromptsPage() {
+  const navigate = useNavigate();
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const {
+    items: prompts,
+    hasMore,
+    initialLoading,
+    loadingMore,
+    search,
+    setSearch,
+    loadMore,
+    total,
+    filters,
+    setFilter,
+  } = useInfiniteScroll<GetAgentSummaryPromptsParams, AgentSummaryPromptDoc>({
+    fetchFn: async (params) => {
+      const response = await getAgentSummaryPrompts({
+        page: params.page,
+        limit: params.limit,
+        start: params.start,
+        search: params.search,
+        status: (params.status as GetAgentSummaryPromptsParams['status']) ?? 'all',
+      });
+
+      if (Array.isArray(response)) {
+        return {
+          data: response,
+          hasMore: false,
+          total: response.length,
+        };
+      }
+
+      return {
+        data: response.items,
+        hasMore: response.hasMore,
+        total: response.total,
+      };
+    },
+    initialParams: { status: 'all' },
+    pageSize: 20,
+    debounceMs: 300,
+    autoLoad: true,
+  });
+
+  const columns = useMemo<ColumnDef<AgentSummaryPromptDoc>[]>(
+    () => [
+      {
+        accessorKey: 'title',
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+            className="h-8 px-2"
+          >
+            Title
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+        ),
+        cell: ({ row }) => <div className="font-medium">{row.original.title || row.original.name}</div>,
+      },
+      {
+        accessorKey: 'slug',
+        header: 'Slug',
+        cell: ({ row }) => <div className="text-sm text-muted-foreground">{row.original.slug || '-'}</div>,
+      },
+      {
+        accessorKey: 'version',
+        header: 'Version',
+        cell: ({ row }) => <div>v{row.original.version ?? 1}</div>,
+      },
+      {
+        accessorKey: 'visibility',
+        header: 'Visibility',
+        cell: ({ row }) => <div>{row.original.visibility || 'Private'}</div>,
+      },
+      {
+        accessorKey: 'is_active',
+        header: 'Status',
+        cell: ({ row }) => (
+          <Badge variant={getStatusVariant(row.original.is_active)}>
+            {row.original.is_active === 1 ? 'Active' : 'Inactive'}
+          </Badge>
+        ),
+      },
+      {
+        id: 'modified',
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+            className="h-8 px-2"
+          >
+            Modified
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+        ),
+        cell: ({ row }) => (
+          <div className="text-sm text-muted-foreground">{formatTimeAgo(row.original.modified ?? null)}</div>
+        ),
+        sortingFn: (rowA, rowB) => {
+          const timeA = rowA.original.modified ? new Date(rowA.original.modified).getTime() : 0;
+          const timeB = rowB.original.modified ? new Date(rowB.original.modified).getTime() : 0;
+          return timeA - timeB;
+        },
+      },
+    ],
+    []
+  );
+
+  const table = useReactTable({
+    data: prompts,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    state: { sorting },
+  });
+
+  const statusOptions = [
+    { label: 'All Status', value: 'all' },
+    { label: 'Active', value: 'active' },
+    { label: 'Inactive', value: 'inactive' },
+  ];
+
+  return (
+    <PageLayout
+      subtitle="Manage shared summary prompt templates for agents"
+      filters={
+        <FilterBar
+          searchPlaceholder="Search summary prompts..."
+          searchValue={search}
+          onSearchChange={setSearch}
+          actions={
+            <div className="w-full sm:w-48">
+              <Combobox
+                options={statusOptions}
+                value={filters.status || 'all'}
+                onValueChange={(value) => setFilter('status', value || 'all')}
+                placeholder="Status"
+              />
+            </div>
+          }
+        />
+      }
+    >
+      <div className="w-full">
+        {initialLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-md border">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.length ? (
+                  table.getRowModel().rows.map((row) => (
+                    <TableRow
+                      key={row.id}
+                      className="cursor-pointer hover:bg-muted/50"
+                      onClick={() => navigate(`/summary-prompts/${row.original.name}`)}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
+                      <div className="text-muted-foreground">No Agent Summary Prompts found.</div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+
+      <LoadMoreButton
+        hasMore={hasMore}
+        loading={loadingMore}
+        onLoadMore={loadMore}
+        disabled={!!search || initialLoading}
+      />
+
+      {!hasMore && prompts.length > 0 && (
+        <div className="text-center py-4 text-sm text-muted-foreground">
+          {total !== undefined ? `Showing all ${total} summary prompts` : 'No more summary prompts to load'}
+        </div>
+      )}
+    </PageLayout>
+  );
+}
+
+export default AgentSummaryPromptsPage;

--- a/frontend/src/services/agentSummaryPromptApi.ts
+++ b/frontend/src/services/agentSummaryPromptApi.ts
@@ -1,0 +1,230 @@
+import { call, db } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+import { doctype } from '@/data/doctypes';
+import { fetchDocCount, fetchPaginatedCount } from './utilsApi';
+
+export interface AgentSummaryPromptDoc {
+  name: string;
+  title: string;
+  slug?: string;
+  description?: string;
+  is_active: 0 | 1;
+  is_system?: 0 | 1;
+  visibility?: 'Public' | 'App' | 'Private';
+  tags?: string;
+  prompt_body: string;
+  version?: number;
+  is_latest?: 0 | 1;
+  previous_version?: string;
+  forked_from?: string;
+  prompt_group?: string;
+  modified?: string;
+  category?: string;
+}
+
+export interface GetAgentSummaryPromptsParams {
+  page?: number;
+  limit?: number;
+  start?: number;
+  search?: string;
+  status?: 'active' | 'inactive' | 'all';
+  [key: string]: unknown;
+}
+
+export interface PaginatedAgentSummaryPromptsResponse {
+  items: AgentSummaryPromptDoc[];
+  hasMore: boolean;
+  total?: number;
+}
+
+export interface AgentSummaryPromptUsageAgent {
+  name: string;
+  agent_name?: string;
+}
+
+export async function getAgentSummaryPrompts(
+  params?: GetAgentSummaryPromptsParams
+): Promise<PaginatedAgentSummaryPromptsResponse | AgentSummaryPromptDoc[]> {
+  try {
+    if (!params) {
+      const response = await db.getDocList(doctype['Agent Summary Prompt'], {
+        fields: [
+          'name',
+          'title',
+          'slug',
+          'description',
+          'is_active',
+          'is_system',
+          'visibility',
+          'tags',
+          'version',
+          'is_latest',
+          'previous_version',
+          'forked_from',
+          'prompt_group',
+          'modified',
+        ],
+        limit: 100,
+        orderBy: { field: 'modified', order: 'desc' },
+      });
+
+      return response as AgentSummaryPromptDoc[];
+    }
+
+    const { page = 1, limit = 20, start = (page - 1) * limit, search, status = 'all' } = params;
+    const filters: Array<[string, string, string | number | boolean]> = [];
+
+    if (status === 'active') {
+      filters.push(['is_active', '=', 1]);
+    } else if (status === 'inactive') {
+      filters.push(['is_active', '=', 0]);
+    }
+
+    if (search && search.trim()) {
+      filters.push(['title', 'like', `%${search.trim()}%`]);
+    }
+
+    const prompts = await db.getDocList(doctype['Agent Summary Prompt'], {
+      fields: [
+        'name',
+        'title',
+        'slug',
+        'description',
+        'is_active',
+        'is_system',
+        'visibility',
+        'tags',
+        'version',
+        'is_latest',
+        'previous_version',
+        'forked_from',
+        'prompt_group',
+        'modified',
+      ],
+      filters: filters.length > 0 ? (filters as never) : undefined,
+      limit: limit + 1,
+      ...(start > 0 && { limit_start: start }),
+      orderBy: { field: 'modified', order: 'desc' },
+    });
+
+    const mappedPrompts = prompts as AgentSummaryPromptDoc[];
+    const hasMore = mappedPrompts.length > limit;
+    const items = hasMore ? mappedPrompts.slice(0, limit) : mappedPrompts;
+    const total = await fetchPaginatedCount(page, items.length, doctype['Agent Summary Prompt'], filters);
+
+    return {
+      items,
+      hasMore,
+      total,
+    };
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching Agent Summary Prompts');
+    throw error;
+  }
+}
+
+export async function getAgentSummaryPrompt(name: string): Promise<AgentSummaryPromptDoc> {
+  try {
+    const response = await db.getDoc(doctype['Agent Summary Prompt'], name);
+    return response as AgentSummaryPromptDoc;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function createAgentSummaryPrompt(data: Partial<AgentSummaryPromptDoc>): Promise<AgentSummaryPromptDoc> {
+  try {
+    const response = await db.createDoc(doctype['Agent Summary Prompt'], data);
+    return response as AgentSummaryPromptDoc;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function updateAgentSummaryPrompt(
+  name: string,
+  data: Partial<AgentSummaryPromptDoc>
+): Promise<AgentSummaryPromptDoc> {
+  try {
+    const response = await db.updateDoc(doctype['Agent Summary Prompt'], name, data);
+    return response as AgentSummaryPromptDoc;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function deleteAgentSummaryPrompt(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype['Agent Summary Prompt'], name);
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function getAgentSummaryPromptUsageCount(name: string): Promise<number> {
+  const count = await fetchDocCount(doctype.Agent, [['summary_prompt_template', '=', name]]);
+  return count ?? 0;
+}
+
+export async function getAgentsUsingSummaryPrompt(name: string): Promise<AgentSummaryPromptUsageAgent[]> {
+  try {
+    const response = await db.getDocList(doctype.Agent, {
+      fields: ['name', 'agent_name'],
+      filters: [['summary_prompt_template', '=', name]],
+      limit: 1000,
+      orderBy: { field: 'modified', order: 'desc' },
+    });
+
+    return response as AgentSummaryPromptUsageAgent[];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching summary prompt usage agents');
+    throw error;
+  }
+}
+
+export interface AgentSummaryPromptVersionResult {
+  name: string;
+  version: number;
+}
+
+export async function createAgentSummaryPromptNewVersion(
+  promptName: string,
+  promptBody: string,
+  title?: string,
+  description?: string
+): Promise<AgentSummaryPromptVersionResult> {
+  try {
+    const response = await call.post('huf.ai.prompt_api.create_new_summary_version', {
+      prompt_name: promptName,
+      prompt_body: promptBody,
+      title,
+      description,
+    });
+
+    return response?.message as AgentSummaryPromptVersionResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function forkAgentSummaryPrompt(
+  promptName: string,
+  title?: string
+): Promise<AgentSummaryPromptVersionResult> {
+  try {
+    const response = await call.post('huf.ai.prompt_api.fork_summary_prompt', {
+      prompt_name: promptName,
+      title,
+    });
+
+    return response?.message as AgentSummaryPromptVersionResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -251,6 +251,11 @@ export interface AgentDoc {
   context_strategy?: string | null; // Summarize, FIFO, or None
   summary_model?: string | null; // AI Model name for summarization when strategy is Summarize
   summary_ratio?: number | null; // Ratio of history to summarize (0-1)
+  summary_prompt_mode?: 'Local' | 'Template';
+  summary_prompt_template?: string | null;
+  summary_prompt_version_locked?: number; // 0 or 1
+  summary_template_version_at_attach?: number;
+  summary_prompt?: string | null;
   history_limit?: number | null; // Maximum number of messages to keep
   max_knowledge_tokens?: number | null; // Maximum tokens for knowledge context
   max_turns?: number | null; // Maximum consecutive turns/steps

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -530,6 +530,8 @@ def run_background_summarization(conversation_name, agent_name):
     Background job to summarize conversation history.
     """
     try:
+        from huf.ai.prompt_resolver import resolve_summary_prompt
+
         agent_doc = frappe.get_doc("Agent", agent_name)
         conv_manager = ConversationManager(agent_name=agent_name)
         
@@ -558,18 +560,12 @@ def run_background_summarization(conversation_name, agent_name):
             "existing_summary": stored_summary or "None",
             "new_messages_to_incorporate": to_summarize
         }
-        
-        summary_prompt = f"""
-        You are maintaining a rolling summary of a conversation.
-        
-        1. Update the 'Existing Summary' by incorporating the 'New Messages'.
-        2. Keep the summary concise but retain key details (names, decisions, technical context).
-        3. Output ONLY the new summary text.
 
-        Data:
-        {json.dumps(summary_input_data, indent=2)}
-        """
-        
+        summary_prompt_template = resolve_summary_prompt(agent_doc)
+        summary_prompt = summary_prompt_template.replace(
+            "{summary_data}", json.dumps(summary_input_data, indent=2)
+        )
+
         messages = [{"role": "user", "content": summary_prompt}]
         
         # Run completion (sync in this background job context or safely in thread if nested)
@@ -1451,6 +1447,8 @@ async def run_agent_stream(
 
         if to_summarize:
             try:
+                from huf.ai.prompt_resolver import resolve_summary_prompt
+
                 summary_agent = Agent(
                     name=agent_name, 
                     instructions="You are a helpful assistant. Summarize the provided conversation history concisely, capturing key decisions and context.",
@@ -1460,9 +1458,12 @@ async def run_agent_stream(
                 )
                 
                 summary_input = json.dumps(to_summarize, indent=2)
-                summary_prompt = f"Summarize this conversation history:\n{summary_input}"
+                summary_prompt_template = resolve_summary_prompt(agent_doc)
+                summary_prompt = summary_prompt_template.format(
+                    summary_data=summary_input
+                )
 
-                sum_context = {"agent_name": agent_name, "is_system_op": True} 
+                sum_context = {"agent_name": agent_name, "is_system_op": True}
                 sum_result = await RunProvider.run(summary_agent, summary_prompt, resolved_provider, resolved_model, sum_context)
                 summary_text = getattr(sum_result, "final_output", "Could not generate summary.")
 

--- a/huf/ai/prompt_api.py
+++ b/huf/ai/prompt_api.py
@@ -256,11 +256,250 @@ def get_version_history(prompt_name):
 		            ``name``, ``version``, ``title``, ``is_latest``,
 		            ``modified``, and ``owner``.
 	"""
-	prompt_group = frappe.db.get_value("Agent Prompt", prompt_name, "prompt_group")
+	return _get_version_history("Agent Prompt", prompt_name)
+
+
+# -----------------------------------------------------------------------------
+# Agent Summary Prompt lifecycle API
+# -----------------------------------------------------------------------------
+
+@frappe.whitelist()
+def create_new_summary_version(prompt_name, prompt_body, title=None, description=None):
+	"""Create a new immutable version of an existing Agent Summary Prompt.
+
+	The current prompt is marked as ``is_latest = 0`` and a new row is
+	inserted with an incremented version number.  All agents that are
+	**not** version-locked will automatically pick up the new version
+	because they link to the latest via ``summary_prompt_template``.
+
+	Args:
+		prompt_name: Name (ID) of the current Agent Summary Prompt to version.
+		prompt_body: The updated summary prompt text for the new version.
+		title:       Optional new title (inherits from previous if omitted).
+		description: Optional new description.
+
+	Returns:
+		dict: ``{"name": "<new_prompt_name>", "version": <int>}``
+	"""
+	current = frappe.get_doc("Agent Summary Prompt", prompt_name)
+
+	if current.is_system:
+		frappe.throw(_("System summary prompts cannot be versioned by users."))
+
+	new_version = cint(current.version) + 1
+
+	# Mark current as no longer latest
+	frappe.db.set_value(
+		"Agent Summary Prompt", prompt_name, "is_latest", 0, update_modified=False
+	)
+
+	new_prompt = frappe.get_doc({
+		"doctype": "Agent Summary Prompt",
+		"title": title or current.title,
+		"category": current.category,
+		"description": description or current.description,
+		"prompt_body": prompt_body,
+		"visibility": current.visibility,
+		"is_active": current.is_active,
+		"is_system": 0,
+		"tags": current.tags,
+		"version": new_version,
+		"is_latest": 1,
+		"previous_version": prompt_name,
+		"forked_from": current.forked_from,
+		"prompt_group": current.prompt_group or prompt_name,
+	})
+	new_prompt.insert(ignore_permissions=True)
+
+	# Update agents that point to the old version and are NOT locked
+	_update_summary_agent_links(prompt_name, new_prompt.name, new_version)
+
+	frappe.db.commit()
+
+	return {"name": new_prompt.name, "version": new_version}
+
+
+def _update_summary_agent_links(old_prompt_name, new_prompt_name, new_version):
+	"""Point unlocked agents from old summary prompt to new version."""
+	agents = frappe.get_all(
+		"Agent",
+		filters={
+			"summary_prompt_mode": "Template",
+			"summary_prompt_template": old_prompt_name,
+			"summary_prompt_version_locked": 0,
+		},
+		pluck="name",
+	)
+	for agent_name in agents:
+		frappe.db.set_value(
+			"Agent", agent_name,
+			{
+				"summary_prompt_template": new_prompt_name,
+				"summary_template_version_at_attach": new_version,
+			},
+			update_modified=False,
+		)
+
+
+@frappe.whitelist()
+def fork_summary_prompt(prompt_name, title=None):
+	"""Fork (copy) a summary prompt template into a new independent lineage.
+
+	Creates a version-1 prompt with ``forked_from`` pointing to the
+	source.  The fork has its own ``prompt_group`` so subsequent
+	versions are tracked independently.
+
+	Args:
+		prompt_name: Name of the summary prompt to fork.
+		title:       Optional title for the fork (defaults to
+		             ``"<original title> (Fork)"``).
+
+	Returns:
+		dict: ``{"name": "<new_prompt_name>", "version": 1}``
+	"""
+	source = frappe.get_doc("Agent Summary Prompt", prompt_name)
+
+	forked = frappe.get_doc({
+		"doctype": "Agent Summary Prompt",
+		"title": title or f"{source.title} (Fork)",
+		"category": source.category,
+		"description": source.description,
+		"prompt_body": source.prompt_body,
+		"visibility": "Private",
+		"is_active": 1,
+		"is_system": 0,
+		"tags": source.tags,
+		"version": 1,
+		"is_latest": 1,
+		"previous_version": None,
+		"forked_from": prompt_name,
+	})
+	forked.insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"name": forked.name, "version": 1}
+
+
+@frappe.whitelist()
+def detach_from_summary_template(agent_name):
+	"""Detach an agent from its linked summary prompt template.
+
+	Copies the current resolved summary prompt body into the agent's
+	``summary_prompt`` field, switches to Local mode, and records
+	``copied_from_prompt`` for traceability.
+
+	Args:
+		agent_name: Name of the Agent to detach.
+
+	Returns:
+		dict: ``{"success": True, "summary_prompt_mode": "Local"}``
+	"""
+	agent = frappe.get_doc("Agent", agent_name)
+
+	if (agent.summary_prompt_mode or "Local") != "Template":
+		frappe.throw(_("Agent summary prompt is already in Local mode."))
+
+	if not agent.summary_prompt_template:
+		frappe.throw(_("No summary prompt template is attached to detach from."))
+
+	from huf.ai.prompt_resolver import resolve_summary_prompt
+	prompt_text = resolve_summary_prompt(agent)
+
+	agent.summary_prompt = prompt_text or ""
+	agent.copied_from_summary_prompt = agent.summary_prompt_template
+	agent.summary_prompt_template = None
+	agent.summary_prompt_mode = "Local"
+	agent.summary_prompt_version_locked = 0
+	agent.summary_template_version_at_attach = 0
+	agent.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"success": True, "summary_prompt_mode": "Local"}
+
+
+@frappe.whitelist()
+def save_as_summary_template(agent_name, title, category=None, visibility="Private", description=None):
+	"""Save an agent's local summary prompt as a new Agent Summary Prompt template.
+
+	Creates a new Agent Summary Prompt from the agent's current ``summary_prompt``
+	and optionally switches the agent to Template mode.
+
+	Args:
+		agent_name:  Name of the Agent.
+		title:       Title for the new template.
+		category:    Optional category link.
+		visibility:  Public / App / Private (default Private).
+		description: Optional description.
+
+	Returns:
+		dict: ``{"name": "<prompt_name>", "version": 1}``
+	"""
+	agent = frappe.get_doc("Agent", agent_name)
+
+	if not agent.summary_prompt:
+		frappe.throw(_("Agent has no local summary prompt to save as a template."))
+
+	prompt = frappe.get_doc({
+		"doctype": "Agent Summary Prompt",
+		"title": title,
+		"category": category,
+		"description": description or agent.description,
+		"prompt_body": agent.summary_prompt,
+		"visibility": visibility,
+		"is_active": 1,
+		"is_system": 0,
+		"version": 1,
+		"is_latest": 1,
+	})
+	prompt.insert(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"name": prompt.name, "version": 1}
+
+
+@frappe.whitelist()
+def attach_summary_template(agent_name, prompt_name, lock_version=0):
+	"""Attach an Agent Summary Prompt template to an agent.
+
+	Switches the agent's summary prompt to Template mode and links the
+	specified prompt.  Optionally locks to the current version.
+
+	Args:
+		agent_name:   Name of the Agent.
+		prompt_name:  Name of the Agent Summary Prompt to attach.
+		lock_version: Whether to lock to the current version (0 or 1).
+
+	Returns:
+		dict: ``{"success": True, "summary_prompt_mode": "Template", "version": <int>}``
+	"""
+	agent = frappe.get_doc("Agent", agent_name)
+	prompt = frappe.get_doc("Agent Summary Prompt", prompt_name)
+
+	if not prompt.is_active:
+		frappe.throw(_("Cannot attach an inactive summary prompt template."))
+
+	agent.summary_prompt_mode = "Template"
+	agent.summary_prompt_template = prompt_name
+	agent.summary_prompt_version_locked = cint(lock_version)
+	agent.summary_template_version_at_attach = prompt.version
+	agent.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	return {"success": True, "summary_prompt_mode": "Template", "version": prompt.version}
+
+
+@frappe.whitelist()
+def get_summary_version_history(prompt_name):
+	"""Return the full version history for a summary prompt lineage."""
+	return _get_version_history("Agent Summary Prompt", prompt_name)
+
+
+def _get_version_history(doctype, prompt_name):
+	"""Shared helper to return version history for a prompt lineage."""
+	prompt_group = frappe.db.get_value(doctype, prompt_name, "prompt_group")
 
 	if not prompt_group:
-		# Single prompt, no lineage
-		doc = frappe.get_doc("Agent Prompt", prompt_name)
+		doc = frappe.get_doc(doctype, prompt_name)
 		return [{
 			"name": doc.name,
 			"version": doc.version,
@@ -271,7 +510,7 @@ def get_version_history(prompt_name):
 		}]
 
 	versions = frappe.get_all(
-		"Agent Prompt",
+		doctype,
 		filters={"prompt_group": prompt_group},
 		fields=["name", "version", "title", "is_latest", "modified", "owner"],
 		order_by="version desc",

--- a/huf/ai/prompt_resolver.py
+++ b/huf/ai/prompt_resolver.py
@@ -15,6 +15,16 @@ import frappe
 from frappe import _
 
 
+DEFAULT_SUMMARY_PROMPT = """You are maintaining a rolling summary of a conversation.
+
+1. Update the 'Existing Summary' by incorporating the 'New Messages'.
+2. Keep the summary concise but retain key details (names, decisions, technical context).
+3. Output ONLY the new summary text.
+
+Data:
+{summary_data}"""
+
+
 def resolve_prompt(agent_doc):
 	"""Return the effective prompt text for an agent.
 
@@ -43,6 +53,29 @@ def resolve_prompt(agent_doc):
 	return agent_doc.instructions or None
 
 
+def resolve_summary_prompt(agent_doc):
+	"""Return the effective summary prompt text for an agent.
+
+	Follows the same Template / Local / version-lock semantics as
+	``resolve_prompt``.  When no custom summary prompt is configured,
+	returns the system default template.
+
+	Args:
+		agent_doc: A loaded Agent document.
+
+	Returns:
+		str: The resolved summary prompt body.
+	"""
+	mode = getattr(agent_doc, "summary_prompt_mode", None) or "Local"
+
+	if mode == "Template":
+		return _resolve_summary_template_prompt(agent_doc)
+
+	# Local mode — use the agent's local summary prompt if provided,
+	# otherwise fall back to the system default.
+	return agent_doc.summary_prompt or DEFAULT_SUMMARY_PROMPT
+
+
 def _resolve_template_prompt(agent_doc):
 	"""Resolve prompt from the linked Agent Prompt template."""
 	prompt_name = agent_doc.agent_prompt
@@ -57,7 +90,28 @@ def _resolve_template_prompt(agent_doc):
 	return prompt_body or agent_doc.instructions or None
 
 
-def _get_locked_version_body(prompt_name, target_version):
+def _resolve_summary_template_prompt(agent_doc):
+	"""Resolve summary prompt from the linked Agent Summary Prompt template."""
+	prompt_name = agent_doc.summary_prompt_template
+	if not prompt_name:
+		return agent_doc.summary_prompt or DEFAULT_SUMMARY_PROMPT
+
+	if (
+		getattr(agent_doc, "summary_prompt_version_locked", 0)
+		and getattr(agent_doc, "summary_template_version_at_attach", None)
+	):
+		body = _get_locked_version_body(
+			prompt_name,
+			agent_doc.summary_template_version_at_attach,
+			doctype="Agent Summary Prompt",
+		)
+		return body or agent_doc.summary_prompt or DEFAULT_SUMMARY_PROMPT
+
+	prompt_body = frappe.db.get_value("Agent Summary Prompt", prompt_name, "prompt_body")
+	return prompt_body or agent_doc.summary_prompt or DEFAULT_SUMMARY_PROMPT
+
+
+def _get_locked_version_body(prompt_name, target_version, doctype="Agent Prompt"):
 	"""Walk the version lineage to find the exact version body.
 
 	The ``prompt_name`` on the Agent may point to the latest version.
@@ -67,7 +121,7 @@ def _get_locked_version_body(prompt_name, target_version):
 	"""
 	# First check if the linked prompt itself is the right version
 	prompt_doc_data = frappe.db.get_value(
-		"Agent Prompt", prompt_name, ["prompt_body", "version", "prompt_group"], as_dict=True
+		doctype, prompt_name, ["prompt_body", "version", "prompt_group"], as_dict=True
 	)
 	if not prompt_doc_data:
 		return None
@@ -78,7 +132,7 @@ def _get_locked_version_body(prompt_name, target_version):
 	# Look up the correct version within the same prompt group
 	if prompt_doc_data.prompt_group:
 		match = frappe.db.get_value(
-			"Agent Prompt",
+			doctype,
 			{"prompt_group": prompt_doc_data.prompt_group, "version": target_version},
 			"prompt_body",
 		)

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -41,6 +41,7 @@
   "prompt_version_locked",
   "template_version_at_attach",
   "copied_from_prompt",
+  "copied_from_summary_prompt",
   "instruction_section",
   "instructions",
   "tools_and_mcp_tab",
@@ -54,15 +55,26 @@
   "context_settings_section",
   "context_strategy",
   "history_limit",
+  "column_break_jrdw",
+  "max_turns",
+  "summarization_engine_section",
+  "summary_ratio",
+  "summary_prompt_mode",
+  "summary_prompt_version_locked",
+  "summary_prompt_template",
+  "summary_template_version_at_attach",
+  "summary_prompt",
+  "column_break_ctx",
+  "summary_model",
+  "knowledge_and_tools_section",
+  "max_knowledge_tokens",
+  "column_break_summary_prompt",
+  "max_context_chars",
+  "agent_behaviors_section",
+  "autonaming_of_conversation_title",
+  "column_break_wr4j",
   "enable_conversation_data",
   "inject_conversation_data",
-  "autonaming_of_conversation_title",
-  "column_break_ctx",
-  "summary_ratio",
-  "summary_model",
-  "max_knowledge_tokens",
-  "max_context_chars",
-  "max_turns",
   "image_generation_section",
   "image_generation_model",
   "audio_generation_section",
@@ -176,6 +188,15 @@
    "hidden": 1,
    "label": "Copied From Prompt",
    "options": "Agent Prompt",
+   "read_only": 1
+  },
+  {
+   "description": "If this agent was detached from a summary prompt template, this tracks the original summary prompt for traceability.",
+   "fieldname": "copied_from_summary_prompt",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Copied From Summary Prompt",
+   "options": "Agent Summary Prompt",
    "read_only": 1
   },
   {
@@ -297,10 +318,10 @@
    "label": "Advanced Settings"
   },
   {
-   "description": "Configure advanced context and memory settings",
+   "description": "Define the rules for how the agent manages its memory window when a conversation grows long and approaches token limits.",
    "fieldname": "context_settings_section",
    "fieldtype": "Section Break",
-   "label": "Context Settings"
+   "label": "Conversation Strategy"
   },
   {
    "default": "Summarize",
@@ -337,6 +358,49 @@
    "fieldtype": "Link",
    "label": "Summary Model",
    "options": "AI Model"
+  },
+  {
+   "default": "Local",
+   "description": "How this agent's conversation summary prompt is managed. 'Local' uses the summary prompt field below. 'Template' links to a reusable Agent Summary Prompt.",
+   "fieldname": "summary_prompt_mode",
+   "fieldtype": "Select",
+   "label": "Summary Prompt Mode",
+   "options": "Local\nTemplate"
+  },
+  {
+   "depends_on": "eval:doc.summary_prompt_mode=='Template'",
+   "description": "Link to a reusable summary prompt template from the Agent Summary Prompt library for conversation summarization.",
+   "fieldname": "summary_prompt_template",
+   "fieldtype": "Link",
+   "label": "Summary Prompt Template",
+   "options": "Agent Summary Prompt"
+  },
+  {
+   "fieldname": "column_break_summary_prompt",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.summary_prompt_mode=='Template'",
+   "description": "If checked, this agent will stay on the summary prompt version it was attached to, ignoring newer versions.",
+   "fieldname": "summary_prompt_version_locked",
+   "fieldtype": "Check",
+   "label": "Lock Summary Prompt Version"
+  },
+  {
+   "depends_on": "eval:doc.summary_prompt_mode=='Template'",
+   "description": "The version number of the summary prompt template when it was attached to this agent.",
+   "fieldname": "summary_template_version_at_attach",
+   "fieldtype": "Int",
+   "label": "Summary Attached at Version",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.summary_prompt_mode=='Local'",
+   "description": "The prompt used to summarize conversation history when the context strategy is 'Summarize'. Leave blank to use the system default.",
+   "fieldname": "summary_prompt",
+   "fieldtype": "Code",
+   "label": "Summary Prompt"
   },
   {
    "default": "4000",
@@ -603,12 +667,38 @@
    "hidden": 1,
    "label": "Source File",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_jrdw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Configure the model and prompts used to compress conversation history. These settings are only active when using the Summarize strategy.",
+   "fieldname": "summarization_engine_section",
+   "fieldtype": "Section Break",
+   "label": "Summarization Engine"
+  },
+  {
+   "description": "Set strict boundaries on how much external data the agent can pull into its context window at once.",
+   "fieldname": "knowledge_and_tools_section",
+   "fieldtype": "Section Break",
+   "label": "Knowledge And Tools"
+  },
+  {
+   "description": "Enable or disable background tasks and auxiliary capabilities related to context management.",
+   "fieldname": "agent_behaviors_section",
+   "fieldtype": "Section Break",
+   "label": "Agent Behaviors"
+  },
+  {
+   "fieldname": "column_break_wr4j",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-12 11:10:42.372998",
+ "modified": "2026-06-30 11:03:29.825518",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent",

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -107,6 +107,7 @@ def get_cacheable_models(provider: str, model: str = None) -> dict:
 class Agent(Document):
     def validate(self):
         self._validate_prompt()
+        self._validate_summary_prompt()
 
         if self.allow_chat == 1 and self.persist_conversation == 0:
             frappe.throw(_("An agent cannot be allowed in Agent Chat when persistent conversation is off."))
@@ -218,6 +219,24 @@ class Agent(Document):
         if self.agent_prompt:
             version = frappe.db.get_value("Agent Prompt", self.agent_prompt, "version")
             self.template_version_at_attach = version or 1
+
+    def _validate_summary_prompt(self):
+        """Validate summary prompt configuration based on summary_prompt_mode."""
+        mode = self.summary_prompt_mode or "Local"
+
+        if mode == "Template":
+            if not self.summary_prompt_template:
+                frappe.throw(_("Please select an Agent Summary Prompt when using Template mode for Summary Prompt."))
+            if self.has_value_changed("summary_prompt_template") or not self.summary_template_version_at_attach:
+                self._record_summary_template_version()
+
+    def _record_summary_template_version(self):
+        """Snapshot the current version of the linked Agent Summary Prompt."""
+        if self.summary_prompt_template:
+            version = frappe.db.get_value(
+                "Agent Summary Prompt", self.summary_prompt_template, "version"
+            )
+            self.summary_template_version_at_attach = version or 1
 
     def get_indicator(doc):
         if doc.disabled:

--- a/huf/huf/doctype/agent_summary_prompt/agent_summary_prompt.json
+++ b/huf/huf/doctype/agent_summary_prompt/agent_summary_prompt.json
@@ -1,0 +1,193 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-06-30 05:40:14.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "details_section",
+  "title",
+  "slug",
+  "category",
+  "description",
+  "column_break_details",
+  "is_active",
+  "is_system",
+  "visibility",
+  "tags",
+  "prompt_section",
+  "prompt_body",
+  "version_section",
+  "version",
+  "is_latest",
+  "column_break_version",
+  "previous_version",
+  "forked_from",
+  "prompt_group"
+ ],
+ "fields": [
+  {
+   "fieldname": "details_section",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "description": "URL-friendly identifier for this summary prompt template. Auto-generated from title if left blank.",
+   "fieldname": "slug",
+   "fieldtype": "Data",
+   "label": "Slug",
+   "unique": 1
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Link",
+   "label": "Category",
+   "options": "Agent Summary Prompt Category"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "column_break_details",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "description": "Whether this summary prompt template is active and available for use.",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Active"
+  },
+  {
+   "default": "0",
+   "description": "System prompts are managed by HUF and cannot be edited by users.",
+   "fieldname": "is_system",
+   "fieldtype": "Check",
+   "label": "Is System"
+  },
+  {
+   "default": "Private",
+   "description": "Controls who can see and use this summary prompt template.",
+   "fieldname": "visibility",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Visibility",
+   "options": "Public\nApp\nPrivate"
+  },
+  {
+   "description": "Comma-separated tags for search and filtering.",
+   "fieldname": "tags",
+   "fieldtype": "Small Text",
+   "label": "Tags"
+  },
+  {
+   "fieldname": "prompt_section",
+   "fieldtype": "Section Break",
+   "label": "Prompt"
+  },
+  {
+   "description": "The summary prompt template content. This is the prompt text used to summarize conversation history.",
+   "fieldname": "prompt_body",
+   "fieldtype": "Code",
+   "label": "Prompt Body",
+   "reqd": 1
+  },
+  {
+   "fieldname": "version_section",
+   "fieldtype": "Section Break",
+   "label": "Version History"
+  },
+  {
+   "default": "1",
+   "description": "Version number of this summary prompt. Incremented on each new version.",
+   "fieldname": "version",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Version",
+   "read_only": 1
+  },
+  {
+   "default": "1",
+   "description": "Marks this as the latest version in the summary prompt lineage.",
+   "fieldname": "is_latest",
+   "fieldtype": "Check",
+   "label": "Is Latest",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_version",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Link to the previous version of this summary prompt template.",
+   "fieldname": "previous_version",
+   "fieldtype": "Link",
+   "label": "Previous Version",
+   "options": "Agent Summary Prompt",
+   "read_only": 1
+  },
+  {
+   "description": "If this summary prompt was forked from another, link to the original prompt.",
+   "fieldname": "forked_from",
+   "fieldtype": "Link",
+   "label": "Forked From",
+   "options": "Agent Summary Prompt",
+   "read_only": 1
+  },
+  {
+   "description": "Shared identifier across all versions of the same summary prompt lineage. Auto-set on creation.",
+   "fieldname": "prompt_group",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Prompt Group",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-30 05:40:14.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Agent Summary Prompt",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "select": 1,
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/huf/huf/doctype/agent_summary_prompt/agent_summary_prompt.py
+++ b/huf/huf/doctype/agent_summary_prompt/agent_summary_prompt.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import cint
+
+
+class AgentSummaryPrompt(Document):
+	def before_insert(self):
+		self._generate_slug()
+		self._set_prompt_group()
+
+	def validate(self):
+		if not self.prompt_body:
+			frappe.throw(_("Prompt body is required."))
+
+		if not self.version:
+			self.version = 1
+
+	def _generate_slug(self):
+		"""Auto-generate slug from title if not provided."""
+		if not self.slug and self.title:
+			slug = frappe.scrub(self.title).replace("_", "-")
+			# Ensure uniqueness by appending version
+			if self.version and cint(self.version) > 1:
+				slug = f"{slug}-v{self.version}"
+			# Check for duplicates
+			if frappe.db.exists("Agent Summary Prompt", {"slug": slug}):
+				slug = f"{slug}-v{self.version or 1}"
+				if frappe.db.exists("Agent Summary Prompt", {"slug": slug}):
+					slug = f"{slug}-{frappe.generate_hash(length=4)}"
+			self.slug = slug
+
+	def _set_prompt_group(self):
+		"""Set prompt_group to tie versions together.
+
+		For a brand-new prompt lineage the group is the document name itself.
+		When a new version is created from an existing prompt the group is
+		inherited from the previous version so all versions share the same
+		identifier.
+		"""
+		if self.previous_version:
+			parent_group = frappe.db.get_value(
+				"Agent Summary Prompt", self.previous_version, "prompt_group"
+			)
+			self.prompt_group = parent_group or self.previous_version
+		elif not self.prompt_group:
+			# Will be set to self.name after insert via after_insert
+			self.prompt_group = ""
+
+	def after_insert(self):
+		"""Finalise prompt_group for brand-new lineages (no previous_version)."""
+		if not self.prompt_group:
+			frappe.db.set_value(
+				"Agent Summary Prompt", self.name, "prompt_group", self.name, update_modified=False
+			)
+			self.prompt_group = self.name

--- a/huf/huf/doctype/agent_summary_prompt/test_agent_summary_prompt.py
+++ b/huf/huf/doctype/agent_summary_prompt/test_agent_summary_prompt.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestAgentSummaryPrompt(FrappeTestCase):
+	def test_prompt_group_set_for_new_lineage(self):
+		prompt = frappe.get_doc({
+			"doctype": "Agent Summary Prompt",
+			"title": "Test Summary Prompt",
+			"prompt_body": "Summarize this: {summary_data}",
+		}).insert(ignore_permissions=True)
+
+		self.assertTrue(prompt.prompt_group)
+		self.assertEqual(prompt.prompt_group, prompt.name)
+		self.assertEqual(prompt.version, 1)
+		self.assertEqual(prompt.is_latest, 1)
+
+	def test_slug_generation(self):
+		prompt = frappe.get_doc({
+			"doctype": "Agent Summary Prompt",
+			"title": "My Summary Prompt",
+			"prompt_body": "Summarize this: {summary_data}",
+		}).insert(ignore_permissions=True)
+
+		self.assertTrue(prompt.slug)
+		self.assertIn("my-summary-prompt", prompt.slug)
+
+	def test_version_inheritance_on_new_version(self):
+		first = frappe.get_doc({
+			"doctype": "Agent Summary Prompt",
+			"title": "Versioned Summary Prompt",
+			"prompt_body": "Version 1",
+		}).insert(ignore_permissions=True)
+
+		first.is_latest = 0
+		first.save(ignore_permissions=True)
+
+		second = frappe.get_doc({
+			"doctype": "Agent Summary Prompt",
+			"title": "Versioned Summary Prompt",
+			"prompt_body": "Version 2",
+			"version": 2,
+			"is_latest": 1,
+			"previous_version": first.name,
+		}).insert(ignore_permissions=True)
+
+		self.assertEqual(second.prompt_group, first.prompt_group)
+		self.assertEqual(second.version, 2)
+
+	def test_validate_requires_prompt_body(self):
+		with self.assertRaises(frappe.ValidationError):
+			frappe.get_doc({
+				"doctype": "Agent Summary Prompt",
+				"title": "Invalid Prompt",
+			}).insert(ignore_permissions=True)

--- a/huf/huf/doctype/agent_summary_prompt_category/agent_summary_prompt_category.json
+++ b/huf/huf/doctype/agent_summary_prompt_category/agent_summary_prompt_category.json
@@ -1,0 +1,89 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:category_name",
+ "creation": "2026-06-30 05:40:14.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "category_name",
+  "description",
+  "column_break_main",
+  "icon",
+  "color",
+  "parent_category"
+ ],
+ "fields": [
+  {
+   "fieldname": "category_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Category Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "icon",
+   "fieldtype": "Data",
+   "label": "Icon"
+  },
+  {
+   "fieldname": "color",
+   "fieldtype": "Data",
+   "description": "Hex color code for the category badge, e.g. #6366F1",
+   "label": "Color"
+  },
+  {
+   "description": "Optional parent category for hierarchical grouping.",
+   "fieldname": "parent_category",
+   "fieldtype": "Link",
+   "label": "Parent Category",
+   "options": "Agent Summary Prompt Category"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-30 05:40:14.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Agent Summary Prompt Category",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "select": 1,
+   "share": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/huf/huf/doctype/agent_summary_prompt_category/agent_summary_prompt_category.py
+++ b/huf/huf/doctype/agent_summary_prompt_category/agent_summary_prompt_category.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class AgentSummaryPromptCategory(Document):
+	pass


### PR DESCRIPTION
**Description:**
This PR introduces the frontend interface and state management for the new Agent Summary Prompts feature, allowing users to configure how agents handle conversation summarization.
**Key Changes:**
* **Summary Prompts Library (`/summary-prompts`)**: Added a new main navigation route, list view, and form view wrapper to create and manage reusable Agent Summary Prompt templates.
* **Agent Configuration (Advanced Tab)**: 
  * Added a new `Conversation Strategy` and `Summarization Engine` section.
  * Implemented a toggle to switch between `Local` (custom inline prompt) and `Template` (reusable library prompt) modes.
  * Added a searchable combobox to select an active summary prompt template, complete with a quick-create "New" button.
  * Added UI toggles for `Lock Summary Prompt Version` and a read-only field to display the snapshot version at the time of attachment.
* **State Management & Validation**: Updated Zod schemas (`agentFormSchema`) to validate that a template is selected when Template mode is active. Added `useEffect` hooks to safely clear or default values when toggling between modes.
* **API Integration**: Created `agentSummaryPromptApi.ts` to interface with the backend lifecycle RPCs (versioning, forking) and standard CRUD operations.
**Related Backend PR:** *[[Link to Backend PR](https://github.com/tridz-dev/huf/pull/322)]*