### PR TITLE
feat(agent run): extract and validate trigger references in Agent Run

### DIFF
--- a/huf/huf/doctype/agent_run/agent_run.json
+++ b/huf/huf/doctype/agent_run/agent_run.json
@@ -37,7 +37,11 @@
   "flow_node_id",
   "column_break_flow1",
   "flow_id",
-  "run_kind"
+  "run_kind",
+  "trigger_reference_section",
+  "reference_doctype",
+  "column_break_hbrm",
+  "reference_name"
  ],
  "fields": [
   {
@@ -192,6 +196,25 @@
    "read_only": 1
   },
   {
+   "fieldname": "trigger_reference_section",
+   "fieldtype": "Section Break",
+   "label": "Trigger Reference"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "label": "Reference DocType",
+   "options": "DocType",
+   "read_only": 1
+  },
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Dynamic Link",
+   "label": "Reference Name",
+   "options": "reference_doctype",
+   "read_only": 1
+  },
+  {
    "fieldname": "call_recording",
    "fieldtype": "Attach",
    "label": "Call Recording",
@@ -249,12 +272,16 @@
    "label": "Run Kind",
    "options": "agent\ntool\norchestrator",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_hbrm",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-25 21:07:39.245567",
+ "modified": "2026-07-14 16:40:35.708364",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Run",

--- a/huf/huf/doctype/agent_run/agent_run.py
+++ b/huf/huf/doctype/agent_run/agent_run.py
@@ -1,9 +1,35 @@
 # Copyright (c) 2025, Tridz Technologies Pvt Ltd and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe import _
+import re
 
 
 class AgentRun(Document):
-	pass
+	def validate(self):
+		self.extract_reference_from_prompt()
+		self.validate_reference()
+
+	def extract_reference_from_prompt(self):
+		if not self.reference_doctype or not self.reference_name:
+			if self.prompt and isinstance(self.prompt, str):
+				doctype_match = re.search(r'reference_doctype\s*=\s*["\']([^"\']+)["\']', self.prompt)
+				name_match = re.search(r'reference_name\s*=\s*["\']([^"\']+)["\']', self.prompt)
+				if doctype_match and name_match:
+					candidate_doctype = doctype_match.group(1).strip()
+					candidate_name = name_match.group(1).strip()
+					if frappe.db.exists("DocType", candidate_doctype):
+						self.reference_doctype = candidate_doctype
+						self.reference_name = candidate_name
+
+	def validate_reference(self):
+		if self.reference_doctype:
+			if not frappe.db.exists("DocType", self.reference_doctype):
+				frappe.throw(_("Invalid Reference DocType: {0}").format(self.reference_doctype))
+			if self.reference_name:
+				if not frappe.db.exists(self.reference_doctype, self.reference_name):
+					frappe.throw(_("Invalid Reference Name: {0} for DocType {1}").format(self.reference_name, self.reference_doctype))
+		elif self.reference_name:
+			frappe.throw(_("Reference DocType is required when Reference Name is specified."))


### PR DESCRIPTION
### Summary
This PR adds support for automatically capturing and validating trigger references (`reference_doctype` and `reference_name`) when an `Agent Run` is initialized via document event triggers.

### Changes
- **DocType (`agent_run.json`)**: Added `reference_doctype` and `reference_name` read-only fields side-by-side (using a Column Break) under a new "Trigger Reference" section in the Metadata tab.
- **Model Controller (`agent_run.py`)**: 
  - Added extraction logic inside the `validate` hook using Regex to fetch `reference_doctype` and `reference_name` parameters from the prompt.
  - Added validation check to confirm the target DocType and document exist in the database.
  - Added localization and type-safety check (`isinstance(self.prompt, str)`).

### Verification
- Verified extraction regex against multiple prompt syntax patterns (single/double quotes, variations in spaces).
- Verified validation triggers a translation-friendly error message if a non-existent document or invalid DocType is passed.

---

