### PR TITLE
docs(agent-message): message context semantics audit

### DIFF
--- a/docs/audits/message-audit/CONTEXT.md
+++ b/docs/audits/message-audit/CONTEXT.md
@@ -4,8 +4,8 @@
 |-------|-------|
 | Track | `MessageAudit` |
 | Huf piece | `product` ([`huf/`](../../huf/)) |
-| Status | Done (Audit complete: STATE.md (as-built semantics), FINDINGS.md (MA-01..25), PLAN.md (4 phases); implementation phases queued as future tracks) |
-| Last updated | 2026-07-18 |
+| Status | Rebased audit against current `origin/develop`; docs-only update. |
+| Last updated | 2026-08-02 |
 
 ## What
 Audit of the **Agent Message** doctype and its context semantics — `context_policy`,
@@ -23,16 +23,15 @@ context-policy machinery; (3) the Agent Message ↔ Agent Tool Call duplication 
 register; (6) an incremental unification plan. Docs-only — no product code changes.
 
 ## Source & working copy
-- Reference (read-only): [`huf/`](../../huf/) symlink → `/Users/safwan/Code/Huf/huf`
-- **Branch audited:** `feature/inline-video-playback` @ `eebb9dc` (same base as
-  CodeDiscovery/CommitAudit; verified current for these semantics — `origin/develop`
-  @ `95daa90` only fixes the `Queues` typo + adds Agent Run trigger refs, and
-  `origin/feature/queue-first-agent-runs` @ `726762f` touches run lifecycle, not
-  message context semantics).
-- No working copy: docs-only track.
+- Working copy: `/Users/safwan/Code/Huf/worktrees/artifact-result-context-v1` (branch
+  `feat/artifact-result-context-v1`, rebased onto `origin/develop` @
+  `2c3fd73c81d2af40a392c7dbd1976f6068019d20`).
+- **Branch audited:** `origin/develop` @ `2c3fd73c81d2af40a392c7dbd1976f6068019d20`.
+- `docs/audits/` does not exist on `origin/develop`; this audit is the docs-only PR
+  #405 branch content.
 - Path note: repo nests the app one level deep — doctypes live at
-  `huf/huf/huf/doctype/<name>/` from the workspace root; `huf/ai/` citations from
-  CodeDiscovery resolve to `huf/huf/ai/`.
+  `huf/huf/doctype/<name>/` from the workspace root; `huf/ai/` citations resolve to
+  `huf/huf/ai/`.
 
 ## Key files
 - [`STATE.md`](STATE.md) — current-state report: schema, writers, readers, semantics per field.
@@ -43,26 +42,32 @@ register; (6) an incremental unification plan. Docs-only — no product code cha
 
 ## How to resume
 1. Read this file, then `STATE.md` → `FINDINGS.md` → `PLAN.md`.
-2. Code citations are repo-relative paths at `eebb9dc`; use the `huf/` symlink.
+2. Code citations are repo-relative paths at `origin/develop` @ `2c3fd73c`.
 3. Cross-check terminology against `Tracks/CodeDiscovery/GLOSSARY.md` (frozen).
-4. If implementing fixes: create a worktree inside this track, base on `develop`,
-   and file issues on `tridz-dev/huf` (precedent: CodeDiscovery issues #363–#385).
+4. If implementing fixes: work in `/Users/safwan/Code/Huf/worktrees/artifact-result-context-v1`,
+   base on `origin/develop` @ `2c3fd73c`, and file issues on `tridz-dev/huf`.
 
 ## Constraints / gotchas
-- Docs-only: do not edit code through the symlinked `huf/`.
-- Queue-first (PR #362) is treated-as-merged per owner (CodeDiscovery F-03) but is
-  **not** in the audited base; where behavior differs, it is flagged in STATE.md.
+- Docs-only: do not edit product code while updating this audit.
 - `frappe.db.commit()` policy for message paths is CommitAudit's scope — referenced,
   not re-audited here.
 
-## Verification pass (2026-07-18)
-Independent re-verification of STATE/FINDINGS/PLAN at `eebb9dc`, orchestrated per
-sub-task: 4 parallel kimi executors (policy table & history assembly; dead
-fields/write census/public API; ATC duplication/merge/stream usage; execution
-records & tests), each report reviewed and the load-bearing claims re-checked
-first-hand by the orchestrator. Outcome: 23/25 findings confirmed as written;
-**MA-14 withdrawn** (precedence claim was wrong — agent messages always get
-`user="Agent"`); MA-11/MA-15 sharpened (3 MAX+1 copies in sdk_tools; stream-path
-repair runs once per run, Error Log only on actual repairs); minor cite fixes
-(chatApi path is `frontend/src/services/`, ChatMessage kind branches at :149/:169,
-elevenlabs path under `providers/`, sync fallback lacks the 500-char floor).
+## Relationship to Result Store and Artifact Workspace
+
+- `Agent Message` is not the durable owner of large tool/API payloads.
+- `Agent Tool Call` is not by itself a sufficient large-result store.
+- Results require bounded envelopes and selective reads.
+- Artifacts require immutable versions and operations.
+- `Agent Context Artifact` is a compatibility/context bridge, not the canonical
+  artifact registry.
+- Result references and artifact references must be version-aware where mutation is
+  possible.
+- Message history must carry compact references, not complete work or unbounded
+  results.
+
+## Verification pass (2026-08-02)
+Rebased audit against `origin/develop` @ `2c3fd73c`. Re-classified findings in
+`FINDINGS.md` based on direct code checks; updated line numbers and census results in
+`STATE.md`. Added the required relationship to Result Store and Artifact Workspace.
+Track boundaries for `ResultContextFoundation` (Steps 1–3) and `Artifact Workspace V1`
+(Step 4) are documented in `PLAN.md`.

--- a/docs/audits/message-audit/CONTEXT.md
+++ b/docs/audits/message-audit/CONTEXT.md
@@ -1,0 +1,68 @@
+# CONTEXT — MessageAudit
+
+| Field | Value |
+|-------|-------|
+| Track | `MessageAudit` |
+| Huf piece | `product` ([`huf/`](../../huf/)) |
+| Status | Done (Audit complete: STATE.md (as-built semantics), FINDINGS.md (MA-01..25), PLAN.md (4 phases); implementation phases queued as future tracks) |
+| Last updated | 2026-07-18 |
+
+## What
+Audit of the **Agent Message** doctype and its context semantics — `context_policy`,
+`record_kind`, `token_estimate`, `visibility`, `context_summary` (plus the `kind`/
+`record_kind` duality and tool-call fields) — how they are written, read, and whether
+the logic is sound. Extends to the structural observation that Huf keeps three
+partially separate execution records (Agent Run, Agent Orchestration, Flow Run) while
+Agent Message duplicates tool-call data already in Agent Tool Call.
+
+## Goal
+A documented, file:line-cited register covering: (1) current state of Agent Message
+context fields (writers, readers, semantics); (2) soundness assessment of the
+context-policy machinery; (3) the Agent Message ↔ Agent Tool Call duplication map;
+(4) the three-execution-records overlap analysis; (5) gaps/locks/traps/issues
+register; (6) an incremental unification plan. Docs-only — no product code changes.
+
+## Source & working copy
+- Reference (read-only): [`huf/`](../../huf/) symlink → `/Users/safwan/Code/Huf/huf`
+- **Branch audited:** `feature/inline-video-playback` @ `eebb9dc` (same base as
+  CodeDiscovery/CommitAudit; verified current for these semantics — `origin/develop`
+  @ `95daa90` only fixes the `Queues` typo + adds Agent Run trigger refs, and
+  `origin/feature/queue-first-agent-runs` @ `726762f` touches run lifecycle, not
+  message context semantics).
+- No working copy: docs-only track.
+- Path note: repo nests the app one level deep — doctypes live at
+  `huf/huf/huf/doctype/<name>/` from the workspace root; `huf/ai/` citations from
+  CodeDiscovery resolve to `huf/huf/ai/`.
+
+## Key files
+- [`STATE.md`](STATE.md) — current-state report: schema, writers, readers, semantics per field.
+- [`FINDINGS.md`](FINDINGS.md) — gaps/locks/traps/issues register (MA-xx IDs).
+- [`PLAN.md`](PLAN.md) — incremental unification plan (phases, tasks).
+- Upstream inputs: [`Tracks/CodeDiscovery/`](../CodeDiscovery/) (GLOSSARY, FINDINGS,
+  ADR 0001/0002, discovery/02), [`Tracks/CommitAudit/`](../CommitAudit/) (REPORT).
+
+## How to resume
+1. Read this file, then `STATE.md` → `FINDINGS.md` → `PLAN.md`.
+2. Code citations are repo-relative paths at `eebb9dc`; use the `huf/` symlink.
+3. Cross-check terminology against `Tracks/CodeDiscovery/GLOSSARY.md` (frozen).
+4. If implementing fixes: create a worktree inside this track, base on `develop`,
+   and file issues on `tridz-dev/huf` (precedent: CodeDiscovery issues #363–#385).
+
+## Constraints / gotchas
+- Docs-only: do not edit code through the symlinked `huf/`.
+- Queue-first (PR #362) is treated-as-merged per owner (CodeDiscovery F-03) but is
+  **not** in the audited base; where behavior differs, it is flagged in STATE.md.
+- `frappe.db.commit()` policy for message paths is CommitAudit's scope — referenced,
+  not re-audited here.
+
+## Verification pass (2026-07-18)
+Independent re-verification of STATE/FINDINGS/PLAN at `eebb9dc`, orchestrated per
+sub-task: 4 parallel kimi executors (policy table & history assembly; dead
+fields/write census/public API; ATC duplication/merge/stream usage; execution
+records & tests), each report reviewed and the load-bearing claims re-checked
+first-hand by the orchestrator. Outcome: 23/25 findings confirmed as written;
+**MA-14 withdrawn** (precedence claim was wrong — agent messages always get
+`user="Agent"`); MA-11/MA-15 sharpened (3 MAX+1 copies in sdk_tools; stream-path
+repair runs once per run, Error Log only on actual repairs); minor cite fixes
+(chatApi path is `frontend/src/services/`, ChatMessage kind branches at :149/:169,
+elevenlabs path under `providers/`, sync fallback lacks the 500-char floor).

--- a/docs/audits/message-audit/FINDINGS.md
+++ b/docs/audits/message-audit/FINDINGS.md
@@ -1,7 +1,7 @@
 # FINDINGS — MessageAudit register
 
 Gaps / locks / traps / issues in Agent Message context semantics and the execution
-records, consolidated from STATE.md (evidence cited there). Base: `eebb9dc`.
+records, consolidated from STATE.md (evidence cited there). Base: `origin/develop` @ `2c3fd73c`.
 Categories: **G** = gap (missing/broken behavior), **L** = lock (coupling that
 constrains change), **T** = trap (misleads a rewrite/new-language effort),
 **I** = issue (outright bug). Severity: Critical / High / Medium / Low.
@@ -26,11 +26,11 @@ Cross-refs: CodeDiscovery FINDINGS IDs (A-*, B-*, C-*, D-*) and their GitHub iss
 |---|---|---|---|
 | MA-09 | High | **Stream token undercount**: `stream_usage` reset per tool round (`litellm.py:975`) → streaming runs record only the final LLM round's tokens/cost on Agent Run + Conversation totals. Sync path correct | STATE §7.4 |
 | MA-10 | High | **`tool_status` staleness**: `fetch_from` copies refresh only on message save; sync-fallback rows keep `tool_status="Queued"` forever; stream merge failures only logged → UI status silently disagrees with ATC truth | STATE §7.2 |
-| MA-11 | High | **`conversation_index` race**: MAX+1 via SQL with no lock/unique constraint (duplicated 3× in `sdk_tools.py:1539-1550,2154-2166,2468-2475`); equal indices → undefined history order. Queue-first's per-conversation lock mitigates only on its branch | STATE §2.3 |
+| MA-11 | High | **`conversation_index` race**: MAX+1 via SQL with no lock/unique constraint in `conversation_manager.py:439-467` and `audio_service.py:697-708`; equal indices → undefined history order. `sdk_tools.py` no longer assigns the index directly on current `develop` | STATE §2.3 |
 | MA-12 | High | **Unguarded public write API**: `agent_chat.add_message` — no in-repo callers, no ownership/permission check, free `role` choice (`system`/`agent` injection into any conversation, re-enters model context as `include_full`) | STATE §3.4 |
 | MA-13 | Medium | Merge path fragility: `"**Tool Result:**"` substring guard couples persistence to a display string; mutated full `content` (call text + result) sent as the tool message, contradicting the Tool Call branch's UI-text sanitation; missing link → empty tool name + `{}` args sent to provider | STATE §6 |
 | MA-14 | — | **WITHDRAWN** (verification pass 2026-07-18, 4× kimi + orchestrator re-check): the claimed precedence bug does not exist — `(external_id or session.user) if role == "user" else "Agent"` is the actual parse; agent messages always get `user="Agent"` | STATE §4 |
-| MA-15 | Medium | `repair_message_sequence` writes an Error Log entry on **every routine repair** (trimming is by-design) → error-log spam + extra DB writes. Precision (verification pass): logs only when a repair actually occurred, and the stream path repairs once per run, not per round | STATE §2.2 |
+| MA-15 | Medium | `repair_message_sequence` writes an Error Log entry on **every routine repair** (trimming is by-design) → error-log spam + extra DB writes (`conversation_manager.py:321-328`) | STATE §2.2 |
 | MA-16 | Low | ElevenLabs webhook writes nonexistent `Agent Run.total_cost` (silently dropped) and rewrites message `creation` timestamps | STATE §10, §4 |
 | MA-17 | Low | Conversation totals updated by fire-and-forget SQL; failures only logged → run-level vs conversation-level token/cost drift | STATE §7.4 |
 
@@ -50,24 +50,23 @@ Cross-refs: CodeDiscovery FINDINGS IDs (A-*, B-*, C-*, D-*) and their GitHub iss
 | MA-22 | **The 8-policy enum looks designed; it is 2 behaviors + aliases + tests that pin only the real ones.** A rewrite that "preserves all 8 policies + 10 record kinds + 5 visibilities" carries forward 4 aliases, 2 dead fields, and a broken on-demand contract — the observation's "same complexity at a higher cost" in miniature | STATE §2.1, §8 |
 | MA-23 | **Three status vocabularies + split token/cost ownership**: 4/6/6 option sets (+ lowercase plan steps), tokens/cost only on Agent Run, errors triplicated under different names, Flow Run holding one overwritten `last_agent_run`. A new execution language over these inherits all three vocabularies and every aggregation rule | STATE §10 |
 | MA-24 | **Dead statuses and fields are load-bearing in readers**: `Waiting User`/`Paused` are checked but never set; `Status`/`Error` message kinds render as plain text but enter model context as content. Removing them naively changes behavior; keeping them preserves noise | STATE §10, C2 §3 |
-| MA-25 | **Branch drift**: `Queues` typo fixed on `develop` but not at audit base; `generated_video` existed on no branch until the 417 fix; queue-first rewrites run lifecycle without touching message semantics. Any rewrite must name its base and merge policy first (see `DOCKER_BENCH.md` §3 drift warnings) | STATE §9 |
+| MA-25 | **Branch drift**: Audit rebased onto `origin/develop` @ `2c3fd73c`; `generated_video` still has no writer on this base (see MA-06). Any rewrite must name its base and merge policy first (see `DOCKER_BENCH.md` §3 drift warnings) | STATE §9 |
 
 ## Relation to prior registers
 
 - Confirms and sharpens CodeDiscovery **B-01** (#365, artifact creation path), **B-04**
   (#368, flow tool.call → no Tool Call), **C-01** (#373, dead status options — ATC
   `"Started"` joins the list).
-- CommitAudit overlap: message write paths commit at `agent_integration.py:749,945,
-  1144`, `litellm.py:1177`, `sdk_tools.py:1662,2242,2522`, `ocr_engine.py:712` —
-  classified there (guarded/`safe_commit`); this register adds only the
-  data-consistency consequences (MA-09/MA-10/MA-17), not commit-policy items.
+- CommitAudit overlap: message write paths are classified there
+  (guarded/`safe_commit`); this register adds only the data-consistency
+  consequences (MA-09/MA-10/MA-17), not commit-policy items.
 - ProviderBrand417 overlap: `generated_video` no-writer fact (MA-06) is the same
   half-shipped feature that caused the 417s.
 
 ## Suggested issue filing
 
 Batch-file on `tridz-dev/huf` following the CodeDiscovery precedent (#363–#385,
-base `feature/inline-video-playback` @ `eebb9dc`): one issue per MA row, or grouped
+base `origin/develop` @ `2c3fd73c`): one issue per MA row, or grouped
 as "context-policy truthfulness" (MA-01..05), "tool-call consistency" (MA-08..13),
 "execution-record unification" (MA-21..23). Filing is an outward action — do it only
 on owner request.

--- a/docs/audits/message-audit/FINDINGS.md
+++ b/docs/audits/message-audit/FINDINGS.md
@@ -1,0 +1,73 @@
+# FINDINGS — MessageAudit register
+
+Gaps / locks / traps / issues in Agent Message context semantics and the execution
+records, consolidated from STATE.md (evidence cited there). Base: `eebb9dc`.
+Categories: **G** = gap (missing/broken behavior), **L** = lock (coupling that
+constrains change), **T** = trap (misleads a rewrite/new-language effort),
+**I** = issue (outright bug). Severity: Critical / High / Medium / Low.
+Cross-refs: CodeDiscovery FINDINGS IDs (A-*, B-*, C-*, D-*) and their GitHub issues.
+
+## G. Gaps — missing or broken behavior
+
+| ID | Sev | Finding | Evidence |
+|---|---|---|---|
+| MA-01 | High | `visibility` is a **dead field**: no reader anywhere (not history assembly, not permission hooks, not UI); options `ui_only/audit_only/model_visible/developer_only` are dead values. Messages carry a security-looking label that enforces nothing | STATE §3, §3.4 |
+| MA-02 | Medium | `token_estimate` is a **dead field**: no reader anywhere; the `token_budgeted` policy that should consume it ignores it | STATE §3 |
+| MA-03 | High | **Policy enum is mostly phantom**: `token_budgeted`→alias of `include_summary`; `provider_cached`→alias of `include_full`; `transient_only`→alias of `exclude`; `include_on_demand`→drops content leaving no discovery handle. Only `include_full`/`include_reference` are ever written by app code | STATE §2.1, §4 |
+| MA-04 | Medium | `record_kind` near-dead: 9 of 10 values never written; read only as a label in `include_reference` handles | STATE §3, §5 |
+| MA-05 | Medium | `include_summary` silently falls back to full content when no summary exists (cost-inflating no-op); `context_summary` is a 200-char truncation, never a real summary | STATE §2.1, §3 |
+| MA-06 | Low | No writers at all for `status`, `content_type`, `generated_video` (schema declares, nothing produces) | STATE §4 |
+| MA-07 | High | Agent Context Artifact has **no creation path** (CodeDiscovery B-01 / issue #365 re-confirmed): artifact-typed `record_kind` values and artifact `context_policy` are unreachable; `include_reference` handles only ever point at Agent Tool Call | STATE §3, C2 |
+| MA-08 | Medium | ATC status semantics broken: `"Started"` never written (joins CodeDiscovery C-01 / #373); `Failed` effectively dead — tool exceptions persist as `Completed` with `"Error executing tool …"` in the result body | STATE §7.1 |
+
+## I. Issues — outright bugs
+
+| ID | Sev | Finding | Evidence |
+|---|---|---|---|
+| MA-09 | High | **Stream token undercount**: `stream_usage` reset per tool round (`litellm.py:975`) → streaming runs record only the final LLM round's tokens/cost on Agent Run + Conversation totals. Sync path correct | STATE §7.4 |
+| MA-10 | High | **`tool_status` staleness**: `fetch_from` copies refresh only on message save; sync-fallback rows keep `tool_status="Queued"` forever; stream merge failures only logged → UI status silently disagrees with ATC truth | STATE §7.2 |
+| MA-11 | High | **`conversation_index` race**: MAX+1 via SQL with no lock/unique constraint (duplicated 3× in `sdk_tools.py:1539-1550,2154-2166,2468-2475`); equal indices → undefined history order. Queue-first's per-conversation lock mitigates only on its branch | STATE §2.3 |
+| MA-12 | High | **Unguarded public write API**: `agent_chat.add_message` — no in-repo callers, no ownership/permission check, free `role` choice (`system`/`agent` injection into any conversation, re-enters model context as `include_full`) | STATE §3.4 |
+| MA-13 | Medium | Merge path fragility: `"**Tool Result:**"` substring guard couples persistence to a display string; mutated full `content` (call text + result) sent as the tool message, contradicting the Tool Call branch's UI-text sanitation; missing link → empty tool name + `{}` args sent to provider | STATE §6 |
+| MA-14 | — | **WITHDRAWN** (verification pass 2026-07-18, 4× kimi + orchestrator re-check): the claimed precedence bug does not exist — `(external_id or session.user) if role == "user" else "Agent"` is the actual parse; agent messages always get `user="Agent"` | STATE §4 |
+| MA-15 | Medium | `repair_message_sequence` writes an Error Log entry on **every routine repair** (trimming is by-design) → error-log spam + extra DB writes. Precision (verification pass): logs only when a repair actually occurred, and the stream path repairs once per run, not per round | STATE §2.2 |
+| MA-16 | Low | ElevenLabs webhook writes nonexistent `Agent Run.total_cost` (silently dropped) and rewrites message `creation` timestamps | STATE §10, §4 |
+| MA-17 | Low | Conversation totals updated by fire-and-forget SQL; failures only logged → run-level vs conversation-level token/cost drift | STATE §7.4 |
+
+## L. Locks — couplings that constrain any change
+
+| ID | Finding | Evidence |
+|---|---|---|
+| MA-18 | **Three persisted tool shapes** coexist — separate Tool Call row, combined Tool Result row (in-place mutation), legacy separate `role=tool` rows — each with its own expansion branch; plus a repair synthesis path and a data patch. Any schema change must migrate all three shapes and keep OpenAI pairing valid | STATE §2.2, §7.2 |
+| MA-19 | **One row serves two masters**: Agent Message is simultaneously UI presentation (fetch copies, socket events, mappers keyed on legacy `kind`) and model context (policy machinery reading the same `content`/`kind`). The in-place Tool Call→Tool Result mutation is the sharpest example. Changing either side breaks the other — this is the coupling that produced the duplication | STATE §6, §7.2 |
+| MA-20 | **ATC is the truth but invisible**: repairs flow ATC→message, `get_result_context` serves from ATC, yet ATC is System-Manager-only and the frontend reads only the denormalized copies. Unification must re-home presentation data, not just pick a winner | STATE §7.2 |
+| MA-21 | **Execution linkage runs through Agent Run only**: messages/tool calls attach to flows/orchestrations indirectly via `agent_run`; Flow Run keeps only `last_agent_run`; orchestration state split between a shell run and plan rows. Any unified timeline must first unify the run linkage | STATE §10 |
+
+## T. Traps — what would mislead a rewrite / new-language effort
+
+| ID | Finding | Evidence |
+|---|---|---|
+| MA-22 | **The 8-policy enum looks designed; it is 2 behaviors + aliases + tests that pin only the real ones.** A rewrite that "preserves all 8 policies + 10 record kinds + 5 visibilities" carries forward 4 aliases, 2 dead fields, and a broken on-demand contract — the observation's "same complexity at a higher cost" in miniature | STATE §2.1, §8 |
+| MA-23 | **Three status vocabularies + split token/cost ownership**: 4/6/6 option sets (+ lowercase plan steps), tokens/cost only on Agent Run, errors triplicated under different names, Flow Run holding one overwritten `last_agent_run`. A new execution language over these inherits all three vocabularies and every aggregation rule | STATE §10 |
+| MA-24 | **Dead statuses and fields are load-bearing in readers**: `Waiting User`/`Paused` are checked but never set; `Status`/`Error` message kinds render as plain text but enter model context as content. Removing them naively changes behavior; keeping them preserves noise | STATE §10, C2 §3 |
+| MA-25 | **Branch drift**: `Queues` typo fixed on `develop` but not at audit base; `generated_video` existed on no branch until the 417 fix; queue-first rewrites run lifecycle without touching message semantics. Any rewrite must name its base and merge policy first (see `DOCKER_BENCH.md` §3 drift warnings) | STATE §9 |
+
+## Relation to prior registers
+
+- Confirms and sharpens CodeDiscovery **B-01** (#365, artifact creation path), **B-04**
+  (#368, flow tool.call → no Tool Call), **C-01** (#373, dead status options — ATC
+  `"Started"` joins the list).
+- CommitAudit overlap: message write paths commit at `agent_integration.py:749,945,
+  1144`, `litellm.py:1177`, `sdk_tools.py:1662,2242,2522`, `ocr_engine.py:712` —
+  classified there (guarded/`safe_commit`); this register adds only the
+  data-consistency consequences (MA-09/MA-10/MA-17), not commit-policy items.
+- ProviderBrand417 overlap: `generated_video` no-writer fact (MA-06) is the same
+  half-shipped feature that caused the 417s.
+
+## Suggested issue filing
+
+Batch-file on `tridz-dev/huf` following the CodeDiscovery precedent (#363–#385,
+base `feature/inline-video-playback` @ `eebb9dc`): one issue per MA row, or grouped
+as "context-policy truthfulness" (MA-01..05), "tool-call consistency" (MA-08..13),
+"execution-record unification" (MA-21..23). Filing is an outward action — do it only
+on owner request.

--- a/docs/audits/message-audit/PLAN.md
+++ b/docs/audits/message-audit/PLAN.md
@@ -1,0 +1,90 @@
+# PLAN — MessageAudit: incremental unification
+
+Derived from [`FINDINGS.md`](FINDINGS.md) (MA-01…MA-25) and the structural
+observation this track verified (STATE.md §11). Guiding rule from the observation:
+**unify semantics before any new language/rewrite** — otherwise the three execution
+vocabularies, the 3× tool-data duplication, and the phantom policy enum are
+preserved at higher cost.
+
+Each phase is independently shippable, ordered by risk (no schema change → additive
+→ structural). Every task lists: findings addressed, files touched, and the check
+that proves it done. Base branch for implementation: `develop` (per workspace
+branch topology), in a worktree inside this track.
+
+---
+
+## Phase 0 — Baseline (docs, this track) ✅
+
+- [x] STATE.md / FINDINGS.md / PLAN.md written, cited at `eebb9dc`.
+- [ ] File GitHub issues for MA items (needs owner go-ahead — outward action).
+- [ ] Owner review: pick which "decide" tasks (P2.1–P2.3) land as designed.
+
+## Phase 1 — Stop the bleeding (bug fixes, no schema change)
+
+Small, reviewable PRs; each behind the existing test suite + one new test.
+
+| # | Task | Findings | Files | Done when |
+|---|---|---|---|---|
+| 1.1 | Harden or remove `agent_chat.add_message`: add conversation-ownership check (mirror `get_message_permission_conditions`) + restrict `role` to `user`/`system`-with-capability; or delete the endpoint (zero in-repo callers) | MA-12 | `ai/agent_chat.py:873-923` | API returns 403 for non-owner; legit callers unaffected; test added |
+| 1.2 | Fix stream token undercount: accumulate `stream_usage` across tool rounds instead of resetting | MA-09 | `ai/providers/litellm.py:975,984-989,1238-1255` | streaming run with tool calls records total tokens == sum of rounds; sync/stream parity test |
+| 1.3 | Make ATC `Failed` real: pass `error=` from exception paths, stop storing exceptions as `Completed`; surface error to the message row | MA-08, MA-10(b) | `ai/agent_integration.py:397-485`, `ai/providers/litellm.py:1080-1102` | a raising tool produces ATC `Failed` + `error_message`; message/socket show failure |
+| 1.4 | Put index assignment behind the per-conversation lock (align with queue-first) or add `UNIQUE(conversation, conversation_index)`; dedupe the 3 MAX+1 copies (~~user-field precedence fix~~ — MA-14 withdrawn, no bug) | MA-11 | `ai/conversation_manager.py:420-448`, `ai/sdk_tools.py:1539-1550,2154-2166,2468-2475` | no duplicate indices under concurrent inserts (test) |
+| 1.5 | Kill `tool_status` staleness: drop the three `fetch_from` fields, read `tool_name/args/status` via the `tool_call` link at read time (report/API projection) | MA-10 | `agent_message.json`, `chatApi.ts:305-306`, desk list views | UI shows live ATC status; no fetch copies in schema |
+| 1.6 | Quiet routine repairs: log repairs at debug level (or count-only), not Error Log | MA-15 | `ai/conversation_manager.py:312-319` | routine trims produce no Error Log rows |
+| 1.7 | ElevenLabs drift: `total_cost`→`cost`; stop rewriting `creation` | MA-16 | `ai/providers/elevenlabs_convai_api.py:186-237` | voice runs record cost; message timestamps immutable |
+
+## Phase 2 — Truthful context semantics (additive schema evolution)
+
+Principle: the enum must only contain behaviors that exist. Introduce new behavior
+**or** remove the option — never keep a label without semantics.
+
+| # | Task | Findings | Decision needed |
+|---|---|---|---|
+| 2.1 | Collapse the policy enum to implemented behaviors: `include_full`, `include_summary`, `include_reference`, `exclude`. Data patch mapping `token_budgeted`→`include_summary`, `provider_cached`→`include_full`, `transient_only`→`exclude`; remove the aliases from options | MA-03 | none (mechanical) |
+| 2.2 | `include_on_demand`: either implement discovery (emit a handle like `include_reference` but withhold content until `get_result_context` fetches it) or drop the option | MA-03 | owner pick — recommend **implement via handle** (unifies with 2.5) |
+| 2.3 | `token_estimate` + `token_budgeted`: either implement real budgeting (estimate at write time via chars/4 heuristic or tokenizer; enforce a per-conversation token budget in `get_conversation_history` using estimates) or drop field + policy | MA-02 | owner pick — recommend **implement** (it's the only token-aware knob; aligns with queue-first cost work) |
+| 2.4 | `visibility`: either enforce (extend `get_message_permission_conditions` + history filter so `ui_only` never enters model context and `audit_only` never leaves the backend) or drop the field | MA-01 | owner pick — recommend **enforce minimally**: `model_visible` vs `ui_only` split is genuinely useful for status/debug rows |
+| 2.5 | Generalize `get_result_context` to any `include_reference` handle (today: ATC + Context Artifact only) and add a backend creation path for Agent Context Artifacts | MA-07, B-01/#365 | none — completes the designed loop |
+| 2.6 | Merge `kind`/`record_kind` into one canonical `record_kind` (superset vocabulary), data patch `kind`→`record_kind`, switch readers, deprecate then remove `kind` | MA-04, MA-05 | naming ratification (GLOSSARY update) |
+| 2.7 | Real summaries: replace 200-char truncation with the existing summarization machinery (`run_background_summarization`) for `include_summary` rows; hard-fail (not silent full-include) when summary missing | MA-05 | perf note: summarization is a background job today |
+
+Validation per task: extend `ai/tests/test_context_policy.py` (it already pins the
+real behaviors) + add policy-matrix tests for every enum value (the currently
+untested ones are exactly the phantom ones — STATE §8).
+
+## Phase 3 — Unify the execution records (structural; the observation's core)
+
+| # | Task | Findings | Notes |
+|---|---|---|---|
+| 3.1 | Write **Execution Semantics ADR** (follow CodeDiscovery ADR format): one canonical execution = **Agent Run**; Orchestration and Flow Run become *coordination metadata* over runs, not parallel state machines. Define the status-vocabulary mapping (Queued/Started/Success/Failed as canonical; flow Waiting Approval/Waiting User as substates) | MA-21, MA-23 | owner sign-off — this is the hard-to-reverse call; candidate ADR 0003 |
+| 3.2 | Flow `tool.call` produces a real **Agent Tool Call** (structured tool/args/result/call_id/conversation), keeping the audit run only if still needed | MA-21, B-04/#368 | removes the last non-ATC tool path |
+| 3.3 | Single token/cost aggregation: run-level write stays; conversation totals become derived (sum over runs) or transactional — no fire-and-forget SQL | MA-17 | after 1.2 (streaming totals fixed first) |
+| 3.4 | Unified read API + timeline UI: one endpoint returning runs (all kinds) with linkage; Executions page + flow sheets + orchestration card consume it | MA-21, MA-23 | frontend after backend API lands |
+| 3.5 | Retire dead statuses (`Waiting User`, `Paused`, ATC `Started`, message `Queues`→`Queued` backport) and lowercase plan-step vocabulary | MA-24, C-01/#373 | mechanical after 3.1 mapping |
+
+## Phase 4 — Message ↔ Tool Call unification (after 1–3)
+
+| # | Task | Findings | Notes |
+|---|---|---|---|
+| 4.1 | Agent Message tool rows become **pure projections** of ATC: no `fetch_from` copies (done in 1.5), no `tool_call_id`/`tool_calls` duplication — history expansion always resolves via the link (the code paths already exist and are used as fallbacks today) | MA-18, MA-19, MA-20 | the repair patch proves this direction is safe |
+| 4.2 | Collapse to **one persisted tool shape** (assistant declaration row + linked ATC holding result); migration for the three legacy shapes using the existing patch + `_synthesize_assistant_tool_call` logic | MA-18, MA-13 | biggest data migration; dry-run on a bench copy first |
+| 4.3 | Separate presentation from context: UI renders from ATC+message projection; `content` stops being mutated in place (Tool Call row stays a call; result lives on ATC; the model view is assembled, not stored) | MA-19, MA-13 | completes the two-masters decoupling |
+
+## Cross-track dependencies
+
+- **QueueFirstRuns**: queue-first's per-conversation lock is the natural home for
+  1.4; land that branch or cherry-pick the lock first.
+- **CommitAudit**: Phases 1–2 touch commit-adjacent paths — follow its
+  `safe_commit` guidance, don't reintroduce raw commits.
+- **CodeDiscovery**: ADR 0003 (3.1) and GLOSSARY updates (2.6) belong to its
+  domain-model governance; file issues in its numbering style.
+
+## Incremental context-building (how to execute)
+
+1. Land Phase 1 PRs individually (each is a few files, each verifiable on bench 16).
+2. Re-run this track's sweeps after Phase 1 to re-baseline STATE.md (fields that
+   became live/dead).
+3. Take Phase 2 decisions to the owner in one grill session (precedent:
+   CodeDiscovery GRILL-LOG), then implement.
+4. Phases 3–4 each get their own track registered via `tools/ws track-add` when
+   started (3 → e.g. `ExecutionUnify`, 4 → e.g. `MessageUnify`).

--- a/docs/audits/message-audit/PLAN.md
+++ b/docs/audits/message-audit/PLAN.md
@@ -11,11 +11,35 @@ Each phase is independently shippable, ordered by risk (no schema change → add
 that proves it done. Base branch for implementation: `develop` (per workspace
 branch topology), in a worktree inside this track.
 
+## Track boundaries — Result/Context Foundation vs Artifact Workspace V1
+
+This MessageAudit plan is now the docs baseline for the larger Result/Context +
+Artifact Workspace program. The program is split into two tracks:
+
+- **`ResultContextFoundation` (Steps 1–3, this plan + `HUF_ARTIFACT_RESULT_CONTEXT_IMPLEMENTATION_PLAN.md`):**
+  - Step 1: rebase PR #405 / MessageAudit onto current `origin/develop` and push.
+  - Step 2: critical correctness/security fixes from the audit that are still valid.
+  - Step 3: Result/Context Foundation V1 — durable result store, bounded envelopes,
+    selective reads, private payload storage, and lineage from run/tool to message.
+  - Do **not** create Artifact Workspace DocTypes here.
+
+- **`Artifact Workspace V1` (Step 4, `HUF_ARTIFACT_WORKSPACE_COMPLETE_SPEC_AND_PHASED_PLAN.md`):**
+  - Build `Artifact`, `Artifact Version`, `Artifact Asset`, and `Artifact Operation`
+    records and APIs.
+  - Reuse the envelope/reference contract, private-file storage policy, `result_read`
+    view model, idempotency/compare-and-swap pattern, and provenance fields from
+    Step 3.
+  - Start only after Result/Context Foundation V1 is working and its DoD is met.
+
+- **Future tracks (Steps 5–7):** Message/tool-call projection cleanup, execution-record
+  unification, and format-specific plans (XLSX/PPTX/optimization) will each get their
+  own detailed plan written against the post-V1 code, migration state, and tests.
+
 ---
 
 ## Phase 0 — Baseline (docs, this track) ✅
 
-- [x] STATE.md / FINDINGS.md / PLAN.md written, cited at `eebb9dc`.
+- [x] STATE.md / FINDINGS.md / PLAN.md rebased against `origin/develop` @ `2c3fd73c`; citations and findings updated.
 - [ ] File GitHub issues for MA items (needs owner go-ahead — outward action).
 - [ ] Owner review: pick which "decide" tasks (P2.1–P2.3) land as designed.
 
@@ -25,13 +49,13 @@ Small, reviewable PRs; each behind the existing test suite + one new test.
 
 | # | Task | Findings | Files | Done when |
 |---|---|---|---|---|
-| 1.1 | Harden or remove `agent_chat.add_message`: add conversation-ownership check (mirror `get_message_permission_conditions`) + restrict `role` to `user`/`system`-with-capability; or delete the endpoint (zero in-repo callers) | MA-12 | `ai/agent_chat.py:873-923` | API returns 403 for non-owner; legit callers unaffected; test added |
-| 1.2 | Fix stream token undercount: accumulate `stream_usage` across tool rounds instead of resetting | MA-09 | `ai/providers/litellm.py:975,984-989,1238-1255` | streaming run with tool calls records total tokens == sum of rounds; sync/stream parity test |
-| 1.3 | Make ATC `Failed` real: pass `error=` from exception paths, stop storing exceptions as `Completed`; surface error to the message row | MA-08, MA-10(b) | `ai/agent_integration.py:397-485`, `ai/providers/litellm.py:1080-1102` | a raising tool produces ATC `Failed` + `error_message`; message/socket show failure |
-| 1.4 | Put index assignment behind the per-conversation lock (align with queue-first) or add `UNIQUE(conversation, conversation_index)`; dedupe the 3 MAX+1 copies (~~user-field precedence fix~~ — MA-14 withdrawn, no bug) | MA-11 | `ai/conversation_manager.py:420-448`, `ai/sdk_tools.py:1539-1550,2154-2166,2468-2475` | no duplicate indices under concurrent inserts (test) |
+| 1.1 | Harden or remove `agent_chat.add_message`: add conversation-ownership check (mirror `get_message_permission_conditions`) + restrict `role` to `user`/`system`-with-capability; or delete the endpoint (zero in-repo callers) | MA-12 | `huf/ai/agent_chat.py:1048-1100` | API returns 403 for non-owner; legit callers unaffected; test added |
+| 1.2 | Fix stream token undercount: accumulate `stream_usage` across tool rounds instead of resetting | MA-09 | `huf/ai/providers/litellm.py:1519,1851-1857,1922-1928` | streaming run with tool calls records total tokens == sum of rounds; sync/stream parity test |
+| 1.3 | Make ATC `Failed` real: pass `error=` from exception paths, stop storing exceptions as `Completed`; surface error to the message row | MA-08, MA-10(b) | `huf/ai/providers/litellm.py:1049-1057,1670-1698`; `huf/ai/providers/anthropic.py:139`; `huf/ai/providers/google.py:178`; `huf/ai/providers/openrouter.py:102` | a raising tool produces ATC `Failed` + `error_message`; message/socket show failure |
+| 1.4 | Put index assignment behind the per-conversation lock or add `UNIQUE(conversation, conversation_index)`; cover `audio_service.py` and `conversation_manager.py` (~~user-field precedence fix~~ — MA-14 withdrawn, no bug) | MA-11 | `huf/ai/conversation_manager.py:439-467`, `huf/ai/audio_service.py:697-708` | no duplicate indices under concurrent inserts (test) |
 | 1.5 | Kill `tool_status` staleness: drop the three `fetch_from` fields, read `tool_name/args/status` via the `tool_call` link at read time (report/API projection) | MA-10 | `agent_message.json`, `chatApi.ts:305-306`, desk list views | UI shows live ATC status; no fetch copies in schema |
-| 1.6 | Quiet routine repairs: log repairs at debug level (or count-only), not Error Log | MA-15 | `ai/conversation_manager.py:312-319` | routine trims produce no Error Log rows |
-| 1.7 | ElevenLabs drift: `total_cost`→`cost`; stop rewriting `creation` | MA-16 | `ai/providers/elevenlabs_convai_api.py:186-237` | voice runs record cost; message timestamps immutable |
+| 1.6 | Quiet routine repairs: log repairs at debug level (or count-only), not Error Log | MA-15 | `huf/ai/conversation_manager.py:321-328` | routine trims produce no Error Log rows |
+| 1.7 | ElevenLabs drift: `total_cost`→`cost`; stop rewriting `creation` | MA-16 | `huf/ai/providers/elevenlabs_convai_api.py:194,238` | voice runs record cost; message timestamps immutable |
 
 ## Phase 2 — Truthful context semantics (additive schema evolution)
 
@@ -72,8 +96,8 @@ untested ones are exactly the phantom ones — STATE §8).
 
 ## Cross-track dependencies
 
-- **QueueFirstRuns**: queue-first's per-conversation lock is the natural home for
-  1.4; land that branch or cherry-pick the lock first.
+- **QueueFirstRuns**: queue-first has merged into `develop`; its per-conversation
+  lock is the natural home for 1.4.
 - **CommitAudit**: Phases 1–2 touch commit-adjacent paths — follow its
   `safe_commit` guidance, don't reintroduce raw commits.
 - **CodeDiscovery**: ADR 0003 (3.1) and GLOSSARY updates (2.6) belong to its

--- a/docs/audits/message-audit/STATE.md
+++ b/docs/audits/message-audit/STATE.md
@@ -1,10 +1,10 @@
 # STATE — Agent Message context semantics (as-built)
 
-Audit base: `feature/inline-video-playback` @ `eebb9dc` (verified current for these
-semantics — see CONTEXT.md). All citations are repo-relative paths with lines at that
+Audit base: `origin/develop` @ `2c3fd73c81d2af40a392c7dbd1976f6068019d20` (rebasing
+covered in CONTEXT.md). All citations are repo-relative paths with lines at that
 commit. Terminology follows `Tracks/CodeDiscovery/GLOSSARY.md` (frozen). Built from
-first-hand reading (schema, consumer, tests, public API) plus four verified code
-sweeps: write-path census (A), Agent Tool Call map (B), execution records (C1),
+first-hand reading (schema, consumer, tests, public API) plus focused re-sweeps for
+this rebase: write-path census (A), Agent Tool Call map (B), execution records (C1),
 read-side/frontend consumers (C2).
 
 ---
@@ -29,7 +29,7 @@ Field groups:
 Permissions (`agent_message.json:346-391`): System Manager + Huf Manager full; **Huf
 User can create/write**; Huf Viewer read. Row-level scoping exists only as a
 list-query condition — `get_message_permission_conditions`
-(`agent_integration.py:1997-2013`, registered `hooks.py:155`) restricts message lists
+(`agent_integration.py:3328+`, registered `hooks.py:165`) restricts message lists
 to conversations the user owns unless they hold `chat.view_all`. There is **no
 doc-level `has_permission` hook**, and the `visibility` field does **not** interact
 with Frappe permissions at all; it is pure metadata (nothing enforces it — see §3.4).
@@ -38,7 +38,7 @@ with Frappe permissions at all; it is pure metadata (nothing enforces it — see
 
 ## 2. History assembly — the only policy consumer
 
-`ConversationManager.get_conversation_history` (`huf/ai/conversation_manager.py:493-526`)
+`ConversationManager.get_conversation_history` (`huf/ai/conversation_manager.py:517-550`)
 fetches the last N messages (`conversation_index desc`, then reversed) projecting:
 
 ```
@@ -50,23 +50,23 @@ reference_name, record_kind, tool_call, tool_call_id, tool_calls, creation
 fields.** Whatever those fields say has zero effect on what the model sees.
 
 The slice limit is a **message count** (default 20, caller passes
-`(history_limit or 20) + 10` — `agent_integration.py:702`), never tokens. Token-based
+`(history_limit or 20) + 10` — `agent_integration.py:1160+`), never tokens. Token-based
 bounding exists only for knowledge (RAG) injection, separately
 (`knowledge/context_builder.py`, `max_knowledge_tokens or 4000`).
 
-### 2.1 `_message_to_context` (`conversation_manager.py:549-667`) — policy truth table
+### 2.1 `_message_to_context` (`conversation_manager.py:573-714`) — policy truth table
 
 | `context_policy` | Actual behavior | Sound? |
 |---|---|---|
-| `NULL`/missing | treated as `include_full` (`:551`) | backward-compat, fine |
+| `NULL`/missing | treated as `include_full` (`:575`) | backward-compat, fine |
 | `include_full` | full `content` | ✅ as named |
-| `include_summary` | `context_summary` **or full content fallback** (`:564`) | ⚠️ silent fallback doubles cost when summary missing |
-| `include_reference` | emits `[record_kind: summary · handle=Dt/Name]` text (`:565-573`); raw content excluded | ✅ works; the only place `record_kind` is ever read |
-| `include_on_demand` | **dropped entirely** (`:554`) | ❌ misnamed: no handle is left behind, so the model cannot know the content exists to demand it |
+| `include_summary` | `context_summary` **or full content fallback** (`:588`) | ⚠️ silent fallback doubles cost when summary missing |
+| `include_reference` | emits `[record_kind: summary · handle=Dt/Name]` text (`:589-597`); raw content excluded | ✅ works; the only place `record_kind` is ever read |
+| `include_on_demand` | **dropped entirely** (`:578`) | ❌ misnamed: no handle is left behind, so the model cannot know the content exists to demand it |
 | `exclude` | dropped entirely | ✅ as named (indistinguishable from `transient_only`) |
 | `transient_only` | dropped entirely | ⚠️ duplicates `exclude`; "transient" intent (show once, then drop) is not implementable — no "seen" marker exists |
-| `token_budgeted` | `context_summary` or content (`:574-575`) | ❌ **no budgeting**: `token_estimate` is never read anywhere; behavior identical to `include_summary` |
-| `provider_cached` | full content (`:576-577`) | ❌ **no caching semantics**: identical to `include_full`; pure label |
+| `token_budgeted` | `context_summary` or content (`:598-599`) | ❌ **no budgeting**: `token_estimate` is never read by history assembly; behavior identical to `include_summary` |
+| `provider_cached` | full content (`:600-601`) | ❌ **no caching semantics**: identical to `include_full`; pure label |
 
 Of 8 declared policies: 4 work as named (`include_full`, `include_summary` with
 caveat, `include_reference`, `exclude`), 2 are aliases that mislead
@@ -87,24 +87,26 @@ assistant(`tool_calls`) + `role:"tool"` pairs:
    produced by the merge path (`update_tool_call_message`, §6).
 3. **Separate tool row** — `role="tool"` → single `role:"tool"` message (`:653-662`).
 
-`repair_message_sequence` (`:220-321`) runs before every completion call in the sync
+`repair_message_sequence` (`:229-321`) runs before every completion call in the sync
 path (`providers/litellm.py:484`, inside the round loop) but only **once per run** in
-the stream path (`:938`, before the round loop — rounds 2+ reuse the repaired
+the stream path (before the round loop — rounds 2+ reuse the repaired
 sequence): drops assistant declarations with no
 matching results, synthesizes missing assistant declarations from Agent Tool Call
-(`_synthesize_assistant_tool_call`, `:106-137`), drops unrepairable tool results, and
-**writes an Error Log entry on every repair** (`:312-319`) — routine trims become
+(`_synthesize_assistant_tool_call`, `:107-138`), drops unrepairable tool results, and
+**writes an Error Log entry on every repair** (`:321-328`) — routine trims become
 error-log spam.
 
 ### 2.3 Ordering & indexing hazards
 
 - `add_message` assigns `conversation_index = MAX(conversation_index)+1` via SQL
-  (`conversation_manager.py:420-448`). No unique constraint, no locking → concurrent
+  (`conversation_manager.py:439-467`). No unique constraint, no locking → concurrent
   inserts in one conversation can share an index; history order between equal indices
-  is undefined. (Queue-first's per-conversation lock mitigates this on its branch.)
-  The media-tool paths re-implement the same MAX+1 logic **three times**
-  (`sdk_tools.py:1539-1550` image, `:2154-2166` audio, `:2468-2475` STT).
-- `total_messages` on the conversation is set to `last_index+1` (`:483-486`) — a
+  is undefined.
+- `audio_service.py` duplicates the same MAX+1 pattern (`:697-708`) for voice messages.
+- The media-tool paths in `sdk_tools.py` no longer assign `conversation_index`
+  directly (they route through `ConversationManager.add_message`); the MAX+1 hazard is
+  now concentrated in `conversation_manager.py` and `audio_service.py`.
+- `total_messages` on the conversation is set to `last_index+1` (`:507-510`) — a
   denormalized counter that drifts if any insert fails between the two writes.
 
 ---
@@ -113,11 +115,11 @@ error-log spam.
 
 | Field | Writers | Readers | Verdict |
 |---|---|---|---|
-| `context_policy` | `update_tool_call_message` (`conversation_manager.py:197`) + sync fallback (`agent_integration.py:1004`) — the only automatic writers: `include_reference` iff result > `agent.max_context_chars` (default 2000, min 500), else explicit `include_full`; public API passthrough (`agent_chat.py:873-923`) | `_message_to_context` only | **Two policies ever set automatically.** The other 6 are reachable only via the public API, desk, or tests |
-| `record_kind` | same two paths → `tool_result` only (`conversation_manager.py:196`, `agent_integration.py:1003`); API passthrough | `_message_to_context` `include_reference` formatting (`:566`) | 9 of 10 values never written; cosmetic even when read |
-| `context_summary` | same two paths → first 200 chars + `"..."` (`:179,198`, `:988`); API passthrough | `include_summary` / `token_budgeted` / `include_reference` paths | Works, but summary = dumb truncation, never a real summary |
-| `visibility` | **Nothing** (schema default `user_visible`); API passthrough | **Nothing anywhere** — not projected in history query, no query filter, no permission branch, no UI. The `ui_only`/`audit_only`/`model_visible`/`developer_only` options are dead values | **Dead field** (repo-wide confirmed, sweep C2) |
-| `token_estimate` | **Nothing**; API passthrough | **Nothing anywhere** — not even history assembly fetches it | **Dead field** (repo-wide confirmed, sweep C2). `token_budgeted` ignores it |
+| `context_policy` | `update_tool_call_message` (`conversation_manager.py:198`) + sync fallback (`agent_integration.py:1654`) — the only automatic writers: `include_reference` iff result > `agent.max_context_chars` (default 2000, min 500), else explicit `include_full`; public API passthrough (`agent_chat.py:1054-1089`); code execution writes it on `Agent Context Artifact` (`code_execution.py:349`) | `_message_to_context` only | **Two policies ever set automatically on Agent Message.** The other 6 are reachable only via the public API, desk, or tests. `Agent Context Artifact` uses `context_policy` for display/filter but not as an enforced model-context contract |
+| `record_kind` | same two paths → `tool_result` only (`conversation_manager.py:197`, `agent_integration.py:1653`); API passthrough | `_message_to_context` `include_reference` formatting (`:590`) | 9 of 10 values never written by app code; cosmetic even when read |
+| `context_summary` | same two paths → first 200 chars + `"..."` (`:180,199`, `:1638`); API passthrough | `include_summary` / `token_budgeted` / `include_reference` paths | Works, but summary = dumb truncation, never a real summary |
+| `visibility` | **Nothing on Agent Message** (schema default `user_visible`); API passthrough (`agent_chat.py:1058-1088`); `Agent Context Artifact` has a writer (`code_execution.py:348`) | **Nothing on Agent Message** — not projected in history query, no query filter, no permission branch, no UI. The `ui_only`/`audit_only`/`model_visible`/`developer_only` options are dead values for messages | **Dead field on Agent Message** (repo-wide confirmed, sweep C2). Live only on `Agent Context Artifact` |
+| `token_estimate` | **Nothing on Agent Message**; API passthrough; `Agent Context Artifact` has a writer (`code_execution.py:351`) | **Nothing on Agent Message** — not even history assembly fetches it | **Dead field on Agent Message** (repo-wide confirmed, sweep C2). Live only on `Agent Context Artifact` |
 
 **Read-side census (sweep C2, repo-wide):** besides `_message_to_context`, no code
 branches on any of the five fields for Agent Message. None of the five is ever sent
@@ -133,10 +135,11 @@ read by the frontend — display/filter only (`agentContextArtifactApi.ts:39-88`
 
 ### 3.4 The public write API is a trust-boundary hole
 
-`agent_chat.add_message` (`agent_chat.py:873-923`) is `@frappe.whitelist()` (no
-`allow_guest`, so any authenticated session) and performs **no ownership or
-permission check** on the target conversation. It has **zero in-repo callers**
-(sweeps A+C2) — an unused but live endpoint. Any logged-in user can:
+`agent_chat.add_message` (`agent_chat.py:1049-1099`) is `@frappe.whitelist()` (no
+`allow_guest`, so any authenticated session). It loads the conversation but performs
+**no ownership or write-permission check** on it (only the standard `Agent Message`
+create/write permission checks inside `ConversationManager`). It has **zero in-repo
+callers** (sweeps A+C2) — an unused but live endpoint. Any logged-in user can:
 
 - insert a message into **any** conversation by id;
 - choose `role` freely — including `system` or `agent` — injecting content that
@@ -149,43 +152,44 @@ permission check** on the target conversation. It has **zero in-repo callers**
 
 ## 4. Write-path census (sweep A, verified repo-wide)
 
-Hub: `ConversationManager.add_message` (`conversation_manager.py:396-491`). Census:
+Hub: `ConversationManager.add_message` (`conversation_manager.py:415-516`). Census:
 
 | Path | Trigger | Context-field writes |
 |---|---|---|
-| `agent_integration.py:747` (sync) / `:1447` (stream) | user prompt | none (`kind="Message"`) |
-| `agent_integration.py:926-942` / `:1583-1599` | tool call starts | `kind="Tool Call"`, `tool_call` link, `tool_call_id`, `tool_calls` JSON |
-| `agent_integration.py:992-1008` (sync fallback) | tool result, merge failed | `kind="Tool Result"`, `record_kind="tool_result"`, policy per threshold, `context_summary`, `reference_*` |
-| `agent_integration.py:1134` / `:1702-1704` | final agent reply | none |
-| `agent_integration.py:1227-1254` / `:1799-1914` | error events | `kind="Error"` |
-| `conversation_manager.py:140-217` (update) | tool result merge | see §6 |
-| `agent_chat.py:873-923` (whitelisted API) | external HTTP | passthrough of all five fields (see §3.4) |
+| `agent_integration.py:1160` (sync) / `:1572` (stream tool-call start) | user prompt / tool call starts | none (`kind="Message"`) / `kind="Tool Call"`, `tool_call` link, `tool_call_id`, `tool_calls` JSON |
+| `agent_integration.py:1642-1658` (stream fallback) | tool result, merge failed | `kind="Tool Result"`, `record_kind="tool_result"`, policy per threshold, `context_summary`, `reference_*` |
+| `agent_integration.py:1846` / `:2927` | final agent reply | none |
+| `agent_integration.py:2008+` / `:3079+` / `:3188+` | error events | `kind="Error"` |
+| `conversation_manager.py:141-227` (update) | tool result merge | see §6 |
+| `agent_chat.py:1049-1099` (whitelisted API) | external HTTP | passthrough of all five fields (see §3.4) |
 | `agent_chat.py:37-45,168-176,477-485,584-592,784-792` | voice/file uploads | `kind="Audio"`/`"Message"`; note `:477-485`/`:584-592` insert **with** permissions — inconsistent with every other path |
-| `sdk_tools.py:1608-1622,2180-2195,2479-2503` | image/audio/STT tool results | `kind="Image"`/`"Audio"`; own MAX+1 index (`:1539-1550`) — same race as §2.3 |
-| `ocr_engine.py:684-702` | OCR extraction | none |
-| `transcription_handler.py:119-135` | provider STT | none (no `kind`, no `session_id`) |
-| `elevenlabs_convai_api.py:228-237` | voice-call transcript backfill | none; then `db_set("creation", ...)` rewrites timestamps |
+| `sdk_tools.py` | image/audio/STT tool results | `kind="Image"`/`"Audio"`; no longer writes `Agent Message` directly; routes through `ConversationManager.add_message` |
+| `code_execution.py:341-362` | code-execution file write-back | writes `context_policy`, `visibility`, `token_estimate` to `Agent Context Artifact` (not `Agent Message`) |
+| `ocr_engine.py` | OCR extraction | none |
+| `transcription_handler.py` | provider STT | none (no `kind`, no `session_id`) |
+| `elevenlabs_convai_api.py` | voice-call transcript backfill | none; then `db_set("creation", ...)` rewrites timestamps |
 | `patches/v1/repair_tool_call_messages.py` | migration | backfills `tool_call_id`/`tool_calls` from Agent Tool Call |
 
 Census conclusions:
 
-- **Only two paths** ever set `context_policy` (same threshold rule) and
-  **`tool_result` is the only `record_kind` ever written** by app code.
+- **Only two paths** ever set `context_policy` on `Agent Message` (same threshold
+  rule) and **`tool_result` is the only `record_kind` ever written** by app code.
   `include_summary / exclude / transient_only / token_budgeted / provider_cached /
   include_on_demand` and the other 9 record kinds are written **only by tests** or
-  the public API.
+  the public API. `Agent Context Artifact` now has writers for `context_policy`,
+  `visibility`, and `token_estimate` (`code_execution.py:341-362`), but those fields
+  remain dead on `Agent Message` itself.
 - **No writers anywhere** for `status`, `content_type`, `generated_video` — three
-  more dead-on-arrival fields beyond `visibility`/`token_estimate`.
+  more dead-on-arrival fields beyond `visibility`/`token_estimate` on `Agent Message`.
 - `flow_engine.py` and `huf/ai/orchestration/` write **zero** Agent Messages
   directly; flow/orchestration messages exist only via `run_agent_sync`.
-- `sdk_tools.py:1669`/`:2249` `new_agent_message` are realtime socket events, not writes.
+- `sdk_tools.py` realtime socket events (`new_agent_message`) are not writes.
 - ATC↔AM asymmetry both directions: (i) streaming — if the message lookup for the
   merge fails, the result is saved on the Agent Tool Call and **no message gets it**
-  (only an error log, `litellm.py:1104-1151`); sync — `process_tool_call(is_output=True)`
-  returns `None` when no Queued ATC is found (`agent_integration.py:430-431`), no
+  (only an error log, `litellm.py:1709-1748`); sync — `process_tool_call(is_output=True)`
+  returns `None` when no Queued ATC is found (`agent_integration.py:618-719`), no
   message written. (ii) Media/user/error messages have no `tool_call` link at all;
-  the sync path needs a special `kind="Image"` lookup to merge image results
-  (`:1014-1028`).
+  the sync path needs a special `kind="Image"` lookup to merge image results.
 - ~~`add_message` `user` field bug (`conversation_manager.py:441`)~~ — **withdrawn
   (verification pass 2026-07-18)**: Python's conditional expression binds looser than
   `or`, so the line parses as `(external_id or session.user) if role == "user" else
@@ -345,13 +349,11 @@ shapes — the misleading/unsupported policies are exactly the untested ones.
 
 ## 9. Branch deltas
 
-- `origin/develop` @ `95daa90`: `Queues`→`Queued` typo fix in `status` options;
-  Agent Run gains `reference_doctype`/`reference_name` trigger links (PR #401). No
-  message-semantics change.
-- `origin/feature/queue-first-agent-runs` @ `726762f`: reworks `agent_integration.py`
-  (+619) around queued execution; `conversation_manager.py` untouched; adds a guard
-  re-creating the user message if missing when a queued run executes (checks
-  `Agent Message` by `agent_run`+`role=user`). Context semantics unchanged.
+- Audit base is now `origin/develop` @ `2c3fd73c`. The `Queues`→`Queued` typo fix
+  and Agent Run `reference_doctype`/`reference_name` trigger links are already
+  present on this base. No message-semantics change relative to the prior audit.
+- `origin/feature/queue-first-agent-runs` has been merged into `develop`; the
+  per-conversation lock and queued-run drainer are now the default execution mode.
 
 ---
 

--- a/docs/audits/message-audit/STATE.md
+++ b/docs/audits/message-audit/STATE.md
@@ -1,0 +1,421 @@
+# STATE — Agent Message context semantics (as-built)
+
+Audit base: `feature/inline-video-playback` @ `eebb9dc` (verified current for these
+semantics — see CONTEXT.md). All citations are repo-relative paths with lines at that
+commit. Terminology follows `Tracks/CodeDiscovery/GLOSSARY.md` (frozen). Built from
+first-hand reading (schema, consumer, tests, public API) plus four verified code
+sweeps: write-path census (A), Agent Tool Call map (B), execution records (C1),
+read-side/frontend consumers (C2).
+
+---
+
+## 1. Schema inventory — `huf/huf/doctype/agent_message/agent_message.json`
+
+The DocType has **no controller logic** (`agent_message.py` is an empty `Document`
+subclass). Every semantic lives in writers and readers scattered across `huf/ai/`.
+
+Field groups:
+
+| Group | Fields | Notes |
+|---|---|---|
+| Identity/linkage | `conversation` (Link), `conversation_index` (Int), `session_id`, `user` (Data, not Link), `agent`, `agent_run` (Link), `provider`, `model` | `user` is plain Data — holds a username, external id, or the literal string `"Agent"` |
+| Content | `content` (Code/Markdown), `content_type` (Text/JSX/Mermaid/Markdown/Artifact/HTML/Image), `role` (user/tool/agent/system, default user, hidden), `is_agent_message` (Check) | `role="agent"` maps to OpenAI `assistant` at read time |
+| Kind — **two parallel fields** | `kind` (Message/Tool Call/Tool Result/Status/Error/Image/Audio/Video, no default) and `record_kind` (message/tool_call/tool_result/retrieval_context/result_snapshot/artifact/summary/status/error/debug_trace, no default) | Same concept, two vocabularies; see §5 |
+| Tool-call block | `tool_call` (Link→Agent Tool Call), `tool_name`/`tool_args`/`tool_status` (**`fetch_from`** the link), `tool_call_id` (Long Text — provider call id), `tool_calls` (JSON hidden — OpenAI-style array), `raw_payload` (JSON hidden) | `fetch_from` materializes copies at insert; see §7 |
+| Media/voice | `generated_image`, `generated_audio`, `generated_video`, `voice_message`, `tts_voice`, `tts_model`, `stt_model` | `generated_video` was the missing-field 417 bug (ProviderBrand417 track) |
+| **Context semantics** | `context_policy` (8 options, no default), `record_kind` (no default), `context_summary` (Small Text), `reference_doctype` + `reference_name` (**both plain Data**, not Link/Dynamic Link), `visibility` (5 options, default `user_visible`), `token_estimate` (Int) | Detailed per-field analysis in §3 |
+| Lifecycle | `status` (Started/`Queues`/Completed/Failed, hidden) | `Queues` typo — fixed on `origin/develop`; still present at audit base |
+
+Permissions (`agent_message.json:346-391`): System Manager + Huf Manager full; **Huf
+User can create/write**; Huf Viewer read. Row-level scoping exists only as a
+list-query condition — `get_message_permission_conditions`
+(`agent_integration.py:1997-2013`, registered `hooks.py:155`) restricts message lists
+to conversations the user owns unless they hold `chat.view_all`. There is **no
+doc-level `has_permission` hook**, and the `visibility` field does **not** interact
+with Frappe permissions at all; it is pure metadata (nothing enforces it — see §3.4).
+
+---
+
+## 2. History assembly — the only policy consumer
+
+`ConversationManager.get_conversation_history` (`huf/ai/conversation_manager.py:493-526`)
+fetches the last N messages (`conversation_index desc`, then reversed) projecting:
+
+```
+role, kind, content, context_policy, context_summary, reference_doctype,
+reference_name, record_kind, tool_call, tool_call_id, tool_calls, creation
+```
+
+**Not fetched: `visibility`, `token_estimate`, `status`, `content_type`, media
+fields.** Whatever those fields say has zero effect on what the model sees.
+
+The slice limit is a **message count** (default 20, caller passes
+`(history_limit or 20) + 10` — `agent_integration.py:702`), never tokens. Token-based
+bounding exists only for knowledge (RAG) injection, separately
+(`knowledge/context_builder.py`, `max_knowledge_tokens or 4000`).
+
+### 2.1 `_message_to_context` (`conversation_manager.py:549-667`) — policy truth table
+
+| `context_policy` | Actual behavior | Sound? |
+|---|---|---|
+| `NULL`/missing | treated as `include_full` (`:551`) | backward-compat, fine |
+| `include_full` | full `content` | ✅ as named |
+| `include_summary` | `context_summary` **or full content fallback** (`:564`) | ⚠️ silent fallback doubles cost when summary missing |
+| `include_reference` | emits `[record_kind: summary · handle=Dt/Name]` text (`:565-573`); raw content excluded | ✅ works; the only place `record_kind` is ever read |
+| `include_on_demand` | **dropped entirely** (`:554`) | ❌ misnamed: no handle is left behind, so the model cannot know the content exists to demand it |
+| `exclude` | dropped entirely | ✅ as named (indistinguishable from `transient_only`) |
+| `transient_only` | dropped entirely | ⚠️ duplicates `exclude`; "transient" intent (show once, then drop) is not implementable — no "seen" marker exists |
+| `token_budgeted` | `context_summary` or content (`:574-575`) | ❌ **no budgeting**: `token_estimate` is never read anywhere; behavior identical to `include_summary` |
+| `provider_cached` | full content (`:576-577`) | ❌ **no caching semantics**: identical to `include_full`; pure label |
+
+Of 8 declared policies: 4 work as named (`include_full`, `include_summary` with
+caveat, `include_reference`, `exclude`), 2 are aliases that mislead
+(`token_budgeted`→summary, `provider_cached`→full), 1 is a no-op duplicate
+(`transient_only`), 1 is broken-by-design (`include_on_demand` — no discovery path).
+
+### 2.2 Tool-call expansion (`:581-662`)
+
+Three persisted shapes are recognized and expanded into OpenAI-style
+assistant(`tool_calls`) + `role:"tool"` pairs:
+
+1. **Assistant tool-call row** — `kind="Tool Call"` or any of `tool_call`/
+   `tool_call_id`/`tool_calls` set → `{role:assistant, content:None, tool_calls:[...]}`.
+   Stored `tool_calls` JSON preferred; else synthesized from the linked Agent Tool
+   Call (`_resolve_tool_call_details`, `:528-547`).
+2. **Combined row** — `kind="Tool Result"` with role agent/assistant → returns a
+   **pair** `[assistant(tool_calls), tool(result)]` (`:629-650`). This is the shape
+   produced by the merge path (`update_tool_call_message`, §6).
+3. **Separate tool row** — `role="tool"` → single `role:"tool"` message (`:653-662`).
+
+`repair_message_sequence` (`:220-321`) runs before every completion call in the sync
+path (`providers/litellm.py:484`, inside the round loop) but only **once per run** in
+the stream path (`:938`, before the round loop — rounds 2+ reuse the repaired
+sequence): drops assistant declarations with no
+matching results, synthesizes missing assistant declarations from Agent Tool Call
+(`_synthesize_assistant_tool_call`, `:106-137`), drops unrepairable tool results, and
+**writes an Error Log entry on every repair** (`:312-319`) — routine trims become
+error-log spam.
+
+### 2.3 Ordering & indexing hazards
+
+- `add_message` assigns `conversation_index = MAX(conversation_index)+1` via SQL
+  (`conversation_manager.py:420-448`). No unique constraint, no locking → concurrent
+  inserts in one conversation can share an index; history order between equal indices
+  is undefined. (Queue-first's per-conversation lock mitigates this on its branch.)
+  The media-tool paths re-implement the same MAX+1 logic **three times**
+  (`sdk_tools.py:1539-1550` image, `:2154-2166` audio, `:2468-2475` STT).
+- `total_messages` on the conversation is set to `last_index+1` (`:483-486`) — a
+  denormalized counter that drifts if any insert fails between the two writes.
+
+---
+
+## 3. The five context fields — writers, readers, verdict
+
+| Field | Writers | Readers | Verdict |
+|---|---|---|---|
+| `context_policy` | `update_tool_call_message` (`conversation_manager.py:197`) + sync fallback (`agent_integration.py:1004`) — the only automatic writers: `include_reference` iff result > `agent.max_context_chars` (default 2000, min 500), else explicit `include_full`; public API passthrough (`agent_chat.py:873-923`) | `_message_to_context` only | **Two policies ever set automatically.** The other 6 are reachable only via the public API, desk, or tests |
+| `record_kind` | same two paths → `tool_result` only (`conversation_manager.py:196`, `agent_integration.py:1003`); API passthrough | `_message_to_context` `include_reference` formatting (`:566`) | 9 of 10 values never written; cosmetic even when read |
+| `context_summary` | same two paths → first 200 chars + `"..."` (`:179,198`, `:988`); API passthrough | `include_summary` / `token_budgeted` / `include_reference` paths | Works, but summary = dumb truncation, never a real summary |
+| `visibility` | **Nothing** (schema default `user_visible`); API passthrough | **Nothing anywhere** — not projected in history query, no query filter, no permission branch, no UI. The `ui_only`/`audit_only`/`model_visible`/`developer_only` options are dead values | **Dead field** (repo-wide confirmed, sweep C2) |
+| `token_estimate` | **Nothing**; API passthrough | **Nothing anywhere** — not even history assembly fetches it | **Dead field** (repo-wide confirmed, sweep C2). `token_budgeted` ignores it |
+
+**Read-side census (sweep C2, repo-wide):** besides `_message_to_context`, no code
+branches on any of the five fields for Agent Message. None of the five is ever sent
+to a client: the React app's message APIs request only legacy fields
+(`chatApi.ts:291-323`), the realtime `new_agent_message` payloads carry only
+`kind`+media (`sdk_tools.py:1666-1680`), the TS types omit them (`chatApi.ts:39-71`),
+and rendering branches on legacy `kind` alone (`ChatMessage.tsx:71-83`,
+`chatMessageList.mappers.ts:207-230`; `Status`/`Error` kinds have no UI branch and
+render as plain text). The same-named fields on **Agent Context Artifact** *are*
+read by the frontend — display/filter only (`agentContextArtifactApi.ts:39-88`,
+`AgentContextArtifactsPage.tsx`) — and that doctype still has no creation path
+(CodeDiscovery B-01, re-confirmed: zero creation UI, zero backend writer).
+
+### 3.4 The public write API is a trust-boundary hole
+
+`agent_chat.add_message` (`agent_chat.py:873-923`) is `@frappe.whitelist()` (no
+`allow_guest`, so any authenticated session) and performs **no ownership or
+permission check** on the target conversation. It has **zero in-repo callers**
+(sweeps A+C2) — an unused but live endpoint. Any logged-in user can:
+
+- insert a message into **any** conversation by id;
+- choose `role` freely — including `system` or `agent` — injecting content that
+  re-enters the model window as `include_full` by default (prompt-injection vector
+  into other users' agent runs);
+- set `visibility`/`token_estimate`/etc., which nothing reads — the API offers knobs
+  with no effect, while the effective knob (policy) is unchecked input.
+
+---
+
+## 4. Write-path census (sweep A, verified repo-wide)
+
+Hub: `ConversationManager.add_message` (`conversation_manager.py:396-491`). Census:
+
+| Path | Trigger | Context-field writes |
+|---|---|---|
+| `agent_integration.py:747` (sync) / `:1447` (stream) | user prompt | none (`kind="Message"`) |
+| `agent_integration.py:926-942` / `:1583-1599` | tool call starts | `kind="Tool Call"`, `tool_call` link, `tool_call_id`, `tool_calls` JSON |
+| `agent_integration.py:992-1008` (sync fallback) | tool result, merge failed | `kind="Tool Result"`, `record_kind="tool_result"`, policy per threshold, `context_summary`, `reference_*` |
+| `agent_integration.py:1134` / `:1702-1704` | final agent reply | none |
+| `agent_integration.py:1227-1254` / `:1799-1914` | error events | `kind="Error"` |
+| `conversation_manager.py:140-217` (update) | tool result merge | see §6 |
+| `agent_chat.py:873-923` (whitelisted API) | external HTTP | passthrough of all five fields (see §3.4) |
+| `agent_chat.py:37-45,168-176,477-485,584-592,784-792` | voice/file uploads | `kind="Audio"`/`"Message"`; note `:477-485`/`:584-592` insert **with** permissions — inconsistent with every other path |
+| `sdk_tools.py:1608-1622,2180-2195,2479-2503` | image/audio/STT tool results | `kind="Image"`/`"Audio"`; own MAX+1 index (`:1539-1550`) — same race as §2.3 |
+| `ocr_engine.py:684-702` | OCR extraction | none |
+| `transcription_handler.py:119-135` | provider STT | none (no `kind`, no `session_id`) |
+| `elevenlabs_convai_api.py:228-237` | voice-call transcript backfill | none; then `db_set("creation", ...)` rewrites timestamps |
+| `patches/v1/repair_tool_call_messages.py` | migration | backfills `tool_call_id`/`tool_calls` from Agent Tool Call |
+
+Census conclusions:
+
+- **Only two paths** ever set `context_policy` (same threshold rule) and
+  **`tool_result` is the only `record_kind` ever written** by app code.
+  `include_summary / exclude / transient_only / token_budgeted / provider_cached /
+  include_on_demand` and the other 9 record kinds are written **only by tests** or
+  the public API.
+- **No writers anywhere** for `status`, `content_type`, `generated_video` — three
+  more dead-on-arrival fields beyond `visibility`/`token_estimate`.
+- `flow_engine.py` and `huf/ai/orchestration/` write **zero** Agent Messages
+  directly; flow/orchestration messages exist only via `run_agent_sync`.
+- `sdk_tools.py:1669`/`:2249` `new_agent_message` are realtime socket events, not writes.
+- ATC↔AM asymmetry both directions: (i) streaming — if the message lookup for the
+  merge fails, the result is saved on the Agent Tool Call and **no message gets it**
+  (only an error log, `litellm.py:1104-1151`); sync — `process_tool_call(is_output=True)`
+  returns `None` when no Queued ATC is found (`agent_integration.py:430-431`), no
+  message written. (ii) Media/user/error messages have no `tool_call` link at all;
+  the sync path needs a special `kind="Image"` lookup to merge image results
+  (`:1014-1028`).
+- ~~`add_message` `user` field bug (`conversation_manager.py:441`)~~ — **withdrawn
+  (verification pass 2026-07-18)**: Python's conditional expression binds looser than
+  `or`, so the line parses as `(external_id or session.user) if role == "user" else
+  "Agent"`. Agent messages always get `user="Agent"`; no leak exists (ex-MA-14).
+
+---
+
+## 5. The `kind` / `record_kind` duality
+
+Two fields classify the same rows:
+
+- `kind` — UI vocabulary: `Message/Tool Call/Tool Result/Status/Error/Image/Audio/Video`
+  (drives media `depends_on` rendering and the history tool-call expansion).
+- `record_kind` — context vocabulary: `message/tool_call/tool_result/
+  retrieval_context/result_snapshot/artifact/summary/status/error/debug_trace`.
+
+They overlap for 5 values (message/tool_call/tool_result/status/error) with different
+spellings; `record_kind` adds 5 values no writer produces automatically
+(`retrieval_context`, `result_snapshot`, `artifact`, `summary`, `debug_trace`). No
+code keeps them consistent — `update_tool_call_message` sets both
+(`kind="Tool Result"`, `record_kind="tool_result"`, `:195-196`), other writers set
+`kind` only, so `record_kind` is NULL on virtually all rows. The read side only
+consults `record_kind` when formatting an `include_reference` handle — i.e. the
+classification that matters for the model is `kind`, and `record_kind` is near-dead.
+
+---
+
+## 6. Tool result merge path — `update_tool_call_message` (`conversation_manager.py:140-217`)
+
+The streaming-era "one row per tool interaction" mutation:
+
+1. loads the Agent Message created when the tool call started;
+2. appends `\n\n**Tool Result:**\n{result}` to `content` (guarded against double-append
+   by a substring check, `:192`);
+3. flips `kind` → `Tool Result`, `record_kind` → `tool_result`;
+4. sets policy: `include_reference` if `len(result) > max_context_chars` else
+   `include_full`; always writes `context_summary` (200-char truncation);
+5. points `reference_*` at the linked Agent Tool Call; stores provider `tool_call_id`
+   and the raw `tool_calls` payload;
+6. `save(ignore_permissions=True)`; swallows all exceptions → returns `False`
+   (callers log and continue — a failed merge leaves a permanent `kind="Tool Call"`
+   row whose result never lands; history then shows a declaration without result and
+   `repair_message_sequence` drops or re-synthesizes it).
+
+Soundness notes:
+
+- The `include_reference` threshold is **characters, not tokens** (`max_context_chars`,
+  default 2000) — the field the schema offers for this (`token_estimate`) is unused,
+  so the one size-control knob is a char heuristic.
+- The tool message sent to the model carries the **entire mutated `content`**
+  (call text + result text) — the "don't leak UI text" sanitation at `:619-621`
+  applies only to the Tool Call branch, not the combined Tool Result branch.
+- If the `tool_call` link is missing, `_resolve_tool_call_details` yields an empty
+  tool name and `{}` args (`:532-547`) — an invalid function declaration is then sent
+  to the provider.
+
+---
+
+## 7. Duplication with Agent Tool Call (sweep B, verified)
+
+### 7.1 Agent Tool Call inventory — `huf/huf/doctype/agent_tool_call/`
+
+10 fields: `agent_run`, `conversation`, `tool` (Data), `tool_args` (JSON),
+`tool_result` (JSON), `status` (Started/Queued/Completed/Failed, hidden), `call_id`
+(Long Text), `error_message`, `is_mcp_tool`, `mcp_server`. **No token/cost fields.**
+Permissions: **System Manager only**. Controller empty. Writers exist in exactly two
+files:
+
+| Writer | What |
+|---|---|
+| `agent_integration.py:451-464` (`process_tool_call`, request) | insert `status="Queued"`, MCP detection (`:438-441`), `call_id` |
+| `agent_integration.py:397-428` (`process_tool_call`, output) | find Queued by run+`call_id` → update `tool_result` (140k cap, `:411-419`), `status` Completed/Failed, `error_message` |
+| `providers/litellm.py:1089-1102` (stream) | update by conversation+`call_id`; `status="Completed"` **hardcoded** (`:1096`) |
+
+Readers: history reconstruction (`_synthesize_assistant_tool_call`,
+`_resolve_tool_call_details`), the agent-callable `get_result_context`
+(`sdk_tools.py:1373-1414`, advertised in system instructions
+`agent_integration.py:242-246`), desk dashboards. **Zero frontend references** — the
+tool-call UI is built entirely from the message's `fetch_from` copies and socket
+events (`chatApi.ts:305-306`, `useChatSocket.tsx`).
+
+Status semantics are broken two ways: `"Started"` is never written (dead option,
+joins CodeDiscovery C-01), and the `Failed` branch is effectively dead — no caller
+passes `error=`; a raised tool exception is stored as result text
+`"Error executing tool …"` with status **`Completed`** (`litellm.py:1080-1081,1096`).
+
+### 7.2 Field-by-field duplication (ATC vs paired Agent Message)
+
+| Datum | Agent Tool Call | Agent Message | Verdict |
+|---|---|---|---|
+| Tool name | `tool` | `tool_name` (fetch copy) + `tool_calls` JSON + `content` text | duplicated **3×** |
+| Arguments | `tool_args` (JSON) | `tool_args` (fetch copy) + `tool_calls[].function.arguments` + `content` text | duplicated **3×** |
+| Status | `status` (authoritative) | `tool_status` (fetch copy, refreshed only on message save) | **can silently disagree** |
+| LLM call id | `call_id` | `tool_call_id` + `tool_calls[].id` | duplicated (patch back-fills) |
+| Result | `tool_result` (canonical JSON) | stringified into `content`; 200-char `context_summary` | duplicated |
+| Error | `error_message` | **nowhere** (socket payload only) | ATC only |
+| MCP flags | `is_mcp_tool`, `mcp_server` | — | ATC only |
+| Run/conversation links | ✅ | ✅ | duplicated |
+| OpenAI-format payload | — (rebuildable) | `tool_calls` JSON | message only, derivable |
+| provider/model/agent | — | ✅ | message only |
+| Context metadata | — | `record_kind`, `context_*`, `reference_*` (pointing back at the ATC) | message only |
+| Tokens/cost | — | — | **neither** (see §7.4) |
+
+Disagreement windows: (a) `tool_status` is `fetch_from` — refreshed only when the
+message is saved; if the ATC update succeeds but the message merge fails, the failure
+is merely logged (`litellm.py:1141-1151`); in the sync fallback path the original
+Tool Call message is never re-saved after the ATC flips to Completed
+(`agent_integration.py:984-1009`) → `tool_status="Queued"` forever. (b) Errors never
+reach the message. (c) `kind` is mutated in place Tool Call → Tool Result, so one
+message row represents both request and result while the ATC holds the lifecycle.
+
+**Source of truth is the ATC** — proven by direction of repair:
+`patches/v1/repair_tool_call_messages.py` back-fills message columns *from* the ATC;
+`_synthesize_assistant_tool_call` rebuilds model context from the ATC; the provider
+docstring says "We keep the full result in the Agent Tool Call record for audit /
+reference" (`litellm.py:201-208`); `get_result_context` serves the canonical full
+result from the ATC. Agent Message tool rows are denormalized presentation/context
+copies that can silently disagree with the truth.
+
+### 7.3 Flow `tool.call` gap — confirmed
+
+`_exec_tool_call` (`flow_engine.py:539-607`) creates **no Agent Tool Call** — only an
+audit Agent Run with `run_kind="tool"` (`_create_flow_agent_run`, `:1265-1281`).
+Captured: tool name+args as an unstructured `prompt` string, result JSON in
+`response`, error, flow linkage. Lost vs ATC: conversation link, `call_id`,
+structured `tool`/`tool_args`/`tool_result`, MCP flags. (CodeDiscovery B-04: model
+violation — every tool invocation should produce a Tool Call.)
+
+### 7.4 Token/cost accounting — no double count, but a real undercount
+
+- ATC has no token/cost fields; Agent Message only the dead `token_estimate`.
+- Agent Run `input/output/cached_tokens` + `cost` written **once per run** (sync
+  `agent_integration.py:1127-1132`; stream `:1706-1717`); Agent Conversation totals
+  incremented by raw SQL `+=` once per run (`:1115-1123` / `:1689-1697`); providers
+  accumulate usage across LLM rounds in memory. **No double counting via ATC.**
+- **Stream undercount bug:** in `run_stream`, `stream_usage` is reset per tool round
+  (`litellm.py:975`) and overwritten by each usage chunk (`:984-989`), so the
+  `complete` event carries **only the final round's usage** — tool-call rounds'
+  tokens vanish from Agent Run and Conversation totals for streaming runs, and the
+  stream cost computation inherits the same undercount (`litellm.py:1238-1255` →
+  `agent_integration.py:1657`). Sync accumulates correctly.
+- Conversation totals are fire-and-forget SQL; failures only logged
+  (`:1124-1125,1698-1699`) → run-level and conversation-level totals drift silently.
+
+---
+
+## 8. Test-pinned behavior — `huf/ai/tests/test_context_policy.py`
+
+The only tests covering this machinery pin: `include_full`, `include_reference`
+(raw content excluded, handle present), `exclude`, `transient_only`, NULL backward
+compat, bounded token growth under `include_reference` (char-length proxy), and
+`include_summary`. Notably **no tests** for `token_budgeted`, `provider_cached`,
+`include_on_demand`, `visibility`, `token_estimate`, or the tool-pair expansion
+shapes — the misleading/unsupported policies are exactly the untested ones.
+
+---
+
+## 9. Branch deltas
+
+- `origin/develop` @ `95daa90`: `Queues`→`Queued` typo fix in `status` options;
+  Agent Run gains `reference_doctype`/`reference_name` trigger links (PR #401). No
+  message-semantics change.
+- `origin/feature/queue-first-agent-runs` @ `726762f`: reworks `agent_integration.py`
+  (+619) around queued execution; `conversation_manager.py` untouched; adds a guard
+  re-creating the user message if missing when a queued run executes (checks
+  `Agent Message` by `agent_run`+`role=user`). Context semantics unchanged.
+
+---
+
+## 10. The three execution records (sweep C1, verified)
+
+| | **Agent Run** | **Agent Orchestration** | **Flow Run** |
+|---|---|---|---|
+| Status vocab | Started/Queued/Success/Failed | Planned/Running/Paused/Completed/Failed/Cancelled (+ lowercase per-step `pending/in_progress/done/failed`) | Queued/Running/Waiting Approval/Waiting User/Success/Failed |
+| Tokens/cost/duration | ✅ `input/output/cached_tokens`, `cost`, `start_time`/`end_time` — **the only carrier** | ❌ (only `last_run_at`) | ❌ (only `started_at`/`completed_at`) |
+| Prompt/response | ✅ `prompt`, `response` | per-step `instruction`/`output_ref`, `scratchpad` | `trigger_payload` + `context_json` (initially **identical**, `flow_engine.py:103,105`) |
+| Error | `error_code` + `error_message` | `error_log` | `last_error` |
+| Linkage | `parent_run`, `is_child`, `agent_orchestration`, `flow_run`, `flow_node_id`, `flow_id`, `run_kind` | `parent_run` (shell run) | `last_agent_run` (overwritten per node), `conversation` |
+| Controller | empty | empty | empty |
+
+Key structural facts:
+
+- **Orchestration = shell parent run + plan rows.** The parent Agent Run never makes
+  a provider call (marked Started with a placeholder response,
+  `agent_integration.py:762-766`); only final status/summary is mirrored back
+  (`orchestrator.py:158-162`, `:208`). Each plan step is a child Agent Run
+  (`parent_run` = shell, `is_child=1`), hidden in the UI by the `is_child=0` filter
+  (`Executions.tsx:60`).
+- **Flow Run retains no node history** — only `last_agent_run`, overwritten per node
+  (`flow_engine.py:518,588,664,1221`). Per-node outputs are duplicated into
+  `context_json` only when the node opts in (`save_response_to_context`,
+  `save_result_to_context`) — the same text stored on the linked Agent Run's
+  `response`. The real audit trail is Agent Runs with matching
+  `flow_run`+`flow_node_id` — queryable, but nothing aggregates it.
+- **Tokens/cost system of record is Agent Run alone**; aggregation duplicated in
+  Agent Conversation totals via raw SQL + `Agent.total_run/last_run` counters.
+  Orchestration/flow cost must be derived by summing child runs; shell parent runs
+  and `run_kind="tool"` audit runs carry none.
+- **Agent Message / Agent Tool Call attach to executions only via `agent_run`
+  (+`conversation`)** — neither links Flow Run or Agent Orchestration directly, so
+  flow/orchestration message timelines must be reconstructed through the run table.
+- Dead statuses: Flow Run `Waiting User`, Orchestration `Paused` (declared, read,
+  never set). Drift: ElevenLabs webhook writes `total_cost` — **not a field** on
+  Agent Run (field is `cost`), silently dropped (`elevenlabs_convai_api.py:194`).
+- Frontend: **three separate surfaces, no unified timeline** — Executions page lists
+  Agent Runs only (`Executions.tsx:53-60`); Flow Runs appear only inside the flow
+  canvas sheets (`FlowRunHistory.tsx`, `FlowRunViewer.tsx`); "orchestration" UI is a
+  child-runs card on the run detail page that **never fetches the Agent Orchestration
+  doctype** (`AgentRunDetailPage.tsx:135-146,419-425`). Nothing lists Agent
+  Orchestration docs anywhere in the React app.
+
+---
+
+## 11. Verdict on the observation
+
+> "HUF has three partially separate execution records—Agent Run, Agent Orchestration,
+> and Flow Run—while Agent Message also duplicates tool-call data already stored in
+> Agent Tool Call. A rewrite should unify those semantics first; otherwise a new
+> language would preserve the same complexity at a higher cost."
+
+**Confirmed, and stronger than stated.** The three execution records are not just
+"partially separate": they run three divergent status vocabularies, duplicate error/
+timestamp fields under different names, keep tokens/cost in exactly one of them, and
+have no unified read surface. The message/tool-call duplication is not symmetric
+copying: Agent Tool Call is the de-facto source of truth (repairs flow ATC→message),
+yet the UI reads only the denormalized message copies — which can silently disagree
+(status staleness, missing errors) — while the truth is System-Manager-only and
+frontend-invisible. On top, the context-policy layer that a rewrite would "preserve"
+is 8 declared policies of which only 2 are ever written by app code, 4 are aliases
+or no-ops, 1 is broken by design, and 2 of the 5 context fields (`visibility`,
+`token_estimate`) have no readers at all. A new language over this surface would
+inherit all three vocabularies, the 3× tool-data duplication, and the phantom policy
+enum — the unification must happen at the semantics layer first. See PLAN.md.


### PR DESCRIPTION
Adds the MessageAudit track docs under `docs/audits/message-audit/` (docs only, no code changes).

- **STATE.md** — as-built semantics of `context_policy`, `record_kind`, `token_estimate`, `visibility`, `context_summary`: writers/readers, per-policy truth table, write-path census, Agent Tool Call duplication map, three-execution-records comparison. Key result: history assembly is the only reader; `visibility`/`token_estimate` are dead fields; 4 of 8 policies are aliases or no-ops; `include_on_demand` is broken by design.
- **FINDINGS.md** — 25 gaps/locks/traps/issues (MA-01…MA-25) with file:line evidence at `eebb9dc`, cross-referenced to CodeDiscovery/CommitAudit.
- **PLAN.md** — 4-phase incremental unification plan (bug fixes → truthful policy enum → execution-record unification → message/tool-call projection).
- **CONTEXT.md** — track context, incl. the 2026-07-18 independent verification pass (4 parallel verifier agents + orchestrator re-checks): 23/25 findings confirmed; **MA-14 withdrawn**; MA-11/MA-15 sharpened.

WIP: open for owner review of the Phase 2 decision items (PLAN 2.1–2.4) and issue-filing go-ahead.