### PR TITLE
fix(ci): manifest job missing checkout, caused empty tag

### DIFF
--- a/.github/workflows/fasterdocker-publish.yml
+++ b/.github/workflows/fasterdocker-publish.yml
@@ -122,6 +122,13 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout
+        # Without this, `git rev-parse --short HEAD` in "Determine tags"
+        # below has no repo to read. It fails silently (the echo/output write
+        # still "succeeds"), producing an empty huf_tag and
+        # "ERROR: invalid reference format" from imagetools create.
+        uses: actions/checkout@v4
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The manifest job never checked out the repo, so 9db48c9 in 'Determine tags' silently produced an empty tag on push-triggered runs (step still reported success). imagetools create then failed with 'invalid reference format'. Confirmed on run 28767881258: both per-arch builds succeeded fully (first successful CI amd64 build this session, 13m33s; arm64 16m15s) — only this manifest step failed. Manually assembled and verified the manifest from the already-pushed per-arch tags in the meantime (ghcr.io/tridz-dev/huf-demo:latest and :991de9b confirmed multi-arch via docker manifest inspect).