### PR TITLE
feat(apps): HUF Apps MVP — registry, discovery, and permission-aware launcher

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { DataTableViewWrapper } from './pages/DataTableViewWrapper';
 import { Toaster } from './components/ui/sonner';
 
 const HomePage = lazy(() => import('./pages/HomePage'));
+const AppsPage = lazy(() => import('./pages/AppsPage'));
 const AgentsPage = lazy(() => import('./pages/AgentsPage'));
 const AgentFormPageWrapper = lazy(() => import('./pages/AgentFormPageWrapper'));
 const AgentPromptsPage = lazy(() => import('./pages/AgentPromptsPage'));
@@ -82,6 +83,18 @@ function AppShell() {
                 <UnifiedLayout headerActions={<HomeHeaderActions />}>
                   <Suspense fallback={<PageLoader />}>
                     <HomePage />
+                  </Suspense>
+                </UnifiedLayout>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/apps"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout>
+                  <Suspense fallback={<PageLoader />}>
+                    <AppsPage />
                   </Suspense>
                 </UnifiedLayout>
               </ProtectedRoute>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Home, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Boxes, Terminal, Settings, ChevronRight, Shield } from "lucide-react"
+import { Home, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Boxes, Terminal, Settings, ChevronRight, Shield, LayoutGrid } from "lucide-react"
 import { NavLink, useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -36,6 +36,19 @@ const dashboardNavItems = [
     url: "/",
     icon: Home,
     capability: null,
+  },
+]
+
+/**
+ * The "Use" side of the platform: end-user HUF Apps discovered from
+ * installed provider apps. Build/Operate/People remain the manage side.
+ */
+const useNavItems = [
+  {
+    title: "Apps",
+    url: "/apps",
+    icon: LayoutGrid,
+    capability: "agent.use",
   },
 ]
 
@@ -188,6 +201,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	// While permissions are loading show only uncapability-gated items so the
 	// sidebar doesn't flash/jump once capabilities resolve.
 	const dashboardItems = filterItemsByCapability(dashboardNavItems)
+	const useItems = filterItemsByCapability(useNavItems)
 	const buildItems = filterItemsByCapability(buildNavItems).map((item) =>
 		item.title === "Agents" ? { ...item, count: agentCount } : item
 	)
@@ -222,6 +236,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </SidebarHeader>
       <SidebarContent>
 			{dashboardItems.length > 0 && <NavMain items={dashboardItems} />}
+			{useItems.length > 0 && <NavMain items={useItems} label="Use" />}
 			{buildItems.length > 0 && <NavMain items={buildItems} label="Build" />}
 			{operateItems.length > 0 && <NavMain items={operateItems} label="Operate" />}
 			{peopleItems.length > 0 && <NavMain items={peopleItems} label="People" />}

--- a/frontend/src/components/data-table/AppTablesSection.tsx
+++ b/frontend/src/components/data-table/AppTablesSection.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Table2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { getExposedAppTables } from '@/services/appsApi';
+import type { ExposedAppTable } from '@/services/appsApi';
+
+/**
+ * Frappe desk list route for a DocType: lowercase, spaces → hyphens
+ * (e.g. "Sales Invoice" → /app/sales-invoice).
+ */
+function deskRoute(doctype: string): string {
+	return `/app/${doctype.trim().toLowerCase().replace(/\s+/g, '-')}`;
+}
+
+/**
+ * "App Tables" section for the bottom of the Data page: DocTypes exposed
+ * by installed HUF Apps, each linking to its Frappe desk list. Renders
+ * nothing when no app exposes tables (or the fetch fails — the section
+ * is supplementary, never worth an error state).
+ */
+export function AppTablesSection() {
+	const [rows, setRows] = useState<ExposedAppTable[]>([]);
+
+	useEffect(() => {
+		let cancelled = false;
+		getExposedAppTables()
+			.then((tables) => {
+				if (!cancelled) setRows(tables);
+			})
+			.catch(() => {
+				// Stay hidden on error.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (rows.length === 0) return null;
+
+	return (
+		<section className="mt-8 border-t border-line pt-6 space-y-3">
+			<div className="space-y-1">
+				<h2 className="font-display font-bold text-[16px] uppercase text-ink">
+					App Tables
+				</h2>
+				<p className="text-sm font-body text-steel">
+					Tables exposed by installed HUF Apps.
+				</p>
+			</div>
+			<div className="border border-line divide-y divide-line">
+				{rows.map((row) => (
+					<div
+						key={`${row.app_id}:${row.doctype}`}
+						className="flex items-center justify-between gap-4 px-4 py-2.5"
+					>
+						<div className="flex items-center gap-3 min-w-0">
+							<Table2 className="w-4 h-4 shrink-0 text-steel-soft" />
+							<Link
+								to={deskRoute(row.doctype)}
+								className="font-body text-[14px] text-ink hover:underline truncate"
+							>
+								{row.doctype}
+							</Link>
+						</div>
+						<Badge variant="secondary" className="shrink-0">
+							{row.app_title}
+						</Badge>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/pages/AppsPage.tsx
+++ b/frontend/src/pages/AppsPage.tsx
@@ -1,14 +1,54 @@
-import { useCallback, useEffect, useState } from 'react';
-import { AppWindow, ExternalLink, TriangleAlert } from 'lucide-react';
-import { PageLayout, GridView, BaseCard } from '../components/dashboard';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+	AppWindow,
+	CircleHelp,
+	ExternalLink,
+	MoreVertical,
+	Power,
+	TriangleAlert,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { PageLayout, GridView, BaseCard, FilterBar } from '../components/dashboard';
 import { CardHeader, CardTitle, CardDescription, CardAction } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { getHufApps } from '../services/appsApi';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import { getHufApps, setHufAppEnabled } from '../services/appsApi';
 import type { HufApp } from '@/types/hufApp.types';
 
 export { AppsPage };
 export default AppsPage;
+
+/**
+ * Search + category filters only appear once the launcher holds enough
+ * apps to be worth filtering.
+ */
+const FILTER_THRESHOLD = 8;
+
+/** Known HUF App categories; chips also pick up custom ones from data. */
+const DEFAULT_CATEGORIES = [
+	'Create',
+	'Plan',
+	'Research',
+	'Automate',
+	'Analyze',
+	'Communicate',
+	'Manage',
+	'Other',
+];
 
 /**
  * Resolve the launch URL for a registered HUF App. Apps are independent
@@ -51,13 +91,54 @@ function AppIcon({ app }: { app: HufApp }) {
 	);
 }
 
-function AppCard({ app }: { app: HufApp }) {
-	const route = appRoute(app);
+function CategoryChip({
+	label,
+	active,
+	onClick,
+}: {
+	label: string;
+	active: boolean;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				'inline-flex items-center rounded-none border px-2 py-1 font-mono text-[10.5px] uppercase tracking-wide transition-colors',
+				active
+					? 'border-ink text-ink'
+					: 'border-line bg-paper-deep text-steel hover:text-ink'
+			)}
+		>
+			{label}
+		</button>
+	);
+}
+
+function AppCard({
+	app,
+	onToggleEnabled,
+}: {
+	app: HufApp;
+	onToggleEnabled: (app: HufApp) => void;
+}) {
+	// `enabled` is only present for System Managers; its presence doubles
+	// as the signal to offer the admin enable/disable action.
+	const canAdminister = typeof app.enabled === 'number';
+	const isDisabled = app.enabled === 0;
+	const route = isDisabled ? null : appRoute(app);
 
 	// The whole card is a real anchor: left-click navigates (full page
-	// load), cmd/ctrl/middle-click opens a new tab natively.
+	// load), cmd/ctrl/middle-click opens a new tab natively. Disabled apps
+	// never get the anchor — the card is inert and can't be opened.
 	const card = (
-		<BaseCard className="flex flex-col cursor-pointer hover:border-ink">
+		<BaseCard
+			className={cn(
+				'flex flex-col',
+				isDisabled ? 'opacity-60' : 'cursor-pointer hover:border-ink'
+			)}
+		>
 			<CardHeader className="pb-3">
 				<CardTitle className="font-body font-semibold text-[15px] line-clamp-1 flex items-center gap-2">
 					<AppIcon app={app} />
@@ -67,6 +148,11 @@ function AppCard({ app }: { app: HufApp }) {
 					{app.description || 'No description'}
 				</CardDescription>
 				<CardAction className="top-5 flex items-center gap-1">
+					{isDisabled && (
+						<Badge variant="secondary" className="text-xs">
+							Disabled
+						</Badge>
+					)}
 					{app.category && (
 						<Badge variant="secondary" className="text-xs">
 							{app.category}
@@ -88,6 +174,42 @@ function AppCard({ app }: { app: HufApp }) {
 							<ExternalLink className="w-3.5 h-3.5" />
 						</Button>
 					)}
+					{canAdminister && (
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className="h-7 w-7 text-steel-soft hover:text-ink"
+									title="App actions"
+									onClick={(e) => {
+										e.stopPropagation();
+										e.preventDefault();
+									}}
+								>
+									<MoreVertical className="w-3.5 h-3.5" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="end"
+								onClick={(e) => {
+									e.stopPropagation();
+									e.preventDefault();
+								}}
+							>
+								<DropdownMenuItem
+									onClick={(e) => {
+										e.stopPropagation();
+										e.preventDefault();
+										onToggleEnabled(app);
+									}}
+								>
+									<Power className="w-3.5 h-3.5" />
+									{isDisabled ? 'Enable app' : 'Disable app'}
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					)}
 				</CardAction>
 			</CardHeader>
 		</BaseCard>
@@ -103,10 +225,61 @@ function AppCard({ app }: { app: HufApp }) {
 	);
 }
 
+function AppsHelpDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>About HUF Apps</DialogTitle>
+					<DialogDescription>
+						What shows up here, and why.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="space-y-4 text-sm font-body text-steel">
+					<section className="space-y-1">
+						<h3 className="font-semibold text-ink">What is a HUF App?</h3>
+						<p>
+							A HUF App is an independently installed Frappe app that registers
+							itself with HUF. Each one gets a card here so you can launch its
+							own frontend.
+						</p>
+					</section>
+					<section className="space-y-1">
+						<h3 className="font-semibold text-ink">Where do apps come from?</h3>
+						<p>
+							Apps are installed server-side with bench and discovered
+							automatically once they register. Nothing is ever installed from
+							this screen — it's a launcher, not an installer.
+						</p>
+					</section>
+					<section className="space-y-1">
+						<h3 className="font-semibold text-ink">Why is the list filtered?</h3>
+						<p>
+							You only see apps you're allowed to open. Apps an administrator
+							has disabled are hidden entirely.
+						</p>
+					</section>
+					<section className="space-y-1">
+						<h3 className="font-semibold text-ink">What does HUF give them?</h3>
+						<p>
+							Registered apps build on HUF's agents, runs, knowledge, and tools,
+							so they share the same automation backbone as the rest of your
+							workspace.
+						</p>
+					</section>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
 function AppsPage() {
 	const [apps, setApps] = useState<HufApp[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const [helpOpen, setHelpOpen] = useState(false);
+	const [search, setSearch] = useState('');
+	const [category, setCategory] = useState<string>('All');
 
 	const load = useCallback(async () => {
 		setLoading(true);
@@ -124,10 +297,92 @@ function AppsPage() {
 		load();
 	}, [load]);
 
+	const handleToggleEnabled = useCallback(
+		async (app: HufApp) => {
+			const enabling = app.enabled === 0;
+			try {
+				await setHufAppEnabled(app.app_id, enabling);
+				toast.success(`${app.title} ${enabling ? 'enabled' : 'disabled'}`);
+				await load();
+			} catch (err: any) {
+				toast.error(`Failed to update ${app.title}`, {
+					description: err?.message,
+				});
+			}
+		},
+		[load]
+	);
+
+	// Chip set: the known categories plus any custom ones present in data.
+	const categories = useMemo(() => {
+		const seen = new Set(DEFAULT_CATEGORIES.map((c) => c.toLowerCase()));
+		const custom: string[] = [];
+		for (const app of apps) {
+			const cat = app.category?.trim();
+			if (cat && !seen.has(cat.toLowerCase())) {
+				seen.add(cat.toLowerCase());
+				custom.push(cat);
+			}
+		}
+		return [...DEFAULT_CATEGORIES, ...custom];
+	}, [apps]);
+
+	const showFilters = apps.length >= FILTER_THRESHOLD;
+
+	const visibleApps = useMemo(() => {
+		if (!showFilters) return apps;
+		const query = search.trim().toLowerCase();
+		return apps.filter((app) => {
+			if (category !== 'All' && (app.category || 'Other') !== category) return false;
+			if (!query) return true;
+			return (
+				app.title.toLowerCase().includes(query) ||
+				(app.description || '').toLowerCase().includes(query)
+			);
+		});
+	}, [apps, showFilters, search, category]);
+
 	return (
 		<PageLayout
 			title="Apps"
 			subtitle="Launch applications built on HUF"
+			toolbar={
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-9 w-9 text-steel-soft hover:text-ink"
+					title="About HUF Apps"
+					onClick={() => setHelpOpen(true)}
+				>
+					<CircleHelp className="w-5 h-5" />
+				</Button>
+			}
+			filters={
+				showFilters ? (
+					<FilterBar
+						searchPlaceholder="Search apps..."
+						searchValue={search}
+						onSearchChange={setSearch}
+						actions={
+							<div className="flex flex-wrap items-center gap-1.5">
+								<CategoryChip
+									label="All"
+									active={category === 'All'}
+									onClick={() => setCategory('All')}
+								/>
+								{categories.map((cat) => (
+									<CategoryChip
+										key={cat}
+										label={cat}
+										active={category === cat}
+										onClick={() => setCategory(cat)}
+									/>
+								))}
+							</div>
+						}
+					/>
+				) : undefined
+			}
 		>
 			{error ? (
 				<div className="flex flex-col items-center justify-center py-12 text-center">
@@ -140,22 +395,27 @@ function AppsPage() {
 				</div>
 			) : (
 				<GridView
-					items={apps}
+					items={visibleApps}
 					columns={{ sm: 1, md: 2, lg: 3 }}
 					loading={loading}
 					emptyState={
 						<div className="text-center py-12">
 							<AppWindow className="w-12 h-12 text-steel-soft mx-auto mb-4" />
-							<p className="font-body text-steel-soft mb-2">No apps available yet</p>
+							<p className="font-body text-steel-soft mb-2">
+								{apps.length > 0 ? 'No apps match your filters' : 'No apps available yet'}
+							</p>
 							<p className="text-sm text-steel">
-								Installed apps that depend on HUF will appear here.
+								{apps.length > 0
+									? 'Try a different search or category.'
+									: 'Installed apps that depend on HUF will appear here.'}
 							</p>
 						</div>
 					}
-					renderItem={(app) => <AppCard app={app} />}
+					renderItem={(app) => <AppCard app={app} onToggleEnabled={handleToggleEnabled} />}
 					keyExtractor={(app) => app.app_id}
 				/>
 			)}
+			<AppsHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
 		</PageLayout>
 	);
 }

--- a/frontend/src/pages/AppsPage.tsx
+++ b/frontend/src/pages/AppsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AppWindow, TriangleAlert } from 'lucide-react';
+import { AppWindow, ExternalLink, TriangleAlert } from 'lucide-react';
 import { PageLayout, GridView, BaseCard } from '../components/dashboard';
 import { CardHeader, CardTitle, CardDescription, CardAction } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -11,18 +11,20 @@ export { AppsPage };
 export default AppsPage;
 
 /**
- * Launch a registered HUF App. Apps are independent Frappe apps with
- * their own frontends, so this is a full-page site-local navigation —
- * never an iframe, never SPA router navigation.
+ * Resolve the launch URL for a registered HUF App. Apps are independent
+ * Frappe apps with their own frontends, so cards are plain anchors doing
+ * full-page site-local navigation — never an iframe, never SPA router
+ * navigation.
+ *
+ * Defensive: manifests are validated server-side, but never link to
+ * anything that isn't a plain site-local path.
  */
-function launchApp(app: HufApp) {
+function appRoute(app: HufApp): string | null {
 	const route = app.route;
-	// Defensive: manifests are validated server-side, but never navigate
-	// to anything that isn't a plain site-local path.
 	if (typeof route !== 'string' || !route.startsWith('/') || route.startsWith('//')) {
-		return;
+		return null;
 	}
-	window.location.assign(route);
+	return route;
 }
 
 function AppIcon({ app }: { app: HufApp }) {
@@ -50,8 +52,12 @@ function AppIcon({ app }: { app: HufApp }) {
 }
 
 function AppCard({ app }: { app: HufApp }) {
-	return (
-		<BaseCard onClick={() => launchApp(app)} className="flex flex-col">
+	const route = appRoute(app);
+
+	// The whole card is a real anchor: left-click navigates (full page
+	// load), cmd/ctrl/middle-click opens a new tab natively.
+	const card = (
+		<BaseCard className="flex flex-col cursor-pointer hover:border-ink">
 			<CardHeader className="pb-3">
 				<CardTitle className="font-body font-semibold text-[15px] line-clamp-1 flex items-center gap-2">
 					<AppIcon app={app} />
@@ -60,15 +66,40 @@ function AppCard({ app }: { app: HufApp }) {
 				<CardDescription className="text-steel text-[13px] line-clamp-2 min-h-[2.5rem]">
 					{app.description || 'No description'}
 				</CardDescription>
-				{app.category && (
-					<CardAction className="top-5">
+				<CardAction className="top-5 flex items-center gap-1">
+					{app.category && (
 						<Badge variant="secondary" className="text-xs">
 							{app.category}
 						</Badge>
-					</CardAction>
-				)}
+					)}
+					{route && (
+						<Button
+							variant="ghost"
+							size="icon"
+							className="h-7 w-7 text-steel-soft hover:text-ink"
+							title="Open in new tab"
+							onClick={(e) => {
+								// Don't let the click reach the wrapping anchor.
+								e.stopPropagation();
+								e.preventDefault();
+								window.open(route, '_blank', 'noopener');
+							}}
+						>
+							<ExternalLink className="w-3.5 h-3.5" />
+						</Button>
+					)}
+				</CardAction>
 			</CardHeader>
 		</BaseCard>
+	);
+
+	if (!route) {
+		return card;
+	}
+	return (
+		<a href={route} className="block h-full text-inherit no-underline">
+			{card}
+		</a>
 	);
 }
 

--- a/frontend/src/pages/AppsPage.tsx
+++ b/frontend/src/pages/AppsPage.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AppWindow, TriangleAlert } from 'lucide-react';
+import { PageLayout, GridView, BaseCard } from '../components/dashboard';
+import { CardHeader, CardTitle, CardDescription, CardAction } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { getHufApps } from '../services/appsApi';
+import type { HufApp } from '@/types/hufApp.types';
+
+export { AppsPage };
+export default AppsPage;
+
+/**
+ * Launch a registered HUF App. Apps are independent Frappe apps with
+ * their own frontends, so this is a full-page site-local navigation —
+ * never an iframe, never SPA router navigation.
+ */
+function launchApp(app: HufApp) {
+	const route = app.route;
+	// Defensive: manifests are validated server-side, but never navigate
+	// to anything that isn't a plain site-local path.
+	if (typeof route !== 'string' || !route.startsWith('/') || route.startsWith('//')) {
+		return;
+	}
+	window.location.assign(route);
+}
+
+function AppIcon({ app }: { app: HufApp }) {
+	const [iconFailed, setIconFailed] = useState(false);
+	// Icons are site-local asset paths (e.g. /assets/huf_workspace/icon.svg).
+	// Anything else — missing, malformed, or failed to load — falls back to
+	// the generic app icon.
+	const iconSrc =
+		typeof app.icon === 'string' && app.icon.startsWith('/') && !app.icon.startsWith('//')
+			? app.icon
+			: null;
+
+	if (!iconSrc || iconFailed) {
+		return <AppWindow className="w-5 h-5 shrink-0 text-steel-soft" />;
+	}
+
+	return (
+		<img
+			src={iconSrc}
+			alt=""
+			className="w-5 h-5 shrink-0 object-contain"
+			onError={() => setIconFailed(true)}
+		/>
+	);
+}
+
+function AppCard({ app }: { app: HufApp }) {
+	return (
+		<BaseCard onClick={() => launchApp(app)} className="flex flex-col">
+			<CardHeader className="pb-3">
+				<CardTitle className="font-body font-semibold text-[15px] line-clamp-1 flex items-center gap-2">
+					<AppIcon app={app} />
+					{app.title}
+				</CardTitle>
+				<CardDescription className="text-steel text-[13px] line-clamp-2 min-h-[2.5rem]">
+					{app.description || 'No description'}
+				</CardDescription>
+				{app.category && (
+					<CardAction className="top-5">
+						<Badge variant="secondary" className="text-xs">
+							{app.category}
+						</Badge>
+					</CardAction>
+				)}
+			</CardHeader>
+		</BaseCard>
+	);
+}
+
+function AppsPage() {
+	const [apps, setApps] = useState<HufApp[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			setApps(await getHufApps());
+		} catch (err: any) {
+			setError(err?.message || 'An error occurred while loading apps.');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	return (
+		<PageLayout
+			title="Apps"
+			subtitle="Launch applications built on HUF"
+		>
+			{error ? (
+				<div className="flex flex-col items-center justify-center py-12 text-center">
+					<TriangleAlert className="w-12 h-12 text-steel-soft mb-4" />
+					<p className="font-body text-steel-soft mb-2">Couldn't load apps</p>
+					<p className="text-sm text-steel mb-4">{error}</p>
+					<Button variant="outline" onClick={load}>
+						Retry
+					</Button>
+				</div>
+			) : (
+				<GridView
+					items={apps}
+					columns={{ sm: 1, md: 2, lg: 3 }}
+					loading={loading}
+					emptyState={
+						<div className="text-center py-12">
+							<AppWindow className="w-12 h-12 text-steel-soft mx-auto mb-4" />
+							<p className="font-body text-steel-soft mb-2">No apps available yet</p>
+							<p className="text-sm text-steel">
+								Installed apps that depend on HUF will appear here.
+							</p>
+						</div>
+					}
+					renderItem={(app) => <AppCard app={app} />}
+					keyExtractor={(app) => app.app_id}
+				/>
+			)}
+		</PageLayout>
+	);
+}

--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -12,6 +12,7 @@ import {
 	LoadMoreButton,
 } from '../components/dashboard';
 import { DeleteTableDialog } from '../components/data-table/DeleteTableDialog';
+import { AppTablesSection } from '../components/data-table/AppTablesSection';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getDataTables, deleteDataTable } from '../services/dataTableApi';
 import { formatTimeAgo } from '../utils/time';
@@ -158,6 +159,8 @@ function DataPage() {
 						: 'No more tables to load'}
 				</div>
 			)}
+
+			<AppTablesSection />
 
 			<DeleteTableDialog
 				open={!!deleteTable}

--- a/frontend/src/services/appsApi.ts
+++ b/frontend/src/services/appsApi.ts
@@ -21,3 +21,55 @@ export async function getHufApps(): Promise<HufApp[]> {
 		handleFrappeError(error, 'Error fetching HUF apps');
 	}
 }
+
+/**
+ * Enable or disable a registered HUF App (System Manager only). Backed
+ * by `huf.ai.apps_api.set_huf_app_enabled`, which returns `{ok: true}`
+ * or throws — either way the caller refetches the list afterwards.
+ */
+export async function setHufAppEnabled(appId: string, enabled: boolean): Promise<void> {
+	try {
+		await call.post('huf.ai.apps_api.set_huf_app_enabled', {
+			app_id: appId,
+			enabled: enabled ? 1 : 0,
+		});
+	} catch (error) {
+		handleFrappeError(error, 'Error updating HUF app');
+	}
+}
+
+/** A DocType an installed HUF App exposes, with its source app. */
+export interface ExposedAppTable {
+	doctype: string;
+	app_id: string;
+	app_title: string;
+}
+
+/**
+ * Flatten the `exposed_tables` (comma-separated DocType names) carried
+ * by apps in the `get_huf_apps` response into rows for the Data page's
+ * "App Tables" section. Apps without the field contribute nothing.
+ */
+export async function getExposedAppTables(): Promise<ExposedAppTable[]> {
+	try {
+		const result = await call.get('huf.ai.apps_api.get_huf_apps');
+		const apps = result?.message?.apps;
+		if (!Array.isArray(apps)) return [];
+		const rows: ExposedAppTable[] = [];
+		for (const app of apps as HufApp[]) {
+			if (typeof app?.exposed_tables !== 'string' || !app.exposed_tables.trim()) continue;
+			for (const raw of app.exposed_tables.split(',')) {
+				const doctype = raw.trim();
+				if (!doctype) continue;
+				rows.push({
+					doctype,
+					app_id: app.app_id,
+					app_title: app.title || app.app_id,
+				});
+			}
+		}
+		return rows;
+	} catch (error) {
+		handleFrappeError(error, 'Error fetching exposed app tables');
+	}
+}

--- a/frontend/src/services/appsApi.ts
+++ b/frontend/src/services/appsApi.ts
@@ -57,8 +57,13 @@ export async function getExposedAppTables(): Promise<ExposedAppTable[]> {
 		if (!Array.isArray(apps)) return [];
 		const rows: ExposedAppTable[] = [];
 		for (const app of apps as HufApp[]) {
-			if (typeof app?.exposed_tables !== 'string' || !app.exposed_tables.trim()) continue;
-			for (const raw of app.exposed_tables.split(',')) {
+			// Backend may return a list (current) or a comma-joined string.
+			const rawTables: string[] = Array.isArray(app?.exposed_tables)
+				? app.exposed_tables
+				: typeof app?.exposed_tables === 'string'
+					? app.exposed_tables.split(',')
+					: [];
+			for (const raw of rawTables) {
 				const doctype = raw.trim();
 				if (!doctype) continue;
 				rows.push({

--- a/frontend/src/services/appsApi.ts
+++ b/frontend/src/services/appsApi.ts
@@ -1,0 +1,23 @@
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+import type { HufApp } from '@/types/hufApp.types';
+
+/**
+ * Fetch the HUF Apps the current user is permitted to open, for the
+ * Apps launcher screen. Backed by the whitelisted method
+ * `huf.ai.apps_api.get_huf_apps`, whose payload is wrapped in the
+ * standard Frappe `{ message: ... }` envelope.
+ *
+ * Defensive by design: a missing/malformed `apps` key is treated as an
+ * empty list (the launcher shows its empty state), while a failed
+ * request (e.g. 404 before the backend ships) surfaces as an error.
+ */
+export async function getHufApps(): Promise<HufApp[]> {
+	try {
+		const result = await call.get('huf.ai.apps_api.get_huf_apps');
+		const apps = result?.message?.apps;
+		return Array.isArray(apps) ? (apps as HufApp[]) : [];
+	} catch (error) {
+		handleFrappeError(error, 'Error fetching HUF apps');
+	}
+}

--- a/frontend/src/types/hufApp.types.ts
+++ b/frontend/src/types/hufApp.types.ts
@@ -11,4 +11,12 @@ export interface HufApp {
 	icon?: string;
 	category?: string;
 	version?: string;
+	/**
+	 * Present only for System Managers: 1 = enabled, 0 = disabled. The
+	 * frontend treats the mere presence of this field as the signal to
+	 * show the enable/disable admin action (no client-side role check).
+	 */
+	enabled?: 0 | 1;
+	/** Comma-separated DocType names the app exposes to the Data page. */
+	exposed_tables?: string;
 }

--- a/frontend/src/types/hufApp.types.ts
+++ b/frontend/src/types/hufApp.types.ts
@@ -1,0 +1,14 @@
+/**
+ * Launcher metadata for a registered HUF App, as returned by the
+ * `huf.ai.apps_api.get_huf_apps` whitelisted method. Only safe,
+ * user-facing fields are exposed to the frontend.
+ */
+export interface HufApp {
+	app_id: string;
+	title: string;
+	description?: string;
+	route: string;
+	icon?: string;
+	category?: string;
+	version?: string;
+}

--- a/frontend/src/types/hufApp.types.ts
+++ b/frontend/src/types/hufApp.types.ts
@@ -18,5 +18,5 @@ export interface HufApp {
 	 */
 	enabled?: 0 | 1;
 	/** Comma-separated DocType names the app exposes to the Data page. */
-	exposed_tables?: string;
+	exposed_tables?: string | string[];
 }

--- a/huf/ai/app_seeding/apps_loader.py
+++ b/huf/ai/app_seeding/apps_loader.py
@@ -25,6 +25,21 @@ APP_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_\-]*$")
 ICON_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_\-]*$")
 URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:")
 
+# Documented default launcher categories. Custom categories are allowed (only
+# shape-checked) but noted at sync time; see _nonstandard_category_note.
+DEFAULT_CATEGORIES = (
+	"Create",
+	"Plan",
+	"Research",
+	"Automate",
+	"Analyze",
+	"Communicate",
+	"Manage",
+	"Other",
+)
+CATEGORY_MAX_LENGTH = 30
+MAX_EXPOSED_TABLES = 20
+
 # Top-level fields a manifest may declare. Anything else (including
 # provenance/sync fields such as source_app or manifest_hash) is rejected.
 ALLOWED_FIELDS = {
@@ -41,6 +56,7 @@ ALLOWED_FIELDS = {
 	"permission_method",
 	"sort_order",
 	"enabled",
+	"exposed_tables",
 }
 
 STRING_FIELDS = (
@@ -102,6 +118,66 @@ def _validate_permission_method(path) -> str | None:
 	return None
 
 
+def _validate_category(category) -> str | None:
+	"""Return an error message if the category has an invalid shape.
+
+	Only the shape is enforced (single line, no HTML, length cap); custom
+	categories are accepted and merely noted at sync time.
+	"""
+	if "\n" in category or "\r" in category:
+		return "category must be a single line"
+	if len(category) > CATEGORY_MAX_LENGTH:
+		return f"category must be at most {CATEGORY_MAX_LENGTH} characters"
+	if "<" in category or ">" in category:
+		return "category must not contain HTML"
+	return None
+
+
+def _validate_exposed_tables_shape(value) -> str | None:
+	"""Return an error message unless exposed_tables is a list of at most
+	MAX_EXPOSED_TABLES single-line DocType name strings."""
+	if not isinstance(value, list) or len(value) > MAX_EXPOSED_TABLES:
+		return f"exposed_tables must be a list of at most {MAX_EXPOSED_TABLES} DocType names"
+	for table in value:
+		if not isinstance(table, str) or not table.strip() or "\n" in table or "\r" in table:
+			return "exposed_tables entries must be single-line DocType name strings"
+	return None
+
+
+def _get_module_app(module: str) -> str | None:
+	"""App that owns the given Module Def (seam for tests)."""
+	return frappe.db.get_value("Module Def", module, "app_name")
+
+
+def _get_doctype_module(doctype: str) -> str:
+	"""Module of an existing DocType; raises for unknown ones (seam for tests)."""
+	return frappe.get_meta(doctype).module
+
+
+def _validate_exposed_tables(tables: list, source_app: str) -> str | None:
+	"""Return an error message unless every exposed table is an existing
+	DocType whose module belongs to the provider app. Never raises."""
+	for table in tables:
+		try:
+			module = _get_doctype_module(table)
+		except Exception:
+			return f"exposed_tables references unknown DocType '{table}'"
+		owner_app = _get_module_app(module)
+		if owner_app != source_app:
+			return (
+				f"exposed_tables DocType '{table}' is owned by app "
+				f"'{owner_app}', not provider app '{source_app}'"
+			)
+	return None
+
+
+def _nonstandard_category_note(app_id: str, category: str) -> str | None:
+	"""Info note for accepted categories outside the documented defaults."""
+	if category in DEFAULT_CATEGORIES:
+		return None
+	return f"HUF App '{app_id}' declares non-standard category '{category}'"
+
+
 def validate_manifest(data) -> tuple:
 	"""
 	Validate a raw manifest dict against the MVP grammar.
@@ -145,6 +221,15 @@ def validate_manifest(data) -> tuple:
 		if error := _validate_icon(icon):
 			return None, error
 
+	category = (data.get("category") or "").strip()
+	if category:
+		if error := _validate_category(category):
+			return None, error
+
+	exposed_tables = data.get("exposed_tables", [])
+	if error := _validate_exposed_tables_shape(exposed_tables):
+		return None, error
+
 	launch_mode = data.get("launch_mode", "route")
 	if not isinstance(launch_mode, str) or launch_mode.lower() != "route":
 		return None, "launch_mode must be 'route'"
@@ -167,12 +252,14 @@ def validate_manifest(data) -> tuple:
 		"version": (data.get("version") or "").strip(),
 		"route": route,
 		"icon": icon,
-		"category": (data.get("category") or "").strip() or "Other",
+		"category": category or "Other",
 		"launch_mode": "Route",
 		"required_huf_version": (data.get("required_huf_version") or "").strip(),
 		"permission_method": permission_method,
 		"sort_order": data.get("sort_order", 100),
 		"enabled": 1 if data.get("enabled", True) else 0,
+		# Stored on the DocType as a comma-joined string.
+		"exposed_tables": ",".join(t.strip() for t in exposed_tables),
 	}
 	return normalized, None
 
@@ -197,8 +284,17 @@ def upsert_huf_app(data: dict, source_app: str, source_file: str) -> tuple:
 		_record_invalid_manifest(data, error, source_app, source_file)
 		return False, error
 
+	# DocType existence/ownership can only be checked against the live site.
+	tables = [t for t in normalized["exposed_tables"].split(",") if t]
+	if error := _validate_exposed_tables(tables, source_app):
+		_record_invalid_manifest(data, error, source_app, source_file)
+		return False, error
+
 	app_id = normalized["app_id"]
 	manifest_hash = compute_manifest_hash(normalized)
+
+	if note := _nonstandard_category_note(app_id, normalized["category"]):
+		frappe.logger().info(note)
 
 	existing = frappe.db.get_value(
 		"HUF App",
@@ -240,6 +336,10 @@ def upsert_huf_app(data: dict, source_app: str, source_file: str) -> tuple:
 
 	try:
 		if existing:
+			# Manual-disable-wins: the manifest's enabled applies only when
+			# inserting a new record; updates never touch the stored flag
+			# (an admin may have disabled the app manually).
+			values.pop("enabled", None)
 			doc = frappe.get_doc("HUF App", app_id)
 			doc.update(values)
 			doc.save(ignore_permissions=True)
@@ -346,6 +446,7 @@ def sync_huf_apps() -> dict:
 		"deleted": 0,
 		"errors": [],
 		"deleted_apps": [],
+		"notes": [],
 	}
 	seen = set()
 
@@ -373,6 +474,10 @@ def sync_huf_apps() -> dict:
 					ok, error = upsert_huf_app(item, app_name, source_file)
 					if ok:
 						summary["synced"] += 1
+						if isinstance(item, dict):
+							category = (item.get("category") or "").strip() or "Other"
+							if note := _nonstandard_category_note(item.get("app_id"), category):
+								summary["notes"].append(note)
 					else:
 						summary["invalid"] += 1
 						summary["errors"].append(

--- a/huf/ai/app_seeding/apps_loader.py
+++ b/huf/ai/app_seeding/apps_loader.py
@@ -1,0 +1,414 @@
+"""
+HUF App manifest loader.
+
+Discovers flat ``*.json`` manifests under ``<installed_app>/huf/apps/``,
+validates them against the MVP manifest grammar (see HUF_APPS_MVP.md §6/§8.3)
+and syncs them into the ``HUF App`` registry DocType.
+
+Provenance fields (``source_app``, ``source_file``, ``manifest_hash`` and all
+sync state) are always derived here, never trusted from the manifest JSON.
+"""
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import frappe
+
+from .scanner import find_seed_dirs, get_seed_files
+
+APPS_FOLDER = "apps"
+
+SUPPORTED_MANIFEST_VERSION = 1
+
+APP_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_\-]*$")
+ICON_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_\-]*$")
+URL_SCHEME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:")
+
+# Top-level fields a manifest may declare. Anything else (including
+# provenance/sync fields such as source_app or manifest_hash) is rejected.
+ALLOWED_FIELDS = {
+	"manifest_version",
+	"app_id",
+	"title",
+	"description",
+	"version",
+	"route",
+	"icon",
+	"category",
+	"launch_mode",
+	"required_huf_version",
+	"permission_method",
+	"sort_order",
+	"enabled",
+}
+
+STRING_FIELDS = (
+	"app_id",
+	"title",
+	"description",
+	"version",
+	"route",
+	"icon",
+	"category",
+	"required_huf_version",
+	"permission_method",
+)
+
+
+def _is_int(value) -> bool:
+	return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_route(route) -> str | None:
+	"""Return an error message if the route is not a site-local path."""
+	if not route.startswith("/"):
+		return "route must be an absolute site-local path beginning with '/'"
+	if route.startswith("//"):
+		return "route must begin with exactly one '/' (protocol-relative URLs are not allowed)"
+	if "://" in route or URL_SCHEME_PATTERN.search(route):
+		return "route must not contain a URL scheme (external URLs are not allowed)"
+	return None
+
+
+def _validate_icon(icon) -> str | None:
+	"""Return an error message if the icon is neither a site-local asset
+	path nor a plain icon identifier."""
+	if icon.startswith("/"):
+		if icon.startswith("//") or "://" in icon:
+			return "icon must be a site-local asset path, not an external URL"
+		return None
+	if URL_SCHEME_PATTERN.search(icon):
+		return "icon must not contain a URL scheme"
+	if not ICON_NAME_PATTERN.match(icon):
+		return "icon must be a site-local asset path or a simple icon identifier"
+	return None
+
+
+def _validate_permission_method(path) -> str | None:
+	"""Return an error message unless the dotted path belongs to an installed
+	app and resolves to a callable."""
+	if "." not in path:
+		return "permission_method must be a dotted Python path"
+	root_module = path.split(".", 1)[0]
+	if root_module not in frappe.get_installed_apps():
+		return f"permission_method module '{root_module}' is not an installed app"
+	try:
+		fn = frappe.get_attr(path)
+	except Exception as e:
+		return f"permission_method '{path}' could not be imported: {e}"
+	if not callable(fn):
+		return f"permission_method '{path}' does not resolve to a callable"
+	return None
+
+
+def validate_manifest(data) -> tuple:
+	"""
+	Validate a raw manifest dict against the MVP grammar.
+
+	Returns (normalized_manifest, None) on success or (None, error_message).
+	The normalized manifest has defaults applied and launch_mode normalized to
+	the DocType Select value ("Route").
+	"""
+	if not isinstance(data, dict):
+		return None, "manifest must be a JSON object"
+
+	unknown = sorted(set(data) - ALLOWED_FIELDS)
+	if unknown:
+		return None, f"unknown top-level field(s): {', '.join(unknown)}"
+
+	if data.get("manifest_version") != SUPPORTED_MANIFEST_VERSION or not _is_int(data.get("manifest_version")):
+		return None, f"manifest_version must be the integer {SUPPORTED_MANIFEST_VERSION}"
+
+	for field in STRING_FIELDS:
+		if field in data and not isinstance(data[field], str):
+			return None, f"{field} must be a string"
+
+	app_id = (data.get("app_id") or "").strip()
+	if not app_id:
+		return None, "app_id is required"
+	if not APP_ID_PATTERN.match(app_id):
+		return None, "app_id must match ^[a-z][a-z0-9_\\-]*$"
+
+	title = (data.get("title") or "").strip()
+	if not title:
+		return None, "title is required"
+
+	route = (data.get("route") or "").strip()
+	if not route:
+		return None, "route is required"
+	if error := _validate_route(route):
+		return None, error
+
+	icon = (data.get("icon") or "").strip()
+	if icon:
+		if error := _validate_icon(icon):
+			return None, error
+
+	launch_mode = data.get("launch_mode", "route")
+	if not isinstance(launch_mode, str) or launch_mode.lower() != "route":
+		return None, "launch_mode must be 'route'"
+
+	if "sort_order" in data and not _is_int(data["sort_order"]):
+		return None, "sort_order must be an integer"
+
+	if "enabled" in data and not isinstance(data["enabled"], bool):
+		return None, "enabled must be a boolean"
+
+	permission_method = (data.get("permission_method") or "").strip()
+	if permission_method:
+		if error := _validate_permission_method(permission_method):
+			return None, error
+
+	normalized = {
+		"app_id": app_id,
+		"title": title,
+		"description": (data.get("description") or "").strip(),
+		"version": (data.get("version") or "").strip(),
+		"route": route,
+		"icon": icon,
+		"category": (data.get("category") or "").strip() or "Other",
+		"launch_mode": "Route",
+		"required_huf_version": (data.get("required_huf_version") or "").strip(),
+		"permission_method": permission_method,
+		"sort_order": data.get("sort_order", 100),
+		"enabled": 1 if data.get("enabled", True) else 0,
+	}
+	return normalized, None
+
+
+def compute_manifest_hash(normalized: dict) -> str:
+	"""sha256 over the normalized manifest, used to skip unchanged writes."""
+	payload = json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+	return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def upsert_huf_app(data: dict, source_app: str, source_file: str) -> tuple:
+	"""
+	Loader for the seeding LOAD_ORDER. Validates one manifest and inserts or
+	updates the matching ``HUF App`` registry record keyed by ``app_id``.
+
+	Returns (True, None) on success, (False, error_message) otherwise. Invalid
+	manifests are still recorded (sync_status="Invalid") when a usable app_id
+	is present, so System Managers can see what failed and why.
+	"""
+	normalized, error = validate_manifest(data)
+	if error:
+		_record_invalid_manifest(data, error, source_app, source_file)
+		return False, error
+
+	app_id = normalized["app_id"]
+	manifest_hash = compute_manifest_hash(normalized)
+
+	existing = frappe.db.get_value(
+		"HUF App",
+		app_id,
+		["source_app", "manifest_hash", "sync_status"],
+		as_dict=True,
+	)
+
+	if existing and existing.source_app and existing.source_app != source_app:
+		note = (
+			f"Duplicate app_id '{app_id}': already registered by app "
+			f"'{existing.source_app}'; manifest from app '{source_app}' "
+			f"({source_file}) was rejected."
+		)
+		frappe.log_error(note, "HUF App Registration Collision")
+		# Surface the collision on the registry without overwriting the
+		# existing valid registration.
+		frappe.db.set_value("HUF App", app_id, "sync_error", note, update_modified=False)
+		return False, note
+
+	now = frappe.utils.now_datetime()
+	values = {
+		**normalized,
+		"source_app": source_app,
+		"source_file": source_file,
+		"manifest_hash": manifest_hash,
+		"last_synced_at": now,
+		"sync_status": "Active",
+		"sync_error": "",
+	}
+
+	# Skip the write entirely when nothing changed.
+	if (
+		existing
+		and existing.manifest_hash == manifest_hash
+		and existing.sync_status == "Active"
+	):
+		return True, None
+
+	try:
+		if existing:
+			doc = frappe.get_doc("HUF App", app_id)
+			doc.update(values)
+			doc.save(ignore_permissions=True)
+		else:
+			frappe.get_doc({"doctype": "HUF App", **values}).insert(ignore_permissions=True)
+		return True, None
+	except Exception as e:
+		return False, str(e)
+
+
+def _record_invalid_manifest(data, error: str, source_app: str, source_file: str) -> None:
+	"""Best-effort registry record for an invalid manifest.
+
+	Only possible when the manifest still carries a usable app_id (the
+	registry is keyed by it); otherwise the failure is only logged.
+	"""
+	frappe.log_error(
+		f"Invalid HUF App manifest in {source_file} from app '{source_app}': {error}",
+		"HUF App Sync",
+	)
+	if not isinstance(data, dict):
+		return
+	app_id = data.get("app_id")
+	if not isinstance(app_id, str) or not APP_ID_PATTERN.match(app_id.strip()):
+		return
+	app_id = app_id.strip()
+	try:
+		# Never let an invalid manifest claim another provider's app_id.
+		existing_app = frappe.db.get_value("HUF App", app_id, "source_app")
+		if existing_app and existing_app != source_app:
+			return
+		title = data.get("title")
+		route = data.get("route")
+		values = {
+			"title": title.strip() if isinstance(title, str) and title.strip() else app_id,
+			"route": route.strip() if isinstance(route, str) and route.strip() and not _validate_route(route.strip()) else "/",
+			"enabled": 0,
+			"source_app": source_app,
+			"source_file": source_file,
+			"manifest_hash": "",
+			"last_synced_at": frappe.utils.now_datetime(),
+			"sync_status": "Invalid",
+			"sync_error": error,
+		}
+		if frappe.db.exists("HUF App", app_id):
+			doc = frappe.get_doc("HUF App", app_id)
+			doc.update(values)
+			doc.save(ignore_permissions=True)
+		else:
+			frappe.get_doc({"doctype": "HUF App", "app_id": app_id, **values}).insert(
+				ignore_permissions=True
+			)
+	except Exception as e:
+		frappe.log_error(
+			f"Failed to record invalid HUF App manifest '{app_id}': {e}",
+			"HUF App Sync",
+		)
+
+
+def cleanup_orphaned_apps(seen: set | None = None) -> list:
+	"""
+	Delete registry records whose provider app is no longer installed or whose
+	source manifest file was not seen during discovery (MVP: delete, do not
+	mark Missing).
+
+	``seen`` is a set of (source_app, source_file) pairs discovered during the
+	current sync run. When None, every record from an installed app is treated
+	as seen unless its source app was uninstalled.
+	Returns the list of deleted app_ids.
+	"""
+	installed_apps = set(frappe.get_installed_apps())
+	deleted = []
+	records = frappe.get_all(
+		"HUF App",
+		fields=["name", "app_id", "source_app", "source_file"],
+	)
+	for record in records:
+		orphaned = record.source_app not in installed_apps
+		if not orphaned and seen is not None:
+			orphaned = (record.source_app, record.source_file) not in seen
+		if not orphaned:
+			continue
+		try:
+			frappe.delete_doc("HUF App", record.name, ignore_permissions=True, force=True)
+			deleted.append(record.app_id or record.name)
+		except Exception as e:
+			frappe.log_error(
+				f"Failed to delete orphaned HUF App '{record.name}': {e}",
+				"HUF App Sync",
+			)
+	return deleted
+
+
+def sync_huf_apps() -> dict:
+	"""
+	Full registry sync: discover every ``huf/apps/`` manifest across installed
+	apps, upsert valid ones, record invalid ones, then delete orphaned
+	registry records. Commits one provider app at a time so a single failure
+	does not roll back other registrations.
+	"""
+	summary = {
+		"synced": 0,
+		"invalid": 0,
+		"deleted": 0,
+		"errors": [],
+		"deleted_apps": [],
+	}
+	seen = set()
+
+	for app_name, huf_dir in find_seed_dirs().items():
+		try:
+			for file_path in sorted(get_seed_files(huf_dir, APPS_FOLDER), key=lambda p: p.name):
+				source_file = f"huf/{APPS_FOLDER}/{file_path.name}"
+				try:
+					with open(file_path, "r", encoding="utf-8") as f:
+						data = json.load(f)
+				except Exception as e:
+					summary["invalid"] += 1
+					summary["errors"].append(
+						{"app": app_name, "file": source_file, "error": f"Error parsing manifest: {e}"}
+					)
+					frappe.log_error(
+						f"Error parsing HUF App manifest {file_path}: {e}",
+						"HUF App Sync",
+					)
+					continue
+
+				seen.add((app_name, source_file))
+				items = data if isinstance(data, list) else [data]
+				for item in items:
+					ok, error = upsert_huf_app(item, app_name, source_file)
+					if ok:
+						summary["synced"] += 1
+					else:
+						summary["invalid"] += 1
+						summary["errors"].append(
+							{"app": app_name, "file": source_file, "error": str(error)}
+						)
+			frappe.db.commit()
+		except Exception as e:
+			frappe.db.rollback()
+			summary["errors"].append({"app": app_name, "file": None, "error": str(e)})
+			frappe.log_error(
+				f"HUF App sync failed for provider app '{app_name}': {e}",
+				"HUF App Sync",
+			)
+
+	deleted = cleanup_orphaned_apps(seen)
+	summary["deleted"] = len(deleted)
+	summary["deleted_apps"] = deleted
+	frappe.db.commit()
+	return summary
+
+
+def on_app_uninstalled(app_name):
+	"""Hook for after_app_uninstall: remove registry entries of the provider
+	app that was just uninstalled."""
+	try:
+		records = frappe.get_all(
+			"HUF App",
+			filters={"source_app": app_name},
+			pluck="name",
+		)
+		for name in records:
+			frappe.delete_doc("HUF App", name, ignore_permissions=True, force=True)
+		if records:
+			frappe.db.commit()
+	except Exception as e:
+		frappe.log_error(
+			f"Error removing HUF App registry entries for uninstalled app '{app_name}': {e}",
+			"HUF App Sync",
+		)

--- a/huf/ai/app_seeding/seeder.py
+++ b/huf/ai/app_seeding/seeder.py
@@ -12,6 +12,7 @@ from .loaders import (
     upsert_agent,
     upsert_trigger
 )
+from .apps_loader import upsert_huf_app
 
 @dataclass
 class SeedResult:
@@ -21,13 +22,16 @@ class SeedResult:
     errors: List[str]
     skipped_records: List[dict] = field(default_factory=list)
 
-# Load order matters for dependency resolution
+# Load order matters for dependency resolution.
+# Apps load last so a manifest may later reference agents/capabilities
+# seeded by the same provider app.
 LOAD_ORDER = [
     ("prompts", upsert_prompt),
     ("tools", upsert_tool),
     ("knowledge", upsert_knowledge),
     ("agents", upsert_agent),
-    ("triggers", upsert_trigger)
+    ("triggers", upsert_trigger),
+    ("apps", upsert_huf_app)
 ]
 
 def seed_app(app_name: str, huf_dir: Path) -> SeedResult:
@@ -51,7 +55,7 @@ def seed_app(app_name: str, huf_dir: Path) -> SeedResult:
                     else:
                         result.skipped += 1
                         # Use a fallback name if the key isn't standard across all types
-                        item_name = item.get('name') or item.get('title') or item.get('agent_name') or item.get('tool_name') or item.get('source_name') or file_path.name
+                        item_name = item.get('name') or item.get('app_id') or item.get('title') or item.get('agent_name') or item.get('tool_name') or item.get('source_name') or file_path.name
 
                         if isinstance(error, dict) and error.get("reason") == "missing_refs":
                             missing_refs = error.get("missing_refs", [])

--- a/huf/ai/app_seeding/tests/test_apps_sync.py
+++ b/huf/ai/app_seeding/tests/test_apps_sync.py
@@ -14,7 +14,7 @@ import frappe
 from huf.ai.app_seeding import apps_loader
 from huf.ai.app_seeding.apps_loader import sync_huf_apps, upsert_huf_app, validate_manifest
 from huf.ai.app_seeding.seeder import seed_app
-from huf.ai.apps_api import get_huf_app, get_huf_apps
+from huf.ai.apps_api import get_huf_app, get_huf_apps, set_huf_app_enabled
 
 
 def allow_all(user=None, app=None):
@@ -286,6 +286,182 @@ class TestAppsSync(unittest.TestCase):
 
 		self.assertFalse(frappe.db.exists("HUF App", app_id))
 
+	# ------------------------------------------------------------------
+	# Manual-disable-wins
+	# ------------------------------------------------------------------
+
+	def test_enabled_applied_on_initial_insert(self):
+		"""The manifest's enabled flag applies when a record is first created."""
+		app_id = self._app_id("insertdisabled")
+		ok, error = upsert_huf_app(
+			self._valid_manifest(app_id, enabled=False),
+			self.test_app,
+			"huf/apps/insert_disabled.app.json",
+		)
+		self.assertTrue(ok, error)
+		self.assertEqual(frappe.db.get_value("HUF App", app_id, "enabled"), 0)
+
+	def test_manual_disable_wins_on_resync(self):
+		"""Re-syncing never re-enables an app an admin disabled manually."""
+		app_id = self._app_id("manualdisable")
+		ok, error = upsert_huf_app(
+			self._valid_manifest(app_id, enabled=True),
+			self.test_app,
+			"huf/apps/manual_disable.app.json",
+		)
+		self.assertTrue(ok, error)
+		frappe.db.set_value("HUF App", app_id, "enabled", 0)
+
+		ok, error = upsert_huf_app(
+			self._valid_manifest(app_id, enabled=True, title="Renamed App"),
+			self.test_app,
+			"huf/apps/manual_disable.app.json",
+		)
+		self.assertTrue(ok, error)
+
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.enabled, 0, "Manual disable must survive re-sync")
+		self.assertEqual(doc.title, "Renamed App", "Other manifest changes still apply")
+
+	def test_enabled_only_change_updates_hash_not_flag(self):
+		"""A manifest whose only change is `enabled` updates manifest_hash
+		but leaves the stored enabled flag untouched."""
+		app_id = self._app_id("enabledonly")
+		ok, error = upsert_huf_app(
+			self._valid_manifest(app_id, enabled=True),
+			self.test_app,
+			"huf/apps/enabled_only.app.json",
+		)
+		self.assertTrue(ok, error)
+		hash_before = frappe.db.get_value("HUF App", app_id, "manifest_hash")
+
+		ok, error = upsert_huf_app(
+			self._valid_manifest(app_id, enabled=False),
+			self.test_app,
+			"huf/apps/enabled_only.app.json",
+		)
+		self.assertTrue(ok, error)
+
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.enabled, 1, "Stored flag must not flip on update")
+		self.assertNotEqual(doc.manifest_hash, hash_before, "manifest_hash must still update")
+
+	# ------------------------------------------------------------------
+	# Category conventions
+	# ------------------------------------------------------------------
+
+	def test_nonstandard_category_accepted_and_noted(self):
+		"""A custom single-line category syncs fine and is noted in the
+		sync summary (never rejected)."""
+		app_id = self._app_id("customcat")
+		self._write_manifest(
+			self.huf_dir,
+			"customcat.app.json",
+			self._valid_manifest(app_id, category="Growth Hacks"),
+		)
+
+		original_find_seed_dirs = apps_loader.find_seed_dirs
+		original_get_installed_apps = frappe.get_installed_apps
+		apps_loader.find_seed_dirs = lambda: {self.test_app: self.huf_dir}
+		frappe.get_installed_apps = lambda: original_get_installed_apps() + [self.test_app]
+		try:
+			summary = sync_huf_apps()
+		finally:
+			apps_loader.find_seed_dirs = original_find_seed_dirs
+			frappe.get_installed_apps = original_get_installed_apps
+
+		self.assertEqual(summary["invalid"], 0, f"Unexpected errors: {summary['errors']}")
+		self.assertEqual(frappe.db.get_value("HUF App", app_id, "category"), "Growth Hacks")
+		self.assertEqual(frappe.db.get_value("HUF App", app_id, "sync_status"), "Active")
+		self.assertTrue(
+			any("Growth Hacks" in note for note in summary["notes"]),
+			"Non-standard category should be noted in the sync summary",
+		)
+
+	def test_bad_categories_rejected(self):
+		"""Overlong, multi-line and HTML categories are rejected; a synced
+		manifest with one is recorded Invalid."""
+		for bad in ("x" * 31, "Multi\nLine", "<b>Evil</b>"):
+			normalized, error = validate_manifest(self._valid_manifest("tapps_x", category=bad))
+			self.assertIsNone(normalized)
+			self.assertIn("category", error)
+
+		app_id = self._app_id("longcat")
+		ok, error = upsert_huf_app(
+			self._valid_manifest(app_id, category="x" * 31),
+			self.test_app,
+			"huf/apps/longcat.app.json",
+		)
+		self.assertFalse(ok)
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.sync_status, "Invalid")
+		self.assertIn("category", doc.sync_error)
+
+	# ------------------------------------------------------------------
+	# exposed_tables
+	# ------------------------------------------------------------------
+
+	def test_exposed_tables_shape_validated(self):
+		"""exposed_tables must be a list of at most 20 single-line strings."""
+		normalized, error = validate_manifest(
+			self._valid_manifest("tapps_x", exposed_tables="HUF App")
+		)
+		self.assertIsNone(normalized)
+		self.assertIn("exposed_tables", error)
+
+		normalized, error = validate_manifest(
+			self._valid_manifest("tapps_x", exposed_tables=[f"Table {i}" for i in range(21)])
+		)
+		self.assertIsNone(normalized)
+		self.assertIn("exposed_tables", error)
+
+	def test_exposed_tables_valid_syncs_and_is_exposed(self):
+		"""Tables owned by the provider app sync (stored comma-joined) and
+		are exposed as a list by get_huf_app."""
+		app_id = self._app_id("tables")
+		manifest = self._valid_manifest(
+			app_id, exposed_tables=["Fake Table One", "Fake Table Two"]
+		)
+
+		original_get_doctype_module = apps_loader._get_doctype_module
+		original_get_module_app = apps_loader._get_module_app
+		apps_loader._get_doctype_module = lambda doctype: "Test Apps Sync"
+		apps_loader._get_module_app = lambda module: self.test_app
+		try:
+			ok, error = upsert_huf_app(manifest, self.test_app, "huf/apps/tables.app.json")
+		finally:
+			apps_loader._get_doctype_module = original_get_doctype_module
+			apps_loader._get_module_app = original_get_module_app
+
+		self.assertTrue(ok, error)
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.exposed_tables, "Fake Table One,Fake Table Two")
+
+		app = get_huf_app(app_id)
+		self.assertEqual(app["exposed_tables"], ["Fake Table One", "Fake Table Two"])
+
+	def test_exposed_tables_unknown_doctype_recorded_invalid(self):
+		"""An unknown DocType in exposed_tables records the manifest
+		Invalid without crashing the sync."""
+		app_id = self._app_id("badtables")
+		manifest = self._valid_manifest(app_id, exposed_tables=["No Such DocType"])
+
+		original_get_doctype_module = apps_loader._get_doctype_module
+
+		def fake_get_doctype_module(doctype):
+			raise frappe.DoesNotExistError(doctype)
+
+		apps_loader._get_doctype_module = fake_get_doctype_module
+		try:
+			ok, error = upsert_huf_app(manifest, self.test_app, "huf/apps/badtables.app.json")
+		finally:
+			apps_loader._get_doctype_module = original_get_doctype_module
+
+		self.assertFalse(ok)
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.sync_status, "Invalid")
+		self.assertIn("unknown DocType", doc.sync_error)
+
 
 class TestAppsApiPermissions(unittest.TestCase):
 	"""Permission filtering in the launcher API."""
@@ -452,6 +628,41 @@ class TestAppsApiPermissions(unittest.TestCase):
 				sync_endpoint()
 		finally:
 			frappe.set_user("Administrator")
+
+	def test_set_huf_app_enabled_requires_system_manager(self):
+		"""Non-System-Managers cannot toggle registry records."""
+		frappe.set_user(self.normal_user)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				set_huf_app_enabled(self.enabled_id, False)
+		finally:
+			frappe.set_user("Administrator")
+		self.assertEqual(frappe.db.get_value("HUF App", self.enabled_id, "enabled"), 1)
+
+	def test_set_huf_app_enabled_toggles_flag(self):
+		"""Administrator can toggle the flag; truthy strings are parsed."""
+		result = set_huf_app_enabled(self.enabled_id, "false")
+		self.assertEqual(result, {"ok": True, "app_id": self.enabled_id, "enabled": False})
+		self.assertEqual(frappe.db.get_value("HUF App", self.enabled_id, "enabled"), 0)
+
+		result = set_huf_app_enabled(self.enabled_id, "1")
+		self.assertTrue(result["enabled"])
+		self.assertEqual(frappe.db.get_value("HUF App", self.enabled_id, "enabled"), 1)
+
+	def test_enabled_field_only_exposed_to_system_manager(self):
+		"""get_huf_apps includes enabled/exposed_tables for System Managers,
+		never for normal users."""
+		admin_apps = {a["app_id"]: a for a in get_huf_apps()["apps"]}
+		self.assertIn("enabled", admin_apps[self.enabled_id])
+		self.assertIn("exposed_tables", admin_apps[self.enabled_id])
+
+		frappe.set_user(self.normal_user)
+		try:
+			user_apps = {a["app_id"]: a for a in get_huf_apps()["apps"]}
+		finally:
+			frappe.set_user("Administrator")
+		self.assertNotIn("enabled", user_apps[self.enabled_id])
+		self.assertNotIn("exposed_tables", user_apps[self.enabled_id])
 
 
 if __name__ == "__main__":

--- a/huf/ai/app_seeding/tests/test_apps_sync.py
+++ b/huf/ai/app_seeding/tests/test_apps_sync.py
@@ -1,0 +1,458 @@
+"""
+Tests for HUF App manifest sync and the launcher API.
+Run with:
+    bench --site hufai.localhost run-tests --app huf --module huf.ai.app_seeding.tests.test_apps_sync
+"""
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import frappe
+
+from huf.ai.app_seeding import apps_loader
+from huf.ai.app_seeding.apps_loader import sync_huf_apps, upsert_huf_app, validate_manifest
+from huf.ai.app_seeding.seeder import seed_app
+from huf.ai.apps_api import get_huf_app, get_huf_apps
+
+
+def allow_all(user=None, app=None):
+	"""permission_method test double: always allow."""
+	return True
+
+
+def deny_all(user=None, app=None):
+	"""permission_method test double: always deny."""
+	return False
+
+
+ALLOW_ALL_PATH = "huf.ai.app_seeding.tests.test_apps_sync.allow_all"
+DENY_ALL_PATH = "huf.ai.app_seeding.tests.test_apps_sync.deny_all"
+
+
+class TestAppsSync(unittest.TestCase):
+	"""Acceptance tests for the HUF Apps registry sync."""
+
+	def setUp(self):
+		self.test_app = "test_apps_sync_app"
+		self.test_app_b = "test_apps_sync_app_b"
+		self.huf_dir = Path(tempfile.mkdtemp()) / "huf"
+		self.huf_dir.mkdir()
+		self.huf_dir_b = Path(tempfile.mkdtemp()) / "huf"
+		self.huf_dir_b.mkdir()
+
+		# Unique, app_id-safe suffix to avoid collisions across test runs
+		self.suffix = frappe.generate_hash(length=8).lower()
+		self._created_app_ids = []
+
+	def tearDown(self):
+		shutil.rmtree(self.huf_dir.parent, ignore_errors=True)
+		shutil.rmtree(self.huf_dir_b.parent, ignore_errors=True)
+
+		for app_id in self._created_app_ids:
+			try:
+				frappe.db.sql("DELETE FROM `tabHUF App` WHERE name = %s", app_id)
+			except Exception:
+				pass
+
+		frappe.set_user("Administrator")
+		frappe.db.commit()
+
+	def _write_manifest(self, folder_path, filename, payload):
+		target_dir = folder_path / "apps"
+		target_dir.mkdir(exist_ok=True)
+		target_path = target_dir / filename
+		with open(target_path, "w", encoding="utf-8") as f:
+			json.dump(payload, f)
+		return target_path
+
+	def _app_id(self, label):
+		app_id = f"tapps_{label}_{self.suffix}"
+		self._created_app_ids.append(app_id)
+		return app_id
+
+	def _valid_manifest(self, app_id, **overrides):
+		manifest = {
+			"manifest_version": 1,
+			"app_id": app_id,
+			"title": "Test App",
+			"description": "A test HUF App.",
+			"version": "0.1.0",
+			"route": f"/{app_id}",
+			"icon": "/assets/test_apps_sync_app/icon.svg",
+			"category": "Create",
+			"launch_mode": "route",
+			"sort_order": 10,
+			"enabled": True,
+		}
+		manifest.update(overrides)
+		return manifest
+
+	# ------------------------------------------------------------------
+	# Valid manifests
+	# ------------------------------------------------------------------
+
+	def test_valid_manifest_syncs_to_registry(self):
+		"""A valid manifest is discovered by seed_app and synced to the
+		registry with provenance and sync state recorded by HUF."""
+		app_id = self._app_id("valid")
+		self._write_manifest(self.huf_dir, "valid.app.json", self._valid_manifest(app_id))
+
+		result = seed_app(self.test_app, self.huf_dir)
+
+		self.assertEqual(result.skipped, 0, f"Valid manifest should not be skipped: {result.errors}")
+		self.assertTrue(frappe.db.exists("HUF App", app_id))
+
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.title, "Test App")
+		self.assertEqual(doc.route, f"/{app_id}")
+		self.assertEqual(doc.category, "Create")
+		self.assertEqual(doc.launch_mode, "Route")
+		self.assertEqual(doc.sort_order, 10)
+		self.assertEqual(doc.enabled, 1)
+		self.assertEqual(doc.sync_status, "Active")
+		self.assertEqual(doc.source_app, self.test_app)
+		self.assertEqual(doc.source_file, "huf/apps/valid.app.json")
+		self.assertTrue(doc.manifest_hash)
+		self.assertTrue(doc.last_synced_at)
+
+	def test_provenance_fields_in_manifest_are_rejected(self):
+		"""source_app/source_file/manifest_hash must never be trusted from
+		the manifest JSON; they are unknown top-level fields."""
+		app_id = self._app_id("provenance")
+		manifest = self._valid_manifest(app_id, source_app="malicious_app")
+
+		normalized, error = validate_manifest(manifest)
+
+		self.assertIsNone(normalized)
+		self.assertIn("unknown top-level field", error)
+
+	def test_unchanged_manifest_skips_write(self):
+		"""A second sync with an identical manifest does not rewrite the
+		registry record (hash comparison)."""
+		app_id = self._app_id("hashskip")
+		manifest = self._valid_manifest(app_id)
+
+		ok, error = upsert_huf_app(manifest, self.test_app, "huf/apps/hashskip.app.json")
+		self.assertTrue(ok, error)
+		modified_after_insert = frappe.db.get_value("HUF App", app_id, "modified")
+
+		ok, error = upsert_huf_app(manifest, self.test_app, "huf/apps/hashskip.app.json")
+		self.assertTrue(ok, error)
+		modified_after_resync = frappe.db.get_value("HUF App", app_id, "modified")
+
+		self.assertEqual(modified_after_insert, modified_after_resync)
+
+	# ------------------------------------------------------------------
+	# Invalid manifests
+	# ------------------------------------------------------------------
+
+	def test_invalid_manifests_do_not_break_valid_ones(self):
+		"""Bad route, unknown field, bad app_id and external URL manifests
+		are isolated; the valid manifest in the same folder still syncs."""
+		valid_id = self._app_id("mixedvalid")
+		bad_route_id = self._app_id("badroute")
+		unknown_field_id = self._app_id("unknownfield")
+		external_url_id = self._app_id("externalurl")
+
+		self._write_manifest(self.huf_dir, "valid.app.json", self._valid_manifest(valid_id))
+		self._write_manifest(
+			self.huf_dir,
+			"bad_route.app.json",
+			self._valid_manifest(bad_route_id, route="//evil.com/app"),
+		)
+		self._write_manifest(
+			self.huf_dir,
+			"unknown_field.app.json",
+			self._valid_manifest(unknown_field_id, bundle_url="https://evil.com/x.js"),
+		)
+		self._write_manifest(
+			self.huf_dir,
+			"external_url.app.json",
+			self._valid_manifest(external_url_id, route="https://evil.com/app"),
+		)
+		self._write_manifest(
+			self.huf_dir,
+			"bad_app_id.app.json",
+			self._valid_manifest("Bad App ID!"),
+		)
+
+		result = seed_app(self.test_app, self.huf_dir)
+
+		# Valid manifest still loads
+		self.assertTrue(frappe.db.exists("HUF App", valid_id))
+		self.assertEqual(
+			frappe.db.get_value("HUF App", valid_id, "sync_status"), "Active"
+		)
+
+		# Manifests with a usable app_id are recorded as Invalid, not Active
+		for app_id in (bad_route_id, unknown_field_id, external_url_id):
+			self.assertTrue(frappe.db.exists("HUF App", app_id), f"{app_id} should be recorded")
+			doc = frappe.get_doc("HUF App", app_id)
+			self.assertEqual(doc.sync_status, "Invalid")
+			self.assertTrue(doc.sync_error)
+			self.assertEqual(doc.enabled, 0)
+
+		# A manifest without a usable app_id cannot be recorded, but must not crash
+		self.assertFalse(frappe.db.exists("HUF App", "Bad App ID!"))
+		self.assertEqual(result.skipped, 4)
+
+	def test_invalid_permission_method_recorded_invalid(self):
+		"""A permission_method that does not resolve to a callable marks the
+		record Invalid without crashing the sync."""
+		app_id = self._app_id("badperm")
+		self._write_manifest(
+			self.huf_dir,
+			"bad_perm.app.json",
+			self._valid_manifest(app_id, permission_method="huf.does.not.exist"),
+		)
+
+		result = seed_app(self.test_app, self.huf_dir)
+
+		self.assertEqual(result.skipped, 1)
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.sync_status, "Invalid")
+		self.assertIn("permission_method", doc.sync_error)
+
+	# ------------------------------------------------------------------
+	# Duplicate app_id
+	# ------------------------------------------------------------------
+
+	def test_duplicate_app_id_does_not_silently_overwrite(self):
+		"""Two provider apps declaring the same app_id: the existing valid
+		registration is kept, the collision is logged and surfaced."""
+		app_id = self._app_id("duplicate")
+		self._write_manifest(
+			self.huf_dir, "dup.app.json", self._valid_manifest(app_id, title="First App")
+		)
+		self._write_manifest(
+			self.huf_dir_b, "dup.app.json", self._valid_manifest(app_id, title="Second App")
+		)
+
+		result_a = seed_app(self.test_app, self.huf_dir)
+		self.assertEqual(result_a.skipped, 0)
+
+		result_b = seed_app(self.test_app_b, self.huf_dir_b)
+		self.assertEqual(result_b.skipped, 1, "Colliding manifest should be rejected")
+
+		doc = frappe.get_doc("HUF App", app_id)
+		self.assertEqual(doc.title, "First App", "Existing registration must be kept")
+		self.assertEqual(doc.source_app, self.test_app)
+		self.assertEqual(doc.sync_status, "Active")
+		self.assertIn("Duplicate app_id", doc.sync_error)
+
+	# ------------------------------------------------------------------
+	# Orphan cleanup
+	# ------------------------------------------------------------------
+
+	def test_removed_manifest_deletes_registry_record(self):
+		"""A registry record whose source file no longer exists is deleted on
+		the next full sync."""
+		app_id = self._app_id("orphan")
+		manifest_path = self._write_manifest(
+			self.huf_dir, "orphan.app.json", self._valid_manifest(app_id)
+		)
+
+		original_find_seed_dirs = apps_loader.find_seed_dirs
+		original_get_installed_apps = frappe.get_installed_apps
+		apps_loader.find_seed_dirs = lambda: {self.test_app: self.huf_dir}
+		frappe.get_installed_apps = lambda: original_get_installed_apps() + [self.test_app]
+		try:
+			summary = sync_huf_apps()
+			self.assertEqual(summary["invalid"], 0, f"Unexpected errors: {summary['errors']}")
+			self.assertTrue(frappe.db.exists("HUF App", app_id))
+
+			manifest_path.unlink()
+			summary = sync_huf_apps()
+		finally:
+			apps_loader.find_seed_dirs = original_find_seed_dirs
+			frappe.get_installed_apps = original_get_installed_apps
+
+		self.assertFalse(
+			frappe.db.exists("HUF App", app_id),
+			"Orphaned registry record should be deleted",
+		)
+		self.assertIn(app_id, summary["deleted_apps"])
+
+	def test_uninstalled_provider_app_removes_registry_entries(self):
+		"""The after_app_uninstall hook deletes all entries of the provider."""
+		app_id = self._app_id("uninstall")
+		self._write_manifest(self.huf_dir, "uninstall.app.json", self._valid_manifest(app_id))
+		seed_app(self.test_app, self.huf_dir)
+		self.assertTrue(frappe.db.exists("HUF App", app_id))
+
+		apps_loader.on_app_uninstalled(self.test_app)
+
+		self.assertFalse(frappe.db.exists("HUF App", app_id))
+
+
+class TestAppsApiPermissions(unittest.TestCase):
+	"""Permission filtering in the launcher API."""
+
+	def setUp(self):
+		self.suffix = frappe.generate_hash(length=8).lower()
+		self.test_app = "test_apps_sync_app"
+		self._created_app_ids = []
+
+		self.enabled_id = self._app_id("enabled")
+		self.disabled_id = self._app_id("disabled")
+		self.allow_id = self._app_id("allow")
+		self.deny_id = self._app_id("deny")
+
+		self._make_registry_app(self.enabled_id, enabled=1)
+		self._make_registry_app(self.disabled_id, enabled=0)
+		self._make_registry_app(self.allow_id, enabled=1, permission_method=ALLOW_ALL_PATH)
+		self._make_registry_app(self.deny_id, enabled=1, permission_method=DENY_ALL_PATH)
+
+		# A normal user with the Huf User role (grants agent.use)
+		self.normal_user = f"test-apps-sync-{self.suffix}@example.com"
+		self._ensure_huf_user_capability()
+		if not frappe.db.exists("User", self.normal_user):
+			user = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": self.normal_user,
+					"first_name": "Test Apps Sync",
+					"send_welcome_email": 0,
+				}
+			)
+			user.insert(ignore_permissions=True)
+		if not frappe.db.exists("Huf User Role", {"user": self.normal_user}):
+			frappe.get_doc(
+				{
+					"doctype": "Huf User Role",
+					"user": self.normal_user,
+					"huf_role": "Huf User",
+					"enabled": 1,
+				}
+			).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for app_id in self._created_app_ids:
+			try:
+				frappe.db.sql("DELETE FROM `tabHUF App` WHERE name = %s", app_id)
+			except Exception:
+				pass
+		try:
+			frappe.db.sql("DELETE FROM `tabHuf User Role` WHERE user = %s", self.normal_user)
+			frappe.db.sql("DELETE FROM `tabUser` WHERE name = %s", self.normal_user)
+		except Exception:
+			pass
+		frappe.db.commit()
+
+	def _app_id(self, label):
+		app_id = f"tapps_api_{label}_{self.suffix}"
+		self._created_app_ids.append(app_id)
+		return app_id
+
+	def _make_registry_app(self, app_id, enabled=1, permission_method=None):
+		frappe.get_doc(
+			{
+				"doctype": "HUF App",
+				"app_id": app_id,
+				"title": app_id,
+				"description": "API permission test app",
+				"route": f"/{app_id}",
+				"category": "Other",
+				"version": "0.1.0",
+				"launch_mode": "Route",
+				"sort_order": 100,
+				"enabled": enabled,
+				"permission_method": permission_method or "",
+				"sync_status": "Active",
+				"source_app": self.test_app,
+				"source_file": "huf/apps/test.app.json",
+			}
+		).insert(ignore_permissions=True)
+
+	def _ensure_huf_user_capability(self):
+		"""Make sure the 'Huf User' Huf Role exists and grants agent.use."""
+		if not frappe.db.exists("Huf Role", "Huf User"):
+			doc = frappe.get_doc(
+				{
+					"doctype": "Huf Role",
+					"role_name": "Huf User",
+					"description": "End user.",
+					"is_system_role": 1,
+					"frappe_role": "Huf User",
+				}
+			)
+			doc.append("permissions", {"capability": "agent.use"})
+			doc.insert(ignore_permissions=True)
+		elif not frappe.db.exists(
+			"Huf Role Permission", {"parent": "Huf User", "capability": "agent.use"}
+		):
+			doc = frappe.get_doc("Huf Role", "Huf User")
+			doc.append("permissions", {"capability": "agent.use"})
+			doc.save(ignore_permissions=True)
+
+	def _listed_ids(self, user):
+		frappe.set_user(user)
+		try:
+			return {app["app_id"] for app in get_huf_apps()["apps"]}
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_administrator_sees_all_valid_registrations(self):
+		ids = self._listed_ids("Administrator")
+		self.assertIn(self.enabled_id, ids)
+		self.assertIn(self.disabled_id, ids, "System Manager sees disabled apps too")
+		self.assertIn(self.allow_id, ids)
+		self.assertIn(self.deny_id, ids)
+
+	def test_normal_user_filtering(self):
+		ids = self._listed_ids(self.normal_user)
+		self.assertIn(self.enabled_id, ids, "Enabled app without permission_method needs base access")
+		self.assertNotIn(self.disabled_id, ids, "Disabled apps are hidden from normal users")
+		self.assertIn(self.allow_id, ids, "permission_method allowing the user is honored")
+		self.assertNotIn(self.deny_id, ids, "permission_method denying the user is honored")
+
+	def test_guest_sees_nothing(self):
+		ids = self._listed_ids("Guest")
+		self.assertEqual(ids, set())
+
+	def test_only_safe_fields_are_returned(self):
+		frappe.set_user(self.normal_user)
+		try:
+			apps = get_huf_apps()["apps"]
+		finally:
+			frappe.set_user("Administrator")
+
+		self.assertTrue(apps)
+		for app in apps:
+			self.assertEqual(
+				set(app),
+				{"app_id", "title", "description", "route", "icon", "category", "version"},
+				"Only safe launcher fields may be exposed",
+			)
+
+	def test_get_huf_app_detail_and_denied(self):
+		frappe.set_user(self.normal_user)
+		try:
+			app = get_huf_app(self.enabled_id)
+			self.assertEqual(app["app_id"], self.enabled_id)
+			self.assertNotIn("permission_method", app)
+
+			with self.assertRaises(frappe.DoesNotExistError):
+				get_huf_app(self.deny_id)
+
+			with self.assertRaises(frappe.DoesNotExistError):
+				get_huf_app(f"tapps_api_missing_{self.suffix}")
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_sync_endpoint_requires_system_manager(self):
+		frappe.set_user(self.normal_user)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				from huf.ai.apps_api import sync_huf_apps as sync_endpoint
+
+				sync_endpoint()
+		finally:
+			frappe.set_user("Administrator")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/apps_api.py
+++ b/huf/ai/apps_api.py
@@ -6,13 +6,21 @@ Security boundaries (HUF_APPS_MVP.md §8.5/§13):
     (never permission_method, source_file, manifest_hash or sync_error);
   - visibility is evaluated server-side per record;
   - a hidden app fails exactly like a nonexistent one.
+
+Note for app developers (known behavior, not a bug): agent runs are
+graceful-error tolerant — a run can return success while carrying an error
+text payload (see run_agent_sync), so providers should surface the payload,
+not just the status.
 """
 import frappe
 from frappe import _
 
 from huf.permissions import ADMINISTRATOR, SYSTEM_MANAGER, has_capability
 
-# Fields that are safe to expose to any permitted user.
+# Fields that are safe to expose to any permitted user. exposed_tables is
+# also safe (it reveals only DocType names the provider explicitly
+# published), but is stored comma-joined and shaped as a list on output;
+# see _safe_app_dict.
 SAFE_FIELDS = ("app_id", "title", "description", "route", "icon", "category", "version")
 
 # Capability required to see apps that declare no permission_method.
@@ -75,8 +83,26 @@ def _can_user_see(record: dict, user: str) -> bool:
 	return has_capability(user, BASE_ACCESS_CAPABILITY)
 
 
-def _safe_app_dict(record: dict) -> dict:
-	return {field: record.get(field) for field in SAFE_FIELDS}
+def _split_exposed_tables(value) -> list:
+	"""Comma-joined registry string -> list of DocType names."""
+	if not value:
+		return []
+	return [table.strip() for table in value.split(",") if table.strip()]
+
+
+def _safe_app_dict(record: dict, system_manager: bool = False, detail: bool = False) -> dict:
+	"""Shape a registry record for output.
+
+	exposed_tables (as a list) goes to any permitted user on the detail
+	endpoint, and to System Managers on the list endpoint. enabled is only
+	ever exposed to System Manager/Administrator requests.
+	"""
+	app = {field: record.get(field) for field in SAFE_FIELDS}
+	if detail or system_manager:
+		app["exposed_tables"] = _split_exposed_tables(record.get("exposed_tables"))
+	if system_manager:
+		app["enabled"] = 1 if record.get("enabled") else 0
+	return app
 
 
 @frappe.whitelist()
@@ -91,6 +117,7 @@ def get_huf_apps() -> dict:
 	if not user or user == "Guest":
 		return {"apps": []}
 
+	system_manager = _is_system_manager(user)
 	records = frappe.get_all(
 		"HUF App",
 		fields=[
@@ -102,6 +129,7 @@ def get_huf_apps() -> dict:
 			"category",
 			"version",
 			"enabled",
+			"exposed_tables",
 			"permission_method",
 			"sync_status",
 			"sort_order",
@@ -109,7 +137,11 @@ def get_huf_apps() -> dict:
 		order_by="sort_order asc, title asc",
 	)
 
-	apps = [_safe_app_dict(r) for r in records if _can_user_see(r, user)]
+	apps = [
+		_safe_app_dict(r, system_manager=system_manager)
+		for r in records
+		if _can_user_see(r, user)
+	]
 	return {"apps": apps}
 
 
@@ -136,6 +168,7 @@ def get_huf_app(app_id: str) -> dict:
 				"category",
 				"version",
 				"enabled",
+				"exposed_tables",
 				"permission_method",
 				"sync_status",
 			],
@@ -145,7 +178,7 @@ def get_huf_app(app_id: str) -> dict:
 	if not record or not _can_user_see(record, user):
 		frappe.throw(_("HUF App {0} not found").format(app_id), frappe.DoesNotExistError)
 
-	return _safe_app_dict(record)
+	return _safe_app_dict(record, system_manager=_is_system_manager(user), detail=True)
 
 
 @frappe.whitelist()
@@ -161,3 +194,28 @@ def sync_huf_apps() -> dict:
 	from huf.ai.app_seeding.apps_loader import sync_huf_apps as _sync
 
 	return _sync()
+
+
+def _parse_truthy(value) -> bool:
+	"""Parse an enabled flag from JSON/bool/int/string payloads."""
+	if isinstance(value, str):
+		return value.strip().lower() in ("1", "true", "yes", "on")
+	return bool(value)
+
+
+@frappe.whitelist()
+def set_huf_app_enabled(app_id: str, enabled) -> dict:
+	"""
+	POST /api/method/huf.ai.apps_api.set_huf_app_enabled  (System Manager only)
+
+	Manually enables/disables a registry record. The stored flag wins over
+	the manifest on subsequent syncs (manual-disable-wins).
+	"""
+	frappe.only_for(SYSTEM_MANAGER)
+
+	if not app_id or not frappe.db.exists("HUF App", app_id):
+		frappe.throw(_("HUF App {0} not found").format(app_id), frappe.DoesNotExistError)
+
+	flag = _parse_truthy(enabled)
+	frappe.db.set_value("HUF App", app_id, "enabled", 1 if flag else 0)
+	return {"ok": True, "app_id": app_id, "enabled": flag}

--- a/huf/ai/apps_api.py
+++ b/huf/ai/apps_api.py
@@ -1,0 +1,163 @@
+"""
+Permission-aware launcher API for discovered HUF Apps.
+
+Security boundaries (HUF_APPS_MVP.md §8.5/§13):
+  - only safe launcher fields are ever returned to non-System-Managers
+    (never permission_method, source_file, manifest_hash or sync_error);
+  - visibility is evaluated server-side per record;
+  - a hidden app fails exactly like a nonexistent one.
+"""
+import frappe
+from frappe import _
+
+from huf.permissions import ADMINISTRATOR, SYSTEM_MANAGER, has_capability
+
+# Fields that are safe to expose to any permitted user.
+SAFE_FIELDS = ("app_id", "title", "description", "route", "icon", "category", "version")
+
+# Capability required to see apps that declare no permission_method.
+BASE_ACCESS_CAPABILITY = "agent.use"
+
+
+def _is_system_manager(user: str) -> bool:
+	return user == ADMINISTRATOR or SYSTEM_MANAGER in frappe.get_roles(user)
+
+
+def _call_permission_method(path: str, user: str, app_meta: dict) -> bool:
+	"""Call the provider's permission_method with the current user and
+	registry metadata. Fails closed: any error hides the app."""
+	try:
+		fn = frappe.get_attr(path)
+	except Exception as e:
+		frappe.log_error(f"Could not import permission_method '{path}': {e}", "HUF Apps API")
+		return False
+
+	for args, kwargs in (
+		((), {"user": user, "app": app_meta}),
+		((user,), {}),
+		((), {}),
+	):
+		try:
+			return bool(fn(*args, **kwargs))
+		except TypeError:
+			continue
+		except Exception as e:
+			frappe.log_error(f"permission_method '{path}' raised: {e}", "HUF Apps API")
+			return False
+
+	frappe.log_error(
+		f"permission_method '{path}' has an unsupported signature", "HUF Apps API"
+	)
+	return False
+
+
+def _can_user_see(record: dict, user: str) -> bool:
+	"""Visibility rules from the spec, in order."""
+	if record.get("sync_status") != "Active":
+		return False
+
+	# 1. Administrator/System Manager see all valid registrations.
+	if _is_system_manager(user):
+		return True
+
+	# 2. Disabled registrations are hidden from normal users.
+	if not record.get("enabled"):
+		return False
+
+	# 3. Provider-declared permission_method wins when present.
+	permission_method = record.get("permission_method")
+	if permission_method:
+		return _call_permission_method(permission_method, user, record)
+
+	# 4. Otherwise require an authenticated user with base HUF access.
+	if not user or user == "Guest":
+		return False
+	return has_capability(user, BASE_ACCESS_CAPABILITY)
+
+
+def _safe_app_dict(record: dict) -> dict:
+	return {field: record.get(field) for field in SAFE_FIELDS}
+
+
+@frappe.whitelist()
+def get_huf_apps() -> dict:
+	"""
+	GET /api/method/huf.ai.apps_api.get_huf_apps
+
+	Returns only the applications the current user may open, with safe
+	launcher fields only, ordered for the launcher.
+	"""
+	user = frappe.session.user
+	if not user or user == "Guest":
+		return {"apps": []}
+
+	records = frappe.get_all(
+		"HUF App",
+		fields=[
+			"app_id",
+			"title",
+			"description",
+			"route",
+			"icon",
+			"category",
+			"version",
+			"enabled",
+			"permission_method",
+			"sync_status",
+			"sort_order",
+		],
+		order_by="sort_order asc, title asc",
+	)
+
+	apps = [_safe_app_dict(r) for r in records if _can_user_see(r, user)]
+	return {"apps": apps}
+
+
+@frappe.whitelist()
+def get_huf_app(app_id: str) -> dict:
+	"""
+	GET /api/method/huf.ai.apps_api.get_huf_app
+
+	Returns a single app the current user may open. Apps that do not exist
+	or are not permitted fail identically with DoesNotExistError.
+	"""
+	user = frappe.session.user
+	record = None
+	if user and user != "Guest" and app_id:
+		record = frappe.db.get_value(
+			"HUF App",
+			app_id,
+			[
+				"app_id",
+				"title",
+				"description",
+				"route",
+				"icon",
+				"category",
+				"version",
+				"enabled",
+				"permission_method",
+				"sync_status",
+			],
+			as_dict=True,
+		)
+
+	if not record or not _can_user_see(record, user):
+		frappe.throw(_("HUF App {0} not found").format(app_id), frappe.DoesNotExistError)
+
+	return _safe_app_dict(record)
+
+
+@frappe.whitelist()
+def sync_huf_apps() -> dict:
+	"""
+	POST /api/method/huf.ai.apps_api.sync_huf_apps  (System Manager only)
+
+	Runs the full registry sync and returns a summary of synced/invalid/
+	deleted counts and per-app errors.
+	"""
+	frappe.only_for(SYSTEM_MANAGER)
+
+	from huf.ai.app_seeding.apps_loader import sync_huf_apps as _sync
+
+	return _sync()

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -134,7 +134,7 @@ after_uninstall = "huf.ai.tool_registry.sync_app_tools"
 # Name of the app being uninstalled is passed as an argument
 
 # before_app_uninstall = "huf.utils.before_app_uninstall"
-# after_app_uninstall = "huf.utils.after_app_uninstall"
+after_app_uninstall = "huf.ai.app_seeding.apps_loader.on_app_uninstalled"
 
 # Desk Notifications
 # ------------------

--- a/huf/huf/doctype/huf_app/huf_app.json
+++ b/huf/huf/doctype/huf_app/huf_app.json
@@ -1,0 +1,190 @@
+{
+ "actions": [],
+ "autoname": "field:app_id",
+ "creation": "2026-07-25 05:33:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "app_id",
+  "title",
+  "description",
+  "column_break_main",
+  "route",
+  "icon",
+  "category",
+  "sort_order",
+  "section_break_details",
+  "version",
+  "launch_mode",
+  "required_huf_version",
+  "permission_method",
+  "enabled",
+  "section_break_sync",
+  "source_app",
+  "source_file",
+  "manifest_hash",
+  "column_break_sync",
+  "last_synced_at",
+  "sync_status",
+  "sync_error"
+ ],
+ "fields": [
+  {
+   "fieldname": "app_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "App ID",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "column_break_main",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Route",
+   "reqd": 1
+  },
+  {
+   "fieldname": "icon",
+   "fieldtype": "Data",
+   "label": "Icon"
+  },
+  {
+   "default": "Other",
+   "fieldname": "category",
+   "fieldtype": "Data",
+   "label": "Category"
+  },
+  {
+   "default": "100",
+   "fieldname": "sort_order",
+   "fieldtype": "Int",
+   "label": "Sort Order"
+  },
+  {
+   "fieldname": "section_break_details",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "fieldname": "version",
+   "fieldtype": "Data",
+   "label": "Version"
+  },
+  {
+   "default": "Route",
+   "fieldname": "launch_mode",
+   "fieldtype": "Select",
+   "label": "Launch Mode",
+   "options": "\nRoute"
+  },
+  {
+   "fieldname": "required_huf_version",
+   "fieldtype": "Data",
+   "label": "Required HUF Version"
+  },
+  {
+   "fieldname": "permission_method",
+   "fieldtype": "Data",
+   "label": "Permission Method"
+  },
+  {
+   "default": "1",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "section_break_sync",
+   "fieldtype": "Section Break",
+   "label": "Sync Metadata"
+  },
+  {
+   "fieldname": "source_app",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Source App",
+   "read_only": 1
+  },
+  {
+   "fieldname": "source_file",
+   "fieldtype": "Data",
+   "label": "Source File",
+   "read_only": 1
+  },
+  {
+   "fieldname": "manifest_hash",
+   "fieldtype": "Data",
+   "label": "Manifest Hash",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_sync",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "last_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Last Synced At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sync_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Sync Status",
+   "options": "\nActive\nInvalid\nMissing",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sync_error",
+   "fieldtype": "Small Text",
+   "label": "Sync Error",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-25 05:33:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "HUF App",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
+}

--- a/huf/huf/doctype/huf_app/huf_app.json
+++ b/huf/huf/doctype/huf_app/huf_app.json
@@ -18,6 +18,7 @@
   "launch_mode",
   "required_huf_version",
   "permission_method",
+  "exposed_tables",
   "enabled",
   "section_break_sync",
   "source_app",
@@ -105,6 +106,12 @@
    "label": "Permission Method"
   },
   {
+   "fieldname": "exposed_tables",
+   "fieldtype": "Small Text",
+   "label": "Exposed Tables",
+   "read_only": 1
+  },
+  {
    "default": "1",
    "fieldname": "enabled",
    "fieldtype": "Check",
@@ -162,7 +169,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-25 05:33:00.000000",
+ "modified": "2026-07-25 16:30:00.000000",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "HUF App",

--- a/huf/huf/doctype/huf_app/huf_app.py
+++ b/huf/huf/doctype/huf_app/huf_app.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class HUFApp(Document):
+	"""Registry record for a discovered HUF App manifest.
+
+	Records are created and maintained by the app-seeding sync
+	(huf.ai.app_seeding.apps_loader); they are discovered, not user-authored.
+	"""
+
+	pass

--- a/huf/install.py
+++ b/huf/install.py
@@ -139,6 +139,16 @@ def after_migrate():
 	except Exception as e:
 		logger.warning(f"App seeding failed: {e!s}")
 
+	try:
+		from huf.ai.app_seeding.apps_loader import sync_huf_apps
+		summary = sync_huf_apps()
+		logger.info(
+			f"Synced HUF Apps after migrate: {summary.get('synced', 0)} synced, "
+			f"{summary.get('invalid', 0)} invalid, {summary.get('deleted', 0)} deleted"
+		)
+	except Exception as e:
+		logger.warning(f"HUF Apps sync failed: {e!s}")
+
 
 def _log_seed_results(results, logger):
 	"""Emit WARNING-level structured logs for skipped seed records and per-app summaries."""

--- a/huf/public/css/huf-tokens.css
+++ b/huf/public/css/huf-tokens.css
@@ -35,6 +35,7 @@
 
   /* Signal (accent) & status */
   --huf-accent:      #E8531F; /* signal orange — hover, focus ring, highlights */
+  --huf-on-accent: #ffffff;
   --huf-accent-ink:  #BC3E0F; /* signal text on light surfaces */
   --huf-success:     #3F7A4E;
   --huf-warning:     #E8531F; /* warnings use the signal color */

--- a/huf/public/css/huf-tokens.css
+++ b/huf/public/css/huf-tokens.css
@@ -1,0 +1,193 @@
+/*
+ * HUF Design Tokens — "Instrument / Control-Room" design system
+ * ==============================================================
+ * Purpose: let independent provider apps (separate Frappe apps with their
+ * own frontends) adopt the HUF look with a single stylesheet.
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="/assets/huf/css/huf-tokens.css">
+ *
+ * Notes:
+ * - Dependency-free: no Tailwind, no JS, no build step.
+ * - Fonts are referenced by name only; load them yourself if desired:
+ *     Big Shoulders Display (display), IBM Plex Sans (body), IBM Plex Mono (mono)
+ *     e.g. via Google Fonts, with system fallbacks already in the stacks below.
+ * - Everything is scoped to `.huf-*` classes — no global resets, so it will
+ *   not fight your app's own styles. Set font-family/background/colors on
+ *   your root container with the opt-in `.huf-root` class.
+ * - The HUF design system is light-mode only by design, so there are
+ *   intentionally no `prefers-color-scheme: dark` overrides here.
+ */
+
+:root {
+  /* Surfaces */
+  --huf-paper:      #F2F3EF;  /* app background            */
+  --huf-paper-deep: #E9EBE4;  /* recessed / secondary fill */
+  --huf-panel:      #FBFCFA;  /* cards, popovers           */
+
+  /* Text & lines */
+  --huf-ink:        #15181C;  /* primary text / primary button */
+  --huf-ink-soft:   #2A2F36;  /* secondary text */
+  --huf-steel:      #5A636F;  /* muted text      */
+  --huf-steel-soft: #8A929C;  /* placeholder     */
+  --huf-line:       #D7DACF;  /* borders, inputs */
+  --huf-line-dark:  #343A42;  /* borders on dark surfaces */
+
+  /* Signal (accent) & status */
+  --huf-accent:      #E8531F; /* signal orange — hover, focus ring, highlights */
+  --huf-accent-ink:  #BC3E0F; /* signal text on light surfaces */
+  --huf-success:     #3F7A4E;
+  --huf-warning:     #E8531F; /* warnings use the signal color */
+  --huf-danger:      #C0392B;
+
+  /* Shape — the HUF look is squared: 2px everywhere, no shadows */
+  --huf-radius:    2px;
+  --huf-radius-sm: 0px;
+
+  /* Typography */
+  --huf-font:         'IBM Plex Sans', -apple-system, 'Segoe UI', sans-serif;
+  --huf-font-display: 'Big Shoulders Display', 'IBM Plex Sans', sans-serif;
+  --huf-font-mono:    'IBM Plex Mono', ui-monospace, 'SF Mono', monospace;
+}
+
+/* ------------------------------------------------------------------ */
+/* Opt-in root: applies HUF background, ink and body font to a scope.  */
+/* Put this on your app's root container (NOT applied to body globally).*/
+/* ------------------------------------------------------------------ */
+.huf-root {
+  background-color: var(--huf-paper);
+  color: var(--huf-ink);
+  font-family: var(--huf-font);
+}
+
+/* ------------------------------------------------------------------ */
+/* Components — styled purely from the tokens above.                   */
+/* ------------------------------------------------------------------ */
+
+/* Card: --panel bg, 1px --line border, 2px radius, no shadow */
+.huf-card {
+  background: var(--huf-panel);
+  color: var(--huf-ink);
+  border: 1px solid var(--huf-line);
+  border-radius: var(--huf-radius);
+  box-shadow: none;
+  padding: 1.5rem; /* p-6 rhythm */
+}
+
+/* Button base: square, no shadow, body font, medium weight */
+.huf-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.25rem;              /* h-9 */
+  padding: 0.5rem 1rem;         /* px-4 py-2 */
+  font-family: var(--huf-font);
+  font-size: 0.875rem;          /* text-sm */
+  font-weight: 500;
+  line-height: 1.25rem;
+  white-space: nowrap;
+  border: 1px solid var(--huf-line);
+  border-radius: var(--huf-radius);
+  background: var(--huf-panel);
+  color: var(--huf-ink);
+  box-shadow: none;
+  cursor: pointer;
+  transition: background-color .15s ease, color .15s ease, border-color .15s ease;
+}
+.huf-btn:hover {
+  background: var(--huf-paper-deep);
+}
+.huf-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--huf-accent); /* ring-1 ring-signal */
+}
+.huf-btn:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+/* Primary button: ink background, signal orange on hover */
+.huf-btn-primary {
+  background: var(--huf-ink);
+  border-color: var(--huf-ink);
+  color: var(--huf-paper);
+}
+.huf-btn-primary:hover {
+  background: var(--huf-accent);
+  border-color: var(--huf-accent);
+  color: var(--huf-paper);
+}
+
+/* Badge: no pill, no fill — mono uppercase label, border + text only */
+.huf-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;     /* px-2 py-0.5 */
+  font-family: var(--huf-font-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  border: 1px solid var(--huf-line);
+  border-radius: var(--huf-radius-sm);
+  background: var(--huf-paper-deep);
+  color: var(--huf-steel);
+}
+.huf-badge-success {
+  border-color: color-mix(in srgb, var(--huf-success) 40%, transparent);
+  background: transparent;
+  color: var(--huf-success);
+}
+.huf-badge-warning {
+  border-color: color-mix(in srgb, var(--huf-accent-ink) 40%, transparent);
+  background: transparent;
+  color: var(--huf-accent-ink);
+}
+.huf-badge-danger {
+  border-color: color-mix(in srgb, var(--huf-danger) 40%, transparent);
+  background: transparent;
+  color: var(--huf-danger);
+}
+
+/* Input: 1px --line border, transparent bg, signal focus ring */
+.huf-input {
+  display: flex;
+  width: 100%;
+  height: 2.25rem;              /* h-9 */
+  padding: 0.25rem 0.75rem;     /* px-3 py-1 */
+  font-family: var(--huf-font);
+  font-size: 0.875rem;
+  color: var(--huf-ink);
+  background: transparent;
+  border: 1px solid var(--huf-line);
+  border-radius: var(--huf-radius);
+  box-shadow: none;
+  transition: border-color .15s ease, box-shadow .15s ease;
+}
+.huf-input::placeholder {
+  color: var(--huf-steel);
+}
+.huf-input:focus-visible {
+  outline: none;
+  border-color: var(--huf-accent);
+  box-shadow: 0 0 0 1px var(--huf-accent);
+}
+.huf-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* Title: display font, tight, semibold */
+.huf-title {
+  font-family: var(--huf-font-display);
+  font-weight: 600;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  color: var(--huf-ink);
+  margin: 0 0 0.5rem;
+}
+
+/* Muted helper text */
+.huf-muted {
+  color: var(--huf-steel);
+  font-size: 0.875rem;
+}

--- a/huf/public/js/huf-app-badge.js
+++ b/huf/public/js/huf-app-badge.js
@@ -1,0 +1,41 @@
+/**
+ * huf-app-badge.js - "Back to HUF" pill for provider apps.
+ * Usage: <script src="/assets/huf/js/huf-app-badge.js" defer></script>
+ * data-* overrides:
+ *   data-position bottom-right (default) | bottom-left | top-right | top-left
+ *   data-label pill text (default "← HUF")
+ *   data-href link target (default "/huf/apps")
+ *   data-new-tab "true" → target="_blank" rel="noopener"
+ *   data-theme auto (default; prefers-color-scheme) | light | dark
+ * Never throws or duplicates.
+ */
+(function () {
+	// document.currentScript is null in callbacks.
+	var script = document.currentScript;
+	function init() {
+		try {
+			if (!script || document.getElementById('huf-app-badge')) return;
+			var d = script.dataset || {},
+				m = window.matchMedia,
+				pos = /^(bottom|top)-(right|left)$/.test(d.position) ? d.position : 'bottom-right',
+				theme = /^(light|dark)$/.test(d.theme) ? d.theme : 'auto',
+				dark = theme === 'dark' || (theme === 'auto' && m && m('(prefers-color-scheme: dark)').matches),
+				c = dark ? ['#e5e7eb', 'rgba(31,41,55,.9)', 'rgba(255,255,255,.16)'] : ['#1f2937', 'rgba(255,255,255,.9)', 'rgba(0,0,0,.12)'],
+				off = ':16px;',
+				a = document.createElement('a'),
+				s = a.style;
+			a.id = 'huf-app-badge';
+			a.href = d.href || '/huf/apps';
+			a.textContent = d.label || '← HUF';
+			if (d.newTab === 'true') { a.target = '_blank'; a.rel = 'noopener'; }
+			s.cssText = 'position:fixed;z-index:9999;padding:8px 12px;border-radius:999px;text-decoration:none;opacity:.45;font:12px system-ui,sans-serif;'
+				+ (pos[0] === 't' ? 'top' : 'bottom') + off + (pos.indexOf('left') > 0 ? 'left' : 'right') + off
+				+ 'color:' + c[0] + ';background:' + c[1] + ';border:1px solid ' + c[2];
+			a.onmouseenter = function () { s.opacity = 1; s.boxShadow = '0 2px 8px rgba(0,0,0,.2)'; };
+			a.onmouseleave = function () { s.opacity = '.45'; s.boxShadow = 'none'; };
+			document.body.appendChild(a);
+		} catch (e) {}
+	}
+	if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+	else init();
+})();


### PR DESCRIPTION
## What

Implements the **HUF Apps MVP** (spec: `workspace/Tracks/HufApp/HUF_APPS_MVP.md`): a minimal application registry, discovery grammar, permission-aware launcher, and stable manifest contract so independently installed Frappe apps that depend on HUF can register a launcher entry and appear in a unified Apps screen.

## Backend

- **`HUF App` DocType** — synchronized registry record: manifest fields (app_id, title, description, version, route, icon, category, launch_mode, required_huf_version, permission_method, sort_order, enabled) + provenance/sync fields (source_app, source_file, manifest_hash, last_synced_at, sync_status, sync_error). System Manager only; ordinary users go through guarded APIs.
- **Discovery** — extends the existing `app_seeding` system: `("apps", upsert_huf_app)` added to LOAD_ORDER (loads last); scans flat `*.json` under a provider app's `huf/apps/` directory.
- **Validation** — manifest_version, app_id grammar, site-local route/icon (external/protocol-relative/data URLs rejected), unknown top-level fields rejected, `permission_method` must resolve to a callable in an installed app, provenance never trusted from JSON.
- **Sync lifecycle** — hash-skip upserts, per-provider-app commit isolation, duplicate `app_id` collision protection (no silent overwrite; collision logged + surfaced), orphan cleanup on removed manifests, `after_app_uninstall` hook, after-migrate sync, manual sync API.
- **APIs** (`huf.ai.apps_api`) — `get_huf_apps()` / `get_huf_app(app_id)` return only safe launcher fields, filtered server-side per user (Administrator/System Manager see all; disabled hidden; `permission_method` honored; default requires `agent.use` capability). `sync_huf_apps()` is System Manager only.
- **Tests** — 12 tests: valid/invalid manifests, duplicate app_id, removed manifests, permission filtering.

## Frontend

- **`/huf/apps`** launcher screen: card grid (icon, title, description, category) with loading skeleton, error+retry, and empty states.
- Cards perform **full-page site-local navigation** to the registered route — no iframe, no microfrontend runtime, no remote JS.
- **Apps** nav entry in a new **Use** sidebar group above the Build group, gated on `agent.use`.

## Out of scope (per spec)

Marketplace, remote apps, dynamic bundle loading, app install from UI, low-code app builder.

## Testing

- Backend: `py_compile` + standalone validation smoke tests pass; unit tests added under `huf/ai/app_seeding/tests/test_apps_sync.py` (to be run on a live bench).
- Frontend: `yarn typecheck` + `yarn build` pass.
- Live-bench verification on an independent docker bench (`16_hufapp`) with 2-3 sample provider apps follows in this PR's checks.