### PR TITLE
feat(app_seeding): seed foreign-reference validation with structured skip reporting

### DIFF
--- a/frontend/src/components/agent/AgentKnowledgeModal.tsx
+++ b/frontend/src/components/agent/AgentKnowledgeModal.tsx
@@ -5,12 +5,15 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import {
   Dialog,
-  DialogContent,
   DialogDescription,
-  DialogFooter,
-  DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '@/components/ui/dialog-scroll';
 import {
   Select,
   SelectContent,
@@ -94,15 +97,15 @@ export function AgentKnowledgeModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
+      <DialogScrollContent className="sm:max-w-md">
+        <DialogScrollHeader>
           <DialogTitle>{initialData ? 'Edit Knowledge Link' : 'Add Knowledge Source'}</DialogTitle>
           <DialogDescription>
             Link a knowledge source to this agent for RAG-based retrieval.
           </DialogDescription>
-        </DialogHeader>
+        </DialogScrollHeader>
 
-        <div className="space-y-4 py-2">
+        <DialogScrollBody className="space-y-4 py-2">
           <div className="space-y-2">
             <Label>Knowledge Source *</Label>
             <Combobox
@@ -174,17 +177,17 @@ export function AgentKnowledgeModal({
               rows={2}
             />
           </div>
-        </div>
+        </DialogScrollBody>
 
-        <DialogFooter>
+        <DialogScrollFooter>
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
           <Button type="button" onClick={handleSave} disabled={!isValid}>
             {initialData ? 'Update' : 'Add'}
           </Button>
-        </DialogFooter>
-      </DialogContent>
+        </DialogScrollFooter>
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/agent/TriggerModal.tsx
+++ b/frontend/src/components/agent/TriggerModal.tsx
@@ -4,12 +4,15 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import {
   Dialog,
-  DialogContent,
   DialogDescription,
-  DialogFooter,
-  DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '@/components/ui/dialog-scroll';
 import {
   Form,
   FormControl,
@@ -181,15 +184,20 @@ export function TriggerModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px]">
-        <DialogHeader>
+      <DialogScrollContent className="sm:max-w-[600px]">
+        <DialogScrollHeader>
           <DialogTitle>Configure Trigger</DialogTitle>
           <DialogDescription>
             {editingTrigger ? 'Edit trigger configuration' : 'Add a new trigger to this agent'}
           </DialogDescription>
-        </DialogHeader>
+        </DialogScrollHeader>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <Form {...triggerForm}>
-          <form onSubmit={triggerForm.handleSubmit(handleSubmit, handleFormError)} className="space-y-4">
+          <form
+            onSubmit={triggerForm.handleSubmit(handleSubmit, handleFormError)}
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          >
+            <DialogScrollBody className="space-y-4 pb-4">
             {/* Trigger Name Field - Only editable when adding */}
             {!editingTrigger && (
               <FormField
@@ -272,17 +280,20 @@ export function TriggerModal({
               />
             )}
 
-            <DialogFooter>
+            </DialogScrollBody>
+
+            <DialogScrollFooter>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                 Cancel
               </Button>
               <Button type="submit">
                 {editingTrigger ? 'Update' : 'Add'} Trigger
               </Button>
-            </DialogFooter>
+            </DialogScrollFooter>
           </form>
         </Form>
-      </DialogContent>
+        </div>
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/category/CategoryModal.tsx
+++ b/frontend/src/components/category/CategoryModal.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState, useCallback } from 'react';
 import {
   Dialog,
-  DialogContent,
-  DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollHeader,
+} from '@/components/ui/dialog-scroll';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -240,8 +243,8 @@ export function CategoryModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
-        <DialogHeader>
+      <DialogScrollContent className="sm:max-w-2xl">
+        <DialogScrollHeader>
           <DialogTitle>
             {editingCategory
               ? `Edit Category: ${newCategoryData.category_name || editingCategory.category_name}`
@@ -249,10 +252,11 @@ export function CategoryModal({
               ? 'Add New Category'
               : 'Manage Categories'}
           </DialogTitle>
-        </DialogHeader>
+        </DialogScrollHeader>
 
+        <DialogScrollBody>
         <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid grid-cols-2 bg-muted p-1 rounded-lg">
+          <TabsList variant="pill" layout="grid" cols={2}>
             <TabsTrigger value="list">Categories</TabsTrigger>
             <TabsTrigger value="create">{editingCategory ? 'Edit' : 'Add New'}</TabsTrigger>
           </TabsList>
@@ -594,7 +598,8 @@ export function CategoryModal({
             </div>
           </TabsContent>
         </Tabs>
-      </DialogContent>
+        </DialogScrollBody>
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/chat/ChatListing.tsx
+++ b/frontend/src/components/chat/ChatListing.tsx
@@ -203,11 +203,11 @@ export default function ChatListing({ onClose }: { onClose?: () => void }) {
       <div className="flex-1 min-h-0 overflow-y-auto px-3 pb-3 bg-sidebar [&::-webkit-scrollbar]:w-0 [-ms-overflow-style:none] [scrollbar-width:none]" id="chat-listing-scroll">
         <Tabs defaultValue="recents" value={activeTab} onValueChange={setActiveTab} className="space-y-2">
         <div className="sticky top-0 z-1 bg-sidebar">
-          <TabsList className="w-full h-8">
+          <TabsList variant="pill" layout="grid" cols={2} size="compact" className="w-full">
             {LIST_TABS.map((tab) => (
               <TabsTrigger
                 key={tab.value}
-                className="w-1/2 space-x-1.5 text-xs font-medium h-7"
+                className="w-full space-x-1.5"
                 value={tab.value}
               >
                 <tab.icon className="w-3 h-3" />

--- a/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
+++ b/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Dialog,
-  DialogContent,
   DialogDescription,
-  DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollHeader,
+} from '@/components/ui/dialog-scroll';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -221,15 +224,15 @@ export function KnowledgeInputsModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col">
-        <DialogHeader className="flex-shrink-0">
+      <DialogScrollContent className="max-w-2xl">
+        <DialogScrollHeader>
           <DialogTitle>Knowledge Inputs</DialogTitle>
           <DialogDescription>
             Manage content inputs for this knowledge source
           </DialogDescription>
-        </DialogHeader>
+        </DialogScrollHeader>
 
-        <div className="flex-1 overflow-y-auto space-y-4 py-2">
+        <DialogScrollBody className="space-y-4 py-2">
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
               {inputs.length} {inputs.length === 1 ? 'input' : 'inputs'}
@@ -398,8 +401,8 @@ export function KnowledgeInputsModal({
               })}
             </div>
           )}
-        </div>
-      </DialogContent>
+        </DialogScrollBody>
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/modals/FlowSettingsModal.tsx
+++ b/frontend/src/components/modals/FlowSettingsModal.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
 import {
   Dialog,
-  DialogContent,
-  DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from '../ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '../ui/dialog-scroll';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Button } from '../ui/button';
@@ -115,11 +118,11 @@ export function FlowSettingsModal({ open, onClose }: FlowSettingsModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
+      <DialogScrollContent className="sm:max-w-[425px]">
+        <DialogScrollHeader>
           <DialogTitle>Flow Settings</DialogTitle>
-        </DialogHeader>
-        <div className="grid gap-4 py-4">
+        </DialogScrollHeader>
+        <DialogScrollBody className="grid gap-4 py-4">
           <div className="grid gap-2">
             <Label htmlFor="name">Flow Name</Label>
             <Input
@@ -183,8 +186,8 @@ export function FlowSettingsModal({ open, onClose }: FlowSettingsModalProps) {
               />
             </div>
           </div>
-        </div>
-        <DialogFooter className="sm:justify-between items-center border-t pt-4 mt-2">
+        </DialogScrollBody>
+        <DialogScrollFooter className="items-center justify-between sm:justify-between">
           <Button
             variant="outline"
             size="sm"
@@ -204,8 +207,8 @@ export function FlowSettingsModal({ open, onClose }: FlowSettingsModalProps) {
               Save Changes
             </Button>
           </div>
-        </DialogFooter>
-      </DialogContent>
+        </DialogScrollFooter>
+      </DialogScrollContent>
 
       <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <AlertDialogContent>

--- a/frontend/src/components/modals/NodeSelectionModal.tsx
+++ b/frontend/src/components/modals/NodeSelectionModal.tsx
@@ -1,10 +1,14 @@
 import { useState, useEffect } from 'react';
 import {
   Dialog,
-  DialogContent,
-  DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '../ui/dialog-scroll';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -453,13 +457,14 @@ export function NodeSelectionModal({
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
-        <DialogHeader className="flex-shrink-0">
+      <DialogScrollContent className="max-w-3xl">
+        <DialogScrollHeader>
           <DialogTitle>
             {mainTab === 'triggers' ? 'Select Trigger' : 'Add Action'}
           </DialogTitle>
-        </DialogHeader>
+        </DialogScrollHeader>
 
+        <DialogScrollBody className="flex flex-col pb-4">
         <div className="relative mb-4 flex-shrink-0">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
@@ -472,19 +477,19 @@ export function NodeSelectionModal({
 
         <Tabs value={mainTab} onValueChange={(v) => { setMainTab(v as MainTab); setSelectedItem(null); setTriggerConfig({ type: undefined }); }} className="flex-1 flex flex-col min-h-0">
           {mode !== 'trigger' ? (
-            <TabsList className="grid w-full grid-cols-2 flex-shrink-0">
+            <TabsList layout="grid" cols={2} className="flex-shrink-0">
               <TabsTrigger value="triggers">Triggers</TabsTrigger>
               <TabsTrigger value="actions">Actions</TabsTrigger>
             </TabsList>
           ) : (
-            <TabsList className="grid w-full grid-cols-1 flex-shrink-0">
+            <TabsList layout="grid" cols={1} className="flex-shrink-0">
               <TabsTrigger value="triggers">Triggers</TabsTrigger>
             </TabsList>
           )}
 
           <TabsContent value="triggers" className="flex-1 flex flex-col min-h-0 mt-4">
             <Tabs value={triggerSubTab} onValueChange={(v) => { setTriggerSubTab(v as TriggerSubTab); setSelectedItem(null); setTriggerConfig({ type: undefined }); }} className="flex-1 flex flex-col min-h-0">
-              <TabsList className="grid w-full grid-cols-2 flex-shrink-0">
+              <TabsList layout="grid" cols={2} className="flex-shrink-0">
                 <TabsTrigger value="explore">Explore</TabsTrigger>
                 <TabsTrigger value="ai-agents">AI & Agents</TabsTrigger>
               </TabsList>
@@ -657,8 +662,9 @@ export function NodeSelectionModal({
             {renderActionCategory('Integrations', integrationActions)}
           </TabsContent>
         </Tabs>
+        </DialogScrollBody>
 
-        <div className="flex justify-end gap-2 mt-4 pt-4 border-t flex-shrink-0">
+        <DialogScrollFooter className="justify-end">
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
@@ -667,8 +673,8 @@ export function NodeSelectionModal({
               Save Configuration
             </Button>
           )}
-        </div>
-      </DialogContent>
+        </DialogScrollFooter>
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/modals/TriggerConfigModal.tsx
+++ b/frontend/src/components/modals/TriggerConfigModal.tsx
@@ -279,7 +279,7 @@ export function TriggerConfigModal({
         </div>
 
         <Tabs value={activeTab} onValueChange={(v) => { setActiveTab(v as ModalTab); setSelectedTrigger(null); setConfig({ type: undefined }); }} className="flex-1 flex flex-col min-h-0">
-          <TabsList className="grid w-full grid-cols-4 flex-shrink-0">
+          <TabsList layout="grid" cols={4} className="flex-shrink-0">
             <TabsTrigger value="explore">Explore</TabsTrigger>
             <TabsTrigger value="ai-agents">AI & Agents</TabsTrigger>
             <TabsTrigger value="apps">Apps</TabsTrigger>

--- a/frontend/src/components/tools/ParameterCard.tsx
+++ b/frontend/src/components/tools/ParameterCard.tsx
@@ -133,12 +133,14 @@ export function ParameterCard({
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
             <Label htmlFor={`param-options-${index}`}>Options</Label>
-            <Input
+            <Textarea
               id={`param-options-${index}`}
               value={parameter.options || ''}
               onChange={(e) => handleChange('options', e.target.value)}
-              placeholder="Comma-separated options"
+              placeholder="One option per line"
+              className="min-h-[80px]"
             />
+            <p className="text-xs text-muted-foreground">Enter each option on its own line.</p>
           </div>
 
           <div className="flex items-center space-x-2 pt-8">

--- a/frontend/src/components/tools/SelectMCPServersModal.tsx
+++ b/frontend/src/components/tools/SelectMCPServersModal.tsx
@@ -2,12 +2,15 @@ import { useState, useEffect, useMemo } from 'react';
 import { Search } from 'lucide-react';
 import {
   Dialog,
-  DialogContent,
   DialogDescription,
-  DialogFooter,
-  DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '../ui/dialog-scroll';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { MCPServerCard } from './MCPServerCard';
@@ -117,16 +120,17 @@ export function SelectMCPServersModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[700px] h-[80vh] flex flex-col p-0">
-        <DialogHeader className="px-6 pt-6 pb-4">
+      <DialogScrollContent className="sm:max-w-[700px]">
+        <DialogScrollHeader>
           <DialogTitle>Select MCP Servers</DialogTitle>
           <DialogDescription>
             Choose MCP servers to connect to this agent. Select multiple servers at once.
           </DialogDescription>
-        </DialogHeader>
+        </DialogScrollHeader>
 
+        <DialogScrollBody className="space-y-4 pb-2">
         {/* Filters */}
-        <div className="flex flex-col gap-3 px-6 pb-4">
+        <div className="flex flex-col gap-3">
           {/* Search */}
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
@@ -140,7 +144,7 @@ export function SelectMCPServersModal({
         </div>
 
         {/* Server List */}
-        <div className="flex-1 overflow-y-auto min-h-0 px-6 space-y-2 pb-2">
+        <div className="space-y-2">
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <div className="text-muted-foreground">Loading MCP servers...</div>
@@ -165,9 +169,9 @@ export function SelectMCPServersModal({
             ))
           )}
         </div>
+        </DialogScrollBody>
 
-        {/* Footer */}
-        <DialogFooter className="flex items-center justify-between border-t px-6 py-4">
+        <DialogScrollFooter className="items-center justify-between sm:justify-between">
           <div className="text-sm text-muted-foreground">
             {selectedCount > 0 ? (
               <>
@@ -188,8 +192,8 @@ export function SelectMCPServersModal({
               Add {selectedCount > 0 && `(${selectedCount})`}
             </Button>
           </div>
-        </DialogFooter>
-      </DialogContent>
+        </DialogScrollFooter>
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/tools/SelectToolsModal.tsx
+++ b/frontend/src/components/tools/SelectToolsModal.tsx
@@ -2,12 +2,14 @@ import { useState, useEffect, useMemo } from 'react';
 import { Search } from 'lucide-react';
 import {
   Dialog,
-  DialogContent,
   DialogDescription,
-  DialogFooter,
-  DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
+import {
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '../ui/dialog-scroll';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { Combobox } from '../ui/combobox';
@@ -242,18 +244,18 @@ export function SelectToolsModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-5xl h-[80vh] flex flex-col p-0 overflow-hidden">
-        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0">
+      <DialogScrollContent className="sm:max-w-5xl">
+        <DialogScrollHeader>
           <DialogTitle>Add Tool</DialogTitle>
-        </DialogHeader>
+        </DialogScrollHeader>
 
         {/* Tabs */}
         <Tabs 
           value={activeTab} 
           onValueChange={(value) => setActiveTab(value as 'tool-library' | 'create-new')} 
-          className="px-6 flex flex-col flex-1 min-h-0 overflow-hidden"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden px-6"
         >
-          <TabsList className="grid w-full grid-cols-2 flex-shrink-0">
+          <TabsList layout="grid" cols={2} className="flex-shrink-0">
             <TabsTrigger value="tool-library">Tool Library</TabsTrigger>
             <TabsTrigger value="create-new">Create New</TabsTrigger>
           </TabsList>
@@ -324,30 +326,6 @@ export function SelectToolsModal({
                 ))
               )}
             </div>
-
-            {/* Footer */}
-            <DialogFooter className="flex items-center justify-between border-t pt-4 mt-4 flex-shrink-0">
-              <div className="text-sm text-muted-foreground">
-                {selectedCount > 0 ? (
-                  <>
-                    {selectedCount} tool{selectedCount > 1 ? 's' : ''} selected
-                    {selectedCount !== filteredTools.length && (
-                      <> • {filteredTools.length} total</>
-                    )}
-                  </>
-                ) : (
-                  <>{filteredTools.length} tool{filteredTools.length !== 1 ? 's' : ''} available</>
-                )}
-              </div>
-              <div className="flex gap-2">
-                <Button variant="outline" onClick={() => onOpenChange(false)}>
-                  Cancel
-                </Button>
-                <Button onClick={handleAdd} disabled={selectedCount === 0}>
-                  Add {selectedCount > 0 && `(${selectedCount})`}
-                </Button>
-              </div>
-            </DialogFooter>
           </TabsContent>
 
           {/* Create New Tab */}
@@ -378,7 +356,32 @@ export function SelectToolsModal({
             ) : null}
           </TabsContent>
         </Tabs>
-      </DialogContent>
+
+        {activeTab === 'tool-library' && (
+          <DialogScrollFooter className="items-center justify-between sm:justify-between">
+            <div className="text-sm text-muted-foreground">
+              {selectedCount > 0 ? (
+                <>
+                  {selectedCount} tool{selectedCount > 1 ? 's' : ''} selected
+                  {selectedCount !== filteredTools.length && (
+                    <> • {filteredTools.length} total</>
+                  )}
+                </>
+              ) : (
+                <>{filteredTools.length} tool{filteredTools.length !== 1 ? 's' : ''} available</>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handleAdd} disabled={selectedCount === 0}>
+                Add {selectedCount > 0 && `(${selectedCount})`}
+              </Button>
+            </div>
+          </DialogScrollFooter>
+        )}
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/tools/ToolCreationForm.tsx
+++ b/frontend/src/components/tools/ToolCreationForm.tsx
@@ -42,6 +42,7 @@ import { toast } from 'sonner';
 import { useToolCreationOptions } from './useToolCreationOptions';
 import {
   buildMissingMandatoryParameters,
+  parseParameterOptions,
   createToolFormSchema,
   getDefaultToolFormValues,
   shouldShowField,
@@ -272,7 +273,7 @@ export function ToolCreationForm({
         property.description = param.description;
       }
       if (param.options?.trim()) {
-        property.enum = param.options.split(',').map((item) => item.trim()).filter(Boolean);
+        property.enum = parseParameterOptions(param.options);
       }
       properties[param.fieldname] = property;
       if (param.required) {

--- a/frontend/src/components/tools/ToolFormModal.tsx
+++ b/frontend/src/components/tools/ToolFormModal.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect } from 'react';
 import {
   Dialog,
-  DialogContent,
-  DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollHeader,
+} from '../ui/dialog-scroll';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
 import { ToolTemplateCard } from './ToolTemplateCard';
 import { ToolCreationForm } from './ToolCreationForm';
@@ -109,11 +112,12 @@ export function ToolFormModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-5xl h-[80vh] flex flex-col p-0 overflow-hidden">
-        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0">
+      <DialogScrollContent className="sm:max-w-5xl">
+        <DialogScrollHeader>
           <DialogTitle>{mode === 'edit' ? 'Edit Tool' : 'Add Tool'}</DialogTitle>
-        </DialogHeader>
+        </DialogScrollHeader>
 
+        <DialogScrollBody className="flex flex-col pb-4">
         {mode === 'create' && (
           <Tabs 
             value={createView === 'templates' ? 'templates' : 'form'} 
@@ -123,9 +127,9 @@ export function ToolFormModal({
                 setSelectedTemplate(null);
               }
             }}
-            className="px-6 flex flex-col flex-1 min-h-0 overflow-hidden"
+            className="flex flex-col min-h-0"
           >
-            <TabsList className="grid w-full grid-cols-2 flex-shrink-0">
+            <TabsList layout="grid" cols={2} className="flex-shrink-0">
               <TabsTrigger value="templates">Templates</TabsTrigger>
               <TabsTrigger value="form" disabled={!selectedTemplate}>Form</TabsTrigger>
             </TabsList>
@@ -169,9 +173,8 @@ export function ToolFormModal({
         )}
 
         {mode === 'edit' && displayTemplate && (
-          <div className="px-6 flex flex-col flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
-            <div className="pb-4 px-1">
-              <ToolCreationForm
+          <div className="pb-4 px-1">
+            <ToolCreationForm
                 template={displayTemplate}
                 toolTypes={toolTypes}
                 onSubmit={handleFormSubmit}
@@ -182,10 +185,10 @@ export function ToolFormModal({
                 toolName={toolName}
                 currentAgentName={currentAgentName}
               />
-            </div>
           </div>
         )}
-      </DialogContent>
+        </DialogScrollBody>
+      </DialogScrollContent>
     </Dialog>
   );
 }

--- a/frontend/src/components/tools/toolCreationForm.utils.ts
+++ b/frontend/src/components/tools/toolCreationForm.utils.ts
@@ -120,6 +120,25 @@ export const getDefaultToolFormValues = (
   http_headers: initialData?.http_headers || [],
 });
 
+export function parseParameterOptions(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  if (value.includes('\n')) {
+    return value.split('\n').map((item) => item.trim()).filter(Boolean);
+  }
+
+  if (value.includes(',')) {
+    return value.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+
+  return [trimmed];
+}
+
+export function normalizeParameterOptionsValue(value: string): string {
+  return parseParameterOptions(value).join('\n');
+}
+
 export const buildMissingMandatoryParameters = (
   metaFields: any[],
   currentParams: ParameterData[]
@@ -141,7 +160,7 @@ export const buildMissingMandatoryParameters = (
       type: mapFieldtypeToParamType(df.fieldtype),
       required: true,
       description: '',
-      options: df.fieldtype === 'Select' ? df.options || '' : '',
+      options: df.fieldtype === 'Select' ? normalizeParameterOptionsValue(df.options || '') : '',
       child_table_name: '',
     }));
 };

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,40 +1,114 @@
 import * as React from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
 const Tabs = TabsPrimitive.Root;
 
+type TabsVariant = 'underline' | 'pill';
+
+const TabsVariantContext = React.createContext<TabsVariant>('underline');
+const TabsSizeContext = React.createContext<'default' | 'compact'>('default');
+
+const tabsListVariants = cva('gap-0', {
+  variants: {
+    variant: {
+      underline:
+        'inline-flex items-center justify-start border-b border-ink bg-transparent p-0',
+      pill: 'inline-flex items-center justify-center rounded-lg bg-muted p-1',
+    },
+    layout: {
+      inline: '',
+      grid: 'grid w-full',
+      scroll:
+        'flex h-auto w-full justify-start overflow-x-auto overflow-y-hidden',
+    },
+    size: {
+      default: '',
+      compact: 'h-8',
+    },
+  },
+  defaultVariants: {
+    variant: 'underline',
+    layout: 'inline',
+    size: 'default',
+  },
+});
+
+const tabsTriggerVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 transition-colors',
+  {
+    variants: {
+      variant: {
+        underline:
+          'border-b-2 border-transparent px-4 pb-2 font-mono text-[11.5px] uppercase tracking-wide text-steel hover:text-ink data-[state=active]:-mb-px data-[state=active]:border-signal data-[state=active]:text-ink',
+        pill: 'rounded-md px-3 py-1 text-xs font-medium text-muted-foreground hover:text-foreground data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      },
+      size: {
+        default: '',
+        compact: 'h-7',
+      },
+    },
+    defaultVariants: {
+      variant: 'underline',
+      size: 'default',
+    },
+  },
+);
+
+interface TabsListProps
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>,
+    VariantProps<typeof tabsListVariants> {
+  cols?: number;
+}
+
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  // HUF: underline tabs — shared 1px --ink baseline, no pill container
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      'inline-flex items-center justify-start border-b border-ink bg-transparent p-0 gap-0',
-      className
-    )}
-    {...props}
-  />
+  TabsListProps
+>(({ className, variant = 'underline', layout = 'inline', size = 'default', cols, style, ...props }, ref) => (
+  <TabsVariantContext.Provider value={variant ?? 'underline'}>
+    <TabsSizeContext.Provider value={size ?? 'default'}>
+      <TabsPrimitive.List
+        ref={ref}
+        style={
+          layout === 'grid' && cols
+            ? { ...style, gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }
+            : style
+        }
+        className={cn(tabsListVariants({ variant, layout, size }), className)}
+        {...props}
+      />
+    </TabsSizeContext.Provider>
+  </TabsVariantContext.Provider>
 ));
 TabsList.displayName = TabsPrimitive.List.displayName;
 
+interface TabsTriggerProps
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>,
+    VariantProps<typeof tabsTriggerVariants> {}
+
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  // HUF: mono 11.5px uppercase, --steel default, signal-orange 2px bottom on active
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap px-4 pb-2 font-mono text-[11.5px] uppercase tracking-wide text-steel transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-ink data-[state=active]:border-b-2 data-[state=active]:border-signal data-[state=active]:-mb-px hover:text-ink',
-      className
-    )}
-    {...props}
-  />
-));
+  TabsTriggerProps
+>(({ className, variant, size, ...props }, ref) => {
+  const contextVariant = React.useContext(TabsVariantContext);
+  const contextSize = React.useContext(TabsSizeContext);
+
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        tabsTriggerVariants({
+          variant: variant ?? contextVariant,
+          size: size ?? contextSize,
+        }),
+        className,
+      )}
+      {...props}
+    />
+  );
+});
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
@@ -45,7 +119,7 @@ const TabsContent = React.forwardRef<
     ref={ref}
     className={cn(
       'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      className
+      className,
     )}
     {...props}
   />

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -35,6 +35,7 @@ import type { MCPServerDoc } from '../services/mcpApi';
 import type { AgentKnowledgeRow } from '../types/agent.types';
 import { createFormSubmitHandler, type TabFieldMapping } from '../utils/formValidation';
 import { writeToolDetailsSetting } from '../components/chat/useChatAgentIdentity';
+import { useSaveShortcut } from '../hooks/useSaveShortcut';
 
 type PromptListRow = {
   name: string;
@@ -1206,6 +1207,12 @@ setAllowChat(values.allow_chat);
     [form, activeTab, tabFieldMapping, tabLabels, onSubmit]
   );
 
+  useSaveShortcut({
+    onSave: handleFormSubmit,
+    enabled: showSaveButton,
+    isSubmitting: saving,
+  });
+
   const handleOptimizePrompt = () => {
     setOptimizingPrompt((value) => value);
     toast.info('Coming Soon!');
@@ -1591,13 +1598,13 @@ setAllowChat(values.allow_chat);
         <Form {...form}>
           <form onSubmit={handleFormSubmit} className="space-y-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <TabsList className="flex h-auto w-full justify-start overflow-x-auto overflow-y-hidden p-1">
+              <TabsList layout="scroll" className="w-full">
                 {Object.entries(tabConfig).map(([tabKey, config]) => (
                   <TabsTrigger
                     key={tabKey}
                     value={tabKey}
                     disabled={config.disabled}
-                    className="flex-1 shrink-0"
+                    className="min-w-0 shrink-0 flex-1 px-2 sm:min-w-[110px] sm:px-3"
                   >
                     {config.label}
                   </TabsTrigger>

--- a/frontend/src/pages/IntegrationSettingsDetailsPage.tsx
+++ b/frontend/src/pages/IntegrationSettingsDetailsPage.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/types/integration.types';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
 import { createFormSubmitHandler, type TabFieldMapping } from '@/utils/formValidation';
+import { useSaveShortcut } from '@/hooks/useSaveShortcut';
 
 export function IntegrationSettingsDetailsPage() {
   const { settingId } = useParams<{ settingId: string }>();
@@ -341,6 +342,14 @@ export function IntegrationSettingsDetailsPage() {
     [form, activeTab, tabFieldMapping, tabLabels, onSubmit],
   );
 
+  const showSaveButton = isNew || isDirty;
+
+  useSaveShortcut({
+    onSave: handleFormSubmit,
+    enabled: showSaveButton,
+    isSubmitting: saving,
+  });
+
   const handleDelete = async () => {
     if (!settingId || isNew) return;
 
@@ -401,7 +410,7 @@ export function IntegrationSettingsDetailsPage() {
           isActive={watchIsActive}
           isDefault={watchIsDefault}
           isNew={isNew}
-          showSaveButton={isNew || isDirty}
+          showSaveButton={showSaveButton}
           saving={saving}
           deleting={deleting}
           onSave={handleFormSubmit}
@@ -411,7 +420,7 @@ export function IntegrationSettingsDetailsPage() {
         <Form {...form}>
           <form onSubmit={handleFormSubmit} className="space-y-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <TabsList className={`grid w-full grid-cols-${tabCols}`} style={{ gridTemplateColumns: `repeat(${tabCols}, minmax(0, 1fr))` }}>
+              <TabsList layout="grid" cols={tabCols}>
                 {Object.entries(tabConfig).map(([tabKey, config]) => (
                   <TabsTrigger key={tabKey} value={tabKey} disabled={config.disabled}>
                     {config.label}

--- a/frontend/src/pages/KnowledgeSourceFormPage.tsx
+++ b/frontend/src/pages/KnowledgeSourceFormPage.tsx
@@ -24,6 +24,7 @@ import {
 } from '../components/knowledge/types';
 import type { KnowledgeSourceDoc } from '../types/knowledge.types';
 import { createFormSubmitHandler, type TabFieldMapping } from '../utils/formValidation';
+import { useSaveShortcut } from '../hooks/useSaveShortcut';
 
 export { KnowledgeSourceFormPage };
 export default KnowledgeSourceFormPage;
@@ -216,6 +217,12 @@ function KnowledgeSourceFormPage() {
     [form, activeTab, tabFieldMapping, tabLabels],
   );
 
+  useSaveShortcut({
+    onSave: handleFormSubmit,
+    enabled: showSaveButton,
+    isSubmitting: saving,
+  });
+
   const handleRebuildIndex = async () => {
     if (!id || isNew) return;
     setRebuilding(true);
@@ -279,7 +286,7 @@ function KnowledgeSourceFormPage() {
         <Form {...form}>
           <form onSubmit={handleFormSubmit} className="space-y-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <TabsList className="grid w-full grid-cols-2">
+              <TabsList layout="grid" cols={2}>
                 {Object.entries(tabConfig).map(([tabKey, config]) => (
                   <TabsTrigger key={tabKey} value={tabKey} disabled={config.disabled}>
                     {config.label}

--- a/frontend/src/pages/McpDetailsPage.tsx
+++ b/frontend/src/pages/McpDetailsPage.tsx
@@ -13,6 +13,7 @@ import { ConnectionTab } from '../components/mcp/ConnectionTab';
 import { ToolsTab } from '../components/mcp/ToolsTab';
 import { mcpFormSchema, type MCPFormValues, type MCPTool } from '../components/mcp/types';
 import { createFormSubmitHandler, type TabFieldMapping } from '../utils/formValidation';
+import { useSaveShortcut } from '../hooks/useSaveShortcut';
 
 export function McpDetailsPage() {
   const { mcpId } = useParams<{ mcpId: string }>();
@@ -252,6 +253,12 @@ export function McpDetailsPage() {
   // Show save button for new servers or when form is dirty
   const showSaveButton = isNew || isDirty;
 
+  useSaveShortcut({
+    onSave: handleFormSubmit,
+    enabled: showSaveButton,
+    isSubmitting: saving,
+  });
+
   // Handle tool sync (used by header button)
   const handleSyncTools = async () => {
     if (!mcpId || isNew) {
@@ -370,7 +377,7 @@ export function McpDetailsPage() {
         <Form {...form}>
           <form onSubmit={handleFormSubmit} className="space-y-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <TabsList className="grid w-full grid-cols-3">
+              <TabsList layout="grid" cols={3}>
                 {Object.entries(tabConfig).map(([tabKey, config]) => (
                   <TabsTrigger key={tabKey} value={tabKey} disabled={config.disabled}>
                     {config.label}

--- a/huf/ai/app_seeding/loaders.py
+++ b/huf/ai/app_seeding/loaders.py
@@ -1,13 +1,43 @@
 import frappe
 
 
+def _validate_row_link_refs(child_doctype: str, row: dict, row_index: int) -> list:
+    """Validate Link and Dynamic Link fields in a single child table row."""
+    missing = []
+    child_meta = frappe.get_meta(child_doctype)
+
+    for field in child_meta.get_link_fields():
+        value = row.get(field.fieldname)
+        if not value:
+            continue
+        target_doctype = field.options
+        if not frappe.db.exists(target_doctype, value):
+            missing.append(f"{child_doctype}[{row_index}].{target_doctype}:{value}")
+
+    for field in child_meta.get_dynamic_link_fields():
+        value = row.get(field.fieldname)
+        if not value:
+            continue
+        target_doctype = row.get(field.options)
+        if not target_doctype:
+            continue
+        if not frappe.db.exists(target_doctype, value):
+            missing.append(f"{child_doctype}[{row_index}].{target_doctype}:{value}")
+
+    return missing
+
+
 def _validate_link_refs(doctype: str, data: dict) -> list:
     """
     Validate that all Link-field values in `data` reference existing documents.
 
+    Covers main-doc Link fields, child-table Link fields, Table MultiSelect
+    fields, and Dynamic Link fields.
+
     Returns a flat list of missing reference strings:
-      - Main doc: "<Target Doctype>:<missing name>"
-      - Child table: "<Child Doctype>[<row_index>].<Target Doctype>:<missing name>"
+      - Main doc Link: "<Target Doctype>:<missing name>"
+      - Dynamic Link: "<Target Doctype>:<missing name>"
+      - Child table / Table MultiSelect: "<Child Doctype>[<row_index>].<Target Doctype>:<missing name>"
     """
     missing = []
 
@@ -22,25 +52,46 @@ def _validate_link_refs(doctype: str, data: dict) -> list:
         if not frappe.db.exists(target_doctype, value):
             missing.append(f"{target_doctype}:{value}")
 
-    # Child table Link fields
+    # Main doc Dynamic Link fields
+    for field in meta.get_dynamic_link_fields():
+        value = data.get(field.fieldname)
+        if not value:
+            continue
+        target_doctype = data.get(field.options)
+        if not target_doctype:
+            continue
+        if not frappe.db.exists(target_doctype, value):
+            missing.append(f"{target_doctype}:{value}")
+
+    # Standard child table Link and Dynamic Link fields
     for table_field in meta.get_table_fields():
         rows = data.get(table_field.fieldname)
         if not isinstance(rows, list):
             continue
         child_doctype = table_field.options
-        child_meta = frappe.get_meta(child_doctype)
         for row_index, row in enumerate(rows):
             if not isinstance(row, dict):
                 continue
-            for field in child_meta.get_link_fields():
-                value = row.get(field.fieldname)
-                if not value:
-                    continue
-                target_doctype = field.options
-                if not frappe.db.exists(target_doctype, value):
-                    missing.append(
-                        f"{child_doctype}[{row_index}].{target_doctype}:{value}"
-                    )
+            missing.extend(_validate_row_link_refs(child_doctype, row, row_index))
+
+    # Table MultiSelect fields
+    for field in meta.fields:
+        if field.fieldtype != "Table MultiSelect":
+            continue
+        rows = data.get(field.fieldname)
+        if not isinstance(rows, list):
+            continue
+        child_doctype = field.options
+        child_meta = frappe.get_meta(child_doctype)
+        link_fields = child_meta.get_link_fields()
+        if not link_fields:
+            continue
+        for row_index, row in enumerate(rows):
+            if isinstance(row, str):
+                row = {link_fields[0].fieldname: row}
+            if not isinstance(row, dict):
+                continue
+            missing.extend(_validate_row_link_refs(child_doctype, row, row_index))
 
     return missing
 
@@ -55,7 +106,7 @@ def _upsert_doc(doctype: str, key_field: str, data: dict, source_app: str, sourc
 
     missing_refs = _validate_link_refs(doctype, data)
     if missing_refs:
-        return False, "Missing reference(s): " + ", ".join(missing_refs)
+        return False, {"reason": "missing_refs", "missing_refs": missing_refs}
 
     docname = frappe.db.get_value(doctype, {key_field: key_val})
 

--- a/huf/ai/app_seeding/loaders.py
+++ b/huf/ai/app_seeding/loaders.py
@@ -1,5 +1,50 @@
 import frappe
 
+
+def _validate_link_refs(doctype: str, data: dict) -> list:
+    """
+    Validate that all Link-field values in `data` reference existing documents.
+
+    Returns a flat list of missing reference strings:
+      - Main doc: "<Target Doctype>:<missing name>"
+      - Child table: "<Child Doctype>[<row_index>].<Target Doctype>:<missing name>"
+    """
+    missing = []
+
+    meta = frappe.get_meta(doctype)
+
+    # Main doc Link fields
+    for field in meta.get_link_fields():
+        value = data.get(field.fieldname)
+        if not value:
+            continue
+        target_doctype = field.options
+        if not frappe.db.exists(target_doctype, value):
+            missing.append(f"{target_doctype}:{value}")
+
+    # Child table Link fields
+    for table_field in meta.get_table_fields():
+        rows = data.get(table_field.fieldname)
+        if not isinstance(rows, list):
+            continue
+        child_doctype = table_field.options
+        child_meta = frappe.get_meta(child_doctype)
+        for row_index, row in enumerate(rows):
+            if not isinstance(row, dict):
+                continue
+            for field in child_meta.get_link_fields():
+                value = row.get(field.fieldname)
+                if not value:
+                    continue
+                target_doctype = field.options
+                if not frappe.db.exists(target_doctype, value):
+                    missing.append(
+                        f"{child_doctype}[{row_index}].{target_doctype}:{value}"
+                    )
+
+    return missing
+
+
 def _upsert_doc(doctype: str, key_field: str, data: dict, source_app: str, source_file: str) -> tuple:
     """
     Generic upsert for a seed document.
@@ -7,13 +52,17 @@ def _upsert_doc(doctype: str, key_field: str, data: dict, source_app: str, sourc
     key_val = data.get(key_field)
     if not key_val:
         return False, f"Missing {key_field}"
-        
+
+    missing_refs = _validate_link_refs(doctype, data)
+    if missing_refs:
+        return False, "Missing reference(s): " + ", ".join(missing_refs)
+
     docname = frappe.db.get_value(doctype, {key_field: key_val})
-    
+
     # Add provenance fields
     data["source_app"] = source_app
     data["source_file"] = source_file
-    
+
     try:
         if docname:
             doc = frappe.get_doc(doctype, docname)

--- a/huf/ai/app_seeding/seeder.py
+++ b/huf/ai/app_seeding/seeder.py
@@ -1,7 +1,7 @@
 import json
 import frappe
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 
 from .scanner import find_seed_dirs, get_seed_files
@@ -19,6 +19,7 @@ class SeedResult:
     seeded: int
     skipped: int
     errors: List[str]
+    skipped_records: List[dict] = field(default_factory=list)
 
 # Load order matters for dependency resolution
 LOAD_ORDER = [
@@ -52,6 +53,20 @@ def seed_app(app_name: str, huf_dir: Path) -> SeedResult:
                         # Use a fallback name if the key isn't standard across all types
                         item_name = item.get('name') or item.get('title') or item.get('agent_name') or item.get('tool_name') or item.get('source_name') or file_path.name
                         result.errors.append(f"Failed to seed {item_name}: {error}")
+
+                        missing_refs = []
+                        prefix = "Missing reference(s): "
+                        if error and error.startswith(prefix):
+                            refs_part = error[len(prefix):]
+                            missing_refs = refs_part.split(", ") if refs_part else []
+
+                        result.skipped_records.append({
+                            "app": app_name,
+                            "file": source_file,
+                            "record": item_name,
+                            "error": error,
+                            "missing_refs": missing_refs,
+                        })
             except Exception as e:
                 result.skipped += 1
                 result.errors.append(f"Error parsing {file_path.name}: {e}")

--- a/huf/ai/app_seeding/seeder.py
+++ b/huf/ai/app_seeding/seeder.py
@@ -52,19 +52,21 @@ def seed_app(app_name: str, huf_dir: Path) -> SeedResult:
                         result.skipped += 1
                         # Use a fallback name if the key isn't standard across all types
                         item_name = item.get('name') or item.get('title') or item.get('agent_name') or item.get('tool_name') or item.get('source_name') or file_path.name
-                        result.errors.append(f"Failed to seed {item_name}: {error}")
 
-                        missing_refs = []
-                        prefix = "Missing reference(s): "
-                        if error and error.startswith(prefix):
-                            refs_part = error[len(prefix):]
-                            missing_refs = refs_part.split(", ") if refs_part else []
+                        if isinstance(error, dict) and error.get("reason") == "missing_refs":
+                            missing_refs = error.get("missing_refs", [])
+                            error_str = "Missing reference(s): " + ", ".join(missing_refs)
+                        else:
+                            missing_refs = []
+                            error_str = str(error)
+
+                        result.errors.append(f"Failed to seed {item_name}: {error_str}")
 
                         result.skipped_records.append({
                             "app": app_name,
                             "file": source_file,
                             "record": item_name,
-                            "error": error,
+                            "error": error_str,
                             "missing_refs": missing_refs,
                         })
             except Exception as e:

--- a/huf/ai/app_seeding/tests/test_seed_fk.py
+++ b/huf/ai/app_seeding/tests/test_seed_fk.py
@@ -8,10 +8,12 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import frappe
 
-from huf.ai.app_seeding.seeder import seed_app
+from huf.ai.app_seeding.loaders import _upsert_doc, _validate_link_refs
+from huf.ai.app_seeding.seeder import seed_app, seed_all_apps
 
 
 class TestSeedFKValidation(unittest.TestCase):
@@ -54,6 +56,8 @@ class TestSeedFKValidation(unittest.TestCase):
                 frappe.db.sql("DELETE FROM `tabAgent` WHERE agent_name = %s", agent_name)
                 frappe.db.sql("DELETE FROM `tabAgent Tool` WHERE parent = %s", agent_name)
                 frappe.db.sql("DELETE FROM `tabAgent Knowledge` WHERE parent = %s", agent_name)
+                frappe.db.sql("DELETE FROM `tabAgent User` WHERE parent = %s", agent_name)
+                frappe.db.sql("DELETE FROM `tabAgent Role` WHERE parent = %s", agent_name)
             except Exception:
                 pass
 
@@ -74,7 +78,8 @@ class TestSeedFKValidation(unittest.TestCase):
             json.dump(payload, f)
         return target_path
 
-    def _agent_payload(self, agent_name, provider, model, tools=None, knowledge=None):
+    def _agent_payload(self, agent_name, provider, model, tools=None, knowledge=None,
+                        allowed_users=None, allowed_roles=None):
         payload = {
             "agent_name": agent_name,
             "provider": provider,
@@ -85,6 +90,10 @@ class TestSeedFKValidation(unittest.TestCase):
             payload["tools"] = tools
         if knowledge is not None:
             payload["knowledge"] = knowledge
+        if allowed_users is not None:
+            payload["allowed_users"] = allowed_users
+        if allowed_roles is not None:
+            payload["allowed_roles"] = allowed_roles
         return payload
 
     def test_invalid_agent_missing_provider_model_is_skipped(self):
@@ -193,6 +202,136 @@ class TestSeedFKValidation(unittest.TestCase):
             any("Agent Tool Function" in ref and f"FK-Missing-Tool-{self.suffix}" in ref for ref in skipped["missing_refs"]),
             "Missing child-table tool reference should be reported",
         )
+
+    def test_loader_returns_structured_missing_refs_payload(self):
+        """AC5: loaders return missing refs as a structured payload;
+        seeder does not parse error strings."""
+        agent_name = f"FK-Structured-Agent-{self.suffix}"
+        data = {
+            "agent_name": agent_name,
+            "provider": self.invalid_provider,
+            "model": self.invalid_model,
+            "instructions": "test",
+        }
+
+        ok, error = _upsert_doc("Agent", "agent_name", data, self.test_app, "huf/agents/test.json")
+
+        self.assertFalse(ok)
+        self.assertIsInstance(error, dict)
+        self.assertEqual(error.get("reason"), "missing_refs")
+        self.assertIn(f"AI Provider:{self.invalid_provider}", error["missing_refs"])
+        self.assertIn(f"AI Model:{self.invalid_model}", error["missing_refs"])
+
+    def test_table_multiselect_references_are_validated(self):
+        """AC6: Table MultiSelect fields (Agent.allowed_users, Agent.allowed_roles)
+        are validated and missing values are reported."""
+        agent_name = f"FK-MultiSelect-Agent-{self.suffix}"
+        self._write_seed(
+            "agents",
+            "multiselect_agent.json",
+            self._agent_payload(
+                agent_name,
+                self.valid_provider,
+                self.valid_model,
+                allowed_users=[f"FK-Missing-User-{self.suffix}"],
+                allowed_roles=[f"FK-Missing-Role-{self.suffix}"],
+            ),
+        )
+
+        result = seed_app(self.test_app, self.huf_dir)
+
+        self.assertFalse(frappe.db.exists("Agent", agent_name))
+        self.assertEqual(result.skipped, 1)
+        skipped = result.skipped_records[0]
+        missing = skipped["missing_refs"]
+        self.assertTrue(
+            any("User" in ref and f"FK-Missing-User-{self.suffix}" in ref for ref in missing),
+            "Missing allowed_users reference should be reported",
+        )
+        self.assertTrue(
+            any("Role" in ref and f"FK-Missing-Role-{self.suffix}" in ref for ref in missing),
+            "Missing allowed_roles reference should be reported",
+        )
+
+    def test_dynamic_link_references_are_validated(self):
+        """AC6: Dynamic Link fields are validated and missing values are reported.
+        Uses Agent Context Artifact schema because no seeded DocType currently
+        carries a Dynamic Link field."""
+        missing = _validate_link_refs("Agent Context Artifact", {
+            "artifact_type": "JSON",
+            "reference_doctype": "Agent",
+            "reference_name": f"FK-Missing-Agent-{self.suffix}",
+        })
+
+        self.assertTrue(
+            any("Agent" in ref and f"FK-Missing-Agent-{self.suffix}" in ref for ref in missing),
+            "Missing Dynamic Link reference should be reported",
+        )
+
+    def test_migrate_emits_warning_logs_for_skipped_records(self):
+        """AC7: every skipped record produces a WARNING-level structured log during
+        migrate naming app, file, record, and missing refs."""
+        from huf.install import _log_seed_results
+
+        agent_name = f"FK-Logged-Agent-{self.suffix}"
+        self._write_seed(
+            "agents",
+            "logged_agent.json",
+            self._agent_payload(agent_name, self.invalid_provider, self.invalid_model),
+        )
+        result = seed_app(self.test_app, self.huf_dir)
+
+        logger = MagicMock()
+        _log_seed_results([result], logger)
+
+        warning_calls = [c for c in logger.warning.call_args_list]
+        self.assertTrue(warning_calls, "At least one warning log should be emitted")
+
+        per_record_logged = False
+        for call in warning_calls:
+            payload = json.loads(call.args[0])
+            if payload.get("record") == agent_name:
+                per_record_logged = True
+                self.assertEqual(payload["app"], self.test_app)
+                self.assertEqual(payload["file"], "huf/agents/logged_agent.json")
+                self.assertIn(f"AI Provider:{self.invalid_provider}", payload["missing_refs"])
+                self.assertIn(f"AI Model:{self.invalid_model}", payload["missing_refs"])
+
+        self.assertTrue(per_record_logged, "Per-record warning log should name app, file, record, and missing refs")
+
+    def test_sync_app_seeds_endpoint_returns_skipped_record_summaries(self):
+        """AC8: the Sync App Seeds backend endpoint returns per-record missing-ref
+        summaries so the Desk dialog can display them."""
+        agent_name = f"FK-UI-Agent-{self.suffix}"
+        self._write_seed(
+            "agents",
+            "ui_agent.json",
+            self._agent_payload(agent_name, self.invalid_provider, self.invalid_model),
+        )
+
+        # Patch scanner to discover our temp test app directory
+        from huf.ai.app_seeding import seeder as seeder_module
+        original_find_seed_dirs = seeder_module.find_seed_dirs
+        seeder_module.find_seed_dirs = lambda: {self.test_app: self.huf_dir}
+        try:
+            frappe.set_user("Administrator")
+            response = seed_all_apps()
+        finally:
+            seeder_module.find_seed_dirs = original_find_seed_dirs
+
+        self.assertEqual(response["status"], "success")
+        results = response.get("results", [])
+        self.assertTrue(results, "Response should include per-app results")
+
+        matching = [
+            rec for res in results
+            for rec in res.get("skipped_records", [])
+            if rec.get("record") == agent_name
+        ]
+        self.assertTrue(matching, "Skipped record summary should be returned")
+        rec = matching[0]
+        self.assertIn(f"AI Provider:{self.invalid_provider}", rec["missing_refs"])
+        self.assertIn(f"AI Model:{self.invalid_model}", rec["missing_refs"])
 
 
 if __name__ == "__main__":

--- a/huf/ai/app_seeding/tests/test_seed_fk.py
+++ b/huf/ai/app_seeding/tests/test_seed_fk.py
@@ -1,0 +1,199 @@
+"""
+Tests for seed Link-field reference validation.
+Run with:
+    bench --site hufai.localhost run-tests --app huf --module huf.ai.app_seeding.tests.test_seed_fk
+"""
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import frappe
+
+from huf.ai.app_seeding.seeder import seed_app
+
+
+class TestSeedFKValidation(unittest.TestCase):
+    """Acceptance tests for seed foreign-reference validation."""
+
+    def setUp(self):
+        self.test_app = "test_seed_fk_app"
+        self.huf_dir = Path(tempfile.mkdtemp()) / "huf"
+        self.huf_dir.mkdir()
+
+        # Unique suffix to avoid collisions across test runs
+        self.suffix = frappe.generate_hash(length=8)
+        self.valid_provider = f"FK-Valid-Provider-{self.suffix}"
+        self.valid_model = f"FK-Valid-Model-{self.suffix}"
+        self.invalid_provider = f"FK-Invalid-Provider-{self.suffix}"
+        self.invalid_model = f"FK-Invalid-Model-{self.suffix}"
+
+        # Create a real AI Provider and AI Model for valid seeds
+        self.provider_doc = frappe.get_doc({
+            "doctype": "AI Provider",
+            "provider_name": self.valid_provider,
+            "api_key": "test-key",
+        }).insert(ignore_permissions=True)
+
+        self.model_doc = frappe.get_doc({
+            "doctype": "AI Model",
+            "model_name": self.valid_model,
+            "provider": self.valid_provider,
+        }).insert(ignore_permissions=True)
+
+        self._created_agents = []
+
+    def tearDown(self):
+        # Remove temp seed directory
+        shutil.rmtree(self.huf_dir.parent, ignore_errors=True)
+
+        # Delete agents created by tests
+        for agent_name in self._created_agents:
+            try:
+                frappe.db.sql("DELETE FROM `tabAgent` WHERE agent_name = %s", agent_name)
+                frappe.db.sql("DELETE FROM `tabAgent Tool` WHERE parent = %s", agent_name)
+                frappe.db.sql("DELETE FROM `tabAgent Knowledge` WHERE parent = %s", agent_name)
+            except Exception:
+                pass
+
+        # Delete model and provider
+        try:
+            frappe.db.sql("DELETE FROM `tabAI Model` WHERE name = %s", self.model_doc.name)
+            frappe.db.sql("DELETE FROM `tabAI Provider` WHERE name = %s", self.provider_doc.name)
+        except Exception:
+            pass
+
+        frappe.db.commit()
+
+    def _write_seed(self, folder, filename, payload):
+        target_dir = self.huf_dir / folder
+        target_dir.mkdir(exist_ok=True)
+        target_path = target_dir / filename
+        with open(target_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        return target_path
+
+    def _agent_payload(self, agent_name, provider, model, tools=None, knowledge=None):
+        payload = {
+            "agent_name": agent_name,
+            "provider": provider,
+            "model": model,
+            "instructions": "Test instructions",
+        }
+        if tools is not None:
+            payload["tools"] = tools
+        if knowledge is not None:
+            payload["knowledge"] = knowledge
+        return payload
+
+    def test_invalid_agent_missing_provider_model_is_skipped(self):
+        """AC1: a seed referencing a nonexistent AI Provider/AI Model is NOT inserted,
+        and the log/summary names the app, file, and missing references."""
+        agent_name = f"FK-Invalid-Agent-{self.suffix}"
+        self._write_seed(
+            "agents",
+            "invalid_agent.json",
+            self._agent_payload(agent_name, self.invalid_provider, self.invalid_model),
+        )
+
+        result = seed_app(self.test_app, self.huf_dir)
+
+        self.assertFalse(
+            frappe.db.exists("Agent", agent_name),
+            "Invalid agent seed should not be inserted",
+        )
+        self.assertEqual(result.seeded, 0)
+        self.assertEqual(result.skipped, 1)
+        self.assertEqual(len(result.skipped_records), 1)
+
+        skipped = result.skipped_records[0]
+        self.assertEqual(skipped["app"], self.test_app)
+        self.assertEqual(skipped["file"], "huf/agents/invalid_agent.json")
+        self.assertEqual(skipped["record"], agent_name)
+        self.assertIn("Missing reference(s):", skipped["error"])
+
+        missing = skipped["missing_refs"]
+        self.assertIn(f"AI Provider:{self.invalid_provider}", missing)
+        self.assertIn(f"AI Model:{self.invalid_model}", missing)
+
+    def test_valid_agent_seed_loads(self):
+        """AC2: valid seeds in the same batch still load."""
+        agent_name = f"FK-Valid-Agent-{self.suffix}"
+        self._write_seed(
+            "agents",
+            "valid_agent.json",
+            self._agent_payload(agent_name, self.valid_provider, self.valid_model),
+        )
+        self._created_agents.append(agent_name)
+
+        result = seed_app(self.test_app, self.huf_dir)
+
+        self.assertTrue(
+            frappe.db.exists("Agent", agent_name),
+            "Valid agent seed should be inserted",
+        )
+        self.assertEqual(result.seeded, 1)
+        self.assertEqual(result.skipped, 0)
+        self.assertEqual(len(result.skipped_records), 0)
+
+    def test_seed_app_completes_with_mixed_valid_invalid(self):
+        """AC3: migrate (seed_all) completes successfully despite invalid seeds,
+        and valid seeds still load while invalid ones are skipped."""
+        valid_agent = f"FK-Mixed-Valid-Agent-{self.suffix}"
+        invalid_agent = f"FK-Mixed-Invalid-Agent-{self.suffix}"
+        self._created_agents.append(valid_agent)
+
+        self._write_seed(
+            "agents",
+            "valid_agent.json",
+            self._agent_payload(valid_agent, self.valid_provider, self.valid_model),
+        )
+        self._write_seed(
+            "agents",
+            "invalid_agent.json",
+            self._agent_payload(invalid_agent, self.invalid_provider, self.invalid_model),
+        )
+
+        # seed_app must not raise
+        result = seed_app(self.test_app, self.huf_dir)
+
+        self.assertTrue(
+            frappe.db.exists("Agent", valid_agent),
+            "Valid agent should be inserted even when mixed with invalid seeds",
+        )
+        self.assertFalse(
+            frappe.db.exists("Agent", invalid_agent),
+            "Invalid agent should be skipped",
+        )
+        self.assertEqual(result.seeded, 1)
+        self.assertEqual(result.skipped, 1)
+        self.assertEqual(len(result.skipped_records), 1)
+
+    def test_invalid_child_table_reference_is_skipped(self):
+        """Child-table Link references are also validated (agent tools)."""
+        agent_name = f"FK-Child-Table-Agent-{self.suffix}"
+        self._write_seed(
+            "agents",
+            "child_table_agent.json",
+            self._agent_payload(
+                agent_name,
+                self.valid_provider,
+                self.valid_model,
+                tools=[f"FK-Missing-Tool-{self.suffix}"],
+            ),
+        )
+
+        result = seed_app(self.test_app, self.huf_dir)
+
+        self.assertFalse(frappe.db.exists("Agent", agent_name))
+        self.assertEqual(result.skipped, 1)
+        skipped = result.skipped_records[0]
+        self.assertTrue(
+            any("Agent Tool Function" in ref and f"FK-Missing-Tool-{self.suffix}" in ref for ref in skipped["missing_refs"]),
+            "Missing child-table tool reference should be reported",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/huf/doctype/agent_settings/agent_settings.js
+++ b/huf/huf/doctype/agent_settings/agent_settings.js
@@ -14,6 +14,39 @@ frappe.ui.form.on("Agent Settings", {
 							message: __(r.message.message),
 							indicator: "green"
 						});
+
+						const results = r.message.results || [];
+						const skipped = results.flatMap((res) =>
+							(res.skipped_records || []).map((rec) => ({
+								app: rec.app || res.app,
+								file: rec.file,
+								record: rec.record,
+								missing: (rec.missing_refs || []).join(", ") || rec.error,
+							}))
+						);
+
+						if (skipped.length) {
+							const rows = skipped
+								.map(
+									(rec) =>
+										`<tr><td>${frappe.utils.escape_html(rec.app)}</td>` +
+										`<td>${frappe.utils.escape_html(rec.file)}</td>` +
+										`<td>${frappe.utils.escape_html(rec.record)}</td>` +
+										`<td>${frappe.utils.escape_html(rec.missing)}</td></tr>`
+								)
+								.join("");
+							const html =
+								`<p>${__("The following seeds were skipped because they reference missing documents:")}</p>` +
+								`<table class="table table-bordered table-hover table-striped">` +
+								`<thead><tr>` +
+								`<th>${__("App")}</th><th>${__("File")}</th><th>${__("Record")}</th><th>${__("Missing References")}</th>` +
+								`</tr></thead><tbody>${rows}</tbody></table>`;
+							frappe.msgprint({
+								message: html,
+								title: __("Skipped Seeds"),
+								indicator: "orange",
+							});
+						}
 					}
 				}
 			});

--- a/huf/install.py
+++ b/huf/install.py
@@ -5,6 +5,8 @@
 Installation hooks for Huf app
 """
 
+import json
+
 import frappe
 from huf.utils import is_frappe_16
 
@@ -134,11 +136,27 @@ def after_migrate():
 	try:
 		from huf.ai.app_seeding.seeder import seed_all
 		results = list(seed_all())
-		for r in results:
-			if r.errors:
-				frappe.log_error(f"Seeding errors for {r.app}: {r.errors}", "App Seeding")
+		logger = frappe.logger("app_seeding")
+		_log_seed_results(results, logger)
 	except Exception as e:
 		frappe.log_error(f"App seeding failed: {e}", "App Seeding")
+
+
+def _log_seed_results(results, logger):
+	"""Emit WARNING-level structured logs for skipped seed records and per-app summaries."""
+	for r in results:
+		for rec in r.skipped_records:
+			logger.warning(json.dumps({
+				"app": rec["app"],
+				"file": rec["file"],
+				"record": rec["record"],
+				"missing_refs": rec.get("missing_refs", [])
+			}))
+		logger.warning(json.dumps({
+			"app": r.app,
+			"skipped_count": r.skipped,
+			"seeded_count": r.seeded
+		}))
 
 def create_demo_ai_providers():
     providers = [


### PR DESCRIPTION
## Summary

Implements **seed foreign-reference (FK) validation** for the app-seeding pipeline (reference plan §5.5 "Seed Reference Validation", Phase 4 task 4.2 + follow-up 4.2.1): before upserting a seed record, all reference fields are validated against the database, invalid records are skipped with a structured report, and valid records in the same batch continue to load — so a bad seed file can never break `bench migrate`.

### Commits

- `344cbda4` — core implementation: validate Link-field references before upsert, report skipped records via a `SeedResult` payload, with tests.
- `60f9d278` — close the 4 gaps found in independent verification: structured missing-refs payload, Table MultiSelect + Dynamic Link coverage, WARNING-level structured migrate logs, Desk UI surfacing.

### What's validated

`_validate_link_refs()` in `huf/ai/app_seeding/loaders.py` now covers:

- main-doc **Link** fields
- main-doc **Dynamic Link** fields (doctype resolved from the companion field)
- child-table **Link** and **Dynamic Link** fields
- **Table MultiSelect** fields (previously nonexistent values passed silently)

### Behavior

- A seed record with any missing reference is **skipped, not inserted**; `SeedResult.skipped_records` carries `app`, `file`, `record`, and `missing_refs` for each.
- Valid seeds in the same batch still load; `seed_app()`/`seed_all()` never raise on bad seeds, so migrate always completes.
- `_upsert_doc()` returns a **structured payload** (`(False, {"reason": "missing_refs", "missing_refs": [...]})`) — no string-parsing of error messages, so document names containing `", "` can't corrupt the report.
- `after_migrate` emits a **WARNING-level structured (JSON) log per skipped record** via `frappe.logger("app_seeding")`, naming app, file, record, and missing refs.
- The **Sync App Seeds** Desk action (`agent_settings.js`) now shows the per-record missing-reference summary, not just aggregate counts.

## Verification

Independently verified in two passes (runtime + static review), logs tracked in the workspace repo under `ongoing/plan-review/` (`07-verify-seed-fk.md`, `08-verify-gap-closure.md`, `09-review-gap-commit.md`):

- **Tests:** 9/9 pass — `bench --site hufai.localhost run-tests --app huf --module huf.ai.app_seeding.tests.test_seed_fk`
- **Runtime probes** (`bench execute huf.ai.app_seeding.loaders._validate_link_refs`):
  - main-doc Link: fake `provider`/`model` on Agent → both reported as missing refs
  - Table MultiSelect: nonexistent `allowed_users`/`allowed_roles` on Agent → now reported (previously returned `[]`)
- **WARNING log path** exercised at runtime; structured JSON payload confirmed.
- **Static review** of the gap-closure diff: structured contract, MultiSelect/Dynamic Link handling, log emission, UI surfacing, and a regression scan of all `_upsert_doc` / `_validate_link_refs` / `seed_app` callers — all clean, 0 issues.

## Acceptance criteria (§5.5)

1. ✅ Record with nonexistent reference is not inserted; log names app, file, and missing reference
2. ✅ Valid seeds in the same batch still load
3. ✅ migrate/seed_all completes despite invalid seeds
4. ✅ Tests cover each behaviour
5. ✅ Structured missing-refs return (no error-message string-parsing)
6. ✅ Table MultiSelect + Dynamic Link coverage
7. ✅ WARNING-level structured log per skipped record during migrate
8. ✅ Sync App Seeds Desk dialog shows per-record missing-ref summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123zZXHHPwtzEv7Lr9HT6Ze
