### PR TITLE
feat(chat): generative UI structured components (PR #210 rebased on develop)

### DIFF
--- a/frontend/src/components/chat/MessageContentWithArtifacts.tsx
+++ b/frontend/src/components/chat/MessageContentWithArtifacts.tsx
@@ -1,17 +1,23 @@
 /**
- * Helper component that parses and renders message content with artifacts, web previews, and JSX previews.
- * Extracts <artifact>, <web-preview>, and <jsx-preview> tags from content and renders them as components.
+ * Helper component that parses and renders message content with artifacts, web previews,
+ * JSX previews, and structured UI components.
+ * Extracts <ui-component>, <artifact>, <web-preview>, and <jsx-preview> tags from content
+ * and renders them as components.
+ * Parse order: UI components → JSX previews → web previews → artifacts.
  */
 
 import { MessageResponse } from '@/components/ai-elements/message';
 import { ArtifactRenderer } from './ArtifactRenderer';
 import { WebPreviewRenderer } from './WebPreviewRenderer';
 import { JSXPreviewRenderer } from './JSXPreviewRenderer';
+import { UIComponentRenderer } from './ui-components/UIComponentRenderer';
 import { hasArtifacts } from '@/utils/artifactParser';
 import { hasWebPreviews } from '@/utils/webPreviewParser';
 import { hasJSXPreviews } from '@/utils/jsxPreviewParser';
 import { parseMessagePreviewContent } from '@/utils/messageContentParser';
 import { decodeHtmlEntities } from '@/utils/decodeHtmlEntities';
+import { parseUIComponents, hasUIComponents } from './ui-components/uiComponentParser';
+import type { ParsedUIComponent } from '@/types/artifact.types';
 
 interface MessageContentWithArtifactsProps {
 	content: string;
@@ -25,8 +31,9 @@ export function MessageContentWithArtifacts({ content, messageId }: MessageConte
 	const contentHasArtifacts = hasArtifacts(decodedContent);
 	const contentHasWebPreviews = hasWebPreviews(decodedContent);
 	const contentHasJSXPreviews = hasJSXPreviews(decodedContent);
+	const contentHasUIComponents = hasUIComponents(decodedContent);
 
-	if (!contentHasArtifacts && !contentHasWebPreviews && !contentHasJSXPreviews) {
+	if (!contentHasArtifacts && !contentHasWebPreviews && !contentHasJSXPreviews && !contentHasUIComponents) {
 		return (
 			<div className="min-w-0 max-w-full overflow-x-auto">
 				<MessageResponse>{content}</MessageResponse>
@@ -34,7 +41,17 @@ export function MessageContentWithArtifacts({ content, messageId }: MessageConte
 		);
 	}
 
-	const parsed = parseMessagePreviewContent(content);
+	// Extract UI components first so the shared preview pipeline never sees
+	// <ui-component> tags (parse order: UI → JSX → web-preview → artifact).
+	let uiComponents: ParsedUIComponent[] = [];
+	let remainingContent = content;
+	if (contentHasUIComponents) {
+		const parsedUI = parseUIComponents(decodedContent);
+		uiComponents = parsedUI.components;
+		remainingContent = parsedUI.text;
+	}
+
+	const parsed = parseMessagePreviewContent(remainingContent);
 	const { textContent, jsxPreviews, webPreviews, artifacts } = parsed;
 
 	return (
@@ -44,6 +61,10 @@ export function MessageContentWithArtifacts({ content, messageId }: MessageConte
 					<MessageResponse>{textContent}</MessageResponse>
 				</div>
 			)}
+
+			{uiComponents.map((comp, idx) => (
+				<UIComponentRenderer key={`${messageId}-ui-${idx}`} component={comp} />
+			))}
 
 			{jsxPreviews.map((preview, idx) => (
 				<JSXPreviewRenderer

--- a/frontend/src/components/chat/ui-components/UIComponentRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/UIComponentRenderer.tsx
@@ -1,0 +1,59 @@
+/**
+ * Dispatcher that renders a ParsedUIComponent using the appropriate
+ * registered renderer.  Falls back to a formatted JSON display for
+ * unknown types or data errors.
+ */
+
+import { AlertCircle } from 'lucide-react';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import type { ParsedUIComponent } from '@/types/artifact.types';
+import { getUIComponentRenderer, getRegisteredComponentTypes } from './registry';
+
+interface Props {
+	component: ParsedUIComponent;
+}
+
+export function UIComponentRenderer({ component }: Props) {
+	// Data-level error from parser
+	if (component.error || !component.data) {
+		return (
+			<Alert variant="destructive" className="my-3">
+				<AlertCircle className="size-4" />
+				<AlertTitle>Component error</AlertTitle>
+				<AlertDescription className="text-xs">
+					<span className="font-mono">&lt;ui-component type=&quot;{component.type}&quot;&gt;</span>
+					{' '}{component.error ?? 'Missing data'}
+				</AlertDescription>
+			</Alert>
+		);
+	}
+
+	const Renderer = getUIComponentRenderer(component.type);
+
+	if (!Renderer) {
+		const known = getRegisteredComponentTypes().join(', ');
+		return (
+			<Alert className="my-3">
+				<AlertCircle className="size-4" />
+				<AlertTitle>Unknown component type: <code className="font-mono">{component.type}</code></AlertTitle>
+				<AlertDescription className="text-xs space-y-2">
+					<p>Registered types: {known}</p>
+					<details>
+						<summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+							Show raw data
+						</summary>
+						<pre className="mt-1 overflow-x-auto rounded bg-muted p-2 text-[11px]">
+							{JSON.stringify(component.data, null, 2)}
+						</pre>
+					</details>
+				</AlertDescription>
+			</Alert>
+		);
+	}
+
+	return (
+		<div className="my-3">
+			<Renderer component={component} />
+		</div>
+	);
+}

--- a/frontend/src/components/chat/ui-components/registry.ts
+++ b/frontend/src/components/chat/ui-components/registry.ts
@@ -1,0 +1,45 @@
+/**
+ * UI Component Registry
+ *
+ * Maps <ui-component type="..."> type strings to their React renderer
+ * components.  Add new renderers here to make them available in chat.
+ */
+
+import type { ComponentType } from 'react';
+import type { ParsedUIComponent } from '@/types/artifact.types';
+
+export interface UIComponentRendererProps {
+	component: ParsedUIComponent;
+}
+
+// Static registry — all renderers are imported eagerly. Recharts is already
+// in the main bundle via jsx-preview, so lazy loading gains nothing here.
+import { StatsCardRenderer } from './renderers/StatsCardRenderer';
+import { KPIGridRenderer } from './renderers/KPIGridRenderer';
+import { BarChartRenderer } from './renderers/BarChartRenderer';
+import { LineChartRenderer } from './renderers/LineChartRenderer';
+import { PieChartRenderer } from './renderers/PieChartRenderer';
+import { AreaChartRenderer } from './renderers/AreaChartRenderer';
+import { DataTableRenderer } from './renderers/DataTableRenderer';
+import { ProgressCardRenderer } from './renderers/ProgressCardRenderer';
+import { InfoCardRenderer } from './renderers/InfoCardRenderer';
+
+const registry: Record<string, ComponentType<UIComponentRendererProps>> = {
+	'stats-card': StatsCardRenderer,
+	'kpi-grid': KPIGridRenderer,
+	'bar-chart': BarChartRenderer,
+	'line-chart': LineChartRenderer,
+	'pie-chart': PieChartRenderer,
+	'area-chart': AreaChartRenderer,
+	'data-table': DataTableRenderer,
+	'progress-card': ProgressCardRenderer,
+	'info-card': InfoCardRenderer,
+};
+
+export function getUIComponentRenderer(type: string): ComponentType<UIComponentRendererProps> | null {
+	return registry[type] ?? null;
+}
+
+export function getRegisteredComponentTypes(): string[] {
+	return Object.keys(registry);
+}

--- a/frontend/src/components/chat/ui-components/renderers/AreaChartRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/AreaChartRenderer.tsx
@@ -1,0 +1,72 @@
+import {
+	AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import type { UIComponentRendererProps } from '../registry';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#00C49F', '#FF8042', '#0088FE'];
+
+interface AreaChartData {
+	title?: string;
+	description?: string;
+	items: Record<string, unknown>[];
+	areas?: { dataKey: string; label?: string; color?: string }[];
+	xKey?: string;
+	stacked?: boolean;
+}
+
+export function AreaChartRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as AreaChartData | null;
+	if (!d?.items?.length) return null;
+
+	const xKey = d.xKey ?? 'name';
+	const areas = d.areas ?? inferAreas(d.items, xKey);
+
+	return (
+		<Card className="w-full">
+			{(d.title || d.description) && (
+				<CardHeader className="pb-2">
+					{d.title && <CardTitle className="text-base">{d.title}</CardTitle>}
+					{d.description && <CardDescription>{d.description}</CardDescription>}
+				</CardHeader>
+			)}
+			<CardContent className="pt-4">
+				<ResponsiveContainer width="100%" height={300}>
+					<AreaChart data={d.items} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+						<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+						<XAxis dataKey={xKey} tick={{ fontSize: 12 }} />
+						<YAxis tick={{ fontSize: 12 }} />
+						<Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} />
+						{areas.length > 1 && <Legend wrapperStyle={{ fontSize: 12 }} />}
+						{areas.map((area, i) => {
+							const color = area.color ?? COLORS[i % COLORS.length];
+							return (
+								<Area
+									key={area.dataKey}
+									type="monotone"
+									dataKey={area.dataKey}
+									name={area.label ?? area.dataKey}
+									stroke={color}
+									fill={color}
+									fillOpacity={0.15}
+									strokeWidth={2}
+									stackId={d.stacked ? 'stack' : undefined}
+								/>
+							);
+						})}
+					</AreaChart>
+				</ResponsiveContainer>
+			</CardContent>
+		</Card>
+	);
+}
+
+function inferAreas(
+	items: Record<string, unknown>[],
+	xKey: string,
+): { dataKey: string; label?: string; color?: string }[] {
+	if (!items.length) return [];
+	return Object.keys(items[0])
+		.filter((k) => k !== xKey && typeof items[0][k] === 'number')
+		.map((k) => ({ dataKey: k }));
+}

--- a/frontend/src/components/chat/ui-components/renderers/BarChartRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/BarChartRenderer.tsx
@@ -1,0 +1,78 @@
+import {
+	BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import type { UIComponentRendererProps } from '../registry';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#00C49F', '#FF8042', '#0088FE'];
+
+interface BarChartData {
+	title?: string;
+	description?: string;
+	items: Record<string, unknown>[];
+	bars?: { dataKey: string; label?: string; color?: string }[];
+	dataKey?: string;
+	categoryKey?: string;
+	stacked?: boolean;
+	horizontal?: boolean;
+}
+
+export function BarChartRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as BarChartData | null;
+	if (!d?.items?.length) return null;
+
+	const catKey = d.categoryKey ?? 'name';
+	const bars = d.bars ?? (d.dataKey ? [{ dataKey: d.dataKey }] : inferBars(d.items, catKey));
+
+	return (
+		<Card className="w-full">
+			{(d.title || d.description) && (
+				<CardHeader className="pb-2">
+					{d.title && <CardTitle className="text-base">{d.title}</CardTitle>}
+					{d.description && <CardDescription>{d.description}</CardDescription>}
+				</CardHeader>
+			)}
+			<CardContent className="pt-4">
+				<ResponsiveContainer width="100%" height={300}>
+					<BarChart
+						data={d.items}
+						layout={d.horizontal ? 'vertical' : 'horizontal'}
+						margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+					>
+						<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+						{d.horizontal ? (
+							<>
+								<YAxis dataKey={catKey} type="category" tick={{ fontSize: 12 }} width={80} />
+								<XAxis type="number" tick={{ fontSize: 12 }} />
+							</>
+						) : (
+							<>
+								<XAxis dataKey={catKey} tick={{ fontSize: 12 }} />
+								<YAxis tick={{ fontSize: 12 }} />
+							</>
+						)}
+						<Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} />
+						{bars.length > 1 && <Legend wrapperStyle={{ fontSize: 12 }} />}
+						{bars.map((bar, i) => (
+							<Bar
+								key={bar.dataKey}
+								dataKey={bar.dataKey}
+								name={bar.label ?? bar.dataKey}
+								fill={bar.color ?? COLORS[i % COLORS.length]}
+								radius={[4, 4, 0, 0]}
+								stackId={d.stacked ? 'stack' : undefined}
+							/>
+						))}
+					</BarChart>
+				</ResponsiveContainer>
+			</CardContent>
+		</Card>
+	);
+}
+
+function inferBars(items: Record<string, unknown>[], categoryKey: string) {
+	if (!items.length) return [];
+	return Object.keys(items[0])
+		.filter((k) => k !== categoryKey && typeof items[0][k] === 'number')
+		.map((k) => ({ dataKey: k }));
+}

--- a/frontend/src/components/chat/ui-components/renderers/DataTableRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/DataTableRenderer.tsx
@@ -1,0 +1,111 @@
+import {
+	Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption,
+} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { UIComponentRendererProps } from '../registry';
+
+interface DataTableData {
+	title?: string;
+	description?: string;
+	columns: (string | { label: string; align?: 'left' | 'center' | 'right'; format?: 'currency' | 'number' | 'percent' | 'badge' })[];
+	rows: (string | number | null)[][];
+	caption?: string;
+	striped?: boolean;
+}
+
+function resolveColumn(col: DataTableData['columns'][number]) {
+	if (typeof col === 'string') return { label: col, align: 'left' as const, format: undefined };
+	return { label: col.label, align: col.align ?? 'left', format: col.format };
+}
+
+function formatCell(value: string | number | null, format?: string): React.ReactNode {
+	if (value === null || value === undefined) return '—';
+
+	if (format === 'badge') {
+		const str = String(value);
+		const variant = badgeVariant(str);
+		return <Badge variant={variant}>{str}</Badge>;
+	}
+
+	if (typeof value === 'number') {
+		switch (format) {
+			case 'currency':
+				return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+			case 'percent':
+				return `${value.toFixed(1)}%`;
+			case 'number':
+				return new Intl.NumberFormat().format(value);
+			default:
+				return new Intl.NumberFormat().format(value);
+		}
+	}
+
+	return String(value);
+}
+
+function badgeVariant(text: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+	const lower = text.toLowerCase();
+	if (['paid', 'completed', 'active', 'approved', 'submitted', 'success'].some((w) => lower.includes(w)))
+		return 'default';
+	if (['overdue', 'failed', 'cancelled', 'rejected', 'error'].some((w) => lower.includes(w)))
+		return 'destructive';
+	if (['pending', 'draft', 'unpaid', 'open'].some((w) => lower.includes(w)))
+		return 'secondary';
+	return 'outline';
+}
+
+export function DataTableRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as DataTableData | null;
+	if (!d?.columns?.length || !d?.rows?.length) return null;
+
+	const cols = d.columns.map(resolveColumn);
+
+	return (
+		<Card className="w-full overflow-hidden">
+			{(d.title || d.description) && (
+				<CardHeader className="pb-2">
+					{d.title && <CardTitle className="text-base">{d.title}</CardTitle>}
+					{d.description && <CardDescription>{d.description}</CardDescription>}
+				</CardHeader>
+			)}
+			<CardContent className={cn(!d.title && !d.description && 'pt-0', 'px-0 pb-0')}>
+				<div className="overflow-x-auto">
+					<Table>
+						{d.caption && <TableCaption>{d.caption}</TableCaption>}
+						<TableHeader>
+							<TableRow>
+								{cols.map((col, i) => (
+									<TableHead key={i} className={cn(col.align === 'right' && 'text-right', col.align === 'center' && 'text-center')}>
+										{col.label}
+									</TableHead>
+								))}
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{d.rows.map((row, ri) => (
+								<TableRow key={ri} className={cn(d.striped && ri % 2 === 1 && 'bg-muted/40')}>
+									{row.map((cell, ci) => {
+										const col = cols[ci];
+										return (
+											<TableCell
+												key={ci}
+												className={cn(
+													col?.align === 'right' && 'text-right',
+													col?.align === 'center' && 'text-center',
+												)}
+											>
+												{formatCell(cell, col?.format)}
+											</TableCell>
+										);
+									})}
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/chat/ui-components/renderers/InfoCardRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/InfoCardRenderer.tsx
@@ -1,0 +1,82 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import type { UIComponentRendererProps } from '../registry';
+
+interface InfoItem {
+	label: string;
+	value: string | number;
+	badge?: boolean;
+}
+
+interface InfoSection {
+	heading?: string;
+	items: InfoItem[];
+}
+
+interface InfoCardData {
+	title: string;
+	description?: string;
+	status?: string;
+	items?: InfoItem[];
+	sections?: InfoSection[];
+}
+
+function badgeVariant(text: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+	const lower = text.toLowerCase();
+	if (['paid', 'completed', 'active', 'approved', 'submitted', 'success'].some((w) => lower.includes(w)))
+		return 'default';
+	if (['overdue', 'failed', 'cancelled', 'rejected', 'error'].some((w) => lower.includes(w)))
+		return 'destructive';
+	if (['pending', 'draft', 'unpaid', 'open'].some((w) => lower.includes(w)))
+		return 'secondary';
+	return 'outline';
+}
+
+function renderItems(items: InfoItem[]) {
+	return (
+		<div className="space-y-2">
+			{items.map((item, i) => (
+				<div key={i} className="flex items-center justify-between gap-4 text-sm">
+					<span className="text-muted-foreground shrink-0">{item.label}</span>
+					{item.badge ? (
+						<Badge variant={badgeVariant(String(item.value))}>{String(item.value)}</Badge>
+					) : (
+						<span className="font-medium text-right truncate">{String(item.value)}</span>
+					)}
+				</div>
+			))}
+		</div>
+	);
+}
+
+export function InfoCardRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as InfoCardData | null;
+	if (!d?.title) return null;
+
+	return (
+		<Card className="w-full max-w-md">
+			<CardHeader className="pb-3">
+				<div className="flex items-center justify-between gap-3">
+					<CardTitle className="text-base">{d.title}</CardTitle>
+					{d.status && <Badge variant={badgeVariant(d.status)}>{d.status}</Badge>}
+				</div>
+				{d.description && <CardDescription>{d.description}</CardDescription>}
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{d.items && renderItems(d.items)}
+				{d.sections?.map((section, si) => (
+					<div key={si} className="space-y-2">
+						{si > 0 && <Separator />}
+						{section.heading && (
+							<p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground pt-1">
+								{section.heading}
+							</p>
+						)}
+						{renderItems(section.items)}
+					</div>
+				))}
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/chat/ui-components/renderers/KPIGridRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/KPIGridRenderer.tsx
@@ -1,0 +1,85 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { UIComponentRendererProps } from '../registry';
+
+interface KPIItem {
+	label: string;
+	value: number | string;
+	change?: number;
+	format?: 'number' | 'currency' | 'percent' | 'compact';
+	prefix?: string;
+	suffix?: string;
+}
+
+interface KPIGridData {
+	title?: string;
+	items: KPIItem[];
+	columns?: number;
+}
+
+function fmtValue(v: number | string, format?: string, prefix?: string, suffix?: string): string {
+	if (typeof v === 'string') return `${prefix ?? ''}${v}${suffix ?? ''}`;
+	const p = prefix ?? '';
+	const s = suffix ?? '';
+	switch (format) {
+		case 'currency':
+			return `${p}${new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(v)}${s}`;
+		case 'percent':
+			return `${p}${v.toFixed(1)}%${s}`;
+		case 'compact':
+			return `${p}${new Intl.NumberFormat('en-US', { notation: 'compact' }).format(v)}${s}`;
+		default:
+			return `${p}${new Intl.NumberFormat().format(v)}${s}`;
+	}
+}
+
+export function KPIGridRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as KPIGridData | null;
+	if (!d?.items?.length) return null;
+
+	const cols = d.columns ?? Math.min(d.items.length, 4);
+	const gridClass = cols <= 2 ? 'grid-cols-2' : cols === 3 ? 'grid-cols-3' : 'grid-cols-4';
+
+	return (
+		<Card className="w-full">
+			{d.title && (
+				<CardHeader className="pb-3">
+					<CardTitle className="text-base">{d.title}</CardTitle>
+				</CardHeader>
+			)}
+			<CardContent className={cn(!d.title && 'pt-6')}>
+				<div className={cn('grid gap-4', gridClass)}>
+					{d.items.map((item, i) => {
+						const change = item.change ?? 0;
+						const isPos = change > 0;
+						const isZero = change === 0;
+						return (
+							<div key={i} className="space-y-1">
+								<p className="text-xs font-medium text-muted-foreground">{item.label}</p>
+								<p className="text-xl font-bold tracking-tight">
+									{fmtValue(item.value, item.format, item.prefix, item.suffix)}
+								</p>
+								{item.change !== undefined && (
+									<div className={cn(
+										'flex items-center gap-1 text-xs',
+										isZero && 'text-muted-foreground',
+										isPos && 'text-emerald-600',
+										!isPos && !isZero && 'text-red-600',
+									)}>
+										{isZero
+											? <Minus className="size-3" />
+											: isPos
+												? <TrendingUp className="size-3" />
+												: <TrendingDown className="size-3" />}
+										<span>{isPos ? '+' : ''}{change.toFixed(1)}%</span>
+									</div>
+								)}
+							</div>
+						);
+					})}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/chat/ui-components/renderers/LineChartRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/LineChartRenderer.tsx
@@ -1,0 +1,70 @@
+import {
+	LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import type { UIComponentRendererProps } from '../registry';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#00C49F', '#FF8042', '#0088FE'];
+
+interface LineChartData {
+	title?: string;
+	description?: string;
+	items: Record<string, unknown>[];
+	lines?: { dataKey: string; label?: string; color?: string; dashed?: boolean }[];
+	xKey?: string;
+	curved?: boolean;
+}
+
+export function LineChartRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as LineChartData | null;
+	if (!d?.items?.length) return null;
+
+	const xKey = d.xKey ?? 'name';
+	const lines = d.lines ?? inferLines(d.items, xKey);
+	const curve = d.curved !== false ? 'monotone' : 'linear';
+
+	return (
+		<Card className="w-full">
+			{(d.title || d.description) && (
+				<CardHeader className="pb-2">
+					{d.title && <CardTitle className="text-base">{d.title}</CardTitle>}
+					{d.description && <CardDescription>{d.description}</CardDescription>}
+				</CardHeader>
+			)}
+			<CardContent className="pt-4">
+				<ResponsiveContainer width="100%" height={300}>
+					<LineChart data={d.items} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+						<CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+						<XAxis dataKey={xKey} tick={{ fontSize: 12 }} />
+						<YAxis tick={{ fontSize: 12 }} />
+						<Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} />
+						{lines.length > 1 && <Legend wrapperStyle={{ fontSize: 12 }} />}
+						{lines.map((line, i) => (
+							<Line
+								key={line.dataKey}
+								type={curve}
+								dataKey={line.dataKey}
+								name={line.label ?? line.dataKey}
+								stroke={line.color ?? COLORS[i % COLORS.length]}
+								strokeWidth={2}
+								strokeDasharray={line.dashed ? '5 5' : undefined}
+								dot={{ r: 3 }}
+								activeDot={{ r: 5 }}
+							/>
+						))}
+					</LineChart>
+				</ResponsiveContainer>
+			</CardContent>
+		</Card>
+	);
+}
+
+function inferLines(
+	items: Record<string, unknown>[],
+	xKey: string,
+): { dataKey: string; label?: string; color?: string; dashed?: boolean }[] {
+	if (!items.length) return [];
+	return Object.keys(items[0])
+		.filter((k) => k !== xKey && typeof items[0][k] === 'number')
+		.map((k) => ({ dataKey: k }));
+}

--- a/frontend/src/components/chat/ui-components/renderers/PieChartRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/PieChartRenderer.tsx
@@ -1,0 +1,65 @@
+import {
+	PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import type { UIComponentRendererProps } from '../registry';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7300', '#00C49F', '#FF8042', '#0088FE', '#FFBB28'];
+
+interface PieChartData {
+	title?: string;
+	description?: string;
+	items: Record<string, unknown>[];
+	nameKey?: string;
+	valueKey?: string;
+	donut?: boolean;
+	colors?: string[];
+}
+
+export function PieChartRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as PieChartData | null;
+	if (!d?.items?.length) return null;
+
+	const nameKey = d.nameKey ?? 'name';
+	const valueKey = d.valueKey ?? 'value';
+	const colors = d.colors ?? COLORS;
+	const innerRadius = d.donut ? 60 : 0;
+
+	return (
+		<Card className="w-full">
+			{(d.title || d.description) && (
+				<CardHeader className="pb-2">
+					{d.title && <CardTitle className="text-base">{d.title}</CardTitle>}
+					{d.description && <CardDescription>{d.description}</CardDescription>}
+				</CardHeader>
+			)}
+			<CardContent className="pt-4">
+				<ResponsiveContainer width="100%" height={300}>
+					<PieChart>
+						<Pie
+							data={d.items}
+							dataKey={valueKey}
+							nameKey={nameKey}
+							cx="50%"
+							cy="50%"
+							innerRadius={innerRadius}
+							outerRadius={100}
+							paddingAngle={2}
+							label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+							labelLine={{ strokeWidth: 1 }}
+						>
+							{d.items.map((_, i) => (
+								<Cell key={i} fill={colors[i % colors.length]} />
+							))}
+						</Pie>
+						<Tooltip
+							formatter={(value: number) => new Intl.NumberFormat().format(value)}
+							contentStyle={{ fontSize: 12, borderRadius: 8 }}
+						/>
+						<Legend wrapperStyle={{ fontSize: 12 }} />
+					</PieChart>
+				</ResponsiveContainer>
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/chat/ui-components/renderers/ProgressCardRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/ProgressCardRenderer.tsx
@@ -1,0 +1,84 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
+import type { UIComponentRendererProps } from '../registry';
+
+interface ProgressItem {
+	label: string;
+	value: number;
+	max?: number;
+	color?: string;
+}
+
+interface ProgressCardData {
+	title?: string;
+	description?: string;
+	items?: ProgressItem[];
+	value?: number;
+	max?: number;
+	label?: string;
+	showPercent?: boolean;
+}
+
+function pct(value: number, max: number): number {
+	return Math.min(100, Math.max(0, (value / max) * 100));
+}
+
+export function ProgressCardRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as ProgressCardData | null;
+	if (!d) return null;
+
+	// Single progress bar mode
+	if (d.value !== undefined && !d.items) {
+		const max = d.max ?? 100;
+		const percent = pct(d.value, max);
+		return (
+			<Card className="w-full max-w-sm">
+				{(d.title || d.description) && (
+					<CardHeader className="pb-3">
+						{d.title && <CardTitle className="text-base">{d.title}</CardTitle>}
+						{d.description && <CardDescription>{d.description}</CardDescription>}
+					</CardHeader>
+				)}
+				<CardContent className={cn(!d.title && !d.description && 'pt-6', 'space-y-2')}>
+					<div className="flex items-center justify-between text-sm">
+						<span className="text-muted-foreground">{d.label ?? 'Progress'}</span>
+						<span className="font-medium">
+							{d.showPercent !== false ? `${percent.toFixed(0)}%` : `${new Intl.NumberFormat().format(d.value)} / ${new Intl.NumberFormat().format(max)}`}
+						</span>
+					</div>
+					<Progress value={percent} className="h-2" />
+				</CardContent>
+			</Card>
+		);
+	}
+
+	// Multi-progress mode
+	if (!d.items?.length) return null;
+
+	return (
+		<Card className="w-full">
+			{(d.title || d.description) && (
+				<CardHeader className="pb-3">
+					{d.title && <CardTitle className="text-base">{d.title}</CardTitle>}
+					{d.description && <CardDescription>{d.description}</CardDescription>}
+				</CardHeader>
+			)}
+			<CardContent className={cn(!d.title && !d.description && 'pt-6', 'space-y-4')}>
+				{d.items.map((item, i) => {
+					const max = item.max ?? 100;
+					const percent = pct(item.value, max);
+					return (
+						<div key={i} className="space-y-1.5">
+							<div className="flex items-center justify-between text-sm">
+								<span className="text-muted-foreground">{item.label}</span>
+								<span className="font-medium">{percent.toFixed(0)}%</span>
+							</div>
+							<Progress value={percent} className="h-2" />
+						</div>
+					);
+				})}
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/chat/ui-components/renderers/StatsCardRenderer.tsx
+++ b/frontend/src/components/chat/ui-components/renderers/StatsCardRenderer.tsx
@@ -1,0 +1,72 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { UIComponentRendererProps } from '../registry';
+
+interface StatsCardData {
+	title: string;
+	value: number | string;
+	change?: number;
+	changeLabel?: string;
+	format?: 'number' | 'currency' | 'percent' | 'compact';
+	prefix?: string;
+	suffix?: string;
+	description?: string;
+}
+
+function formatValue(value: number | string, format?: string, prefix?: string, suffix?: string): string {
+	if (typeof value === 'string') return `${prefix ?? ''}${value}${suffix ?? ''}`;
+	const p = prefix ?? '';
+	const s = suffix ?? '';
+	switch (format) {
+		case 'currency':
+			return `${p}${new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value)}${s}`;
+		case 'percent':
+			return `${p}${value.toFixed(1)}%${s}`;
+		case 'compact':
+			return `${p}${new Intl.NumberFormat('en-US', { notation: 'compact' }).format(value)}${s}`;
+		default:
+			return `${p}${new Intl.NumberFormat().format(value)}${s}`;
+	}
+}
+
+export function StatsCardRenderer({ component }: UIComponentRendererProps) {
+	const d = component.data as StatsCardData | null;
+	if (!d?.title) return null;
+
+	const change = d.change ?? 0;
+	const isPositive = change > 0;
+	const isNeutral = change === 0;
+
+	return (
+		<Card className="w-full max-w-xs shrink-0">
+			<CardHeader className="pb-2">
+				<CardTitle className="text-sm font-medium text-muted-foreground">{d.title}</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-1">
+				<div className="text-2xl font-bold tracking-tight">
+					{formatValue(d.value, d.format, d.prefix, d.suffix)}
+				</div>
+				{d.change !== undefined && (
+					<div className={cn(
+						'flex items-center gap-1 text-xs font-medium',
+						isNeutral && 'text-muted-foreground',
+						isPositive && 'text-emerald-600',
+						!isPositive && !isNeutral && 'text-red-600',
+					)}>
+						{isNeutral
+							? <Minus className="size-3" />
+							: isPositive
+								? <TrendingUp className="size-3" />
+								: <TrendingDown className="size-3" />}
+						<span>{isPositive ? '+' : ''}{change.toFixed(1)}%</span>
+						{d.changeLabel && <span className="font-normal text-muted-foreground">{d.changeLabel}</span>}
+					</div>
+				)}
+				{d.description && (
+					<p className="text-xs text-muted-foreground pt-1">{d.description}</p>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/frontend/src/components/chat/ui-components/uiComponentParser.ts
+++ b/frontend/src/components/chat/ui-components/uiComponentParser.ts
@@ -1,0 +1,79 @@
+/**
+ * Parser for AI-generated structured UI component tags in message content.
+ *
+ * Detects and extracts <ui-component> tags that carry a type and JSON data payload.
+ * Each tag is self-closing and looks like:
+ *   <ui-component type="stats-card" data='{"title":"Revenue","value":48250}' />
+ *
+ * The data attribute uses single-quoted JSON so double quotes inside the JSON
+ * don't break the attribute boundary.  HTML-encoded entities (&quot; &amp;) are
+ * decoded before JSON.parse.
+ */
+
+import type {
+	ParsedUIComponent,
+	UIComponentParseResult,
+} from '@/types/artifact.types';
+
+// Matches self-closing <ui-component type="..." data='...' /> tags.
+// Capture group 1 = type value, group 2 = data value (single- or double-quoted).
+const UI_COMPONENT_REGEX =
+	/<ui-component\s+type=["']([^"']+)["']\s+data='((?:[^'\\]|\\.)*)'\s*\/>/gi;
+
+// Fallback for data wrapped in double quotes (less common because JSON uses double quotes internally)
+const UI_COMPONENT_REGEX_DQ =
+	/<ui-component\s+type=["']([^"']+)["']\s+data="((?:[^"\\]|\\.)*)"\s*\/>/gi;
+
+function decodeDataValue(raw: string): string {
+	return raw
+		.replace(/&quot;/g, '"')
+		.replace(/&amp;/g, '&')
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>')
+		.replace(/&#39;/g, "'");
+}
+
+function extractComponents(
+	content: string,
+	regex: RegExp,
+): { text: string; components: ParsedUIComponent[] } {
+	const components: ParsedUIComponent[] = [];
+	regex.lastIndex = 0;
+
+	const text = content.replace(regex, (_match, type: string, rawData: string) => {
+		try {
+			const decoded = decodeDataValue(rawData);
+			const data = JSON.parse(decoded) as Record<string, unknown>;
+			components.push({ type, data });
+		} catch {
+			components.push({ type, data: null, error: 'Invalid JSON in data attribute' });
+		}
+		return '';
+	});
+
+	return { text, components };
+}
+
+/**
+ * Parse <ui-component> tags from message content.
+ */
+export function parseUIComponents(content: string): UIComponentParseResult {
+	// Try single-quoted data first (preferred), then double-quoted fallback
+	let result = extractComponents(content, UI_COMPONENT_REGEX);
+	if (result.components.length === 0) {
+		result = extractComponents(content, UI_COMPONENT_REGEX_DQ);
+	}
+
+	const cleanedText = result.text.replace(/\n{3,}/g, '\n\n').trim();
+	return { text: cleanedText, components: result.components };
+}
+
+/**
+ * Quick check for presence of <ui-component> tags.
+ */
+export function hasUIComponents(content: string): boolean {
+	if (!content) return false;
+	UI_COMPONENT_REGEX.lastIndex = 0;
+	UI_COMPONENT_REGEX_DQ.lastIndex = 0;
+	return UI_COMPONENT_REGEX.test(content) || UI_COMPONENT_REGEX_DQ.test(content);
+}

--- a/frontend/src/types/artifact.types.ts
+++ b/frontend/src/types/artifact.types.ts
@@ -47,3 +47,19 @@ export interface JSXPreviewParseResult {
 	text: string;
 	previews: ParsedJSXPreview[];
 }
+
+/**
+ * Structured UI component rendered inline in chat.
+ * The AI emits <ui-component type="..." data='...' /> tags
+ * and the frontend maps them to purpose-built renderers.
+ */
+export interface ParsedUIComponent {
+	type: string;
+	data: Record<string, unknown> | null;
+	error?: string;
+}
+
+export interface UIComponentParseResult {
+	text: string;
+	components: ParsedUIComponent[];
+}


### PR DESCRIPTION
## Problem
Repairs #210 (Generative UI: structured component system for rich chat responses). The original branch was 4 months stale and bot-authored; 14 of 16 files were conflict-free, and the one conflicting file (`MessageContentWithArtifacts.tsx`) is re-implemented here against develop's shared parsing pipeline (`parseMessagePreview`). Docs-only commits (`docs/evaluations/*`) deliberately not carried over.

## Scope (14 files, +943)
- `frontend/src/components/chat/ui-components/`: `uiComponentParser.ts` (relocated parser, import paths adjusted to develop's layout) + renderers (ProgressCard, StatsCard, etc.)
- `MessageContentWithArtifacts.tsx`: re-implemented against the shared pipeline
- `types/artifact.types.ts` and chat integration wiring

## Key decisions
- Parser lives at `components/chat/ui-components/uiComponentParser.ts` (develop layout), not the PR's original path.
- No automated tests included — the dossier's T4 (`uiComponentParser.test.ts`) is tracked as a follow-up (suite can't run on develop until #407 lands anyway).

## Agent contributions
Intake dossier + repair (cherry-pick + conflict re-implementation + verification) by the release-orchestration pipeline; the pipeline verified the diff (14 files, in-scope).

## Tests executed
- `npx tsc -b`, `npx vite build`, `npx eslint` on changed dirs — all green.
- Isolated bench 16_ro: `yarn build` green, `/huf` serves 200.

## Risks and limitations
- Renderer coverage is the PR's original set; new artifact kinds need new renderers (by design).
- Not exercised with a live agent producing structured components — a chat smoke with a component-emitting agent is recommended before undrafting.
- Import-path divergence from the original PR means cherry-picking future upstream changes onto this branch needs care.

## Rollback
Revert the branch; chat falls back to plain message rendering.

## Remaining work
- `uiComponentParser.test.ts` (dossier T4) after #407.
- Live generative-UI smoke (agent emitting cards in chat).
- Coordinate with the prompt-side documentation in #390.
