### PR TITLE
Fix duplicate load_conversation_data tool registration causing Gemini BadRequestError

### DIFF
--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -271,8 +271,6 @@ def create_agent_tools(agent) -> list[FunctionTool]:
             )
             if tool: tools.append(tool)
 
-            if tool: tools.append(tool)
-
     existing_types = [t.name for t in tools] if tools else []
     if "get_result_context" not in existing_types:
         tool = create_function_tool(


### PR DESCRIPTION
## Summary
- Agents with `enable_conversation_data=1` fail on Gemini models (e.g. `gemini-3.1-flash-lite`) with:
  ```
  litellm.BadRequestError: GeminiException BadRequestError - {"error": {"code": 400, "message": "Duplicate function declaration found: load_conversation_data", "status": "INVALID_ARGUMENT"}}
  ```
- Root cause: in `create_agent_tools()` (`huf/ai/sdk_tools.py`), the `load_conversation_data` block had a copy-pasted duplicate line:
  ```python
  if tool: tools.append(tool)

  if tool: tools.append(tool)
  ```
  This appended the same `FunctionTool` twice into the tools array sent to the LLM provider, which Gemini rejects as a duplicate function declaration. `get_conversation_data` and `set_conversation_data` right above it only append once — this block was the odd one out.
- Fix: removed the duplicate append, matching the pattern used by the other two conversation-data tools.

## Test plan
- [x] Reproduced: enabled `enable_conversation_data=1` on the "Test New UI" agent and called `huf.ai.agent_integration.run_agent_sync` — failed with the reported `Duplicate function declaration found: load_conversation_data` error before the fix.
- [x] Verified `create_agent_tools()` returns `['get_conversation_data', 'set_conversation_data', 'load_conversation_data', 'get_result_context']` with no duplicate names after the fix.
- [x] Re-ran `run_agent_sync` for the same agent/prompt after the fix — succeeded (`{'success': True, 'response': 'Hi there!', ...}`).