### PR TITLE
feat: granular capability model for Data feature permissions (PR #346 rebased on develop)

### DIFF
--- a/.hufro-owner.json
+++ b/.hufro-owner.json
@@ -1,0 +1,6 @@
+{
+  "orchestrator": "release-orchestrator",
+  "worker_id": "PR-346-repair",
+  "task_id": "PR-346:repair",
+  "ts": 1784521896.307107
+}

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -26,8 +26,9 @@ import {
 } from "@/components/ui/sidebar"
 
 /**
- * Each nav item may declare an optional `capability` string.
- * If present the item is hidden from users who don't have that capability.
+ * Each nav item may declare an optional `capability` string or list.
+ * If present the item is hidden from users who don't have that capability
+ * (a list means any-of: one matching capability is enough).
  * Items with capability === null are always visible (e.g. Dashboard).
  */
 const dashboardNavItems = [
@@ -62,7 +63,11 @@ const buildNavItems = [
     title: "Data",
     url: "/data",
     icon: Database,
-    capability: "agent.view_all",
+    capability: [
+      "data.tables.manage",
+      "data.records.view_own",
+      "data.records.view_all",
+    ],
   },
   {
     title: "Knowledge",
@@ -176,13 +181,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     }
   }, [])
 
-	const filterItemsByCapability = <T extends { capability: string | null }>(items: T[]) => {
+	const filterItemsByCapability = <T extends { capability: string | string[] | null }>(items: T[]) => {
 		if (isLoading) {
 			return items.filter((item) => item.capability === null)
 		}
-		return items.filter(
-			(item) => item.capability === null || (item.capability && hasCapability(item.capability)),
-		)
+		return items.filter((item) => {
+			if (item.capability === null) return true
+			const caps = Array.isArray(item.capability) ? item.capability : [item.capability]
+			return caps.some((cap) => hasCapability(cap))
+		})
 	}
 
 	// While permissions are loading show only uncapability-gated items so the

--- a/frontend/src/pages/DataTableBuilderPage.tsx
+++ b/frontend/src/pages/DataTableBuilderPage.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { useNavigate, useParams, useBlocker, type Location } from 'react-router-dom';
 import { toast } from 'sonner';
-import { Save, Loader2, Settings2 } from 'lucide-react';
+import { Save, Loader2, Settings2, Shield } from 'lucide-react';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { Button } from '@/components/ui/button';
 import { TableBuilderCanvas } from '@/components/data-table/TableBuilderCanvas';
 import { FieldConfigPanel } from '@/components/data-table/FieldConfigPanel';
@@ -133,6 +134,8 @@ export function DataTableBuilderPage() {
 	const { tableId } = useParams<{ tableId: string }>();
 	const navigate = useNavigate();
 	const isEdit = !!tableId && tableId !== 'new';
+
+	const { hasCapability, isLoading: permissionsLoading } = usePermissions();
 
 	const [state, dispatch] = useReducer(builderReducer, initialState);
 	const [saving, setSaving] = useState(false);
@@ -267,6 +270,20 @@ export function DataTableBuilderPage() {
 		enabled: !loading,
 		isSubmitting: saving,
 	});
+
+	if (!permissionsLoading && !hasCapability('data.tables.manage')) {
+		return (
+			<div className="flex items-center justify-center h-full">
+				<div className="text-center max-w-md p-6">
+					<Shield className="w-10 h-10 mx-auto text-muted-foreground mb-4" />
+					<h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+					<p className="text-sm text-muted-foreground">
+						You don't have permission to manage data tables.
+					</p>
+				</div>
+			</div>
+		);
+	}
 
 	if (loading) {
 		return (

--- a/frontend/src/pages/RolesPage.tsx
+++ b/frontend/src/pages/RolesPage.tsx
@@ -13,6 +13,7 @@ const CATEGORY_ORDER = [
   { key: 'knowledge', label: 'Knowledge' },
   { key: 'tools', label: 'Tools' },
   { key: 'flows', label: 'Flows' },
+  { key: 'data', label: 'Data' },
   { key: 'system', label: 'System' },
   { key: 'users', label: 'Users' },
   { key: 'roles', label: 'Roles' },
@@ -36,12 +37,12 @@ function RoleCard({ role }: { role: HufRole }) {
   const groups = groupCapabilities(role.capabilities);
 
   return (
-    <div className="border rounded-none p-4 space-y-3">
+    <div className="border rounded-lg p-4 space-y-3">
       {/* Header */}
       <div className="flex items-center gap-2">
         <span className="font-semibold text-base">{role.role_name}</span>
         {role.is_system_role === 1 && (
-          <span className="inline-flex items-center gap-1 text-xs text-steel-soft">
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
             <Lock className="h-3 w-3" />
             System
           </span>
@@ -49,14 +50,14 @@ function RoleCard({ role }: { role: HufRole }) {
       </div>
 
       {role.description && (
-        <p className="text-sm text-steel">{role.description}</p>
+        <p className="text-sm text-muted-foreground">{role.description}</p>
       )}
 
       {/* Capabilities grouped by category */}
       <div className="space-y-2">
         {CATEGORY_ORDER.filter((cat) => groups[cat.key]?.length).map((cat) => (
           <div key={cat.key}>
-            <div className="text-xs font-medium text-steel-soft mb-1">{cat.label}</div>
+            <div className="text-xs font-medium text-muted-foreground mb-1">{cat.label}</div>
             <div className="flex flex-wrap gap-1">
               {groups[cat.key].map((cap) => (
                 <Badge key={cap} variant="secondary" className="text-xs font-mono">
@@ -69,7 +70,7 @@ function RoleCard({ role }: { role: HufRole }) {
       </div>
 
       {role.capabilities.length === 0 && (
-        <p className="text-xs font-body text-steel-soft italic">No capabilities assigned.</p>
+        <p className="text-xs text-muted-foreground italic">No capabilities assigned.</p>
       )}
     </div>
   );
@@ -97,13 +98,13 @@ export default function RolesPage() {
             <ShieldCheck className="h-6 w-6" />
             Roles
           </h1>
-          <p className="text-sm text-steel mt-1">
+          <p className="text-sm text-muted-foreground mt-1">
             View capability sets granted to each Huf role. System roles cannot be deleted.
           </p>
         </div>
 
         {loading ? (
-          <div className="text-sm font-body text-steel-soft py-12 text-center">Loading…</div>
+          <div className="text-sm text-muted-foreground py-12 text-center">Loading…</div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">
             {roles.map((role) => (

--- a/huf/huf/doctype/huf_data_table/api.py
+++ b/huf/huf/doctype/huf_data_table/api.py
@@ -1,13 +1,26 @@
 import json
 
 import frappe
+from frappe import _
 
+from huf.permissions import has_capability
+
+from .permissions import sync_data_table_permissions
 from .validators import (
 	LAYOUT_FIELD_TYPES,
 	get_search_fields,
 	resolve_autoname,
 	validate_and_prepare_fields,
 )
+
+
+def _require_data_manage():
+	"""Throw if the current user cannot manage data tables."""
+	if not has_capability(frappe.session.user, "data.tables.manage"):
+		frappe.throw(
+			_("You don't have permission to manage data tables."),
+			frappe.PermissionError,
+		)
 
 
 @frappe.whitelist()
@@ -20,6 +33,8 @@ def create_data_table(
 	title_field: str = "",
 ) -> dict:
 	"""Create a new data table (DocType + registry entry)."""
+	_require_data_manage()
+
 	if isinstance(fields, str):
 		fields = json.loads(fields)
 
@@ -90,6 +105,10 @@ def create_data_table(
 	)
 	registry.insert(ignore_permissions=True)
 
+	# Sync permissions so all roles with data.* capabilities get access
+	# to this new table immediately.
+	sync_data_table_permissions()
+
 	frappe.db.commit()
 
 	return {
@@ -110,6 +129,8 @@ def update_data_table(
 	icon: str | None = None,
 ) -> dict:
 	"""Update table structure (add/remove/reorder fields, update metadata)."""
+	_require_data_manage()
+
 	registry = frappe.get_doc("Huf Data Table", name)
 
 	if fields is not None:
@@ -143,6 +164,8 @@ def update_data_table(
 @frappe.whitelist()
 def delete_data_table(name: str) -> dict:
 	"""Delete a data table and all its records."""
+	_require_data_manage()
+
 	registry = frappe.get_doc("Huf Data Table", name)
 	doctype_name = registry.doctype_name
 
@@ -218,3 +241,14 @@ def get_table_schema(name: str) -> dict:
 		"title_field_name": registry.title_field_name,
 		"fields": fields,
 	}
+
+
+@frappe.whitelist()
+def apply_data_permissions() -> dict:
+	"""
+	Rebuild DocType permissions for all data tables.
+
+	Called by the Huf Role on_update hook whenever role capabilities change.
+	"""
+	sync_data_table_permissions()
+	return {"success": True}

--- a/huf/huf/doctype/huf_data_table/api.py
+++ b/huf/huf/doctype/huf_data_table/api.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import frappe
 from frappe import _
@@ -23,6 +24,23 @@ def _require_data_manage():
 		)
 
 
+def _require_data_view():
+	"""Throw if the current user has no data-table access at all."""
+	user = frappe.session.user
+	if not any(
+		has_capability(user, cap)
+		for cap in (
+			"data.tables.manage",
+			"data.records.view_own",
+			"data.records.view_all",
+		)
+	):
+		frappe.throw(
+			_("You don't have permission to view data tables."),
+			frappe.PermissionError,
+		)
+
+
 @frappe.whitelist()
 def create_data_table(
 	table_name: str,
@@ -41,6 +59,10 @@ def create_data_table(
 	table_name = table_name.strip()
 	if not table_name:
 		frappe.throw("Table name is required")
+	if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9 _-]{0,139}", table_name):
+		frappe.throw(
+			"Table name may only contain letters, numbers, spaces, underscores, and hyphens."
+		)
 
 	doctype_name = f"HF {table_name}"
 
@@ -191,6 +213,8 @@ def get_table_record_counts(names: str | list[str]) -> dict:
 	Standard REST can't count records across dynamic DocTypes,
 	so this helper exists for the listing page enrichment.
 	"""
+	_require_data_view()
+
 	if isinstance(names, str):
 		names = json.loads(names)
 
@@ -208,6 +232,8 @@ def get_table_record_counts(names: str | list[str]) -> dict:
 @frappe.whitelist()
 def get_table_schema(name: str) -> dict:
 	"""Get complete table schema (fields with all properties)."""
+	_require_data_view()
+
 	registry = frappe.get_doc("Huf Data Table", name)
 	meta = frappe.get_meta(registry.doctype_name)
 
@@ -250,5 +276,6 @@ def apply_data_permissions() -> dict:
 
 	Called by the Huf Role on_update hook whenever role capabilities change.
 	"""
+	_require_data_manage()
 	sync_data_table_permissions()
 	return {"success": True}

--- a/huf/huf/doctype/huf_data_table/permissions.py
+++ b/huf/huf/doctype/huf_data_table/permissions.py
@@ -1,0 +1,200 @@
+"""
+huf/huf/doctype/huf_data_table/permissions.py
+
+Permission synchronisation for dynamically generated data-table DocTypes.
+
+Each Huf Data Table is backed by a Frappe DocType named "HF {table_name}".
+The rows in that DocType's "permissions" child table are derived from the
+capability assignments of Huf Roles, so changing a role's data.* capabilities
+automatically updates record-level access for every data table.
+"""
+
+import frappe
+
+from huf.permissions import HUF_ROLE_FRAPPE_ROLE_MAP
+
+
+# Capabilities that control data-table record access.
+_DATA_VIEW_ALL = "data.records.view_all"
+_DATA_VIEW_OWN = "data.records.view_own"
+_DATA_EDIT_ALL = "data.records.edit_all"
+_DATA_EDIT_OWN = "data.records.edit_own"
+_DATA_CREATE = "data.records.create"
+
+
+def sync_data_table_permissions() -> None:
+	"""
+	Rebuild the DocType Permission rows for every generated data table.
+
+	Permissions are derived from the current capability assignments of all
+	Huf Roles (except Huf Admin, which maps to System Manager and always
+	keeps full access). Failures for individual tables are logged and skipped
+	so that one broken table does not block the rest.
+	"""
+	if not frappe.db.table_exists("Huf Data Table"):
+		return
+
+	data_tables = frappe.get_all(
+		"Huf Data Table",
+		fields=["doctype_name"],
+		ignore_permissions=True,
+	)
+	if not data_tables:
+		return
+
+	role_caps = _get_role_capabilities()
+
+	for table in data_tables:
+		doctype_name = table.doctype_name
+		if not doctype_name:
+			continue
+
+		try:
+			if not frappe.db.exists("DocType", doctype_name):
+				continue
+
+			dt = frappe.get_doc("DocType", doctype_name)
+			new_permissions = _build_permissions(role_caps)
+			dt.set("permissions", new_permissions)
+			dt.save(ignore_permissions=True)
+		except Exception:
+			frappe.log_error(
+				title="Failed to sync data table permissions",
+				message=frappe.get_traceback(),
+			)
+
+
+def _get_role_capabilities() -> dict[str, set[str]]:
+	"""
+	Return a mapping of Huf Role name -> set of granted capability strings.
+
+	Huf Admin is excluded because it maps to System Manager, which always
+	receives full access unconditionally.
+	"""
+	roles = frappe.get_all(
+		"Huf Role",
+		filters={"name": ["!=", "Huf Admin"]},
+		fields=["name"],
+		ignore_permissions=True,
+	)
+
+	role_caps: dict[str, set[str]] = {}
+	for role in roles:
+		role_name = role.name
+		if role_name not in HUF_ROLE_FRAPPE_ROLE_MAP:
+			continue
+
+		rows = frappe.get_all(
+			"Huf Role Permission",
+			filters={"parent": role_name},
+			fields=["capability"],
+			ignore_permissions=True,
+		)
+		role_caps[role_name] = {r.capability for r in rows if r.capability}
+
+	return role_caps
+
+
+def _build_permissions(role_caps: dict[str, set[str]]) -> list[dict]:
+	"""
+	Build a DocType permissions array from role capability assignments.
+
+	Rules:
+	  - System Manager always keeps full CRUD.
+	  - view_all  -> read, if_owner=0
+	  - view_own  -> read, if_owner=1
+	  - edit_all  -> write + delete, if_owner=0 (merged with view_all row)
+	  - edit_own  -> write + delete, if_owner=1 (merged with view_own row)
+	  - create    -> create flag added to the role's non-owner row if present,
+	                otherwise the owner row, otherwise a new if_owner=0 row.
+	"""
+	permissions: list[dict] = [
+		{
+			"role": "System Manager",
+			"read": 1,
+			"write": 1,
+			"create": 1,
+			"delete": 1,
+			"print": 1,
+			"email": 1,
+			"share": 1,
+			"if_owner": 0,
+		}
+	]
+
+	# One row per (frappe_role, if_owner) pair.
+	rows: dict[tuple[str, int], dict] = {}
+
+	for huf_role, caps in role_caps.items():
+		frappe_role = HUF_ROLE_FRAPPE_ROLE_MAP.get(huf_role)
+		if not frappe_role:
+			continue
+
+		if _DATA_VIEW_ALL in caps or _DATA_EDIT_ALL in caps:
+			key = (frappe_role, 0)
+			row = rows.setdefault(
+				key,
+				{
+					"role": frappe_role,
+					"if_owner": 0,
+					"read": 0,
+					"write": 0,
+					"create": 0,
+					"delete": 0,
+					"print": 0,
+					"email": 0,
+					"share": 0,
+				},
+			)
+			row["read"] = 1
+			if _DATA_EDIT_ALL in caps:
+				row["write"] = 1
+				row["delete"] = 1
+
+		if _DATA_VIEW_OWN in caps or _DATA_EDIT_OWN in caps:
+			key = (frappe_role, 1)
+			row = rows.setdefault(
+				key,
+				{
+					"role": frappe_role,
+					"if_owner": 1,
+					"read": 0,
+					"write": 0,
+					"create": 0,
+					"delete": 0,
+					"print": 0,
+					"email": 0,
+					"share": 0,
+				},
+			)
+			row["read"] = 1
+			if _DATA_EDIT_OWN in caps:
+				row["write"] = 1
+				row["delete"] = 1
+
+		# create is attached to the broadest row available for the role.
+		if _DATA_CREATE in caps:
+			if (frappe_role, 0) in rows:
+				rows[(frappe_role, 0)]["create"] = 1
+			elif (frappe_role, 1) in rows:
+				rows[(frappe_role, 1)]["create"] = 1
+			else:
+				key = (frappe_role, 0)
+				rows[key] = {
+					"role": frappe_role,
+					"if_owner": 0,
+					"read": 0,
+					"write": 0,
+					"create": 1,
+					"delete": 0,
+					"print": 0,
+					"email": 0,
+					"share": 0,
+				}
+
+	# Drop rows that ended up with no effective permissions.
+	for row in rows.values():
+		if any(row.get(k) for k in ("read", "write", "create", "delete")):
+			permissions.append(row)
+
+	return permissions

--- a/huf/huf/doctype/huf_role/huf_role.py
+++ b/huf/huf/doctype/huf_role/huf_role.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from huf.permissions import CAPABILITIES, _bust_cache
+from huf.huf.doctype.huf_data_table.permissions import sync_data_table_permissions
 
 
 class HufRole(Document):
@@ -14,7 +15,6 @@ class HufRole(Document):
 
 	def validate(self):
 		self._validate_capabilities()
-		self._populate_permission_labels()
 
 	def _validate_capabilities(self):
 		"""Reject any capability not in the CAPABILITIES catalogue."""
@@ -25,15 +25,6 @@ class HufRole(Document):
 						row.capability, ", ".join(sorted(CAPABILITIES.keys()))
 					)
 				)
-
-	def _populate_permission_labels(self):
-		"""Set each permission row's label from the CAPABILITIES catalogue.
-
-		Done here rather than in HufRolePermission.before_save(): child-table
-		controller hooks don't fire on parent document save in Frappe v16.
-		"""
-		for row in self.permissions:
-			row.label = CAPABILITIES.get(row.capability, row.capability)
 
 	# ------------------------------------------------------------------
 	# Guard system roles
@@ -54,6 +45,17 @@ class HufRole(Document):
 
 	def on_update(self):
 		self._bust_users_cache()
+		self._sync_data_table_permissions()
+
+	def _sync_data_table_permissions(self):
+		"""Update data table DocType permissions when this role's capabilities change."""
+		try:
+			sync_data_table_permissions()
+		except Exception:
+			frappe.log_error(
+				title="Failed to sync data table permissions from Huf Role update",
+				message=frappe.get_traceback(),
+			)
 
 	def _bust_users_cache(self):
 		"""Bust the capability cache for every user assigned this role."""

--- a/huf/huf/doctype/huf_role_permission/huf_role_permission.json
+++ b/huf/huf/doctype/huf_role_permission/huf_role_permission.json
@@ -14,7 +14,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Capability",
-   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.integrations.manage\nsystem.settings.manage\nusers.invite\nusers.manage\nroles.manage",
+   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.integrations.manage\nsystem.settings.manage\ndata.tables.manage\ndata.records.create\ndata.records.view_own\ndata.records.view_all\ndata.records.edit_own\ndata.records.edit_all\nusers.invite\nusers.manage\nroles.manage",
    "reqd": 1
   },
   {

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -11,4 +11,4 @@ huf.patches.setup_desktop_icon_as_workspace
 huf.patches.v1.update_image_tool
 huf.patches.v1.update_agent_background_color
 huf.patches.v1.repair_tool_call_messages
-huf.patches.v1.fix_agent_message_status
+huf.patches.v1.fix_agent_message_statushuf.patches.v1.sync_data_table_permissions

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -11,4 +11,5 @@ huf.patches.setup_desktop_icon_as_workspace
 huf.patches.v1.update_image_tool
 huf.patches.v1.update_agent_background_color
 huf.patches.v1.repair_tool_call_messages
-huf.patches.v1.fix_agent_message_statushuf.patches.v1.sync_data_table_permissions
+huf.patches.v1.fix_agent_message_status
+huf.patches.v1.sync_data_table_permissions

--- a/huf/patches/v1/sync_data_table_permissions.py
+++ b/huf/patches/v1/sync_data_table_permissions.py
@@ -1,0 +1,22 @@
+import frappe
+
+from huf.huf.doctype.huf_data_table.permissions import sync_data_table_permissions
+
+
+def execute():
+	"""
+	Backfill DocType permissions for existing Huf Data Tables.
+
+	On fresh installs where the Huf Data Table registry does not exist yet,
+	this patch no-ops gracefully.
+	"""
+	if not frappe.db.table_exists("Huf Data Table"):
+		return
+
+	try:
+		sync_data_table_permissions()
+	except Exception:
+		frappe.log_error(
+			title="Patch: failed to sync data table permissions",
+			message=frappe.get_traceback(),
+		)

--- a/huf/permissions.py
+++ b/huf/permissions.py
@@ -56,6 +56,13 @@ CAPABILITIES: dict[str, str] = {
 	"system.mcp.manage": "Manage MCP Servers",
 	"system.integrations.manage": "Manage Integrations",
 	"system.settings.manage": "Manage Settings",
+	# --- Data ---
+	"data.tables.manage": "Manage Data Tables",
+	"data.records.create": "Create Data Records",
+	"data.records.view_own": "View Own Data Records",
+	"data.records.view_all": "View All Data Records",
+	"data.records.edit_own": "Edit/Delete Own Data Records",
+	"data.records.edit_all": "Edit/Delete Any Data Record",
 	# --- Users & Roles ---
 	"users.invite": "Invite Users",
 	"users.manage": "Manage Users",
@@ -84,6 +91,10 @@ DEFAULT_ROLE_CAPABILITIES: dict[str, list[str]] = {
 		"flows.use",
 		"flows.create",
 		"flows.manage",
+		"data.tables.manage",
+		"data.records.create",
+		"data.records.view_all",
+		"data.records.edit_all",
 	],
 	"Huf User": [
 		"agent.use",
@@ -92,10 +103,14 @@ DEFAULT_ROLE_CAPABILITIES: dict[str, list[str]] = {
 		"knowledge.use",
 		"tools.use",
 		"flows.use",
+		"data.records.create",
+		"data.records.view_all",
+		"data.records.edit_own",
 	],
 	"Huf Viewer": [
 		"agent.use",
 		"chat.view_own",
+		"data.records.view_own",
 	],
 }
 


### PR DESCRIPTION
## Problem
Repairs #346: the Data feature (dynamic data tables) had no capability gating — complements #409's route-level gating (finding 1.6, which #340 explicitly deferred). The original PR was CONFLICTING (sidebar restructure + `patches.txt` EOF). This is the same change rebased onto current develop with both conflicts resolved.

## Scope
- `huf/permissions.py`: 6 new `data.*` capabilities in the catalogue.
- `huf/huf/doctype/huf_data_table/permissions.py` (new): capability→DocType-permission sync; `api.py`: guarded endpoints (validate table_name, view checks).
- `huf/huf/doctype/huf_role/huf_role.py`: `on_update` re-syncs data-table permissions (guarded, logs on failure).
- `huf_role_permission.json`: options gain the `data.*` capabilities (needs `bench migrate`).
- `patches.txt`: registers `sync_data_table_permissions` backfill (last line, per intake dossier).
- Frontend: sidebar Data item gated (any-of `data.tables.manage`/`data.records.*`), DataTableBuilderPage guard, RolesPage.

## Key decisions
- `patches.txt` conflict resolved keeping both develop's `fix_agent_message_status` and the new patch (PR's last, per dossier).
- Sidebar change re-applied onto develop's restructured grouped nav, preserving #409's capability gating.
- Sequencing (dossier): land #409 first, then this; #283 (sidebar restructure) landing first means a second sidebar re-application.

## Agent contributions
Rebase + sidebar conflict resolution by the release-orchestration pipeline; a task-scope packaging error accidentally dropped 4 files — restored by the pipeline (huf_role hook, options JSON, patches, RolesPage). Intake dossier by the pipeline.

## Tests executed
- `py_compile` on changed Python; JSON validated; `tsc`+vite build green.
- Isolated bench 16_ro: `bench migrate` clean, patch ran (Patch Log verified), `data.*` capabilities present in the catalogue.

## Risks and limitations
- `sync_data_table_permissions()` rewrites the permissions child table of every HF* DocType; manual customizations to those are overwritten (by design; noted in the original PR).
- Users who saw Data via `agent.view_all` but hold no `data.*` capability lose the menu item (intended gating).
- Live UI verification of the gated Data page not yet done.

## Rollback
Revert the branch; re-run migrate (perm rows revert on DocType sync).

## Remaining work
- Live RBAC walkthrough of the Data feature with a `data.records.view_own`-only user.
