### PR TITLE
fix(ci): use PAT for GHCR push, GITHUB_TOKEN lacks package access

### DIFF
--- a/.github/workflows/fasterdocker-publish.yml
+++ b/.github/workflows/fasterdocker-publish.yml
@@ -48,7 +48,12 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # ghcr.io container packages have their own "Manage Actions access"
+          # list, separate from repo/org Actions permissions. This package
+          # was first created via a manual push (not GITHUB_TOKEN), so that
+          # list was never populated and GITHUB_TOKEN gets permission_denied.
+          # Use a PAT with write:packages that already has push rights instead.
+          password: ${{ secrets.GHCR_PUSH_TOKEN }}
 
       - name: Determine tags
         id: tags
@@ -115,7 +120,12 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # ghcr.io container packages have their own "Manage Actions access"
+          # list, separate from repo/org Actions permissions. This package
+          # was first created via a manual push (not GITHUB_TOKEN), so that
+          # list was never populated and GITHUB_TOKEN gets permission_denied.
+          # Use a PAT with write:packages that already has push rights instead.
+          password: ${{ secrets.GHCR_PUSH_TOKEN }}
 
       - name: Determine tags
         id: tags


### PR DESCRIPTION
GITHUB_TOKEN was denied with 'permission_denied: write_package' on run 28767243903 (both matrix legs got all the way through runtime-build + seed-bake successfully, only the final push failed). Root cause: ghcr.io container packages have their own 'Manage Actions access' list, separate from repo/org Actions permissions — this package was first created via a manual docker push (not GITHUB_TOKEN), so GITHUB_TOKEN was never added to that list. Rather than requiring a manual GitHub UI step, added a GHCR_PUSH_TOKEN repo secret (a PAT scoped write:packages, already has push rights to this package) and switched both login steps to use it.