### PR TITLE
fix(webhook): two pre-merge follow-ups for #404

### DIFF
--- a/huf/ai/permissions_api.py
+++ b/huf/ai/permissions_api.py
@@ -155,7 +155,7 @@ def set_user_enabled(user: str, enabled: int) -> dict:
 	name = frappe.db.get_value("Huf User Role", {"user": user}, "name")
 	doc = frappe.get_doc("Huf User Role", name)
 	doc.enabled = int(enabled)
-	doc.save(ignore_permissions=True)
+	doc.save()
 
 	_bust_cache(user)
 	return doc.as_dict()

--- a/huf/ai/providers/elevenlabs_convai_api.py
+++ b/huf/ai/providers/elevenlabs_convai_api.py
@@ -113,7 +113,7 @@ def _verify_webhook_signature(secret, sig_header, raw_body):
     return hmac.compare_digest(v0_part, calculated)
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def handle_elevenlabs_webhook(type=None, data=None, event_timestamp=None):
     """
     Handles ElevenLabs Post Call Transcription.


### PR DESCRIPTION
## Problem
Stacked on #404 (base: `fix/redundant-db-commits`). Two one-line risks flagged in the intake dossier for #404 (on file):

- **R1**: `handle_elevenlabs_webhook` is `@frappe.whitelist(allow_guest=True)` with no method restriction. Frappe rolls back GET requests; with #404's explicit commit removed, a GET-invoked webhook would silently lose the persisted run/message (the old code was GET-safe, the new code is not).
- **R2**: `permissions_api.set_user_enabled` saved with `ignore_permissions=True` while `update_user_role` (same file) saves with permissions enforced — inconsistent.

## Scope (2 commits, 2 files)
- `huf/ai/providers/elevenlabs_convai_api.py`: webhook restricted to `methods=["POST"]`.
- `huf/ai/permissions_api.py`: `set_user_enabled` now uses `doc.save()` — the endpoint already requires the `users.manage` capability (`_require("users.manage")`), so enforcement is consistent with `update_user_role`.

## Agent contributions
Implemented by the release-orchestration pipeline per the intake dossier (on file); the pipeline verified the diff.

## Tests executed
- `py_compile` on both files.
- Isolated bench 16_ro, this branch: console smoke — webhook declared `methods=["POST"]`; `set_user_enabled` free of `ignore_permissions` and capability-gated.

## Risks
- GET webhook callers now get 405 instead of silent success (intended; ElevenLabs POSTs).
- Non-System-Manager callers of `set_user_enabled` need write permission on Huf User Role in addition to the capability — matches `update_user_role` behavior.

## Rollback
Revert the 2 commits.

## Remaining work
- #404 itself needs maintainer review (dossier risks R3/R4/R5) before this stacks in.
