### PR TITLE
fix(security): route-level capability gating (PR #340 rebased on develop)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -215,7 +215,7 @@ function AppShell() {
           <Route
             path="/models"
             element={
-              <ProtectedRoute capability="system.providers.manage">
+              <ProtectedRoute capability="system.models.manage">
                 <Suspense fallback={<PageLoader />}>
                   <ModelsPageWrapper />
                 </Suspense>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -215,7 +215,7 @@ function AppShell() {
           <Route
             path="/models"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.providers.manage">
                 <Suspense fallback={<PageLoader />}>
                   <ModelsPageWrapper />
                 </Suspense>
@@ -225,7 +225,7 @@ function AppShell() {
           <Route
             path="/providers"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.providers.manage">
                 <Suspense fallback={<PageLoader />}>
                   <AiProvidersPageWrapper />
                 </Suspense>
@@ -367,7 +367,7 @@ function AppShell() {
           <Route
             path="/integrations"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.integrations.manage">
                 <Suspense fallback={<PageLoader />}>
                   <IntegrationSettingsListingPageWrapper />
                 </Suspense>
@@ -377,7 +377,7 @@ function AppShell() {
           <Route
             path="/integrations/:settingId"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.integrations.manage">
                 <Suspense fallback={<PageLoader />}>
                   <IntegrationSettingsDetailsPageWrapper />
                 </Suspense>
@@ -407,7 +407,7 @@ function AppShell() {
           <Route
             path="/mcp"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.mcp.manage">
                 <UnifiedLayout headerActions={<McpHeaderActions />}>
                   <Suspense fallback={<PageLoader />}>
                     <McpListingPage />
@@ -419,7 +419,7 @@ function AppShell() {
           <Route
             path="/mcp/:mcpId"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.mcp.manage">
                 <Suspense fallback={<PageLoader />}>
                   <McpDetailsPageWrapper />
                 </Suspense>
@@ -439,7 +439,7 @@ function AppShell() {
           <Route
             path="/users"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="users.manage">
                 <UnifiedLayout headerActions={<UsersHeaderActions />}>
                   <UsersPage />
                 </UnifiedLayout>
@@ -449,7 +449,7 @@ function AppShell() {
           <Route
             path="/roles"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="roles.manage">
                 <UnifiedLayout>
                   <RolesPage />
                 </UnifiedLayout>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -387,7 +387,7 @@ function AppShell() {
           <Route
             path="/integration-services"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.integrations.manage">
                 <Suspense fallback={<PageLoader />}>
                   <IntegrationServicesListingPageWrapper />
                 </Suspense>
@@ -397,7 +397,7 @@ function AppShell() {
           <Route
             path="/integration-services/:serviceId"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute capability="system.integrations.manage">
                 <Suspense fallback={<PageLoader />}>
                   <IntegrationServiceFormPageWrapper />
                 </Suspense>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -12,7 +12,7 @@ interface ProtectedRouteProps {
   capability?: string;
 }
 
-function AccessDenied() {
+function AccessDenied({ capability }: { capability?: string }) {
   return (
     <div className="flex min-h-screen items-center justify-center p-6 bg-background">
       <Card className="w-full max-w-md text-center">
@@ -20,7 +20,9 @@ function AccessDenied() {
           <ShieldAlert className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
           <h1 className="text-2xl font-semibold text-foreground mb-2">Access Denied</h1>
           <p className="text-muted-foreground mb-6">
-            You don't have permission to view this page. Contact your administrator if you think this is a mistake.
+            {capability
+              ? `You need the "${capability}" permission to view this page. Contact your administrator if you think this is a mistake.`
+              : "You don't have permission to view this page. Contact your administrator if you think this is a mistake."}
           </p>
           <Button asChild variant="outline">
             <Link to="/">Go to Dashboard</Link>
@@ -49,7 +51,7 @@ export function ProtectedRoute({ children, capability }: ProtectedRouteProps) {
       return <AuthenticatingPage />;
     }
     if (!hasCapability(capability)) {
-      return <AccessDenied />;
+      return <AccessDenied capability={capability} />;
     }
   }
 

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,21 +1,56 @@
 import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { ShieldAlert } from 'lucide-react';
 import { useUser } from '@/contexts/UserContext';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { AuthenticatingPage } from './AuthenticatingPage';
+import { Card, CardContent } from './ui/card';
+import { Button } from './ui/button';
 
 interface ProtectedRouteProps {
   children: ReactNode;
+  capability?: string;
 }
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isLoading, isAuthenticated } = useUser();
+function AccessDenied() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-6 bg-background">
+      <Card className="w-full max-w-md text-center">
+        <CardContent className="pt-8 pb-8">
+          <ShieldAlert className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+          <h1 className="text-2xl font-semibold text-foreground mb-2">Access Denied</h1>
+          <p className="text-muted-foreground mb-6">
+            You don't have permission to view this page. Contact your administrator if you think this is a mistake.
+          </p>
+          <Button asChild variant="outline">
+            <Link to="/">Go to Dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
-  if (isLoading) {
+export function ProtectedRoute({ children, capability }: ProtectedRouteProps) {
+  const { isLoading: userLoading, isAuthenticated } = useUser();
+  const { hasCapability, isLoading: permissionsLoading } = usePermissions();
+
+  if (userLoading) {
     return <AuthenticatingPage />;
   }
 
   if (!isAuthenticated) {
     // The redirect will be handled by UserContext
     return null;
+  }
+
+  if (capability) {
+    if (permissionsLoading) {
+      return <AuthenticatingPage />;
+    }
+    if (!hasCapability(capability)) {
+      return <AccessDenied />;
+    }
   }
 
   return <>{children}</>;

--- a/frontend/src/components/UsersHeaderActions.tsx
+++ b/frontend/src/components/UsersHeaderActions.tsx
@@ -1,8 +1,15 @@
 import { Shield } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Button } from './ui/button';
+import { usePermissions } from '@/contexts/PermissionsContext';
 
 export function UsersHeaderActions() {
+  const { hasCapability } = usePermissions();
+
+  if (!hasCapability('roles.manage')) {
+    return null;
+  }
+
   return (
     <Button asChild variant="outline" size="sm">
       <Link to="/roles">

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Home, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Boxes, Terminal, Settings, ChevronRight, Shield } from "lucide-react"
+import { Home, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Boxes, Terminal, Settings, ChevronRight, Shield, FileText } from "lucide-react"
 import { NavLink, useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -49,8 +49,8 @@ const buildNavItems = [
   {
     title: "Agent Prompts",
     url: "/prompts",
-    icon: ScrollText,
-    capability: "agent.use",
+    icon: FileText,
+    capability: "agent.edit",
   },
   {
     title: "Flows",
@@ -68,7 +68,7 @@ const buildNavItems = [
     title: "Knowledge",
     url: "/knowledge",
     icon: BookOpen,
-    capability: "agent.use",
+    capability: "knowledge.use",
   },
 ]
 
@@ -118,13 +118,13 @@ const settingsNavItems = [
     title: "Models",
     url: "/models",
     icon: Cpu,
-    capability: "system.providers.manage",
+    capability: "system.models.manage",
 	},
 	{
 		title: "Agent Summary Prompts",
 		url: "/summary-prompts",
 		icon: ScrollText,
-		capability: "agent.use",
+		capability: "agent.edit",
   },
   {
     title: "Console",

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -217,7 +217,7 @@ function AgentsPage() {
                   onClick: () => navigate(`/executions?agents=${encodeURIComponent(agent.name)}`),
                 },
               ]}
-              onClick={() => navigate(`/agents/${agent.name}`)}
+              onClick={hasCapability('agent.edit') ? () => navigate(`/agents/${agent.name}`) : undefined}
             />
           );
         }}

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
+import { usePermissions } from '../contexts/PermissionsContext';
 import { getAgents } from '../services/agentApi';
 import { formatTimeAgo } from '../utils/time';
 import type { AgentDoc } from '../types/agent.types';
@@ -64,6 +65,7 @@ export default AgentsPage;
 
 function AgentsPage() {
   const navigate = useNavigate();
+  const { hasCapability } = usePermissions();
 
   const {
     items: agents,
@@ -200,11 +202,15 @@ function AgentsPage() {
               ]}
               badges={getAgentBadges(agent)}
               actions={[
-                {
-                  icon: Settings,
-                  label: 'Configure',
-                  onClick: () => navigate(`/agents/${agent.name}`),
-                },
+                ...(hasCapability('agent.edit')
+                  ? [
+                      {
+                        icon: Settings,
+                        label: 'Configure',
+                        onClick: () => navigate(`/agents/${agent.name}`),
+                      },
+                    ]
+                  : []),
                 {
                   icon: Activity,
                   label: 'View Logs',

--- a/frontend/src/pages/DataTableBuilderPage.tsx
+++ b/frontend/src/pages/DataTableBuilderPage.tsx
@@ -253,9 +253,9 @@ export function DataTableBuilderPage() {
 				allowNavigationRef.current = true;
 				navigate(`/data/${result.name}`);
 			}
-		} catch (err: any) {
+		} catch (err: unknown) {
 			toast.error(isEdit ? 'Failed to update table' : 'Failed to create table', {
-				description: err.message,
+				description: err instanceof Error ? err.message : String(err),
 			});
 		} finally {
 			setSaving(false);

--- a/frontend/src/pages/DataTableBuilderPage.tsx
+++ b/frontend/src/pages/DataTableBuilderPage.tsx
@@ -196,7 +196,7 @@ export function DataTableBuilderPage() {
 			const newField: DataTableFieldDef = {
 				fieldname,
 				fieldtype: type,
-				label: isLayout ? '' : '',
+				label: '',
 				...(isLayout ? {} : { in_list_view: state.fields.filter(
 					(f) => f.fieldtype !== 'Section Break' && f.fieldtype !== 'Column Break'
 				).length < 4 ? 1 : 0 as 0 | 1 }),


### PR DESCRIPTION
## Problem
Repairs #340: authorization in the React dashboard was enforced only as sidebar visibility — any authenticated user who guessed an admin URL (`/users`, `/roles`, `/mcp`, `/providers`, `/integrations`, `/models`) could open and use the page. The original PR was CONFLICTING against the merged design-system sidebar; this is the same fix rebased onto current develop with the conflict properly resolved. The vulnerability is still live on develop today.

## Scope
- `ProtectedRoute` gains an optional `capability` prop rendering an Access Denied card when `hasCapability()` fails (backward compatible — prop optional).
- 8 admin routes gated in `App.tsx`; sidebar capability corrections (Models→`system.models.manage`, Knowledge→`knowledge.use`, Agent Prompts/Summary Prompts→`agent.edit`, distinct FileText icon); Agents-page configure click gated to `agent.edit`; dead ternary removed; one pre-existing `no-explicit-any` eslint error fixed.
- Binary screenshots from the original PR deliberately NOT carried over.

## Key decisions (route audit on develop's new routes)
- `/integration-services` (+ `:serviceId`) gated with `system.integrations.manage` — same admin class as the original 8.
- `/console` (`agent.use`) and `/artifacts` (`agent.view_all`) left ungated — user-level capabilities, not admin pages. Documented in commit `2fbd6fe`.
- Finding 1.6 (Data page capability) stays with #346 as agreed; sidebar fixes re-applied by hand onto develop's restructured nav (Artifacts/Console/Integration Services preserved).

## Agent contributions
Intake dossier, rebase, conflict resolution, and route audit by the release-orchestration pipeline; the pipeline verified the diff (exactly 6 in-scope frontend files).

## Tests executed
- `npx tsc -b`, `npx vite build`, `npx eslint` on all 6 changed files — green.
- Isolated bench 16_ro: `yarn build` green, `/huf` serves 200 with the new bundle.
- All capability strings cross-checked against `huf/permissions.py` on develop.

## Baseline vs introduced failures
No backend changes; no test-suite impact (suite's pre-existing crash is fixed separately in #407).

## Risks and limitations
- UX-layer gating only — backend API endpoints remain the real authorization boundary.
- Lockout risk if a capability string is wrong (all verified); `Huf Admin` gets all capabilities so Administrator is unaffected.
- `Huf User`/`Huf Viewer` roles lose Agents-card click navigation (intentional).
- Live RBAC walkthrough (zero-capability session sees Access Denied on all gated routes) not yet done — recommended before undrafting.

## Rollback
Revert the 5 commits; gating disappears, routes revert to auth-only.

## Remaining work
- Live zero-capability RBAC verification with screenshots.
- Sequencing vs #346 (complementary, lands after) and #283 (sidebar restructure — whichever lands second owns the next sidebar conflict).
