### PR TITLE
fix(ci): restore runtime-build + seed-bake steps in fasterdocker publish workflow

### DIFF
--- a/.github/workflows/fasterdocker-publish.yml
+++ b/.github/workflows/fasterdocker-publish.yml
@@ -59,6 +59,39 @@ jobs:
             echo "huf_tag=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Build native Frappe runtime base image
+        # build-demo.sh (via Dockerfile.huf) expects huf-frappe-runtime:16.25.0
+        # to already exist locally. On a fresh runner it doesn't, and without
+        # this step Docker tries (and fails) to pull it from Docker Hub.
+        run: |
+          set -euo pipefail
+          docker build -f docker/fast/Dockerfile.runtime -t huf-frappe-runtime:16.25.0 .
+
+      - name: Bake site seed
+        # docker/fast/.bake-output is gitignored (repo only ships a .gitkeep),
+        # so a fresh checkout has no seed. Build a seed-less huf-app first,
+        # use it to bake a real site via compose.bake.yml, then build the seed
+        # image and rebuild huf-app so the seed is actually embedded before
+        # build-demo.sh runs. Mirrors the manual steps used to verify this
+        # locally on arm64.
+        env:
+          HUF_IMAGE_TAG: ${{ steps.tags.outputs.huf_tag }}
+        run: |
+          set -euo pipefail
+          docker build -f docker/fast/Dockerfile.huf -t "huf-app:${HUF_IMAGE_TAG}" .
+          docker compose -p fasterdocker -f docker/compose.bake.yml up -d --build
+          trap 'docker compose -p fasterdocker -f docker/compose.bake.yml down -v --remove-orphans || true' EXIT
+          code="$(docker wait fasterdocker-build-site-baker)"
+          docker compose -p fasterdocker -f docker/compose.bake.yml logs site-baker
+          if [ "${code}" != "0" ]; then
+            echo "::error::site-baker exited with code ${code}"
+            exit 1
+          fi
+          docker compose -p fasterdocker -f docker/compose.bake.yml down -v --remove-orphans
+          trap - EXIT
+          ./docker/fast/bake-seed.sh sql
+          docker build -f docker/fast/Dockerfile.huf -t "huf-app:${HUF_IMAGE_TAG}" .
+
       - name: Build and push per-arch HUF demo image
         env:
           HUF_IMAGE_TAG: ${{ steps.tags.outputs.huf_tag }}


### PR DESCRIPTION
## What
The multi-arch publish workflow (`fasterdocker-publish.yml`) has been failing on fresh runners since commit `3c6026c` refactored it.

## Root cause
Commit `3c6026c` replaced the explicit "Build and push Frappe runtime image" step (present and working at `976c22a`, which produced the currently-published amd64+arm64 `:latest` manifest) with a bare `./docker/fast/build-demo.sh` call. `build-demo.sh` → `Dockerfile.huf` does `FROM huf-frappe-runtime:16.25.0`, an image that only ever existed as a local build artifact — so a fresh runner fails with `pull access denied`. Additionally `docker/fast/.bake-output/` is gitignored, so CI has no SQL seed to bake into the demo image.

## Fix
Re-add, before `build-demo.sh`:
1. **Build native Frappe runtime base image** from `Dockerfile.runtime`.
2. **Bake site seed** — build seed-less huf-app → run `compose.bake.yml` site-baker → `bake-seed.sh sql` → rebuild huf-app with the seed embedded.

This mirrors the exact manual sequence verified end-to-end locally on native arm64 this pass (cold boot ~7-8s, warm boot ~7-8s, credential rotation confirmed). Two other real bugs fixed in the merged PR #327 (missing `SKIP_SEED_INIT` in compose.bake.yml; missing `common_site_config.json` rewrite in demo-entrypoint.sh) are prerequisites for this bake to succeed in CI.

## After merge
Push to `develop` auto-triggers the workflow, producing a fresh amd64+arm64 manifest with all fixes.