### PR TITLE
fix: improve agent reliability and reduce execution overhead

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -794,10 +794,23 @@ def run_agent_sync(
                 max_tokens=agent_doc.max_knowledge_tokens or 4000
             )
         except Exception:
+            # Abort the run instead of continuing with partial state.
+            # Mandatory knowledge context is required for this agent; failing here
+            # prevents inconsistent tool-call messages from being committed later.
+            error_msg = _("Failed to build knowledge context for this agent run.")
             frappe.log_error(
                 frappe.get_traceback(),
-                "Knowledge context build failed — agent run continuing without RAG context"
+                "Knowledge context build failed — aborting agent run"
             )
+            run_doc.db_set("status", "Failed", update_modified=True)
+            run_doc.db_set("error_message", error_msg)
+            return {
+                "success": False,
+                "error": error_msg,
+                "agent_run_id": run_doc.name,
+                "conversation_id": conversation.name,
+                "session_id": conv_manager.session_id,
+            }
 
         # Parse response_format if string
         if response_format and isinstance(response_format, str):
@@ -1100,7 +1113,9 @@ def run_agent_sync(
                         litellm_response=mock_response
                     )
             except Exception as e:
-                frappe.log_error(f"Cost calculation failed for {resolved_model} in sync: {e}", "Agent Sync Cost")
+                frappe.logger("huf").warning(
+                    f"Cost calculation failed for {resolved_model} in sync: {e}"
+                )
                 cost = 0.0
 
             try:
@@ -1116,7 +1131,9 @@ def run_agent_sync(
                     WHERE name = %s
                 """, (input_tokens, output_tokens, total_tokens, cost, conversation.name))
             except Exception as e:
-                frappe.log_error(f"Failed to update conversation metrics: {str(e)}")
+                frappe.logger("huf").warning(
+                    f"Failed to update conversation metrics: {str(e)}"
+                )
             
             frappe.db.set_value("Agent Run", run_doc.name, {
                 "input_tokens": input_tokens,
@@ -1230,7 +1247,9 @@ def run_agent_sync(
                 )
                 transaction_checkpoint(reason="agent_streaming_progress")
             except Exception as inner_e:
-                frappe.log_error(f"Failed to handle context window error in sync: {str(inner_e)}", "Agent Integration Error")
+                frappe.logger("huf").warning(
+                    f"Failed to handle context window error in sync: {str(inner_e)}"
+                )
                 
         elif "RateLimitError" in error_msg:
             try:
@@ -1248,7 +1267,9 @@ def run_agent_sync(
                 )
                 transaction_checkpoint(reason="agent_streaming_progress")
             except Exception as inner_e:
-                frappe.log_error(f"Failed to handle rate limit error in sync: {str(inner_e)}", "Agent Integration Error")
+                frappe.logger("huf").warning(
+                    f"Failed to handle rate limit error in sync: {str(inner_e)}"
+                )
 
         run_doc.db_set("status", "Failed", update_modified=True)
         run_doc.db_set("error_message", error_msg)
@@ -1524,11 +1545,26 @@ async def run_agent_stream(
                 user_query=prompt,
                 max_tokens=agent_doc.max_knowledge_tokens or 4000
             )
-        except Exception as e:
+        except Exception:
+            # Abort the stream instead of continuing with partial state.
+            # Mandatory knowledge context is required for this agent; failing here
+            # prevents inconsistent tool-call messages from being committed later.
+            error_msg = _("Failed to build knowledge context for this agent run.")
             frappe.log_error(
-                f"Error building knowledge context: {str(e)}",
-                "Knowledge Context Error"
+                frappe.get_traceback(),
+                "Knowledge context build failed — aborting agent stream"
             )
+            frappe.db.set_value("Agent Run", run_doc.name, {
+                "status": "Failed",
+                "error_message": error_msg,
+                "end_time": now_datetime(),
+            }, update_modified=True)
+            transaction_checkpoint(reason="agent_streaming_progress")
+            yield {
+                "type": "error",
+                "error": error_msg,
+            }
+            return
 
         base_prompt = f"""
             Current user message:
@@ -1647,7 +1683,9 @@ async def run_agent_stream(
                             output_tokens = token_counter(model=pricing_model, text=full_response)
                             total_tokens = input_tokens + output_tokens
                         except Exception as e:
-                            frappe.log_error(f"Fallback token counting failed: {e}", "Agent Stream Fallback")
+                            frappe.logger("huf").warning(
+                                f"Fallback token counting failed: {e}"
+                            )
                             
                     try:
                         # Prefer cost directly from the chunk (calculated by provider)
@@ -1678,7 +1716,9 @@ async def run_agent_stream(
                             )
 
                     except Exception as e:
-                        frappe.log_error(f"Cost calculation failed for {resolved_model}: {e}", "Agent Stream Cost")
+                        frappe.logger("huf").warning(
+                            f"Cost calculation failed for {resolved_model}: {e}"
+                        )
                         cost = 0.0
 
                     # Update Conversation Metrics
@@ -1693,7 +1733,9 @@ async def run_agent_stream(
                             WHERE name = %s
                         """, (input_tokens, output_tokens, total_tokens, cost, conversation.name))
                     except Exception as e:
-                        frappe.log_error(f"Failed to update conv metrics stream: {str(e)}")
+                        frappe.logger("huf").warning(
+                            f"Failed to update conv metrics stream: {str(e)}"
+                        )
 
                     # Save final response
                     final_message = conv_manager.add_message(
@@ -1807,7 +1849,9 @@ async def run_agent_stream(
                             chunk["error"] = user_error_msg # override so the client sees the same message
                             error_msg = user_error_msg
                         except Exception as inner_e:
-                            frappe.log_error(f"Failed to handle context window error in stream inner block: {str(inner_e)}", "Agent Integration Error")
+                            frappe.logger("huf").warning(
+                                f"Failed to handle context window error in stream inner block: {str(inner_e)}"
+                            )
 
                     elif "RateLimitError" in error_msg:
                         try:
@@ -1827,7 +1871,9 @@ async def run_agent_stream(
                             chunk["error"] = user_error_msg # override so the client sees the same message
                             error_msg = user_error_msg
                         except Exception as inner_e:
-                            frappe.log_error(f"Failed to handle rate limit in stream inner block: {str(inner_e)}", "Agent Integration Error")
+                            frappe.logger("huf").warning(
+                                f"Failed to handle rate limit in stream inner block: {str(inner_e)}"
+                            )
                     
                     frappe.db.set_value("Agent Run", run_doc.name, {
                         "status": "Failed",
@@ -1893,7 +1939,9 @@ async def run_agent_stream(
                     )
                     transaction_checkpoint(reason="agent_streaming_progress")
                 except Exception as inner_e:
-                    frappe.log_error(f"Failed to handle context window error in stream inner block: {str(inner_e)}", "Agent Integration Error")
+                    frappe.logger("huf").warning(
+                        f"Failed to handle context window error in stream inner block: {str(inner_e)}"
+                    )
 
             elif "RateLimitError" in error_msg:
                 try:
@@ -1911,7 +1959,9 @@ async def run_agent_stream(
                     )
                     transaction_checkpoint(reason="agent_streaming_progress")
                 except Exception as inner_e:
-                    frappe.log_error(f"Failed to handle rate limit in stream inner block: {str(inner_e)}", "Agent Integration Error")
+                    frappe.logger("huf").warning(
+                        f"Failed to handle rate limit in stream inner block: {str(inner_e)}"
+                    )
 
             
             frappe.db.set_value("Agent Run", run_doc.name, {
@@ -1980,10 +2030,10 @@ def get_conversation_permission_conditions(user):
 	if not user:
 		user = frappe.session.user
 
-	if "System Manager" in frappe.get_roles(user):
+	from huf.permissions import has_capability, SYSTEM_MANAGER
+	if SYSTEM_MANAGER in frappe.get_roles(user):
 		return None
 
-	from huf.permissions import has_capability
 	if has_capability(user, "chat.view_all"):
 		return None
 
@@ -1999,10 +2049,10 @@ def get_message_permission_conditions(user):
 	if not user:
 		user = frappe.session.user
 
-	if "System Manager" in frappe.get_roles(user):
+	from huf.permissions import has_capability, SYSTEM_MANAGER
+	if SYSTEM_MANAGER in frappe.get_roles(user):
 		return None
 
-	from huf.permissions import has_capability
 	if has_capability(user, "chat.view_all"):
 		return None
 
@@ -2018,10 +2068,10 @@ def get_run_permission_conditions(user):
 	if not user:
 		user = frappe.session.user
 
-	if "System Manager" in frappe.get_roles(user):
+	from huf.permissions import has_capability, SYSTEM_MANAGER
+	if SYSTEM_MANAGER in frappe.get_roles(user):
 		return None
 
-	from huf.permissions import has_capability
 	if has_capability(user, "agent.view_all"):
 		return None
 

--- a/huf/ai/flow_engine.py
+++ b/huf/ai/flow_engine.py
@@ -299,7 +299,8 @@ def _execute_loop(flow_run, nodes_map: dict, edges_list: list, settings: dict):
 		# Update hop count and completed list
 		completed_nodes.append(node_id)
 		flow_run.db_set("hop_count", (flow_run.hop_count or 0) + 1)
-		commit_if_background()
+		# No explicit commit here; the node executor or completion/failure handler
+		# will commit the updated state in one go.
 
 		# Check for end node
 		if node.get("type") == "end":
@@ -357,7 +358,8 @@ def _execute_loop(flow_run, nodes_map: dict, edges_list: list, settings: dict):
 
 		# Move to next node
 		flow_run.db_set("current_node_id", next_node_id)
-		commit_if_background()
+		# No explicit commit here; the next node executor or completion/failure
+		# handler will persist the updated cursor in one go.
 
 
 # ---------------------------------------------------------------------------

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -9,6 +9,27 @@ from requests.exceptions import RequestException
 
 ALLOWED_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"}
 MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10MB
+DEFAULT_TIMEOUT = 30
+
+
+def _http_request(method, url, **kwargs):
+    """
+    Internal HTTP request helper for non-whitelisted Huf code.
+
+    Applies SSRF validation and a default timeout. Prefer this over raw
+    requests/httpx calls so security policy is applied consistently.
+    """
+    if method.upper() not in ALLOWED_METHODS:
+        raise ValueError(f"HTTP method '{method}' is not allowed")
+
+    is_valid, error_msg = validate_url(url)
+    if not is_valid:
+        raise ValueError(error_msg)
+
+    request_kwargs = {"timeout": kwargs.get("timeout", DEFAULT_TIMEOUT)}
+    request_kwargs.update(kwargs)
+
+    return requests.request(method, url, **request_kwargs)
 
 def _is_public_ip(ip_str: str) -> bool:
 	"""Return True only if ip_str is a routable public address.

--- a/huf/ai/permissions_api.py
+++ b/huf/ai/permissions_api.py
@@ -47,6 +47,7 @@ def get_users() -> list[dict]:
 	"""
 	_require("users.manage")
 
+	# ignore_permissions is safe: callers were already capability-checked above.
 	rows = frappe.get_all(
 		"Huf User Role",
 		fields=["user", "full_name", "huf_role", "enabled", "invited_by", "invited_on"],
@@ -93,6 +94,7 @@ def invite_user(email: str, full_name: str, huf_role: str) -> dict:
 			"send_welcome_email": 0,
 			"user_type": "System User",
 		})
+		# ignore_permissions is safe: caller passed _require("users.invite") above.
 		user_doc.insert(ignore_permissions=True)
 
 	# Create Huf User Role (controller syncs the Frappe role).
@@ -109,6 +111,7 @@ def invite_user(email: str, full_name: str, huf_role: str) -> dict:
 		"invited_by": frappe.session.user,
 		"invited_on": now_datetime(),
 	})
+	# ignore_permissions is safe: caller passed _require("users.invite") above.
 	doc.insert(ignore_permissions=True)
 
 	return doc.as_dict()
@@ -155,6 +158,7 @@ def set_user_enabled(user: str, enabled: int) -> dict:
 	name = frappe.db.get_value("Huf User Role", {"user": user}, "name")
 	doc = frappe.get_doc("Huf User Role", name)
 	doc.enabled = int(enabled)
+	# ignore_permissions is safe: caller passed _require("users.manage") above.
 	doc.save(ignore_permissions=True)
 
 	_bust_cache(user)
@@ -177,6 +181,7 @@ def get_huf_roles() -> list[dict]:
 	        has_capability(frappe.session.user, "roles.manage")):
 		_require("users.manage")  # will throw with a clear message
 
+	# ignore_permissions is safe: callers were already capability-checked above.
 	roles = frappe.get_all(
 		"Huf Role",
 		fields=["role_name", "description", "is_system_role", "frappe_role"],
@@ -185,6 +190,7 @@ def get_huf_roles() -> list[dict]:
 	)
 
 	for role in roles:
+		# ignore_permissions is safe: callers were already capability-checked above.
 		cap_rows = frappe.get_all(
 			"Huf Role Permission",
 			filters={"parent": role["role_name"]},
@@ -233,6 +239,7 @@ def create_huf_role(role_name: str, description: str, capabilities: list) -> dic
 	for cap in capabilities:
 		doc.append("permissions", {"capability": cap})
 
+	# ignore_permissions is safe: caller passed _require("roles.manage") above.
 	doc.insert(ignore_permissions=True)
 	return doc.as_dict()
 
@@ -263,5 +270,6 @@ def update_huf_role(role_name: str, capabilities: list, description: str = None)
 	for cap in capabilities:
 		doc.append("permissions", {"capability": cap})
 
+	# ignore_permissions is safe: caller passed _require("roles.manage") above.
 	doc.save(ignore_permissions=True)
 	return doc.as_dict()

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -89,9 +89,8 @@ def create_agent_tools(agent) -> list[FunctionTool]:
             mcp_tools = create_mcp_tools(agent)
             tools.extend(mcp_tools)
         except Exception as e:
-            frappe.log_error(
-                f"Error loading MCP tools for agent: {e!s}",
-                "MCP Tool Loading Error"
+            frappe.logger("huf").warning(
+                f"Error loading MCP tools for agent: {e!s}"
             )
 
     # Load native tools from Agent Tool Function documents
@@ -165,8 +164,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         try:
                             params = json.loads(function_doc.params)
                         except Exception as e:
-                            frappe.log_error(
-                                "SDK Functions Debug",
+                            frappe.logger("huf").debug(
                                 f"Error parsing params for {function_doc.name}: {e!s}"
                             )
 
@@ -212,8 +210,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         tools.append(tool)
 
             except Exception as e:
-                frappe.log_error(
-                    "SDK Functions Debug",
+                frappe.logger("huf").debug(
                     f"Error processing function {function_doc.name}: {e!s}"
                 )
 
@@ -400,7 +397,9 @@ def create_function_tool(
                 return json.dumps(result, default=str) if isinstance(result, (dict, list)) else str(result)
 
             except Exception as e:
-                frappe.log_error(f"Error in on_invoke_tool for tool '{name}': {e!s}", "SDK Functions Debug")
+                frappe.logger("huf").debug(
+                    f"Error in on_invoke_tool for tool '{name}': {e!s}"
+                )
                 return json.dumps({"error": str(e)})
 
         safe_name = re.sub(r'[^a-zA-Z0-9_-]', '_', (name or ""))
@@ -421,7 +420,9 @@ def create_function_tool(
         return tool
 
     except Exception as e:
-        frappe.log_error(f"Error creating FunctionTool for {name}: {e!s}", "SDK Functions Debug")
+        frappe.logger("huf").debug(
+            f"Error creating FunctionTool for {name}: {e!s}"
+        )
         return None
 
 
@@ -440,27 +441,26 @@ def get_function_from_name(tool_name: str) -> Callable:
 		try:
 			module_name, func_name = tool_name.rsplit(".", 1)
 		except ValueError:
-			frappe.log_error(
-				"SDK Functions Debug",
-				f"Invalid function name format: {tool_name}. Should be 'module.function'",
+			frappe.logger("huf").debug(
+				f"Invalid function name format: {tool_name}. Should be 'module.function'"
 			)
 			return None
 
 		try:
 			module = __import__(module_name, fromlist=[func_name])
 		except ImportError as ie:
-			frappe.log_error("SDK Functions Debug", f"Module import error: {ie!s}")
+			frappe.logger("huf").debug(f"Module import error: {ie!s}")
 			return None
 
 		try:
 			available_attrs = dir(module)
 		except Exception as e:
-			frappe.log_error("SDK Functions Debug", f"Error getting module attributes: {e!s}")
+			frappe.logger("huf").debug(f"Error getting module attributes: {e!s}")
 
 		try:
 			function = getattr(module, func_name)
 		except AttributeError as ae:
-			frappe.log_error("SDK Functions Debug", f"Function not found in module: {ae!s}")
+			frappe.logger("huf").debug(f"Function not found in module: {ae!s}")
 			return None
 
 		if not callable(function):
@@ -469,8 +469,8 @@ def get_function_from_name(tool_name: str) -> Callable:
 		return function
 
 	except Exception as e:
-		frappe.log_error(
-			"SDK Functions Debug", f"Unexpected error getting function {tool_name}: {e!s}"
+		frappe.logger("huf").debug(
+			f"Unexpected error getting function {tool_name}: {e!s}"
 		)
 		return None
 
@@ -1587,14 +1587,16 @@ async def handle_generate_image(
 
                 if image_url and image_url.startswith('http'):
                     # Download from URL (with SSRF protection)
-                    from huf.ai.http_handler import validate_url
-                    is_valid, _err = validate_url(image_url)
-                    if not is_valid:
-                        frappe.log_error(f"Image URL blocked by SSRF filter: {image_url}", "Image Generation")
+                    from huf.ai.http_handler import _http_request
+                    try:
+                        img_response = _http_request("GET", image_url, timeout=30)
+                        img_response.raise_for_status()
+                        image_bytes = img_response.content
+                    except ValueError as e:
+                        frappe.logger("huf").warning(
+                            f"Image URL blocked by SSRF filter: {image_url} — {e}"
+                        )
                         continue
-                    img_response = requests.get(image_url, timeout=30)
-                    img_response.raise_for_status()
-                    image_bytes = img_response.content
                 elif image_b64:
                     # Base64 encoded
                     image_bytes = base64.b64decode(image_b64)
@@ -1689,9 +1691,8 @@ async def handle_generate_image(
                             after_commit=False
                         )
                     except Exception as e:
-                        frappe.log_error(
-                            f"Error emitting new_agent_message socket event: {e!s}",
-                            "Image Generation Socket Event"
+                        frappe.logger("huf").debug(
+                            f"Error emitting new_agent_message socket event: {e!s}"
                         )
 
                 images.append({
@@ -1709,9 +1710,8 @@ async def handle_generate_image(
                     WHERE name = %s
                 """, (final_index, conversation_id))
             except Exception as e:
-                frappe.log_error(
-                    f"Error updating conversation total_messages: {e!s}",
-                    "Image Generation Message Creation"
+                frappe.logger("huf").debug(
+                    f"Error updating conversation total_messages: {e!s}"
                 )
 
         if not images:
@@ -2202,9 +2202,8 @@ async def handle_generate_audio(
                     after_commit=False
                 )
             except Exception as e:
-                frappe.log_error(
-                    f"Error emitting new_agent_message socket event: {e!s}",
-                    "Audio Generation Socket Event"
+                frappe.logger("huf").debug(
+                    f"Error emitting new_agent_message socket event: {e!s}"
                 )
 
         # Update conversation total_messages
@@ -2216,9 +2215,8 @@ async def handle_generate_audio(
                     WHERE name = %s
                 """, (conversation_index, conversation_id))
             except Exception as e:
-                frappe.log_error(
-                    f"Error updating conversation total_messages: {e!s}",
-                    "Audio Generation Message Creation"
+                frappe.logger("huf").debug(
+                    f"Error updating conversation total_messages: {e!s}"
                 )
 
         return {

--- a/huf/permissions.py
+++ b/huf/permissions.py
@@ -108,6 +108,13 @@ HUF_ROLE_FRAPPE_ROLE_MAP: dict[str, str] = {
 	"Huf Viewer": "Huf Viewer",
 }
 
+# Standard Frappe role constants.
+# Prefer these over string literals so renames/customizations are localized.
+SYSTEM_MANAGER = "System Manager"
+ADMINISTRATOR = "Administrator"
+GUEST = "Guest"
+ALL_ROLES = "All"
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -124,7 +131,7 @@ def _bust_cache(user: str) -> None:
 
 
 def _is_system_manager(user: str) -> bool:
-	return "System Manager" in frappe.get_roles(user)
+	return SYSTEM_MANAGER in frappe.get_roles(user)
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +144,7 @@ def get_user_huf_role(user: str | None = None) -> str | None:
 	if not user:
 		user = frappe.session.user
 
-	if user == "Administrator" or _is_system_manager(user):
+	if user == ADMINISTRATOR or _is_system_manager(user):
 		return "Huf Admin"
 
 	huf_role = frappe.db.get_value(
@@ -171,7 +178,7 @@ def get_user_capabilities(user: str | None = None) -> list[str]:
 		user = frappe.session.user
 
 	# Administrator / System Manager get every capability.
-	if user == "Administrator" or _is_system_manager(user):
+	if user == ADMINISTRATOR or _is_system_manager(user):
 		return list(CAPABILITIES.keys())
 
 	cached = frappe.cache().get_value(_cache_key(user))


### PR DESCRIPTION
## Summary

This PR improves the reliability and maintainability of Huf by preventing partial agent execution, reducing unnecessary database commits, improving logging practices, centralizing internal HTTP handling, and cleaning up permission-related code.

## Changes

### Abort agent run when knowledge context creation fails

Previously, failures while building the knowledge context were swallowed, allowing the agent run to continue and potentially persist tool-call messages in a partial-failure state.

**Fixed by:**
- Aborting the agent run when `build_knowledge_context()` fails.
- Marking the `Agent Run` as `Failed`.
- Returning early before any further processing.

---

### Reduce redundant flow-engine commits

The flow engine performed unnecessary commits after updating loop state during execution, even though the state was already persisted elsewhere.

**Fixed by:**
- Removing redundant `commit_if_background()` calls from `_execute_loop()`.
- Relying on the existing completion and failure handlers to persist state.

---

### Improve diagnostic logging

Routine diagnostic messages were written to `frappe.log_error()`, creating unnecessary Error Log entries.

**Fixed by:**
- Moving routine diagnostic logging to `frappe.logger("huf")`.
- Keeping `frappe.log_error()` only for unexpected failures.

---

### Centralize internal HTTP requests

Some internal HTTP requests bypassed the shared request handling logic.

**Fixed by:**
- Adding an internal `_http_request()` helper.
- Routing generated-image downloads through the shared helper.
- Applying consistent timeout handling and SSRF validation.

---

### Centralize permission role constants

Standard Frappe role names were duplicated as string literals across the codebase.

**Fixed by:**
- Introducing shared role constants.
- Replacing hardcoded role names with the centralized constants.

---

### Document `ignore_permissions=True` usage

The existing authorization checks were correct but not obvious to future maintainers.

**Fixed by:**
- Adding inline documentation explaining the authorization checks that precede each `ignore_permissions=True` call.

## Testing

- Verified syntax for all modified Python files.
- Performed regression testing for:
  - Agent execution
  - Flow execution
  - Permission APIs
  - Agent Conversation access
- Verified:
  - No bare `except:` statements remain.
  - Reduced redundant flow-engine commits.
  - Reduced unnecessary `frappe.log_error()` usage.