### PR TITLE
test(audio): restore the audio test suite deleted by #403's final commit

### DIFF
--- a/huf/tests/__init__.py
+++ b/huf/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Huf and Contributors
+# See license.txt

--- a/huf/tests/test_audio_service.py
+++ b/huf/tests/test_audio_service.py
@@ -1,0 +1,475 @@
+# Copyright (c) 2026, Huf and Contributors
+# See license.txt
+
+"""
+Unit tests for the canonical audio service (huf.ai.audio_service) and the
+public audio API (huf.ai.audio_api).
+
+These tests mock frappe (and LiteLLM) so the pure logic can be exercised
+without a full Frappe bench and without hitting real providers:
+
+    python -m unittest huf.tests.test_audio_service
+"""
+
+import base64
+import sys
+import tempfile
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class ThrowError(Exception):
+    """Stand-in for frappe.throw so tests can assert on thrown messages."""
+
+
+def _throw(msg, *args, **kwargs):
+    raise ThrowError(str(msg))
+
+
+# Mock frappe before importing the modules under test so pure logic can be
+# exercised without a full Frappe bench.
+frappe_mock = types.ModuleType("frappe")
+frappe_mock._ = lambda x, *a, **k: x
+frappe_mock.throw = MagicMock(side_effect=_throw)
+frappe_mock.whitelist = MagicMock(return_value=lambda fn: fn)
+frappe_mock.log_error = MagicMock()
+frappe_mock.publish_realtime = MagicMock()
+frappe_mock.get_doc = MagicMock()
+frappe_mock.get_all = MagicMock()
+frappe_mock.db = MagicMock()
+frappe_mock.session = MagicMock()
+frappe_mock.session.user = "Administrator"
+frappe_mock.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+
+frappe_utils = types.ModuleType("frappe.utils")
+frappe_utils.cint = lambda v: 1 if v in (True, 1, "1", "true", "True", "yes") else 0
+frappe_utils.now = MagicMock(return_value="2026-01-01 00:00:00")
+
+frappe_file_manager = types.ModuleType("frappe.utils.file_manager")
+frappe_file_manager.save_file = MagicMock()
+frappe_utils.file_manager = frappe_file_manager
+frappe_mock.utils = frappe_utils
+
+sys.modules["frappe"] = frappe_mock
+sys.modules["frappe.utils"] = frappe_utils
+sys.modules["frappe.utils.file_manager"] = frappe_file_manager
+
+# Mock litellm so no real provider is ever called.
+litellm_mock = types.ModuleType("litellm")
+litellm_mock.transcription = MagicMock()
+litellm_mock.completion = MagicMock()
+sys.modules["litellm"] = litellm_mock
+
+
+def _normalize_model_name(model, provider):
+    """Minimal stand-in for huf.ai.providers.litellm._normalize_model_name."""
+    if "/" in model:
+        return model
+    prefix = (provider or "").lower()
+    return f"{prefix}/{model}" if prefix else model
+
+
+litellm_provider_stub = types.ModuleType("huf.ai.providers.litellm")
+litellm_provider_stub._normalize_model_name = _normalize_model_name
+sys.modules["huf.ai.providers.litellm"] = litellm_provider_stub
+
+from huf.ai import audio_api, audio_service  # noqa: E402
+
+
+def _b64(payload: bytes) -> str:
+    return base64.b64encode(payload).decode("ascii")
+
+
+def _provider_doc(name, api_key="sk-test"):
+    doc = SimpleNamespace(name=name, provider_name=name)
+    doc.get_password = lambda field: api_key
+    return doc
+
+
+def _agent_doc(name="Agent-1", provider="OpenAI", stt_model=None, model="gpt-4o"):
+    return SimpleNamespace(
+        name=name,
+        provider=provider,
+        stt_model=stt_model,
+        model=model,
+    )
+
+
+def _install_docs(agent=None, providers=None, models=None, files=None):
+    """Wire frappe.get_doc/get_all to serve the given fake documents."""
+    agents = {d.name: d for d in ([agent] if agent else [])}
+    providers = providers or {}
+    models = models or {}
+    files = files or {}
+
+    def get_doc(doctype, name=None):
+        if doctype == "Agent":
+            return agents[name]
+        if doctype == "AI Provider":
+            return providers[name]
+        if doctype == "AI Model":
+            return models[name]
+        if doctype == "File":
+            if isinstance(name, dict):
+                for f in files.values():
+                    if all(getattr(f, k) == v for k, v in name.items()):
+                        return f
+                raise frappe_mock.DoesNotExistError("File not found")
+            return files[name]
+        raise ValueError(f"Unexpected get_doc: {doctype} {name}")
+
+    frappe_mock.get_doc.side_effect = get_doc
+    return agents
+
+
+class TestSaveAudioUpload(unittest.TestCase):
+    def setUp(self):
+        frappe_file_manager.save_file.reset_mock()
+        frappe_file_manager.save_file.side_effect = None
+        frappe_file_manager.save_file.return_value = SimpleNamespace(
+            name="FILE-0001",
+            file_name="clip.webm",
+            file_url="/private/files/clip.webm",
+        )
+
+    def test_rejects_unsupported_extension(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.save_audio_upload("notes.txt", _b64(b"audio"))
+        self.assertIn("Unsupported audio file type", str(ctx.exception))
+        frappe_file_manager.save_file.assert_not_called()
+
+    def test_rejects_oversized_file(self):
+        payload = b"x" * (audio_service.MAX_AUDIO_FILE_SIZE + 1)
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.save_audio_upload("big.webm", _b64(payload))
+        self.assertIn("maximum allowed size", str(ctx.exception))
+        frappe_file_manager.save_file.assert_not_called()
+
+    def test_rejects_invalid_base64(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.save_audio_upload("clip.webm", "!!!not-base64!!!")
+        self.assertIn("Invalid base64 audio data", str(ctx.exception))
+        frappe_file_manager.save_file.assert_not_called()
+
+    def test_rejects_empty_audio(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.save_audio_upload("clip.webm", "data:audio/webm;base64,")
+        self.assertIn("empty", str(ctx.exception))
+        frappe_file_manager.save_file.assert_not_called()
+
+    def test_rejects_missing_filename_or_data(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.save_audio_upload("", _b64(b"audio"))
+        self.assertIn("Filename and audio data are required", str(ctx.exception))
+        with self.assertRaises(ThrowError):
+            audio_service.save_audio_upload("clip.webm", "")
+
+    def test_saves_valid_upload(self):
+        result = audio_service.save_audio_upload(
+            "clip.webm",
+            _b64(b"audio-bytes"),
+            attached_to_doctype="Agent Message",
+            attached_to_name="MSG-1",
+        )
+        self.assertEqual(result["file_id"], "FILE-0001")
+        self.assertEqual(result["file_url"], "/private/files/clip.webm")
+        self.assertEqual(result["file_name"], "clip.webm")
+        args, kwargs = frappe_file_manager.save_file.call_args
+        self.assertEqual(args[0], "clip.webm")
+        self.assertEqual(args[1], b"audio-bytes")
+        self.assertEqual(args[2], "Agent Message")
+        self.assertEqual(args[3], "MSG-1")
+        self.assertEqual(kwargs["is_private"], 1)
+
+    def test_strips_data_url_prefix(self):
+        result = audio_service.save_audio_upload(
+            "clip.webm", "data:audio/webm;base64," + _b64(b"audio-bytes")
+        )
+        self.assertEqual(result["file_id"], "FILE-0001")
+        args, _ = frappe_file_manager.save_file.call_args
+        self.assertEqual(args[1], b"audio-bytes")
+
+    def test_accepts_allowed_audio_extensions(self):
+        for ext in ("webm", "wav", "mp3", "m4a", "ogg", "flac", "mp4", "aac"):
+            with self.subTest(ext=ext):
+                result = audio_service.save_audio_upload(f"clip.{ext}", _b64(b"audio"))
+                self.assertEqual(result["file_id"], "FILE-0001")
+
+
+class TestResolveSttConfig(unittest.TestCase):
+    def setUp(self):
+        frappe_mock.get_all.reset_mock()
+        frappe_mock.get_all.side_effect = None
+        frappe_mock.get_all.return_value = []
+
+    def test_explicit_model_wins(self):
+        _install_docs(
+            agent=_agent_doc(),
+            providers={"OpenAI": _provider_doc("OpenAI"), "Groq": _provider_doc("Groq")},
+        )
+        frappe_mock.get_all.side_effect = lambda doctype, **kw: (
+            [SimpleNamespace(provider="Groq")] if doctype == "AI Model" else []
+        )
+
+        config = audio_service.resolve_stt_config("Agent-1", model="whisper-large-v3")
+
+        self.assertEqual(config["source"], "tool_param")
+        self.assertEqual(config["provider_name"], "groq")
+        self.assertEqual(config["stt_model"], "groq/whisper-large-v3")
+        self.assertEqual(config["api_key"], "sk-test")
+
+    def test_agent_stt_model_second_priority(self):
+        _install_docs(
+            agent=_agent_doc(stt_model="Whisper Large"),
+            providers={"OpenAI": _provider_doc("OpenAI"), "Groq": _provider_doc("Groq")},
+            models={
+                "Whisper Large": SimpleNamespace(
+                    name="Whisper Large", model_name="whisper-large-v3", provider="Groq"
+                )
+            },
+        )
+
+        config = audio_service.resolve_stt_config("Agent-1")
+
+        self.assertEqual(config["source"], "agent_config")
+        self.assertEqual(config["provider_name"], "groq")
+        self.assertEqual(config["stt_model"], "groq/whisper-large-v3")
+
+    def test_provider_default_prefers_transcription_modality(self):
+        _install_docs(
+            agent=_agent_doc(),
+            providers={"OpenAI": _provider_doc("OpenAI")},
+        )
+
+        def get_all(doctype, filters=None, **kw):
+            if doctype == "AI Model" and filters and "modalities" in filters:
+                return [SimpleNamespace(model_name="whisper-1")]
+            return []
+
+        frappe_mock.get_all.side_effect = get_all
+
+        config = audio_service.resolve_stt_config("Agent-1")
+
+        self.assertEqual(config["source"], "provider_default")
+        self.assertEqual(config["provider_name"], "openai")
+        self.assertEqual(config["stt_model"], "openai/whisper-1")
+
+    def test_provider_default_falls_back_to_map(self):
+        _install_docs(
+            agent=_agent_doc(provider="Groq"),
+            providers={"Groq": _provider_doc("Groq")},
+        )
+        frappe_mock.get_all.return_value = []
+
+        config = audio_service.resolve_stt_config("Agent-1")
+
+        self.assertEqual(config["source"], "provider_default")
+        self.assertEqual(config["provider_name"], "groq")
+        self.assertEqual(config["stt_model"], "groq/whisper-large-v3")
+
+    def test_missing_api_key_raises(self):
+        _install_docs(
+            agent=_agent_doc(),
+            providers={"OpenAI": _provider_doc("OpenAI", api_key="")},
+        )
+
+        with self.assertRaises(ValueError) as ctx:
+            audio_service.resolve_stt_config("Agent-1")
+        self.assertIn("API key is not configured", str(ctx.exception))
+
+
+class TestTranscribeAudioFile(unittest.TestCase):
+    def setUp(self):
+        litellm_mock.transcription.reset_mock()
+        litellm_mock.completion.reset_mock()
+        litellm_mock.transcription.return_value = SimpleNamespace(text="hello world")
+        frappe_mock.publish_realtime.reset_mock()
+        frappe_mock.get_all.reset_mock()
+        frappe_mock.get_all.side_effect = None
+        frappe_mock.get_all.return_value = []
+
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".webm", delete=False)
+        self.tmp.write(b"fake audio bytes")
+        self.tmp.close()
+
+        self.file_doc = SimpleNamespace(
+            name="FILE-0001",
+            file_name="clip.webm",
+            file_url="/private/files/clip.webm",
+            attached_to_name=None,
+            get_full_path=lambda: self.tmp.name,
+        )
+        _install_docs(
+            agent=_agent_doc(),
+            providers={"OpenAI": _provider_doc("OpenAI")},
+            files={"FILE-0001": self.file_doc},
+        )
+
+    def test_success_returns_transcript_without_side_effects(self):
+        result = audio_service.transcribe_audio_file(
+            file_id="FILE-0001", agent_name="Agent-1"
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["transcript"], "hello world")
+        self.assertEqual(result["text"], "hello world")
+        self.assertEqual(result["file_id"], "FILE-0001")
+        self.assertEqual(result["file_url"], "/private/files/clip.webm")
+        self.assertEqual(result["stt_model"], "openai/whisper-1")
+        self.assertEqual(result["provider"], "openai")
+        self.assertEqual(result["language"], "auto-detected")
+
+        # Pure transcription: no Agent Message creation, no socket events.
+        frappe_mock.publish_realtime.assert_not_called()
+        for call in frappe_mock.get_doc.call_args_list:
+            self.assertNotEqual(call.args[0], "Agent Message")
+
+    def test_language_is_forwarded(self):
+        result = audio_service.transcribe_audio_file(
+            file_id="FILE-0001", agent_name="Agent-1", language="en"
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["language"], "en")
+        _, kwargs = litellm_mock.transcription.call_args
+        self.assertEqual(kwargs["language"], "en")
+
+    def test_requires_agent_name(self):
+        result = audio_service.transcribe_audio_file(file_id="FILE-0001")
+        self.assertFalse(result["success"])
+        self.assertIn("Agent name", result["error"])
+
+    def test_requires_file(self):
+        result = audio_service.transcribe_audio_file(agent_name="Agent-1")
+        self.assertFalse(result["success"])
+        self.assertIn("One of file_id, file_url, or local_path is required", result["error"])
+
+    def test_missing_file_returns_error(self):
+        result = audio_service.transcribe_audio_file(
+            file_id="NOPE", agent_name="Agent-1"
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("File not found", result["error"])
+
+    def test_provider_failure_returns_error(self):
+        litellm_mock.transcription.side_effect = Exception("boom")
+        result = audio_service.transcribe_audio_file(
+            file_id="FILE-0001", agent_name="Agent-1"
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("Transcription failed", result["error"])
+        litellm_mock.transcription.side_effect = None
+
+
+class TestAudioApiValidation(unittest.TestCase):
+    def test_agent_required(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_api.transcribe(file_id="FILE-0001")
+        self.assertIn("agent is required", str(ctx.exception))
+
+    def test_both_inputs_rejected(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_api.transcribe(
+                file_id="FILE-0001",
+                b64data=_b64(b"audio"),
+                filename="clip.webm",
+                agent="Agent-1",
+            )
+        self.assertIn("exactly one", str(ctx.exception))
+
+    def test_no_input_rejected(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_api.transcribe(agent="Agent-1")
+        self.assertIn("Provide one of file_id, b64data", str(ctx.exception))
+
+    def test_create_message_requires_conversation(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_api.transcribe(
+                file_id="FILE-0001", agent="Agent-1", create_message=True
+            )
+        self.assertIn("conversation is required", str(ctx.exception))
+
+    def test_upload_success_shape(self):
+        with patch.object(
+            audio_service,
+            "save_audio_upload",
+            return_value={
+                "file_id": "FILE-0001",
+                "file_url": "/private/files/clip.webm",
+                "file_name": "clip.webm",
+            },
+        ) as save_mock, patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value={
+                "success": True,
+                "transcript": "hello",
+                "text": "hello",
+                "file_id": "FILE-0001",
+                "file_url": "/private/files/clip.webm",
+                "stt_model": "openai/whisper-1",
+                "provider": "openai",
+                "language": "auto-detected",
+                "stt_source": "provider_default",
+            },
+        ) as transcribe_mock, patch.object(
+            audio_service, "create_audio_user_message"
+        ) as message_mock:
+            result = audio_api.transcribe(
+                b64data=_b64(b"audio"),
+                filename="clip.webm",
+                agent="Agent-1",
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["transcript"], "hello")
+        self.assertEqual(result["file_id"], "FILE-0001")
+        self.assertEqual(result["file_url"], "/private/files/clip.webm")
+        self.assertIsNone(result["message_id"])
+        self.assertEqual(result["stt_model"], "openai/whisper-1")
+        self.assertEqual(result["provider"], "openai")
+        self.assertEqual(result["language"], "auto-detected")
+        save_mock.assert_called_once()
+        transcribe_mock.assert_called_once()
+        message_mock.assert_not_called()
+
+    def test_create_message_uses_service(self):
+        with patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value={
+                "success": True,
+                "transcript": "hello",
+                "text": "hello",
+                "file_id": "FILE-0001",
+                "file_url": "/private/files/clip.webm",
+                "stt_model": "openai/whisper-1",
+                "provider": "openai",
+                "language": "auto-detected",
+                "stt_source": "provider_default",
+            },
+        ), patch.object(
+            audio_service,
+            "create_audio_user_message",
+            return_value=SimpleNamespace(name="MSG-0001"),
+        ) as message_mock:
+            result = audio_api.transcribe(
+                file_id="FILE-0001",
+                agent="Agent-1",
+                conversation="CONV-0001",
+                create_message=True,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["message_id"], "MSG-0001")
+        message_mock.assert_called_once()
+        args, kwargs = message_mock.call_args
+        self.assertEqual(args[0], "CONV-0001")
+        self.assertEqual(args[1], "FILE-0001")
+        self.assertEqual(args[2], "hello")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/tests/test_chat_audio_upload.py
+++ b/huf/tests/test_chat_audio_upload.py
@@ -1,0 +1,457 @@
+# Copyright (c) 2026, Huf and Contributors
+# See license.txt
+
+"""
+Unit tests for audio routing in the chat attachment pipeline
+(huf.ai.agent_chat).
+
+Audio attachments must bypass the OCR/Vision modality gate: an audio upload
+is allowed whenever STT is resolvable for the agent
+(``audio_service.resolve_stt_config``), and processing routes to
+``audio_service.transcribe_audio_file`` instead of OCR. Non-audio files keep
+the existing OCR/Vision behavior.
+
+These tests reuse the frappe mock installed by huf.tests.test_audio_service
+so all suites share a single mocked frappe module (and a single binding of
+huf.ai.audio_service) regardless of test ordering:
+
+    python -m unittest huf.tests.test_chat_audio_upload
+"""
+
+import asyncio
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Importing the audio service test module installs its frappe/frappe.utils/
+# litellm stubs into sys.modules and imports huf.ai.audio_service against
+# them. Reusing that mock keeps audio_service.frappe bound to one shared
+# mock no matter which suite is imported first.
+#
+# The module may already be loaded under a different name: unittest
+# discovery (``python -m unittest discover -s huf/tests``) imports it as the
+# top-level module "test_audio_service", while dotted runs
+# (``python -m unittest huf.tests.test_chat_audio_upload``) import it as
+# "huf.tests.test_audio_service". Reuse whichever copy is already loaded so
+# its module-level mock setup executes exactly once; importing it a second
+# time under the other name would rebind sys.modules["litellm"] and break
+# the first copy's mock assertions.
+_audio_mocks = sys.modules.get("huf.tests.test_audio_service") or sys.modules.get(
+    "test_audio_service"
+)
+if _audio_mocks is None:
+    from huf.tests import test_audio_service as _audio_mocks
+
+frappe_mock = _audio_mocks.frappe_mock
+frappe_file_manager = sys.modules["frappe.utils.file_manager"]
+
+# agent_chat touches frappe APIs the base audio mock does not provide.
+frappe_mock.PermissionError = type("PermissionError", (Exception,), {})
+frappe_mock.ValidationError = type("ValidationError", (Exception,), {})
+frappe_mock.get_meta = MagicMock()
+
+# Stub the heavy modules agent_chat pulls in. handle_ocr_document is async,
+# hence AsyncMock; _run_async_safely runs the coroutine it is given.
+#
+# Stubs are reused (and only extended with missing attributes) when another
+# suite already installed them: huf.ai.agent_hooks lazily re-imports
+# huf.ai.sdk_tools at call time, so replacing an existing stub module object
+# would steal that lazy binding from whichever suite installed it first.
+def _get_or_create_stub(module_name, **attrs):
+    stub = sys.modules.get(module_name)
+    if stub is None:
+        stub = types.ModuleType(module_name)
+        sys.modules[module_name] = stub
+    for attr_name, value in attrs.items():
+        if not hasattr(stub, attr_name):
+            setattr(stub, attr_name, value)
+    return stub
+
+
+sdk_tools_stub = _get_or_create_stub(
+    "huf.ai.sdk_tools",
+    handle_ocr_document=AsyncMock(
+        return_value={"success": True, "text": "ocr text", "file_hash": "abc123"}
+    ),
+)
+handle_ocr_document_mock = sdk_tools_stub.handle_ocr_document
+
+
+def _run_async_safely(coro):
+    if asyncio.iscoroutine(coro):
+        return asyncio.run(coro)
+    return coro
+
+
+_get_or_create_stub(
+    "huf.ai.agent_integration",
+    _run_async_safely=_run_async_safely,
+    run_agent_sync=MagicMock(),
+)
+conversation_manager_stub = _get_or_create_stub(
+    "huf.ai.conversation_manager", ConversationManager=MagicMock()
+)
+_get_or_create_stub("huf.ai.transcription_handler")
+
+from huf.ai import agent_chat, audio_service  # noqa: E402
+
+
+def _agent_dict(**overrides):
+    agent = {
+        "allow_file_upload": 1,
+        "max_upload_size_mb": 25,
+        "model": "gpt-4o",
+        "enable_ocr": 0,
+        "provider": "OpenAI",
+    }
+    agent.update(overrides)
+    return agent
+
+
+def _transcript_result(text="hello world"):
+    return {
+        "success": True,
+        "transcript": text,
+        "text": text,
+        "file_id": "FILE-0001",
+        "file_url": "/private/files/clip.mp3",
+        "stt_model": "openai/whisper-1",
+        "provider": "openai",
+        "language": "auto-detected",
+        "stt_source": "provider_default",
+    }
+
+
+def _staged_file(name="FILE-0001", filename="clip.mp3"):
+    return SimpleNamespace(
+        name=name,
+        file_name=filename,
+        file_url=f"/private/files/{filename}",
+        owner="Administrator",
+        attached_to_doctype="Agent",
+        attached_to_name="Agent-1",
+    )
+
+
+def _conversation(name="CONV-1"):
+    return SimpleNamespace(name=name, owner="Administrator", session_id="web:Administrator")
+
+
+def _install(agents=None, conversations=None, files=None):
+    """Wire frappe.get_doc to serve the given fake documents."""
+    agents = agents or {}
+    conversations = conversations or {}
+    files = files or {}
+
+    def get_doc(doctype, name=None):
+        if isinstance(doctype, dict):
+            # frappe.get_doc({...}) creates a new Agent Message
+            return SimpleNamespace(name="MSG-0001", insert=MagicMock())
+        if doctype == "Agent":
+            return agents[name]
+        if doctype == "Agent Conversation":
+            return conversations[name]
+        if doctype == "File":
+            return files[name]
+        raise ValueError(f"Unexpected get_doc: {doctype} {name}")
+
+    frappe_mock.get_doc.side_effect = get_doc
+
+
+def _reset_mocks():
+    frappe_mock.get_doc.reset_mock()
+    frappe_mock.get_doc.side_effect = None
+    frappe_mock.db.reset_mock()
+    frappe_mock.db.get_value.return_value = ""
+    frappe_mock.get_meta.reset_mock()
+    frappe_mock.get_meta.return_value.get_field.return_value = object()
+    frappe_file_manager.save_file.reset_mock()
+    frappe_file_manager.save_file.side_effect = None
+    handle_ocr_document_mock.reset_mock()
+    handle_ocr_document_mock.return_value = {
+        "success": True,
+        "text": "ocr text",
+        "file_hash": "abc123",
+    }
+
+
+class TestWebUploadAudioValidation(unittest.TestCase):
+    """_validate_web_file_upload: audio bypasses the OCR/Vision gate."""
+
+    def setUp(self):
+        _reset_mocks()
+
+    def test_audio_allowed_when_stt_resolvable(self):
+        agent = _agent_dict(enable_ocr=0)
+        _install(agents={"Agent-1": agent})
+
+        with patch.object(
+            audio_service,
+            "resolve_stt_config",
+            return_value={"stt_model": "openai/whisper-1"},
+        ) as stt:
+            agent_doc, error = agent_chat._validate_web_file_upload(
+                "Agent-1", "clip.mp3", b"audio-bytes"
+            )
+
+        self.assertIsNone(error)
+        self.assertIs(agent_doc, agent)
+        stt.assert_called_once_with("Agent-1")
+        # The OCR/Vision modality lookup must not run for audio files.
+        frappe_mock.db.get_value.assert_not_called()
+
+    def test_audio_rejected_when_stt_unresolvable(self):
+        _install(agents={"Agent-1": _agent_dict()})
+
+        with patch.object(
+            audio_service,
+            "resolve_stt_config",
+            side_effect=ValueError(
+                "No transcription model available for provider 'OpenAI'."
+            ),
+        ):
+            agent_doc, error = agent_chat._validate_web_file_upload(
+                "Agent-1", "clip.mp3", b"audio-bytes"
+            )
+
+        self.assertIsNone(agent_doc)
+        self.assertFalse(error["success"])
+        self.assertIn(
+            "no transcription model configured for audio files", error["error"]
+        )
+
+    def test_non_audio_rejected_without_ocr_or_vision(self):
+        _install(agents={"Agent-1": _agent_dict(enable_ocr=0)})
+        frappe_mock.db.get_value.return_value = ""
+
+        with patch.object(audio_service, "resolve_stt_config") as stt:
+            agent_doc, error = agent_chat._validate_web_file_upload(
+                "Agent-1", "report.pdf", b"pdf-bytes"
+            )
+
+        self.assertIsNone(agent_doc)
+        self.assertFalse(error["success"])
+        self.assertIn("does not support file analysis", error["error"])
+        stt.assert_not_called()
+
+    def test_non_audio_allowed_with_ocr(self):
+        agent = _agent_dict(enable_ocr=1)
+        _install(agents={"Agent-1": agent})
+        frappe_mock.db.get_value.return_value = "OCR"
+
+        with patch.object(audio_service, "resolve_stt_config") as stt:
+            agent_doc, error = agent_chat._validate_web_file_upload(
+                "Agent-1", "report.pdf", b"pdf-bytes"
+            )
+
+        self.assertIsNone(error)
+        self.assertIs(agent_doc, agent)
+        stt.assert_not_called()
+
+    def test_non_audio_allowed_with_vision(self):
+        agent = _agent_dict(enable_ocr=0)
+        _install(agents={"Agent-1": agent})
+        frappe_mock.db.get_value.return_value = "Vision"
+
+        with patch.object(audio_service, "resolve_stt_config") as stt:
+            agent_doc, error = agent_chat._validate_web_file_upload(
+                "Agent-1", "photo.png", b"png-bytes"
+            )
+
+        self.assertIsNone(error)
+        self.assertIs(agent_doc, agent)
+        stt.assert_not_called()
+
+
+class TestPrepareMessageWithFileWebAudio(unittest.TestCase):
+    """prepare_message_with_file_web: audio routes to transcription."""
+
+    def setUp(self):
+        _reset_mocks()
+
+    def test_audio_staged_file_routed_to_transcription(self):
+        _install(
+            files={"FILE-0001": _staged_file()},
+            conversations={"CONV-1": _conversation()},
+        )
+
+        with patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value=_transcript_result("hello world"),
+        ) as transcribe:
+            result = agent_chat.prepare_message_with_file_web(
+                agent="Agent-1",
+                conversation="CONV-1",
+                message="what did I say?",
+                file_id="FILE-0001",
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["conversation_id"], "CONV-1")
+        self.assertEqual(result["message_id"], "MSG-0001")
+        self.assertIsNone(result["files"])
+
+        prompt = result["agent_prompt"]
+        self.assertEqual(prompt, "hello world")
+
+        transcribe.assert_called_once_with(file_id="FILE-0001", agent_name="Agent-1")
+        handle_ocr_document_mock.assert_not_called()
+
+        # Audio metadata stamped on the Agent Message (kind becomes "Audio").
+        frappe_mock.db.set_value.assert_any_call(
+            "Agent Message",
+            "MSG-0001",
+            {
+                "kind": "Audio",
+                "content": "hello world",
+                "voice_message": "/private/files/clip.mp3",
+                "stt_model": "openai/whisper-1",
+            },
+            update_modified=False,
+        )
+
+    def test_audio_transcription_failure_returns_error(self):
+        _install(
+            files={"FILE-0001": _staged_file()},
+            conversations={"CONV-1": _conversation()},
+        )
+
+        with patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value={"success": False, "error": "boom"},
+        ):
+            result = agent_chat.prepare_message_with_file_web(
+                agent="Agent-1", conversation="CONV-1", message="", file_id="FILE-0001"
+            )
+
+        self.assertEqual(result, {"success": False, "error": "boom"})
+        handle_ocr_document_mock.assert_not_called()
+
+    def test_audio_b64_upload_validated_and_transcribed(self):
+        agent = _agent_dict(enable_ocr=0)
+        _install(agents={"Agent-1": agent})
+        frappe_file_manager.save_file.return_value = SimpleNamespace(
+            name="FILE-9", file_name="note.wav", file_url="/private/files/note.wav"
+        )
+        conversation_manager_stub.ConversationManager.return_value.create_new_conversation.return_value = SimpleNamespace(
+            name="CONV-NEW", session_id="web:Administrator"
+        )
+
+        with patch.object(
+            audio_service,
+            "resolve_stt_config",
+            return_value={"stt_model": "openai/whisper-1"},
+        ) as stt, patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value=_transcript_result("transcribed words"),
+        ) as transcribe:
+            result = agent_chat.prepare_message_with_file_web(
+                agent="Agent-1",
+                message="",
+                filename="note.wav",
+                b64data=_audio_mocks._b64(b"audio-bytes"),
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["conversation_id"], "CONV-NEW")
+        stt.assert_called_once_with("Agent-1")
+        transcribe.assert_called_once_with(file_id="FILE-9", agent_name="Agent-1")
+        handle_ocr_document_mock.assert_not_called()
+        self.assertIn("transcribed words", result["agent_prompt"])
+
+    def test_non_audio_staged_file_uses_ocr(self):
+        _install(
+            files={"FILE-0002": _staged_file(name="FILE-0002", filename="report.pdf")},
+            conversations={"CONV-1": _conversation()},
+        )
+
+        with patch.object(audio_service, "transcribe_audio_file") as transcribe:
+            result = agent_chat.prepare_message_with_file_web(
+                agent="Agent-1",
+                conversation="CONV-1",
+                message="summarize",
+                file_id="FILE-0002",
+            )
+
+        self.assertTrue(result["success"])
+        self.assertIn("Attached File Content (OCR Extracted):", result["agent_prompt"])
+        self.assertIn("ocr text", result["agent_prompt"])
+        transcribe.assert_not_called()
+        handle_ocr_document_mock.assert_called_once()
+        _, kwargs = handle_ocr_document_mock.call_args
+        self.assertEqual(kwargs["file_id"], "FILE-0002")
+        self.assertFalse(kwargs["create_message"])
+
+
+class TestUploadFileAndProcessWebAudio(unittest.TestCase):
+    """upload_file_and_process_web: audio gate + STT routing."""
+
+    def setUp(self):
+        _reset_mocks()
+
+    def test_audio_upload_processed_via_transcription(self):
+        agent = _agent_dict(enable_ocr=0)
+        _install(
+            agents={"Agent-1": agent},
+            conversations={"CONV-1": _conversation()},
+        )
+        frappe_mock.db.get_value.return_value = ""  # no OCR/Vision modalities
+        frappe_file_manager.save_file.return_value = SimpleNamespace(
+            name="FILE-0001", file_name="clip.mp3", file_url="/private/files/clip.mp3"
+        )
+
+        with patch.object(
+            audio_service,
+            "resolve_stt_config",
+            return_value={"stt_model": "openai/whisper-1"},
+        ), patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value=_transcript_result("hello world"),
+        ) as transcribe:
+            result = agent_chat.upload_file_and_process_web(
+                filename="clip.mp3",
+                b64data=_audio_mocks._b64(b"audio-bytes"),
+                agent="Agent-1",
+                conversation="CONV-1",
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["conversation_id"], "CONV-1")
+        self.assertEqual(result["message_id"], "MSG-0001")
+        self.assertEqual(result["transcript"], "hello world")
+        transcribe.assert_called_once_with(file_id="FILE-0001", agent_name="Agent-1")
+        handle_ocr_document_mock.assert_not_called()
+
+    def test_audio_upload_rejected_when_stt_unresolvable(self):
+        _install(agents={"Agent-1": _agent_dict(enable_ocr=0)})
+        frappe_mock.db.get_value.return_value = ""
+
+        with patch.object(
+            audio_service,
+            "resolve_stt_config",
+            side_effect=ValueError(
+                "No transcription model available for provider 'OpenAI'."
+            ),
+        ):
+            result = agent_chat.upload_file_and_process_web(
+                filename="clip.mp3",
+                b64data=_audio_mocks._b64(b"audio-bytes"),
+                agent="Agent-1",
+            )
+
+        self.assertFalse(result["success"])
+        self.assertIn(
+            "no transcription model configured for audio files", result["error"]
+        )
+        frappe_file_manager.save_file.assert_not_called()
+        handle_ocr_document_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/tests/test_doc_event_audio.py
+++ b/huf/tests/test_doc_event_audio.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2026, Huf and Contributors
+# See license.txt
+
+"""
+Unit tests for doc-event trigger audio routing in huf.ai.agent_hooks.
+
+Attachments configured on Agent Trigger ``file_attachments`` are classified
+per file: audio goes to the canonical audio service
+(``audio_service.transcribe_audio_file``), other documents keep going to OCR
+(``handle_ocr_document``), and images go to neither.
+
+These tests reuse the frappe mock installed by huf.tests.test_audio_service
+so both suites share a single mocked frappe module (and a single binding of
+huf.ai.audio_service) regardless of test ordering:
+
+    python -m unittest huf.tests.test_doc_event_audio huf.tests.test_audio_service
+"""
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Importing the audio service test module installs its frappe/frappe.utils/
+# litellm stubs into sys.modules and imports huf.ai.audio_service against
+# them. Reusing that mock keeps audio_service.frappe bound to one shared
+# mock no matter which suite is imported first.
+#
+# The module may already be loaded under a different name: unittest
+# discovery (``python -m unittest discover -s huf/tests``) imports it as the
+# top-level module "test_audio_service", while dotted runs
+# (``python -m unittest huf.tests.test_doc_event_audio``) import it as
+# "huf.tests.test_audio_service". Reuse whichever copy is already loaded so
+# its module-level mock setup executes exactly once; importing it a second
+# time under the other name would rebind sys.modules["litellm"] and break
+# the first copy's mock assertions.
+_audio_mocks = sys.modules.get("huf.tests.test_audio_service") or sys.modules.get(
+    "test_audio_service"
+)
+if _audio_mocks is None:
+    from huf.tests import test_audio_service as _audio_mocks
+
+frappe_mock = _audio_mocks.frappe_mock
+frappe_utils = sys.modules["frappe.utils"]
+
+# agent_hooks touches frappe APIs the base audio mock does not provide.
+frappe_mock.get_traceback = MagicMock(return_value="traceback")
+frappe_mock.set_user = MagicMock()
+frappe_utils.now_datetime = MagicMock(
+    return_value=SimpleNamespace(isoformat=lambda: "2026-01-01T00:00:00")
+)
+
+background_jobs_stub = types.ModuleType("frappe.utils.background_jobs")
+background_jobs_stub.enqueue = MagicMock()
+sys.modules["frappe.utils.background_jobs"] = background_jobs_stub
+
+safe_exec_stub = types.ModuleType("frappe.utils.safe_exec")
+safe_exec_stub.get_safe_globals = MagicMock(return_value={})
+safe_exec_stub.safe_eval = MagicMock(return_value=True)
+sys.modules["frappe.utils.safe_exec"] = safe_exec_stub
+
+# Stub the heavy modules agent_hooks pulls in: run_agent_sync is a
+# module-level import; handle_ocr_document is a lazy import inside
+# run_agent_for_doc (async, hence AsyncMock for run_until_complete).
+run_agent_sync_mock = MagicMock()
+agent_integration_stub = types.ModuleType("huf.ai.agent_integration")
+agent_integration_stub.run_agent_sync = run_agent_sync_mock
+sys.modules["huf.ai.agent_integration"] = agent_integration_stub
+
+handle_ocr_document_mock = AsyncMock(
+    return_value={"success": True, "text": "ocr text", "file_hash": "abc123"}
+)
+sdk_tools_stub = types.ModuleType("huf.ai.sdk_tools")
+sdk_tools_stub.handle_ocr_document = handle_ocr_document_mock
+sys.modules["huf.ai.sdk_tools"] = sdk_tools_stub
+
+from huf.ai import agent_hooks, audio_service  # noqa: E402
+
+
+def _doc_event_inputs(filename, field="attachment"):
+    doc = {
+        "doctype": "ToDo",
+        "name": "TODO-0001",
+        "owner": "Administrator",
+        field: f"/files/{filename}",
+    }
+    attachments = [
+        {"source_type": "DocField", "field_name": field, "child_table": None}
+    ]
+    return doc, attachments
+
+
+class TestIsAudioFile(unittest.TestCase):
+    """The routing classifier reuses the audio service allowlists."""
+
+    def test_audio_extensions_are_audio(self):
+        for name in ("clip.mp3", "clip.webm", "voice.WAV", "note.m4a", "rec.ogg"):
+            with self.subTest(name=name):
+                self.assertTrue(audio_service.is_audio_file(name))
+
+    def test_browser_audio_container_is_audio(self):
+        # Browsers record audio into mp4/webm containers; the allowlist
+        # intentionally treats those extensions as audio.
+        self.assertTrue(audio_service.is_audio_file("recording.mp4"))
+
+    def test_audio_mime_type_is_audio(self):
+        self.assertTrue(audio_service.is_audio_file("attachment.bin", "audio/mpeg"))
+
+    def test_non_audio_files_are_not_audio(self):
+        for name in ("report.pdf", "photo.png", "notes.txt", "data.csv"):
+            with self.subTest(name=name):
+                self.assertFalse(audio_service.is_audio_file(name))
+
+    def test_extensionless_file_is_not_audio(self):
+        self.assertFalse(audio_service.is_audio_file("README"))
+
+
+class TestDocEventAudioRouting(unittest.TestCase):
+    def setUp(self):
+        frappe_mock.get_doc.reset_mock()
+        frappe_mock.get_doc.side_effect = None
+        frappe_mock.get_doc.return_value = SimpleNamespace(persist_user_history=False)
+        frappe_mock.db.get_value.reset_mock()
+        frappe_mock.db.get_value.return_value = "FILE-0001"
+        frappe_mock.log_error.reset_mock()
+        run_agent_sync_mock.reset_mock()
+        handle_ocr_document_mock.reset_mock()
+        handle_ocr_document_mock.return_value = {
+            "success": True,
+            "text": "ocr text",
+            "file_hash": "abc123",
+        }
+        transcribe_patcher = patch.object(audio_service, "transcribe_audio_file")
+        self.transcribe_mock = transcribe_patcher.start()
+        self.addCleanup(transcribe_patcher.stop)
+        self.transcribe_mock.return_value = {
+            "success": True,
+            "transcript": "hello audio",
+            "text": "hello audio",
+            "file_id": "FILE-0001",
+            "file_url": "/files/clip.mp3",
+            "stt_model": "openai/whisper-1",
+            "provider": "openai",
+            "language": "auto-detected",
+        }
+
+    def _run_agent_for_doc(self, filename):
+        doc, attachments = _doc_event_inputs(filename)
+        agent_hooks.run_agent_for_doc(
+            doc,
+            "Agent-1",
+            "Summarize the attachment.",
+            "after_insert",
+            "OpenAI",
+            "gpt-4o",
+            initiating_user=None,
+            channel_id="doc_event",
+            file_attachments=attachments,
+        )
+
+    def _sent_prompt(self):
+        run_agent_sync_mock.assert_called_once()
+        return run_agent_sync_mock.call_args.args[1]
+
+    def _audio_error_log_titles(self):
+        return [
+            c.kwargs.get("title") or (c.args[1] if len(c.args) > 1 else None)
+            for c in frappe_mock.log_error.call_args_list
+        ]
+
+    def test_audio_file_is_transcribed_not_ocrd(self):
+        self._run_agent_for_doc("clip.mp3")
+
+        self.transcribe_mock.assert_called_once_with(
+            file_id="FILE-0001", file_url="/files/clip.mp3", agent_name="Agent-1"
+        )
+        handle_ocr_document_mock.assert_not_called()
+
+        prompt = self._sent_prompt()
+        self.assertIn("Attached Audio Transcript(s):", prompt)
+        self.assertIn("--- File: clip.mp3 ---", prompt)
+        self.assertIn("hello audio", prompt)
+        self.assertNotIn("OCR Extracted", prompt)
+
+    def test_pdf_is_ocrd_not_transcribed(self):
+        self._run_agent_for_doc("report.pdf")
+
+        handle_ocr_document_mock.assert_called_once_with(
+            file_id="FILE-0001", file_url="/files/report.pdf", agent_name="Agent-1"
+        )
+        self.transcribe_mock.assert_not_called()
+
+        prompt = self._sent_prompt()
+        self.assertIn("Attached File Content (OCR Extracted):", prompt)
+        self.assertIn("--- File: report.pdf (hash: abc123) ---", prompt)
+        self.assertIn("ocr text", prompt)
+        self.assertNotIn("Attached Audio Transcript(s):", prompt)
+
+    def test_image_is_neither_transcribed_nor_ocrd(self):
+        self._run_agent_for_doc("photo.png")
+
+        self.transcribe_mock.assert_not_called()
+        handle_ocr_document_mock.assert_not_called()
+
+        prompt = self._sent_prompt()
+        self.assertNotIn("Attached Audio Transcript(s):", prompt)
+        self.assertNotIn("OCR Extracted", prompt)
+
+    def test_transcription_error_does_not_abort_run(self):
+        self.transcribe_mock.return_value = {"success": False, "error": "boom"}
+        self._run_agent_for_doc("clip.mp3")
+
+        prompt = self._sent_prompt()  # run still executed with the agent
+        self.assertNotIn("Attached Audio Transcript(s):", prompt)
+        self.assertIn("Agent Hooks Audio", self._audio_error_log_titles())
+
+    def test_transcription_exception_does_not_abort_run(self):
+        self.transcribe_mock.side_effect = Exception("kaboom")
+        self._run_agent_for_doc("clip.mp3")
+
+        prompt = self._sent_prompt()
+        self.assertNotIn("Attached Audio Transcript(s):", prompt)
+        self.assertIn("Agent Hooks Audio", self._audio_error_log_titles())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/tests/test_local_audio_path.py
+++ b/huf/tests/test_local_audio_path.py
@@ -1,0 +1,369 @@
+# Copyright (c) 2026, Huf and Contributors
+# See license.txt
+
+"""
+Unit tests for server-side (local filesystem) audio imports in
+huf.ai.audio_service and huf.ai.audio_api: ``resolve_local_audio_path``,
+``transcribe_audio_file(local_path=...)``, ``import_local_audio``, and the
+``file_path`` branch of the public transcribe API.
+
+These tests reuse the frappe mock installed by huf.tests.test_audio_service
+so all suites share a single mocked frappe module (and a single binding of
+huf.ai.audio_service) regardless of test ordering:
+
+    python -m unittest huf.tests.test_local_audio_path
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Importing the audio service test module installs its frappe/frappe.utils/
+# litellm stubs into sys.modules and imports huf.ai.audio_service against
+# them. Reusing that mock keeps audio_service.frappe bound to one shared
+# mock no matter which suite is imported first. It may already be loaded
+# under a different name depending on how unittest discovered it.
+_audio_mocks = sys.modules.get("huf.tests.test_audio_service") or sys.modules.get(
+    "test_audio_service"
+)
+if _audio_mocks is None:
+    from huf.tests import test_audio_service as _audio_mocks
+
+frappe_mock = _audio_mocks.frappe_mock
+frappe_file_manager = sys.modules["frappe.utils.file_manager"]
+litellm_mock = sys.modules["litellm"]
+ThrowError = _audio_mocks.ThrowError
+
+# audio_service now touches site-path/config and role APIs the base audio
+# mock does not provide.
+if not hasattr(frappe_mock, "get_site_path"):
+    frappe_mock.get_site_path = MagicMock()
+if not hasattr(frappe_mock, "get_site_config"):
+    frappe_mock.get_site_config = MagicMock(return_value={})
+if not hasattr(frappe_mock, "only_for"):
+    frappe_mock.only_for = MagicMock()
+
+from huf.ai import audio_api, audio_service  # noqa: E402
+
+
+class LocalAudioTestCase(unittest.TestCase):
+    """Base case: real temp dir acting as the site's allowed import root."""
+
+    def setUp(self):
+        self.site_dir = tempfile.mkdtemp(prefix="huf-site-")
+        self.allowed_root = os.path.join(self.site_dir, "private", "audio_imports")
+        os.makedirs(self.allowed_root, exist_ok=True)
+
+        frappe_mock.get_site_path.reset_mock()
+        frappe_mock.get_site_path.side_effect = lambda *parts: os.path.join(self.site_dir, *parts)
+        frappe_mock.get_site_config.reset_mock()
+        frappe_mock.get_site_config.side_effect = None
+        frappe_mock.get_site_config.return_value = {}
+        frappe_mock.only_for.reset_mock()
+        frappe_mock.only_for.side_effect = None
+
+    def tearDown(self):
+        frappe_mock.get_site_path.reset_mock()
+        frappe_mock.get_site_path.side_effect = None
+        frappe_mock.get_site_config.reset_mock()
+        frappe_mock.get_site_config.side_effect = None
+        frappe_mock.only_for.reset_mock()
+        frappe_mock.only_for.side_effect = None
+
+    def _write_audio(self, name="clip.webm", payload=b"fake audio bytes", root=None):
+        path = os.path.join(root or self.allowed_root, name)
+        with open(path, "wb") as f:
+            f.write(payload)
+        return path
+
+
+class TestResolveLocalAudioPath(LocalAudioTestCase):
+    def test_rejects_relative_path(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.resolve_local_audio_path("relative/clip.webm")
+        self.assertIn("absolute file path", str(ctx.exception))
+
+    def test_rejects_empty_path(self):
+        with self.assertRaises(ThrowError):
+            audio_service.resolve_local_audio_path("")
+        with self.assertRaises(ThrowError):
+            audio_service.resolve_local_audio_path(None)
+
+    def test_rejects_traversal_attempt(self):
+        # "/allowed/../etc/passwd" resolves outside the allowed root.
+        traversal = os.path.join(self.allowed_root, "..", "etc", "passwd")
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.resolve_local_audio_path(traversal)
+        self.assertIn("outside the allowed audio import directories", str(ctx.exception))
+
+    def test_rejects_symlink_escape(self):
+        # A symlink inside the allowed root whose real path escapes it.
+        target = self._write_audio()
+        real_realpath = os.path.realpath
+
+        def fake_realpath(path):
+            if path == target:
+                return os.path.join(self.site_dir, "escape.webm")
+            return real_realpath(path)
+
+        with patch.object(os.path, "realpath", side_effect=fake_realpath):
+            with self.assertRaises(ThrowError) as ctx:
+                audio_service.resolve_local_audio_path(target)
+        self.assertIn("outside the allowed audio import directories", str(ctx.exception))
+
+    def test_rejects_non_allowlisted_dir(self):
+        outside_dir = tempfile.mkdtemp(prefix="huf-outside-")
+        outside_file = self._write_audio(root=outside_dir)
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.resolve_local_audio_path(outside_file)
+        self.assertIn("outside the allowed audio import directories", str(ctx.exception))
+
+    def test_rejects_missing_file(self):
+        missing = os.path.join(self.allowed_root, "nope.webm")
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.resolve_local_audio_path(missing)
+        self.assertIn("Audio file not found", str(ctx.exception))
+
+    def test_rejects_directory(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.resolve_local_audio_path(os.path.realpath(self.allowed_root))
+        self.assertIn("Audio file not found", str(ctx.exception))
+
+    def test_rejects_disallowed_extension(self):
+        notes = self._write_audio(name="notes.txt")
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.resolve_local_audio_path(notes)
+        self.assertIn("Unsupported audio file type", str(ctx.exception))
+
+    def test_rejects_oversized_file(self):
+        big = self._write_audio(name="big.webm")
+        with patch.object(
+            os.path, "getsize", return_value=audio_service.MAX_AUDIO_FILE_SIZE + 1
+        ):
+            with self.assertRaises(ThrowError) as ctx:
+                audio_service.resolve_local_audio_path(big)
+        self.assertIn("maximum allowed size", str(ctx.exception))
+
+    def test_extra_dirs_from_site_config(self):
+        extra_dir = tempfile.mkdtemp(prefix="huf-extra-")
+        dropped = self._write_audio(root=extra_dir)
+        frappe_mock.get_site_config.return_value = {"audio_import_dirs": [extra_dir]}
+
+        resolved = audio_service.resolve_local_audio_path(dropped)
+        self.assertEqual(resolved, os.path.realpath(dropped))
+
+    def test_happy_path_returns_realpath(self):
+        target = self._write_audio()
+        resolved = audio_service.resolve_local_audio_path(target)
+        self.assertEqual(resolved, os.path.realpath(target))
+
+
+class TestTranscribeLocalPath(LocalAudioTestCase):
+    def setUp(self):
+        super().setUp()
+        litellm_mock.transcription.reset_mock()
+        litellm_mock.transcription.side_effect = None
+        litellm_mock.transcription.return_value = SimpleNamespace(text="hello world")
+        frappe_mock.get_all.reset_mock()
+        frappe_mock.get_all.side_effect = None
+        frappe_mock.get_all.return_value = []
+
+        self.audio_path = self._write_audio()
+        _audio_mocks._install_docs(
+            agent=_audio_mocks._agent_doc(),
+            providers={"OpenAI": _audio_mocks._provider_doc("OpenAI")},
+        )
+
+    def test_transcribes_in_place_without_file_record(self):
+        result = audio_service.transcribe_audio_file(
+            local_path=self.audio_path, agent_name="Agent-1"
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["transcript"], "hello world")
+        self.assertEqual(result["text"], "hello world")
+        self.assertIsNone(result["file_id"])
+        self.assertIsNone(result["file_url"])
+        self.assertEqual(result["local_path"], os.path.realpath(self.audio_path))
+        self.assertEqual(result["stt_model"], "openai/whisper-1")
+        self.assertEqual(result["provider"], "openai")
+        litellm_mock.transcription.assert_called_once()
+
+    def test_local_path_mutually_exclusive_with_file_id(self):
+        result = audio_service.transcribe_audio_file(
+            file_id="FILE-0001", local_path=self.audio_path, agent_name="Agent-1"
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("mutually exclusive", result["error"])
+        litellm_mock.transcription.assert_not_called()
+
+    def test_outside_path_returns_error_dict(self):
+        outside_dir = tempfile.mkdtemp(prefix="huf-outside-")
+        outside_file = self._write_audio(root=outside_dir)
+        result = audio_service.transcribe_audio_file(
+            local_path=outside_file, agent_name="Agent-1"
+        )
+        self.assertFalse(result["success"])
+        self.assertIn("outside the allowed audio import directories", result["error"])
+        litellm_mock.transcription.assert_not_called()
+
+
+class TestImportLocalAudio(LocalAudioTestCase):
+    def setUp(self):
+        super().setUp()
+        frappe_file_manager.save_file.reset_mock()
+        frappe_file_manager.save_file.side_effect = None
+        frappe_file_manager.save_file.return_value = SimpleNamespace(
+            name="FILE-0009",
+            file_name="clip.webm",
+            file_url="/private/files/clip.webm",
+        )
+
+    def test_imports_as_frappe_file(self):
+        payload = b"fake audio bytes"
+        target = self._write_audio(payload=payload)
+
+        result = audio_service.import_local_audio(
+            target,
+            attach_to_doctype="Agent Message",
+            attach_to_name="MSG-1",
+        )
+
+        self.assertEqual(result["file_id"], "FILE-0009")
+        self.assertEqual(result["file_url"], "/private/files/clip.webm")
+        self.assertEqual(result["file_name"], "clip.webm")
+        args, kwargs = frappe_file_manager.save_file.call_args
+        self.assertEqual(args[0], "clip.webm")
+        self.assertEqual(args[1], payload)
+        self.assertEqual(args[2], "Agent Message")
+        self.assertEqual(args[3], "MSG-1")
+        self.assertEqual(kwargs["is_private"], 1)
+
+    def test_rejects_outside_path_without_saving(self):
+        outside_dir = tempfile.mkdtemp(prefix="huf-outside-")
+        outside_file = self._write_audio(root=outside_dir)
+        with self.assertRaises(ThrowError) as ctx:
+            audio_service.import_local_audio(outside_file)
+        self.assertIn("outside the allowed audio import directories", str(ctx.exception))
+        frappe_file_manager.save_file.assert_not_called()
+
+
+class TestTranscribeApiFilePath(LocalAudioTestCase):
+    def test_file_path_and_file_id_rejected(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_api.transcribe(
+                file_id="FILE-0001",
+                file_path=os.path.join(self.allowed_root, "clip.webm"),
+                agent="Agent-1",
+            )
+        self.assertIn("exactly one", str(ctx.exception))
+
+    def test_file_path_and_b64data_rejected(self):
+        with self.assertRaises(ThrowError) as ctx:
+            audio_api.transcribe(
+                file_path=os.path.join(self.allowed_root, "clip.webm"),
+                b64data="YXVkaW8=",
+                filename="clip.webm",
+                agent="Agent-1",
+            )
+        self.assertIn("exactly one", str(ctx.exception))
+
+    def test_file_path_requires_system_manager(self):
+        frappe_mock.only_for.side_effect = PermissionError("no")
+        with self.assertRaises(PermissionError):
+            audio_api.transcribe(
+                file_path=os.path.join(self.allowed_root, "clip.webm"),
+                agent="Agent-1",
+            )
+        frappe_mock.only_for.assert_called_once_with("System Manager")
+
+    def test_in_place_transcribe_passes_local_path(self):
+        local = self._write_audio()
+        with patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value={
+                "success": True,
+                "transcript": "hello",
+                "text": "hello",
+                "file_id": None,
+                "file_url": None,
+                "local_path": os.path.realpath(local),
+                "stt_model": "openai/whisper-1",
+                "provider": "openai",
+                "language": "auto-detected",
+                "stt_source": "provider_default",
+            },
+        ) as transcribe_mock, patch.object(
+            audio_service, "import_local_audio"
+        ) as import_mock, patch.object(
+            audio_service, "create_audio_user_message"
+        ) as message_mock:
+            result = audio_api.transcribe(file_path=local, agent="Agent-1")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["transcript"], "hello")
+        self.assertIsNone(result["file_id"])
+        self.assertEqual(result["local_path"], os.path.realpath(local))
+        frappe_mock.only_for.assert_called_once_with("System Manager")
+        _, kwargs = transcribe_mock.call_args
+        self.assertIsNone(kwargs["file_id"])
+        self.assertEqual(kwargs["local_path"], local)
+        import_mock.assert_not_called()
+        message_mock.assert_not_called()
+
+    def test_create_message_imports_then_proceeds_as_file_id(self):
+        local = self._write_audio()
+        with patch.object(
+            audio_service,
+            "import_local_audio",
+            return_value={
+                "file_id": "FILE-IMP",
+                "file_url": "/private/files/clip.webm",
+                "file_name": "clip.webm",
+            },
+        ) as import_mock, patch.object(
+            audio_service,
+            "transcribe_audio_file",
+            return_value={
+                "success": True,
+                "transcript": "hello",
+                "text": "hello",
+                "file_id": "FILE-IMP",
+                "file_url": "/private/files/clip.webm",
+                "local_path": None,
+                "stt_model": "openai/whisper-1",
+                "provider": "openai",
+                "language": "auto-detected",
+                "stt_source": "provider_default",
+            },
+        ) as transcribe_mock, patch.object(
+            audio_service,
+            "create_audio_user_message",
+            return_value=SimpleNamespace(name="MSG-0001"),
+        ) as message_mock:
+            result = audio_api.transcribe(
+                file_path=local,
+                agent="Agent-1",
+                conversation="CONV-0001",
+                create_message=True,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["message_id"], "MSG-0001")
+        self.assertEqual(result["file_id"], "FILE-IMP")
+        import_mock.assert_called_once_with(local, is_private=1)
+        _, kwargs = transcribe_mock.call_args
+        self.assertEqual(kwargs["file_id"], "FILE-IMP")
+        self.assertIsNone(kwargs["local_path"])
+        args, _ = message_mock.call_args
+        self.assertEqual(args[0], "CONV-0001")
+        self.assertEqual(args[1], "FILE-IMP")
+        self.assertEqual(args[2], "hello")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
#403 (canonical audio service) merged today with its final commit deleting the entire new audio test suite — while the PR body still advertised it. Current develop has **no `huf/tests/` directory at all**. This PR restores the suite, unchanged, from the #414 rebase branch (which had excluded the deletion commit and aligned the tests with the consolidated message workflow).

## Scope
- `huf/tests/`: `test_audio_service.py`, `test_chat_audio_upload.py`, `test_doc_event_audio.py`, `test_local_audio_path.py` (+ `__init__.py`) — exactly as restored in #414 (closed by the #403 author after #403 merged).

## Tests
- `py_compile` on all files.
- These are unit-level tests with mocked frappe/LiteLLM; they become runnable in CI once #407 (test-runner fix) lands — recommend merging #407 first so this PR's tests actually execute before undrafting.

## Notes
If the deletion was intentional (e.g. tests were flaky), close this with a note and we'll drop it — the intake dossier for #403 judged the deletion self-inflicted, not deliberate.