### PR TITLE
Fix/agent stability and UI sync

### DIFF
--- a/frontend/src/components/chat/ChatMessageList.tsx
+++ b/frontend/src/components/chat/ChatMessageList.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { getConversationMessages, createAgentRunFeedback, getConversation, type ChatMessage } from "@/services/chatApi";
 import { getAgent } from "@/services/agentApi";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
-import { useChatSocket, type ToolCallEvent, type NewAgentMessageEvent } from '@/hooks/useChatSocket';
+import { useChatSocket, type ToolCallEvent, type NewAgentMessageEvent, type SubAgentCompletedEvent, type SubAgentFailedEvent } from '@/hooks/useChatSocket';
 import { ChatMessage as ChatMessageComponent } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { EmptyChatState } from './EmptyChatState';
@@ -156,10 +156,58 @@ export function ChatMessageList({
         setMessages((prev) => upsertAgentMessageFromSocket(prev, event));
     }, [chatId]);
 
+    // Handle sub-agent completion and failure
+    const handleSubAgentCompleted = useCallback((event: SubAgentCompletedEvent) => {
+        if (event.conversation_id !== chatId) return;
+        toast.success(`Sub-agent ${event.agent_name} completed successfully.`);
+        setMessages((prev) => prev.map(msg => {
+            if (!msg.tools || msg.tools.length === 0) return msg;
+            const updatedTools = msg.tools.map(tool => {
+                if (
+                    (tool.name === 'run_agent' || tool.name === 'Run Agent') &&
+                    tool.parameters?.target_agent_name === event.agent_name &&
+                    tool.status === 'output-available'
+                ) {
+                    return {
+                        ...tool,
+                        result: event.result || "Completed successfully"
+                    };
+                }
+                return tool;
+            });
+            return { ...msg, tools: updatedTools };
+        }));
+    }, [chatId]);
+
+    const handleSubAgentFailed = useCallback((event: SubAgentFailedEvent) => {
+        if (event.conversation_id !== chatId) return;
+        toast.error(`Sub-agent ${event.agent_name} failed: ${event.error || 'Unknown error'}`);
+        setMessages((prev) => prev.map(msg => {
+            if (!msg.tools || msg.tools.length === 0) return msg;
+            const updatedTools = msg.tools.map(tool => {
+                if (
+                    (tool.name === 'run_agent' || tool.name === 'Run Agent') &&
+                    tool.parameters?.target_agent_name === event.agent_name &&
+                    (tool.status === 'output-available' || tool.status === 'input-streaming')
+                ) {
+                    return {
+                        ...tool,
+                        status: 'output-error' as const,
+                        error: event.error || "Unknown error"
+                    };
+                }
+                return tool;
+            });
+            return { ...msg, tools: updatedTools };
+        }));
+    }, [chatId]);
+
     useChatSocket({
         conversationId: chatId,
         onToolUpdate: handleToolUpdate,
         onNewMessage: handleNewMessage,
+        onSubAgentCompleted: handleSubAgentCompleted,
+        onSubAgentFailed: handleSubAgentFailed,
     });
 
     // Show error toast when there's an error loading messages

--- a/frontend/src/hooks/useChatSocket.tsx
+++ b/frontend/src/hooks/useChatSocket.tsx
@@ -26,13 +26,31 @@ export type NewAgentMessageEvent = {
     conversation_index?: number;
 };
 
+export type SubAgentCompletedEvent = {
+    type: 'sub_agent_completed';
+    conversation_id: string;
+    agent_name: string;
+    status: string;
+    result?: string;
+};
+
+export type SubAgentFailedEvent = {
+    type: 'sub_agent_failed';
+    conversation_id: string;
+    agent_name: string;
+    status: string;
+    error?: string;
+};
+
 type ChatSocketProps = {   
     conversationId: string | null;
     onToolUpdate?: (event: ToolCallEvent) => void;
     onNewMessage?: (event: NewAgentMessageEvent) => void;
+    onSubAgentCompleted?: (event: SubAgentCompletedEvent) => void;
+    onSubAgentFailed?: (event: SubAgentFailedEvent) => void;
 }
 
-export function useChatSocket({ conversationId, onToolUpdate, onNewMessage }: ChatSocketProps) {
+export function useChatSocket({ conversationId, onToolUpdate, onNewMessage, onSubAgentCompleted, onSubAgentFailed }: ChatSocketProps) {
     useEffect(() => {
         if (!conversationId) {
             return;
@@ -63,6 +81,10 @@ export function useChatSocket({ conversationId, onToolUpdate, onNewMessage }: Ch
                 data.type === 'tool_call_failed'
             ) {
                 onToolUpdate?.(data as ToolCallEvent);
+            } else if (data.type === 'sub_agent_completed') {
+                onSubAgentCompleted?.(data as SubAgentCompletedEvent);
+            } else if (data.type === 'sub_agent_failed') {
+                onSubAgentFailed?.(data as SubAgentFailedEvent);
             }
         });
 
@@ -83,5 +105,5 @@ export function useChatSocket({ conversationId, onToolUpdate, onNewMessage }: Ch
             socket.off(`conversation:${conversationId}`);
             socket.disconnect();
         };
-    }, [conversationId, onToolUpdate, onNewMessage]);
+    }, [conversationId, onToolUpdate, onNewMessage, onSubAgentCompleted, onSubAgentFailed]);
 }

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -1119,7 +1119,7 @@ def run_agent_sync(
                 "cost": cost
             })
 
-        conv_manager.add_message(conversation, "agent", final_output, resolved_provider, resolved_model, agent_name, run_doc.name)
+        message_doc = conv_manager.add_message(conversation, "agent", final_output, resolved_provider, resolved_model, agent_name, run_doc.name)
 
         frappe.db.set_value("Agent Run", run_doc.name, {
             "status": "Success",
@@ -1130,6 +1130,29 @@ def run_agent_sync(
             "end_time": now_datetime()
         }, update_modified=True)
         safe_commit()
+
+        # Notify connected chat clients so background runs (e.g. sub-agent parent
+        # re-awaken) update the UI without requiring a manual refresh.
+        if message_doc:
+            try:
+                frappe.publish_realtime(
+                    event=f"conversation:{conversation.name}",
+                    message={
+                        "type": "new_agent_message",
+                        "conversation_id": conversation.name,
+                        "message_id": message_doc.name,
+                        "kind": message_doc.kind or "Message",
+                        "content": message_doc.content,
+                        "agent_run_id": run_doc.name,
+                        "conversation_index": message_doc.conversation_index,
+                    },
+                    user=frappe.session.user,
+                )
+            except Exception as socket_err:
+                frappe.log_error(
+                    f"Error emitting new_agent_message socket event: {socket_err!s}",
+                    "Agent Sync Socket Event"
+                )
 
         # Handle Sub-Agent Success Lifecycle Hook
         if parent_conversation_id and invoked_by_agent:

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -1188,6 +1188,8 @@ def handle_run_agent(target_agent_name: str, prompt: str, **kwargs):
             model=target_agent.model,
             parent_conversation_id=conversation_id,
             invoked_by_agent=agent_name_self,
+            channel_id=kwargs.get("channel_id"),
+            external_id=kwargs.get("external_id")
         )
 
         return {


### PR DESCRIPTION
## Description

This PR resolves the issue where responses from multiple agents do not appear immediately in the chat interface and require a manual page refresh. 

The root cause was a lack of real-time socket propagation when background agent jobs completed or generated new messages. To solve this, we've implemented real-time WebSocket events that push updates directly to the frontend, allowing optimistic UI updates and seamless multi-agent interactions.

## Changes Proposed

### Backend 
- **Real-Time Message Broadcast**: Updated `run_agent_sync` in `agent_integration.py` to emit a `new_agent_message` socket event via `frappe.publish_realtime` immediately after an agent successfully generates a message.
- **Context Propagation**: Updated `handle_run_agent` in `sdk_tools.py` to pass context-specific identifiers (`channel_id` and `external_id`) down to the background job, ensuring that sub-agent executions are correctly associated with the active socket channels.

### Frontend 
- **Sub-Agent Lifecycle Events**: Extended the `useChatSocket` hook to subscribe to `sub_agent_completed` and `sub_agent_failed` socket events.
- **Optimistic UI Updates**: Added handlers (`handleSubAgentCompleted` and `handleSubAgentFailed`) in `ChatMessageList.tsx` that directly update the `run_agent` tool's execution status (e.g., setting it to `output-available` or `output-error`) in the local state, eliminating the need for full page reloads to see sub-agent progress.

## How to Test
1. Make sure you have multiple agents enabled.
2. Open the chat interface and ask a question that triggers a sub-agent.
3. Observe the chat interface: The sub-agent's execution status and the final response should appear immediately without needing a manual refresh.
Fixes #310 

