### PR TITLE
Flow engine: fix loop routing, edge serialization, approval routing & permissions; add approvals inbox

### DIFF
--- a/frontend/src/components/ApprovalsBell.tsx
+++ b/frontend/src/components/ApprovalsBell.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Bell } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
+import { Button } from './ui/button';
+import { Badge } from './ui/badge';
+import { approveFlowRun, getPendingApprovals, rejectFlowRun } from '../services/flowApi';
+import type { PendingApproval } from '../services/flowApi';
+
+const REFRESH_INTERVAL_MS = 60000;
+const FLOW_EVENTS = ['frappe:flow_paused', 'frappe:flow_completed', 'frappe:flow_error'];
+
+export function ApprovalsBell() {
+  const [approvals, setApprovals] = useState<PendingApproval[]>([]);
+
+  const fetchApprovals = useCallback(async () => {
+    try {
+      const list = await getPendingApprovals();
+      setApprovals(list || []);
+    } catch (error) {
+      console.warn('ApprovalsBell: failed to fetch pending approvals', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchApprovals();
+    const interval = setInterval(fetchApprovals, REFRESH_INTERVAL_MS);
+    FLOW_EVENTS.forEach((event) => window.addEventListener(event, fetchApprovals));
+    return () => {
+      clearInterval(interval);
+      FLOW_EVENTS.forEach((event) => window.removeEventListener(event, fetchApprovals));
+    };
+  }, [fetchApprovals]);
+
+  const handleApprove = async (flowRunId: string) => {
+    try {
+      await approveFlowRun(flowRunId);
+    } catch (error) {
+      console.warn('ApprovalsBell: failed to approve flow run', error);
+    }
+    await fetchApprovals();
+  };
+
+  const handleReject = async (flowRunId: string) => {
+    try {
+      await rejectFlowRun(flowRunId);
+    } catch (error) {
+      console.warn('ApprovalsBell: failed to reject flow run', error);
+    }
+    await fetchApprovals();
+  };
+
+  const count = approvals.length;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative" aria-label="Pending approvals">
+          <Bell className="w-4 h-4" />
+          {count > 0 && (
+            <Badge
+              variant="destructive"
+              className="absolute -top-1 -right-1 h-4 min-w-[16px] px-1 py-0 flex items-center justify-center"
+            >
+              {count > 9 ? '9+' : count}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        <div className="px-4 py-3 border-b text-sm font-semibold">Pending approvals</div>
+        {count === 0 ? (
+          <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+            No approvals waiting
+          </div>
+        ) : (
+          <div className="max-h-80 overflow-y-auto divide-y">
+            {approvals.map((approval) => (
+              <div key={approval.flow_run_id} className="px-4 py-3 space-y-2">
+                <div>
+                  <div className="text-sm font-medium">{approval.title || approval.flow_id}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {approval.flow_id}
+                    {approval.waiting_since ? ` · waiting since ${approval.waiting_since}` : ''}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button size="sm" variant="outline" onClick={() => handleApprove(approval.flow_run_id)}>
+                    Approve
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => handleReject(approval.flow_run_id)}>
+                    Reject
+                  </Button>
+                  <Button size="sm" variant="ghost" asChild>
+                    <Link to={`/flows/${approval.flow_id}?run=${approval.flow_run_id}`}>Open</Link>
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/components/RightSidebar.tsx
+++ b/frontend/src/components/RightSidebar.tsx
@@ -413,12 +413,12 @@ export function RightSidebar({ onToggle, variant = 'panel' }: RightSidebarProps)
               <div>
                 <Label htmlFor="edge-type" className="text-xs">Edge Type</Label>
                 <Select
-                  value={selectedEdge.data?.type || 'always'}
+                  value={selectedEdge.data?.edgeType || 'always'}
                   onValueChange={(value) => {
                     if (!activeFlow) return;
                     updateEdges(
                       activeFlow.edges.map((edge) =>
-                        edge.id === selectedEdge.id ? { ...edge, data: { ...edge.data, type: value } } : edge
+                        edge.id === selectedEdge.id ? { ...edge, data: { ...edge.data, edgeType: value } } : edge
                       )
                     );
                   }}
@@ -435,24 +435,75 @@ export function RightSidebar({ onToggle, variant = 'panel' }: RightSidebarProps)
                 </Select>
               </div>
 
-              {selectedEdge.data?.type === 'expression' && (
+              {selectedEdge.data?.edgeType === 'expression' && (
                 <div>
                   <Label htmlFor="edge-expr" className="text-xs">Condition Expression</Label>
                   <Input
                     id="edge-expr"
-                    value={selectedEdge.data?.expression || ''}
+                    value={selectedEdge.data?.condition || ''}
                     onChange={(e) => {
                       if (!activeFlow) return;
                       updateEdges(
                         activeFlow.edges.map((edge) =>
-                          edge.id === selectedEdge.id ? { ...edge, data: { ...edge.data, expression: e.target.value } } : edge
+                          edge.id === selectedEdge.id ? { ...edge, data: { ...edge.data, condition: e.target.value } } : edge
                         )
                       );
                     }}
-                    placeholder="e.g., {{context.status}} == 'approved'"
+                    placeholder='e.g., context["status"] == "approved"'
                   />
                 </div>
               )}
+
+              <div>
+                <Label htmlFor="edge-priority" className="text-xs">Priority</Label>
+                <Input
+                  id="edge-priority"
+                  type="number"
+                  value={selectedEdge.data?.priority ?? 0}
+                  onChange={(e) => {
+                    if (!activeFlow) return;
+                    const priority = e.target.value === '' ? 0 : Number(e.target.value);
+                    updateEdges(
+                      activeFlow.edges.map((edge) =>
+                        edge.id === selectedEdge.id ? { ...edge, data: { ...edge.data, priority } } : edge
+                      )
+                    );
+                  }}
+                />
+                <p className="text-[10px] text-muted-foreground mt-1">Higher priority edges are evaluated first</p>
+              </div>
+
+              <div>
+                <Label htmlFor="edge-outcome" className="text-xs">Approval Outcome</Label>
+                <Select
+                  value={selectedEdge.data?.meta?.outcome || 'none'}
+                  onValueChange={(value) => {
+                    if (!activeFlow) return;
+                    updateEdges(
+                      activeFlow.edges.map((edge) => {
+                        if (edge.id !== selectedEdge.id) return edge;
+                        const meta = { ...(edge.data?.meta || {}) };
+                        if (value === 'none') {
+                          delete meta.outcome;
+                        } else {
+                          meta.outcome = value;
+                        }
+                        return { ...edge, data: { ...edge.data, meta } };
+                      })
+                    );
+                  }}
+                >
+                  <SelectTrigger id="edge-outcome">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    <SelectItem value="approved">approved</SelectItem>
+                    <SelectItem value="rejected">rejected</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-[10px] text-muted-foreground mt-1">For edges leaving a Human Approval node: route this edge when the decision matches.</p>
+              </div>
             </div>
           </>
         ) : selectedNode ? (

--- a/frontend/src/layouts/UnifiedHeader.tsx
+++ b/frontend/src/layouts/UnifiedHeader.tsx
@@ -9,6 +9,7 @@ import {
   BreadcrumbSeparator,
 } from '../components/ui/breadcrumb';
 import { BreadcrumbItem as BreadcrumbItemType } from './UnifiedLayout';
+import { ApprovalsBell } from '../components/ApprovalsBell';
 
 interface UnifiedHeaderProps {
   actions?: ReactNode;
@@ -85,6 +86,7 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
       </div> */}
 
       <div className="flex items-center gap-2">
+        <ApprovalsBell />
         {actions}
       </div>
     </div>

--- a/frontend/src/services/flowApi.ts
+++ b/frontend/src/services/flowApi.ts
@@ -39,7 +39,7 @@ export interface BackendFlowGraph {
 
 export interface BackendNode {
     id: string;
-    type: 'trigger.webhook' | 'agent.run' | 'tool.call' | 'router.llm' | 'human.approval' | 'condition' | 'http_request' | 'transform' | 'loop' | 'end';
+    type: 'trigger.webhook' | 'trigger.schedule' | 'trigger.doc-event' | 'agent.run' | 'tool.call' | 'router.llm' | 'human.approval' | 'condition' | 'http_request' | 'transform' | 'loop' | 'end';
     config: Record<string, unknown>;
     /** Frontend-only: stored for visual layout, ignored by engine */
     _position?: { x: number; y: number };
@@ -102,6 +102,19 @@ export interface FlowRunDetail {
     last_agent_run: string | null;
     started_at: string | null;
     completed_at: string | null;
+}
+
+/** Pending human approval (from get_pending_approvals endpoint) */
+export interface PendingApproval {
+    flow_run_id: string;
+    flow_id: string;
+    current_node_id: string;
+    title: string;
+    instructions: string;
+    approval_type: string;
+    started_at: string | null;
+    waiting_since: string | null;
+    view_link: string;
 }
 
 // ─── Flow Definition APIs ────────────────────────────────────────────
@@ -279,5 +292,15 @@ export async function resumeFlowRun(
         return result.message as { flow_run_id: string; status: string; current_node_id: string };
     } catch (error) {
         handleFrappeError(error, `Error resuming flow run ${flowRunId}`);
+    }
+}
+
+/** List flow runs waiting for human approval */
+export async function getPendingApprovals(): Promise<PendingApproval[]> {
+    try {
+        const result = await call.get('huf.ai.flow_api.get_pending_approvals');
+        return result.message as PendingApproval[];
+    } catch (error) {
+        handleFrappeError(error, 'Error fetching pending approvals');
     }
 }

--- a/frontend/src/services/flowSerializer.ts
+++ b/frontend/src/services/flowSerializer.ts
@@ -60,6 +60,9 @@ function mapFrontendNodeTypeToBackend(node: FlowNode): BackendNode['type'] {
     if (nodeType === 'end') return 'end';
 
     if (nodeType === 'trigger') {
+        const triggerType = node.data?.triggerConfig?.type;
+        if (triggerType === 'schedule') return 'trigger.schedule';
+        if (triggerType === 'doc-event') return 'trigger.doc-event';
         return 'trigger.webhook';
     }
 
@@ -178,10 +181,16 @@ function buildNodeData(node: BackendNode): FlowNodeData {
     };
 
     if (frontendType === 'trigger') {
+        const triggerType =
+            node.type === 'trigger.schedule'
+                ? ('schedule' as const)
+                : node.type === 'trigger.doc-event'
+                    ? ('doc-event' as const)
+                    : ('webhook' as const);
         base.triggerConfig = {
-            type: 'webhook' as const,
+            type: triggerType,
             ...node.config,
-        };
+        } as FlowNodeData['triggerConfig'];
     } else if (frontendType === 'action') {
         base.actionConfig = {
             type: mapBackendActionType(node.type),
@@ -195,6 +204,8 @@ function buildNodeData(node: BackendNode): FlowNodeData {
 function getDefaultLabel(backendType: string): string {
     const labels: Record<string, string> = {
         'trigger.webhook': 'Webhook Trigger',
+        'trigger.schedule': 'Schedule Trigger',
+        'trigger.doc-event': 'Document Event Trigger',
         'agent.run': 'Run Agent',
         'tool.call': 'Call Tool',
         'router.llm': 'LLM Router',
@@ -211,6 +222,8 @@ function getDefaultLabel(backendType: string): string {
 function getDefaultIcon(backendType: string): string {
     const icons: Record<string, string> = {
         'trigger.webhook': 'Webhook',
+        'trigger.schedule': 'Clock',
+        'trigger.doc-event': 'Database',
         'agent.run': 'Bot',
         'tool.call': 'Play',
         'router.llm': 'GitBranch',

--- a/huf/ai/flow_api.py
+++ b/huf/ai/flow_api.py
@@ -282,7 +282,7 @@ def approve_flow_run(flow_run_id: str, comment: str | None = None) -> dict:
 	Returns:
 	    dict with status and current_node_id
 	"""
-	if not frappe.has_permission("Flow Run", "write"):
+	if not frappe.has_permission("Flow Run", "read"):
 		frappe.throw(_("Not permitted"), frappe.PermissionError)
 
 	from huf.ai.flow_engine import approve_flow_run as engine_approve
@@ -379,6 +379,9 @@ def flow_webhook(flow_id: str, webhook_key: str | None = None) -> dict:
 	# Validate webhook auth — mandatory, fail closed.
 	if not _webhook_key_is_valid(defn, webhook_key):
 		frappe.throw(_("Invalid webhook key"), frappe.AuthenticationError)
+
+	# Switch execution identity to the flow owner so the run does not execute as Guest
+	frappe.set_user(defn_doc.owner or "Administrator")
 
 	# Get payload from request
 	payload = {}
@@ -801,6 +804,9 @@ def handle_run_flow(flow_id: str, payload: str | dict | None = None, mode: str |
 	Returns:
 	    dict with flow_run_id, status, message
 	"""
+	if not frappe.has_permission("Flow Run", "create"):
+		return {"error": "Insufficient permissions to start flows"}
+
 	try:
 		if isinstance(payload, str):
 			try:
@@ -838,6 +844,9 @@ def handle_get_flow_run(flow_run_id: str, **kwargs) -> dict:
 	Returns:
 	    dict with status, context summary, waiting state
 	"""
+	if not frappe.has_permission("Flow Run", "read"):
+		return {"error": "Insufficient permissions to view flow runs"}
+
 	try:
 		doc = frappe.get_doc("Flow Run", flow_run_id)
 		ctx = {}
@@ -875,6 +884,9 @@ def handle_resume_flow_run(flow_run_id: str, input: dict | None = None, **kwargs
 	Returns:
 	    dict with updated status
 	"""
+	if not frappe.has_permission("Flow Run", "write"):
+		return {"error": "Insufficient permissions to resume flow runs"}
+
 	try:
 		from huf.ai.flow_engine import resume_flow_run as engine_resume
 
@@ -903,11 +915,18 @@ def handle_approve_flow_run(flow_run_id: str, decision: str = "approved", commen
 	Returns:
 	    dict with updated status
 	"""
+	if not frappe.has_permission("Flow Run", "read"):
+		return {"error": "Insufficient permissions to approve flow runs"}
+
 	try:
-		from huf.ai.flow_engine import approve_flow_run as engine_approve
+		from huf.ai.flow_engine import approve_flow_run as engine_approve, _verify_approval_permission
+
+		doc = frappe.get_doc("Flow Run", flow_run_id)
+		waiting = json.loads(doc.waiting) if doc.waiting else {}
+		_verify_approval_permission(waiting)
 
 		engine_approve(flow_run_id, decision=decision, comment=comment)
-		doc = frappe.get_doc("Flow Run", flow_run_id)
+		doc.reload()
 
 		return {
 			"success": True,
@@ -977,7 +996,7 @@ def get_pending_approvals(limit: int = 50) -> list:
 			approver_role = waiting.get("approver_role")
 			if approver_role and approver_role in user_roles:
 				can_approve = True
-		elif approval_type == "users":
+		elif approval_type in ("user", "users"):
 			approver_users = waiting.get("approver_users", [])
 			if isinstance(approver_users, str):
 				approver_users = [u.strip() for u in approver_users.split(",") if u.strip()]

--- a/huf/ai/flow_engine.py
+++ b/huf/ai/flow_engine.py
@@ -218,10 +218,19 @@ def approve_flow_run(flow_run_name: str, decision: str, comment: str | None = No
 			next_node = edge.get("to")
 			break
 
-	if not next_node:
+	if not next_node and decision == "approved":
 		next_node = _evaluate_edges(flow_run, current_node, {"status": "success"}, edges_list)
 
 	if not next_node:
+		if decision == "rejected":
+			# Rejection without an explicit 'rejected' edge must not route like approval
+			flow_run.db_set("waiting", None)
+			_fail_flow_run(
+				flow_run,
+				f"Approval rejected by {frappe.session.user}" + (f": {comment}" if comment else ""),
+			)
+			_clear_flow_notifications(flow_run)
+			return
 		# No outgoing edges — approval was the final step, complete the flow gracefully
 		outgoing = [e for e in edges_list if e.get("from") == current_node]
 		if not outgoing:
@@ -325,6 +334,15 @@ def _execute_loop(flow_run, nodes_map: dict, edges_list: list, settings: dict):
 			next_node_id = node_result.get("next_node_id") if isinstance(node_result, dict) else None
 			if not next_node_id:
 				_fail_flow_run(flow_run, "Condition node did not resolve a branch")
+				return
+
+		elif node.get("type") == "loop":
+			# Loop executor returns next_node_id (body node or done node)
+			next_node_id = node_result.get("next_node_id") if isinstance(node_result, dict) else None
+			if not next_node_id:
+				# No done_node configured — loop finished, complete gracefully
+				_complete_flow_run(flow_run)
+				_publish_flow_event(flow_run, "flow_completed", {"status": "Success"})
 				return
 
 		elif node.get("type") == "human.approval":
@@ -755,7 +773,7 @@ def _send_approval_notifications(flow_run, node: dict, config: dict, waiting_dat
 					},
 					pluck="name"
 				)
-	elif approval_type == "users":
+	elif approval_type in ("user", "users"):
 		approver_users = waiting_data.get("approver_users", [])
 		if isinstance(approver_users, str):
 			# Handle comma-separated string
@@ -1303,7 +1321,7 @@ def _verify_approval_permission(waiting: dict):
 	approval_type = waiting.get("approval_type", "role")
 	user = frappe.session.user
 
-	if approval_type == "user":
+	if approval_type in ("user", "users"):
 		approver_users = waiting.get("approver_users", [])
 		if approver_users and user not in approver_users:
 			frappe.throw(

--- a/huf/huf/doctype/flow_definition/flow_definition.py
+++ b/huf/huf/doctype/flow_definition/flow_definition.py
@@ -8,6 +8,8 @@ from frappe.utils import now_datetime
 
 ALLOWED_NODE_TYPES = {
 	"trigger.webhook",
+	"trigger.schedule",
+	"trigger.doc-event",
 	"agent.run",
 	"tool.call",
 	"router.llm",

--- a/huf/huf/doctype/flow_run/flow_run.json
+++ b/huf/huf/doctype/flow_run/flow_run.json
@@ -211,7 +211,7 @@
    "write": 1
   },
   {
-   "create": 0,
+   "create": 1,
    "delete": 0,
    "email": 1,
    "export": 1,


### PR DESCRIPTION
## Summary

Fixes the highest-priority defects in the Flow system (engine routing, builder serialization, approval routing, permissions) and adds a pending-approvals inbox so human-in-the-loop steps are discoverable.

### Engine (`huf/ai/flow_engine.py`)
- **Loop nodes now loop.** The execution dispatch previously ignored the loop executor's `next_node_id`, so `loop_node`/`done_node` config was dead and loops never iterated. The dispatch now routes body-vs-done from the executor; a loop with no `done_node` completes the run gracefully.
- **Rejection no longer routes like approval.** A rejected approval with no `meta.outcome: rejected` edge used to fall back to the success-edge path (the same path as approval). It now fails the run with `Approval rejected by <user>[: comment]`. The success-edge fallback applies only to approved decisions.
- **`approval_type` spelling split fixed.** Notifications matched only `"users"` while permission checks matched only `"user"`, so UI-authored approvals got no notifications/inbox and API-authored ones got no enforcement. Both spellings are now accepted everywhere (notification fan-out, `_verify_approval_permission`, `get_pending_approvals`).

### Validation (`flow_definition.py`)
- `trigger.schedule` and `trigger.doc-event` added to `ALLOWED_NODE_TYPES` — these executors already exist and are advertised by `get_node_schemas`, but definitions using them could never be saved.

### Permissions (`flow_run.json`, `huf/ai/flow_api.py`)
- Huf Manager gains `create` on Flow Run (previously only System Manager could start flows via the API).
- `approve_flow_run` now requires read + approver identity instead of write, so a named approver with the Huf User role can actually approve.
- All four agent tool handlers (`handle_run_flow`, `handle_get_flow_run`, `handle_resume_flow_run`, `handle_approve_flow_run`) previously had **no permission checks**; they now mirror the REST endpoints, and the approve handler additionally verifies approver identity — an agent session can no longer self-approve unless its user is an authorized approver.
- Webhook-triggered runs now execute as the flow owner instead of Guest (previously any agent/tool node inside a webhook flow failed unless the agent was guest-open).

### Builder (`frontend/src`)
- **Edge settings now survive saving.** The edge editor wrote `data.type`/`data.expression` while the serializer read `data.edgeType`/`data.condition`, so every UI-saved edge silently became `always` — no expression edges, no failure routing. Keys are aligned, and the editor gains **Priority** and **Approval Outcome** (`meta.outcome: approved/rejected`) controls so approve/reject branching is authorable.
- Expression placeholder now shows the syntax the evaluator accepts (`context["status"] == "approved"`) instead of mustache syntax it rejects.
- Trigger types round-trip: schedule and doc-event triggers serialize as `trigger.schedule`/`trigger.doc-event` instead of being flattened to `trigger.webhook` (and deserialize back correctly, with labels/icons).

### Approvals inbox (new)
- `ApprovalsBell` component mounted in the unified header on every page: shows a badge with the pending-approval count for the current user (first consumer of the `get_pending_approvals` endpoint), refreshes on `flow_paused`/`flow_completed`/`flow_error` realtime events plus a 60-second poll, and offers inline **Approve**/**Reject** and an **Open** deep link to the run viewer.

## What to test

**Loop**
1. Build a flow: trigger → loop (list of 3 items, `loop_node` = a transform in the body, `done_node` = end) with a body→loop edge. Run it. Before: one pass then stop. Expect: 3 iterations then completion via `done_node`.
2. Same loop without `done_node`: expect graceful Success after the last iteration.

**Edges**
3. In the builder, set an edge to type `expression` with `context["x"] == 1`, save, reload: type and condition must persist (before: reverted to `always`).
4. Add an `on_failure` edge from a node that fails (e.g. bad HTTP request): the failure branch must be taken after save/reload.
5. Set Priority on two competing edges and confirm the higher one wins.

**Approvals**
6. Flow with `human.approval` (`approval_type: user`, a named approver): the approver must receive a notification and see the item in the bell inbox (before: neither).
7. Author two outgoing edges with Approval Outcome `approved` and `rejected`; approve one run and reject another: each must follow its own branch.
8. Reject a run that has only a plain edge after the approval: run must end **Failed** with "Approval rejected by …" (before: continued down the approve path as Success).
9. Bell: badge count updates when a run pauses (realtime) and after approve/reject from the popover; Open link lands on the run viewer.
10. As a Huf User who is the named approver: approving via API must succeed. As an agent whose session user is *not* an approver, the `approve_flow_run` tool must be refused.

**Triggers**
11. Save a flow whose entry is a schedule trigger, reload: it must save (no validation error) and stay a schedule trigger (before: unsavable; if forced, flattened to webhook).

**Permissions / webhook**
12. As Huf Manager, start a flow via the run API: must succeed (before: PermissionError).
13. Trigger a webhook flow containing an `agent.run` node: it must execute as the flow owner and the agent node must run (before: Guest → agent refused).

**Regression**
14. Existing webhook-triggered flows, condition nodes, and the run viewer approve/reject buttons behave as before.
15. `cd frontend && npm run typecheck` passes; backend imports clean.
