### PR TITLE
feat(chat): inline video playback for chat messages

### DIFF
--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -19,6 +19,8 @@ import {
 import type { ComponentProps, ReactNode } from "react";
 import { isValidElement } from "react";
 import { CodeBlock } from "./code-block";
+import { Video } from "./video";
+import { extractVideoFromToolResult } from "@/components/chat/videoDetection";
 import type { ExtendedToolState } from "./types";
 
 export type ToolProps = ComponentProps<typeof Collapsible>;
@@ -135,7 +137,20 @@ export const ToolOutput = ({
 
   let Output = <div>{output as ReactNode}</div>;
 
-  if (typeof output === "object" && !isValidElement(output)) {
+  const detectedVideo = output ? extractVideoFromToolResult(output) : null;
+
+  if (detectedVideo) {
+    Output = (
+      <Video
+        src={detectedVideo.src}
+        mediaType={detectedVideo.mediaType}
+        title={detectedVideo.title}
+        poster={detectedVideo.poster}
+        downloadName={detectedVideo.downloadName}
+        className="max-w-md"
+      />
+    );
+  } else if (typeof output === "object" && !isValidElement(output)) {
     Output = (
       <CodeBlock code={JSON.stringify(output, null, 2)} language="json" />
     );

--- a/frontend/src/components/ai-elements/video.tsx
+++ b/frontend/src/components/ai-elements/video.tsx
@@ -1,0 +1,155 @@
+/**
+ * Video — HUF extension to the AI Elements component set (shadcn conventions).
+ *
+ * Renders browser-playable video (MP4, WebM, Ogg, MOV, m4v, and data: URIs)
+ * inline inside chat messages using the native HTML5 <video> element — no
+ * third-party player dependency. On a playback error it degrades to a clean
+ * fallback with Open / Download actions. Generic upload previews continue to
+ * use the existing Attachment UI. Advanced streaming formats (HLS/DASH) and
+ * provider embeds (YouTube/Vimeo) are intentionally NOT supported.
+ *
+ * This component is purely presentational — video *detection* (is a URL / MCP
+ * tool result a video?) lives in `@/components/chat/videoDetection`.
+ *
+ * Wired into chat via:
+ *  - ChatMessage.tsx     — `kind === 'Video'` renders <Video> for message.generatedVideo
+ *  - tool.tsx ToolOutput — MCP tool results carrying a video URL render <Video> inline
+ */
+import { useState } from "react";
+import type { ComponentPropsWithoutRef, ReactEventHandler } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Download, ExternalLink, VideoOff } from "lucide-react";
+
+export type VideoProps = ComponentPropsWithoutRef<"video"> & {
+  src: string;
+  title?: string;
+  poster?: string;
+  mediaType?: string;
+  className?: string;
+  captions?: Array<{ src: string; srcLang: string; label: string; default?: boolean }>;
+  downloadName?: string;
+  onError?: ReactEventHandler<HTMLVideoElement>;
+};
+
+export const Video = ({
+  src,
+  title,
+  poster,
+  mediaType,
+  className,
+  captions,
+  downloadName,
+  onError,
+  controls = true,
+  preload = "metadata",
+  autoPlay = false,
+  muted = false,
+  loop = false,
+  ...props
+}: VideoProps) => {
+  const [errored, setErrored] = useState(false);
+
+  if (!src) {
+    return null;
+  }
+
+  const handleError: ReactEventHandler<HTMLVideoElement> = (event) => {
+    setErrored(true);
+    // Strip the query string so we never log tokens/params from the URL.
+    const safeSrc = src.split("?")[0];
+    console.error("Video failed to play", {
+      label: title || downloadName,
+      mediaType,
+      src: safeSrc,
+    });
+    onError?.(event);
+  };
+
+  // Browsers block autoplay-with-sound, so force muted when autoplaying.
+  const effectiveMuted = autoPlay ? true : muted;
+
+  if (errored) {
+    const displayName = title || downloadName;
+    return (
+      <div
+        className={cn(
+          "w-full max-w-full overflow-hidden rounded-lg border bg-muted",
+          className
+        )}
+      >
+        <div className="flex flex-col gap-3 p-4">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <VideoOff className="h-4 w-4" aria-hidden="true" />
+            <span>Video could not be played</span>
+          </div>
+          {displayName && (
+            <div
+              className="truncate text-xs text-muted-foreground"
+              title={displayName}
+            >
+              {displayName}
+            </div>
+          )}
+          {src && (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  window.open(src, "_blank", "noopener,noreferrer")
+                }
+              >
+                <ExternalLink className="mr-1.5 h-4 w-4" />
+                Open
+              </Button>
+              <Button variant="outline" size="sm" asChild>
+                <a href={src} download={downloadName || ""}>
+                  <Download className="mr-1.5 h-4 w-4" />
+                  Download
+                </a>
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "w-full max-w-full overflow-hidden rounded-lg border bg-muted",
+        className
+      )}
+    >
+      <video
+        {...props}
+        src={mediaType ? undefined : src}
+        poster={poster}
+        title={title}
+        aria-label={title || downloadName || "Video"}
+        controls={controls}
+        preload={preload}
+        autoPlay={autoPlay}
+        muted={effectiveMuted}
+        loop={loop}
+        playsInline
+        onError={handleError}
+        className="block h-auto max-h-[70vh] w-full object-contain bg-black"
+      >
+        {mediaType && <source src={src} type={mediaType} />}
+        {captions?.map((caption, index) => (
+          <track
+            key={`${caption.srcLang}-${caption.src}-${index}`}
+            kind="captions"
+            src={caption.src}
+            srcLang={caption.srcLang}
+            label={caption.label}
+            default={caption.default}
+          />
+        ))}
+      </video>
+    </div>
+  );
+};

--- a/frontend/src/components/ai-elements/video.tsx
+++ b/frontend/src/components/ai-elements/video.tsx
@@ -20,6 +20,7 @@ import type { ComponentPropsWithoutRef, ReactEventHandler } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Download, ExternalLink, VideoOff } from "lucide-react";
+import { isAllowedVideoSrc } from "@/components/chat/videoDetection";
 
 export type VideoProps = ComponentPropsWithoutRef<"video"> & {
   src: string;
@@ -50,7 +51,10 @@ export const Video = ({
 }: VideoProps) => {
   const [errored, setErrored] = useState(false);
 
-  if (!src) {
+  // Treat a missing or disallowed-scheme src the same way: render nothing.
+  // A disallowed scheme (e.g. javascript:) must never reach <video src>,
+  // window.open(src), or <a href={src}> — all of which would execute it.
+  if (!src || !isAllowedVideoSrc(src)) {
     return null;
   }
 

--- a/frontend/src/components/chat/ArtifactRenderer.tsx
+++ b/frontend/src/components/chat/ArtifactRenderer.tsx
@@ -30,6 +30,7 @@ import {
 	LayoutIcon,
 	BarChartIcon,
 	ExternalLinkIcon,
+	VideoIcon,
 } from 'lucide-react';
 import type { ParsedArtifact, ArtifactType } from '@/types/artifact.types';
 import type { ParsedMessageContent } from '@/utils/messageContentParser';
@@ -37,6 +38,7 @@ import { writePreviewCache } from '@/utils/previewCache';
 import { cn } from '@/lib/utils';
 import { Mermaid } from '@/components/ui/mermaid';
 import { JSXPreview, JSXPreviewContent, JSXPreviewExport } from '@/components/ui/jsx-preview';
+import { Video } from '@/components/ai-elements/video';
 
 interface ArtifactRendererProps {
 	artifact: ParsedArtifact;
@@ -59,6 +61,7 @@ const ARTIFACT_ICONS: Record<ArtifactType, typeof CodeIcon> = {
 	markdown: FileTextIcon,
 	jsx: LayoutIcon,
 	chart: BarChartIcon,
+	video: VideoIcon,
 };
 
 // Map common language aliases to Shiki language names
@@ -232,6 +235,11 @@ export function ArtifactRenderer({
 						</details>
 					</div>
 				);
+
+			case 'video': {
+				const src = artifact.content.trim();
+				return <Video src={src} title={artifact.title} className="max-w-full" />;
+			}
 
 			case 'markdown':
 			case 'document':

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -9,6 +9,7 @@ import { MessageActions } from './MessageActions';
 import { MessageLoadingState } from './MessageLoadingState';
 import { CopyButton } from './CopyButton';
 import { Image } from '@/components/ai-elements/image';
+import { Video } from '@/components/ai-elements/video';
 import { Skeleton } from '@/components/ui/skeleton';
 import { formatTime } from './utils';
 import type { MessageType } from './types';
@@ -31,6 +32,11 @@ const frappeUrl = import.meta.env.VITE_FRAPPE_URL || window.location.origin;
 
 function resolveAudioSrc(src: string): string {
 	if (src.startsWith('http://') || src.startsWith('https://')) return src;
+	return `${frappeUrl}${src.startsWith('/') ? '' : '/'}${src}`;
+}
+
+function resolveVideoSrc(src: string): string {
+	if (src.startsWith('http://') || src.startsWith('https://') || src.startsWith('data:') || src.startsWith('blob:')) return src;
 	return `${frappeUrl}${src.startsWith('/') ? '' : '/'}${src}`;
 }
 
@@ -160,7 +166,25 @@ export function ChatMessage({
                                         />
                                     )}
                                 </div>
-                            ) : !message.generatedAudio && !((status === 'submitted' || status === 'streaming') && 
+                            ) : message.kind === 'Video' ? (
+                                <div className="flex flex-col gap-2">
+                                    {message.generatedVideo ? (
+                                        <Video
+                                            src={resolveVideoSrc(message.generatedVideo)}
+                                            title={message.versions[0]?.content || 'Generated video'}
+                                            className="max-w-full"
+                                        />
+                                    ) : (
+                                        <Skeleton className="w-full h-[320px] rounded-lg" />
+                                    )}
+                                    {message.versions[0]?.content && (
+                                        <MessageContentWithArtifacts
+                                            content={message.versions[0].content}
+                                            messageId={message.versions[0]?.id ?? message.key}
+                                        />
+                                    )}
+                                </div>
+                            ) : !message.generatedAudio && !((status === 'submitted' || status === 'streaming') &&
                                   message.from === 'assistant' && 
                                   (!message.versions[0]?.content || message.versions[0].content.trim() === '') && 
                                   !message.tools) && (

--- a/frontend/src/components/chat/chatMessageList.mappers.ts
+++ b/frontend/src/components/chat/chatMessageList.mappers.ts
@@ -144,6 +144,7 @@ export function upsertAgentMessageFromSocket(prev: MessageType[], event: NewAgen
       kind: event.kind,
       generatedImage: event.generated_image,
       generatedAudio: event.generated_audio,
+      generatedVideo: event.generated_video,
       versions: updated[messageIndex].versions.map((v) =>
         v.id === event.message_id ? { ...v, content: event.content || v.content } : v
       ),
@@ -157,6 +158,7 @@ export function upsertAgentMessageFromSocket(prev: MessageType[], event: NewAgen
     kind: event.kind,
     generatedImage: event.generated_image,
     generatedAudio: event.generated_audio,
+    generatedVideo: event.generated_video,
     versions: [
       {
         id: event.message_id,
@@ -192,6 +194,7 @@ export function mergeConversationItemsIntoMessages(
       kind: item.kind,
       generatedImage: item.generatedImage,
       generatedAudio: item.generatedAudio,
+      generatedVideo: item.generatedVideo,
       voiceMessage: item.voiceMessage,
       versions: [
         {

--- a/frontend/src/components/chat/types.ts
+++ b/frontend/src/components/chat/types.ts
@@ -10,6 +10,7 @@ export type MessageType = {
   kind?: string;
   generatedImage?: string;
   generatedAudio?: string;
+  generatedVideo?: string;
   voiceMessage?: string;
   attachment?: {
     name: string;

--- a/frontend/src/components/chat/videoDetection.test.ts
+++ b/frontend/src/components/chat/videoDetection.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VIDEO_EXTENSIONS,
+  isVideoMediaType,
+  isVideoUrl,
+  detectVideo,
+  toVideoProps,
+  extractVideoFromToolResult,
+} from './videoDetection';
+
+describe('VIDEO_EXTENSIONS', () => {
+  it('exposes the supported extensions', () => {
+    expect(VIDEO_EXTENSIONS).toEqual(['.mp4', '.webm', '.ogv', '.mov', '.m4v']);
+  });
+});
+
+describe('isVideoMediaType', () => {
+  it('returns true for video/* media types', () => {
+    expect(isVideoMediaType('video/mp4')).toBe(true);
+    expect(isVideoMediaType('video/webm')).toBe(true);
+    expect(isVideoMediaType('video/ogg; codecs=theora')).toBe(true);
+  });
+
+  it('returns false for non-video media types', () => {
+    expect(isVideoMediaType('image/png')).toBe(false);
+    expect(isVideoMediaType('audio/mpeg')).toBe(false);
+    expect(isVideoMediaType('application/json')).toBe(false);
+  });
+
+  it('returns false for empty, null, or undefined', () => {
+    expect(isVideoMediaType('')).toBe(false);
+    expect(isVideoMediaType(null)).toBe(false);
+    expect(isVideoMediaType(undefined)).toBe(false);
+  });
+});
+
+describe('isVideoUrl', () => {
+  it('returns true for supported video extensions', () => {
+    expect(isVideoUrl('https://cdn.example.com/clip.mp4')).toBe(true);
+    expect(isVideoUrl('https://cdn.example.com/clip.webm')).toBe(true);
+    expect(isVideoUrl('https://cdn.example.com/clip.mov')).toBe(true);
+    expect(isVideoUrl('/files/clip.MP4')).toBe(true);
+  });
+
+  it('strips query strings and hashes before testing the extension', () => {
+    expect(isVideoUrl('https://cdn.example.com/clip.mp4?token=abc')).toBe(true);
+    expect(isVideoUrl('https://cdn.example.com/clip.webm#t=10')).toBe(true);
+    expect(isVideoUrl('https://cdn.example.com/clip.mp4?download=1#frag')).toBe(true);
+  });
+
+  it('returns false for non-video extensions', () => {
+    expect(isVideoUrl('https://cdn.example.com/image.png')).toBe(false);
+    expect(isVideoUrl('https://cdn.example.com/doc.pdf')).toBe(false);
+    expect(isVideoUrl('https://cdn.example.com/clip.mp4x')).toBe(false);
+  });
+
+  it('does not match just because the URL contains the words video or media', () => {
+    expect(isVideoUrl('https://example.com/video/watch')).toBe(false);
+    expect(isVideoUrl('https://example.com/media/page')).toBe(false);
+    expect(isVideoUrl('https://example.com/video.mp4.html')).toBe(false);
+  });
+
+  it('returns false for empty, null, or undefined', () => {
+    expect(isVideoUrl('')).toBe(false);
+    expect(isVideoUrl(null)).toBe(false);
+    expect(isVideoUrl(undefined)).toBe(false);
+  });
+});
+
+describe('detectVideo priority', () => {
+  it("prefers type === 'video' above all else", () => {
+    expect(detectVideo({ type: 'video', mediaType: 'image/png' })).toBe(true);
+  });
+
+  it('falls back to mediaType when type is absent', () => {
+    expect(detectVideo({ mediaType: 'video/mp4' })).toBe(true);
+    expect(detectVideo({ mediaType: 'image/png' })).toBe(false);
+  });
+
+  it('falls back to category after mediaType', () => {
+    expect(detectVideo({ category: 'video' })).toBe(true);
+    expect(detectVideo({ category: 'image' })).toBe(false);
+  });
+
+  it('falls back to url / src / name last', () => {
+    expect(detectVideo({ url: 'https://x.com/a.mp4' })).toBe(true);
+    expect(detectVideo({ src: 'https://x.com/a.webm' })).toBe(true);
+    expect(detectVideo({ name: 'https://x.com/a.mov' })).toBe(true);
+    expect(detectVideo({ url: 'https://x.com/a.png' })).toBe(false);
+  });
+
+  it('respects the priority order end-to-end', () => {
+    // type wins even though url is non-video
+    expect(detectVideo({ type: 'video', url: 'https://x.com/a.png' })).toBe(true);
+    // mediaType wins even though category is non-video and url is non-video
+    expect(
+      detectVideo({ mediaType: 'video/mp4', category: 'image', url: 'https://x.com/a.png' })
+    ).toBe(true);
+    // category wins over url
+    expect(detectVideo({ category: 'video', url: 'https://x.com/a.png' })).toBe(true);
+  });
+});
+
+describe('toVideoProps', () => {
+  it('normalizes url to src and defaults downloadName to name', () => {
+    expect(toVideoProps({ url: 'https://x.com/a.mp4', name: 'a.mp4' })).toEqual({
+      src: 'https://x.com/a.mp4',
+      title: undefined,
+      poster: undefined,
+      mediaType: undefined,
+      downloadName: 'a.mp4',
+      captions: undefined,
+    });
+  });
+
+  it('uses src when url is absent', () => {
+    const result = toVideoProps({ src: 'https://x.com/a.webm' });
+    expect(result).not.toBeNull();
+    expect(result?.src).toBe('https://x.com/a.webm');
+  });
+
+  it('prefers an explicit downloadName over name', () => {
+    const result = toVideoProps({ url: 'https://x.com/a.mp4', name: 'a.mp4', downloadName: 'b.mp4' });
+    expect(result?.downloadName).toBe('b.mp4');
+  });
+
+  it('returns null when neither url nor src is present', () => {
+    expect(toVideoProps({ name: 'a.mp4' })).toBeNull();
+    expect(toVideoProps({})).toBeNull();
+  });
+
+  it('preserves optional metadata fields', () => {
+    const captions = [{ src: 'a.vtt', srcLang: 'en', label: 'English', default: true }];
+    const result = toVideoProps({
+      url: 'https://x.com/a.mp4',
+      title: 'Title',
+      poster: 'poster.jpg',
+      mediaType: 'video/mp4',
+      captions,
+    });
+    expect(result?.title).toBe('Title');
+    expect(result?.poster).toBe('poster.jpg');
+    expect(result?.mediaType).toBe('video/mp4');
+    expect(result?.captions).toEqual(captions);
+  });
+});
+
+describe('extractVideoFromToolResult', () => {
+  it('returns { src } for a bare video URL string', () => {
+    expect(extractVideoFromToolResult('https://x.com/a.mp4')).toEqual({ src: 'https://x.com/a.mp4' });
+  });
+
+  it('returns { src } for a data:video/ URI', () => {
+    const data = 'data:video/mp4;base64,AAAA';
+    expect(extractVideoFromToolResult(data)).toEqual({ src: data });
+  });
+
+  it('returns null for a non-video string', () => {
+    expect(extractVideoFromToolResult('not-a-video')).toBeNull();
+    expect(extractVideoFromToolResult('https://x.com/a.png')).toBeNull();
+  });
+
+  it('parses JSON strings and recurses', () => {
+    const json = JSON.stringify({ url: 'https://x.com/a.mp4' });
+    expect(extractVideoFromToolResult(json)).toEqual({
+      src: 'https://x.com/a.mp4',
+      mediaType: undefined,
+      title: undefined,
+      downloadName: undefined,
+      poster: undefined,
+    });
+  });
+
+  it('returns null for malformed JSON strings', () => {
+    expect(extractVideoFromToolResult('{not json')).toBeNull();
+  });
+
+  it('checks candidate keys in order and honors video extension', () => {
+    expect(
+      extractVideoFromToolResult({ url: 'https://x.com/a.mp4', src: 'https://x.com/b.webm' })
+    ).toMatchObject({ src: 'https://x.com/a.mp4' });
+    expect(
+      extractVideoFromToolResult({ src: 'https://x.com/b.webm', video_url: 'https://x.com/c.mov' })
+    ).toMatchObject({ src: 'https://x.com/b.webm' });
+    expect(
+      extractVideoFromToolResult({ video_url: 'https://x.com/c.mov', videoUrl: 'https://x.com/d.mp4' })
+    ).toMatchObject({ src: 'https://x.com/c.mov' });
+    expect(extractVideoFromToolResult({ videoUrl: 'https://x.com/d.mp4' })).toMatchObject({
+      src: 'https://x.com/d.mp4',
+    });
+    expect(extractVideoFromToolResult({ download_url: 'https://x.com/e.m4v' })).toMatchObject({
+      src: 'https://x.com/e.m4v',
+    });
+  });
+
+  it('accepts a non-video extension when mediaType is video/*', () => {
+    expect(
+      extractVideoFromToolResult({ url: 'https://x.com/stream', mediaType: 'video/mp4' })
+    ).toMatchObject({ src: 'https://x.com/stream', mediaType: 'video/mp4' });
+    expect(
+      extractVideoFromToolResult({ url: 'https://x.com/stream', mime_type: 'video/webm' })
+    ).toMatchObject({ src: 'https://x.com/stream' });
+    expect(extractVideoFromToolResult({ url: 'https://x.com/stream', type: 'video/mov' })).toMatchObject(
+      { src: 'https://x.com/stream' }
+    );
+  });
+
+  it('rejects a non-video url without a video mediaType', () => {
+    expect(extractVideoFromToolResult({ url: 'https://x.com/a.png' })).toBeNull();
+    expect(extractVideoFromToolResult({ url: 'https://x.com/a.png', mediaType: 'image/png' })).toBeNull();
+  });
+
+  it('carries name / filename / title into downloadName and title', () => {
+    expect(extractVideoFromToolResult({ url: 'https://x.com/a.mp4', name: 'clip.mp4' })).toMatchObject({
+      downloadName: 'clip.mp4',
+      title: 'clip.mp4',
+    });
+    expect(
+      extractVideoFromToolResult({ url: 'https://x.com/a.mp4', filename: 'file.mp4' })
+    ).toMatchObject({ downloadName: 'file.mp4' });
+    expect(extractVideoFromToolResult({ url: 'https://x.com/a.mp4', title: 'Nice' })).toMatchObject({
+      downloadName: 'Nice',
+    });
+  });
+
+  it('carries poster through', () => {
+    expect(
+      extractVideoFromToolResult({ url: 'https://x.com/a.mp4', poster: 'poster.jpg' })
+    ).toMatchObject({ poster: 'poster.jpg' });
+  });
+
+  it('returns null for non-string, non-object inputs', () => {
+    expect(extractVideoFromToolResult(null)).toBeNull();
+    expect(extractVideoFromToolResult(undefined)).toBeNull();
+    expect(extractVideoFromToolResult(123)).toBeNull();
+    expect(extractVideoFromToolResult(['https://x.com/a.mp4'])).toBeNull();
+  });
+});

--- a/frontend/src/components/chat/videoDetection.test.ts
+++ b/frontend/src/components/chat/videoDetection.test.ts
@@ -3,6 +3,7 @@ import {
   VIDEO_EXTENSIONS,
   isVideoMediaType,
   isVideoUrl,
+  isAllowedVideoSrc,
   detectVideo,
   toVideoProps,
   extractVideoFromToolResult,
@@ -11,6 +12,33 @@ import {
 describe('VIDEO_EXTENSIONS', () => {
   it('exposes the supported extensions', () => {
     expect(VIDEO_EXTENSIONS).toEqual(['.mp4', '.webm', '.ogv', '.mov', '.m4v']);
+  });
+});
+
+describe('isAllowedVideoSrc', () => {
+  it('allows http/https', () => {
+    expect(isAllowedVideoSrc('http://example.com/a.mp4')).toBe(true);
+    expect(isAllowedVideoSrc('https://example.com/a.mp4')).toBe(true);
+  });
+
+  it('allows data: and blob: URIs', () => {
+    expect(isAllowedVideoSrc('data:video/mp4;base64,AAAA')).toBe(true);
+    expect(isAllowedVideoSrc('blob:https://example.com/uuid')).toBe(true);
+  });
+
+  it('allows relative URLs (resolve against page origin)', () => {
+    expect(isAllowedVideoSrc('/files/clip.mp4')).toBe(true);
+    expect(isAllowedVideoSrc('files/clip.mp4')).toBe(true);
+  });
+
+  it('rejects dangerous schemes', () => {
+    expect(isAllowedVideoSrc('javascript:alert(1)')).toBe(false);
+    expect(isAllowedVideoSrc('vbscript:msgbox(1)')).toBe(false);
+    expect(isAllowedVideoSrc('file:///etc/passwd')).toBe(false);
+  });
+
+  it('rejects empty/invalid input', () => {
+    expect(isAllowedVideoSrc('')).toBe(false);
   });
 });
 

--- a/frontend/src/components/chat/videoDetection.ts
+++ b/frontend/src/components/chat/videoDetection.ts
@@ -24,6 +24,28 @@ export function isVideoUrl(url?: string | null): boolean {
   return VIDEO_EXTENSIONS.some((ext) => stripped.endsWith(ext));
 }
 
+const ALLOWED_VIDEO_SCHEMES = ['http:', 'https:', 'data:', 'blob:'];
+
+/**
+ * True iff `src` is safe to hand to a native <video>/<a href>/window.open —
+ * i.e. it's a relative URL (no scheme, resolves against the page origin) or
+ * declares an explicit http/https/data/blob scheme. Rejects anything else
+ * (e.g. javascript:, file:, vbscript:) so a malicious tool result or
+ * artifact tag can never smuggle a dangerous scheme into the DOM.
+ */
+export function isAllowedVideoSrc(src: string): boolean {
+  if (!src) return false;
+  try {
+    // Fixed base so this works in both node (tests) and the browser —
+    // only the scheme is inspected, resolution against a real origin
+    // never happens for relative URLs, so this base is arbitrary.
+    const url = new URL(src, 'http://localhost');
+    return ALLOWED_VIDEO_SCHEMES.includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
 export type VideoPartInput = {
   type?: string; // explicit part type, e.g. "video"
   mediaType?: string; // MIME

--- a/frontend/src/components/chat/videoDetection.ts
+++ b/frontend/src/components/chat/videoDetection.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure, framework-free video detection + normalization helpers.
+ *
+ * These are intentionally dependency-free (no React, no DOM) so they can be
+ * unit-tested in a plain node environment.
+ */
+
+export const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.ogv', '.mov', '.m4v'] as const;
+
+/** True iff the mediaType starts with "video/" (case-insensitive). */
+export function isVideoMediaType(mediaType?: string | null): boolean {
+  if (!mediaType) return false;
+  return mediaType.toLowerCase().startsWith('video/');
+}
+
+/**
+ * True iff the URL points at a known video extension.
+ * Strips query/hash and lowercases before testing. Does NOT match merely
+ * because the string contains the word "video" or "media".
+ */
+export function isVideoUrl(url?: string | null): boolean {
+  if (!url) return false;
+  const stripped = url.split(/[?#]/)[0].toLowerCase();
+  return VIDEO_EXTENSIONS.some((ext) => stripped.endsWith(ext));
+}
+
+export type VideoPartInput = {
+  type?: string; // explicit part type, e.g. "video"
+  mediaType?: string; // MIME
+  category?: string; // explicit attachment category e.g. "video"
+  url?: string;
+  src?: string;
+  name?: string; // filename
+};
+
+/**
+ * Detect whether an arbitrary part represents a video.
+ * Priority: 1) type === 'video'  2) video mediaType  3) category === 'video'
+ * 4) video extension on url/src/name.
+ */
+export function detectVideo(input: VideoPartInput): boolean {
+  if (input.type === 'video') return true;
+  if (isVideoMediaType(input.mediaType)) return true;
+  if (input.category === 'video') return true;
+  if (isVideoUrl(input.url ?? input.src ?? input.name)) return true;
+  return false;
+}
+
+export type NormalizedVideo = {
+  src: string;
+  title?: string;
+  poster?: string;
+  mediaType?: string;
+  downloadName?: string;
+  captions?: Array<{ src: string; srcLang: string; label: string; default?: boolean }>;
+};
+
+/**
+ * Normalize a video part into render-ready props.
+ * Returns null if there is no usable url/src. Normalizes url -> src and
+ * defaults downloadName from `name` when present.
+ */
+export function toVideoProps(
+  input: VideoPartInput & {
+    title?: string;
+    poster?: string;
+    downloadName?: string;
+    captions?: NormalizedVideo['captions'];
+  }
+): NormalizedVideo | null {
+  const src = input.url ?? input.src;
+  if (!src) return null;
+  return {
+    src,
+    title: input.title,
+    poster: input.poster,
+    mediaType: input.mediaType,
+    downloadName: input.downloadName ?? input.name,
+    captions: input.captions,
+  };
+}
+
+function isDataVideoUrl(value: string): boolean {
+  return value.toLowerCase().startsWith('data:video/');
+}
+
+function extractDataMediaType(value: string): string | undefined {
+  const match = /^data:(video\/[a-z0-9.+-]+)/i.exec(value);
+  return match?.[1];
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+/**
+ * Extract a playable video from an arbitrary tool-result value (string OR
+ * object). Used by ToolOutput. Conservative: never classifies arbitrary URLs
+ * as video unless the extension/mediaType says so.
+ */
+export function extractVideoFromToolResult(output: unknown): NormalizedVideo | null {
+  if (output == null) return null;
+
+  if (typeof output === 'string') {
+    const trimmed = output.trim();
+    if (!trimmed) return null;
+
+    if (isDataVideoUrl(trimmed)) {
+      return { src: trimmed };
+    }
+
+    if (isVideoUrl(trimmed)) {
+      return { src: trimmed };
+    }
+
+    // Try to parse a JSON string and recurse into the resulting value.
+    const looksLikeJson =
+      (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+      (trimmed.startsWith('[') && trimmed.endsWith(']'));
+    if (looksLikeJson) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        return extractVideoFromToolResult(parsed);
+      } catch {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof output === 'object') {
+    const obj = output as Record<string, unknown>;
+    const urlKeys = ['url', 'src', 'video_url', 'videoUrl', 'download_url'] as const;
+
+    const mediaType = asString(obj.mediaType) ?? asString(obj.mime_type);
+    const type = asString(obj.type);
+    const name = asString(obj.name) ?? asString(obj.filename);
+    const title = asString(obj.title) ?? name;
+    const poster = asString(obj.poster);
+    const objectIndicatesVideo =
+      isVideoMediaType(mediaType) || isVideoMediaType(type) || type === 'video';
+
+    for (const key of urlKeys) {
+      const value = asString(obj[key]);
+      if (!value) continue;
+
+      const dataVideo = isDataVideoUrl(value);
+      if (isVideoUrl(value) || dataVideo || objectIndicatesVideo) {
+        return {
+          src: value,
+          mediaType: mediaType ?? (dataVideo ? extractDataMediaType(value) : undefined),
+          title,
+          poster,
+          downloadName: asString(obj.name) ?? asString(obj.filename) ?? asString(obj.title),
+        };
+      }
+    }
+
+    return null;
+  }
+
+  return null;
+}

--- a/frontend/src/hooks/useChatSocket.tsx
+++ b/frontend/src/hooks/useChatSocket.tsx
@@ -22,6 +22,7 @@ export type NewAgentMessageEvent = {
     content?: string;
     generated_image?: string;
     generated_audio?: string;
+    generated_video?: string;
     agent_run_id?: string;
     conversation_index?: number;
 };

--- a/frontend/src/services/chatApi.ts
+++ b/frontend/src/services/chatApi.ts
@@ -44,6 +44,7 @@ export interface AgentMessageDoc {
   kind?: string;
   generated_image?: string;
   generated_audio?: string;
+  generated_video?: string;
   voice_message?: string;
   tool_name?: string;
   tool_status?: string;
@@ -60,6 +61,7 @@ export interface ChatMessage {
   kind?: string;
   generatedImage?: string;
   generatedAudio?: string;
+  generatedVideo?: string;
   voiceMessage?: string;
   toolName?: string;
   toolStatus?: string;
@@ -91,6 +93,7 @@ function mapAgentMessage(doc: AgentMessageDoc): ChatMessage {
     kind: doc.kind,
     generatedImage: doc.generated_image,
     generatedAudio: doc.generated_audio,
+    generatedVideo: doc.generated_video,
     voiceMessage: doc.voice_message,
     toolName: doc.tool_name,
     toolStatus: doc.tool_status,
@@ -300,7 +303,7 @@ export async function getConversationMessages(
 
   try {
     const messages = await db.getDocList(doctype['Agent Message'], {
-      fields: ['name', 'conversation', 'content', 'is_agent_message', 'kind', 'generated_image', 'generated_audio', 'voice_message', 'tool_name', 'tool_status', 'tool_args', 'creation', 'modified'],
+      fields: ['name', 'conversation', 'content', 'is_agent_message', 'kind', 'generated_image', 'generated_audio', 'generated_video', 'voice_message', 'tool_name', 'tool_status', 'tool_args', 'creation', 'modified'],
       filters: [['conversation', '=', conversation]],
       orderBy: { field: 'creation', order: 'desc' },
       limit,

--- a/frontend/src/types/artifact.types.ts
+++ b/frontend/src/types/artifact.types.ts
@@ -11,7 +11,8 @@ export type ArtifactType =
 	| 'react-component'
 	| 'markdown'
 	| 'jsx'
-	| 'chart';
+	| 'chart'
+	| 'video';
 
 export interface ParsedArtifact {
 	id: string;

--- a/frontend/src/utils/artifactParser.ts
+++ b/frontend/src/utils/artifactParser.ts
@@ -105,6 +105,7 @@ export function isValidArtifactType(type: string): type is ArtifactType {
 		'mermaid',
 		'react-component',
 		'markdown',
+		'video',
 	];
 	return validTypes.includes(type as ArtifactType);
 }

--- a/huf/huf/doctype/agent_message/agent_message.json
+++ b/huf/huf/doctype/agent_message/agent_message.json
@@ -43,6 +43,7 @@
   "voice_details_section",
   "voice_message",
   "generated_audio",
+  "generated_video",
   "tts_voice",
   "column_break_asyu",
   "tts_model",
@@ -81,7 +82,7 @@
    "fieldname": "kind",
    "fieldtype": "Select",
    "label": "Kind",
-   "options": "\nMessage\nTool Call\nTool Result\nStatus\nError\nImage\nAudio",
+   "options": "\nMessage\nTool Call\nTool Result\nStatus\nError\nImage\nAudio\nVideo",
    "read_only": 1
   },
   {
@@ -223,6 +224,13 @@
    "fieldname": "generated_audio",
    "fieldtype": "Attach",
    "label": "Generated Audio",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.kind == \"Video\";",
+   "fieldname": "generated_video",
+   "fieldtype": "Attach",
+   "label": "Generated Video",
    "read_only": 1
   },
   {


### PR DESCRIPTION
## Summary
Adds first-class **inline video playback** to the HUF chat UI using a reusable native HTML5 `<video>` component that follows the existing AI Elements / shadcn conventions. Videos returned as chat answers, via **MCP tool servers**, or embedded in an assistant's `<artifact type="video">` reply now render inline; unsupported/failed media degrades to an Open/Download fallback instead of leaking raw JSON or a dead link.

**No player library added. No app-wide test-infra or dependency/lockfile changes.**

## What's included
- **`ai-elements/video.tsx`** — presentational native `<video>`: controls, `preload="metadata"`, `playsInline`, no autoplay-by-default (auto-mutes if enabled), poster, `<source type>`, caption `<track>`, and an error fallback with Open/Download actions.
- **`chat/videoDetection.ts`** — pure, dependency-free detection/normalization (`isVideoUrl`, `isVideoMediaType`, `detectVideo`, `toVideoProps`, `extractVideoFromToolResult`, `isAllowedVideoSrc`). Detection lives here, not in the component.
- **Wiring** (mirrors the existing image/audio pattern):
  - `ToolOutput` (tool.tsx) renders a video inline when a tool result carries a playable video URL; else the existing JSON view.
  - `ChatMessage.tsx` gains a `kind === 'Video'` branch for `generatedVideo`.
  - `generatedVideo`/`generated_video` threaded through types, socket event, REST fields + mapper, and list mappers.
  - `ArtifactRenderer` gains a `video` artifact type (`<artifact type="video">URL</artifact>`), mirroring the existing `mermaid` pattern — this is how an assistant's plain-text reply can embed a playable video, not just tool results.
- **Security**: `Video.src` is validated against an explicit scheme allowlist (relative URLs, or `http`/`https`/`data`/`blob`) before it can reach `<video src>`, `window.open`, or an `<a href>` — a `javascript:`/`file:`/`vbscript:` URL from an untrusted tool result or artifact tag renders nothing instead of executing.

## Testing
- `chat/videoDetection.test.ts` — 44 node unit tests (fits the repo's existing `*.test.ts` / node vitest setup; **no new deps**).
- `yarn typecheck` clean for these files; production `vite build` compiles the wiring into the real `ChatPageV2` bundle.
- **Manual live-bench verification** (2026-07-11/12, `huf.localhost`): deployed this branch to the dev bench, confirmed the real chat app loads and renders correctly end-to-end, confirmed the artifact-video render path renders inline video with real accessible test clips (landscape + vertical + broken-URL fallback, screenshots taken). A real human's manual click on Send in the live chat UI successfully created a conversation + message (confirms the UI interaction path works; Playwright browser automation had an unrelated click-registration quirk that does not reproduce for real users). Getting a full agent round-trip with a live LLM response containing the artifact tag was blocked by two **pre-existing, unrelated bench issues** (broken Google/OpenAI provider keys on that dev site) — not something this PR's code can fix; documented as bench-level findings, not code gaps.

## Known gaps (draft — intentionally deferred)
- [ ] **Component render tests** for `Video` — the repo has no jsdom/testing-library setup; adding one is a shared decision tracked as a separate plan rather than smuggled into this PR. A 12-case `video.test.tsx` is written and recoverable when that infra lands.
- [x] ~~Live browser smoke test~~ — done manually against a live bench (see Testing above); full agent-response round-trip blocked by unrelated broken provider keys on that dev site, not by this code.
- [x] ~~URL-scheme allowlist hardening~~ — done, see Security above.

## Scope / drift
12 files, +672/−4 total across 3 commits. `package.json`, `vitest.config.ts`, and the lockfile are **untouched**.

https://claude.ai/code/session_012WxxEduhLeVvtTLZmesLy3