### PR TITLE
feat: add Google Search and Perplexity Search agent tool types

### DIFF
--- a/frontend/src/components/tools/ToolTemplateCard.tsx
+++ b/frontend/src/components/tools/ToolTemplateCard.tsx
@@ -1,4 +1,4 @@
-import { Database, Globe, Cpu, Bot, Code } from 'lucide-react';
+import { Database, Globe, Cpu, Bot, Code, Search } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import type { ToolTemplate } from '@/types/toolTemplate.types';
@@ -14,6 +14,7 @@ const iconMap = {
   cpu: Cpu,
   bot: Bot,
   code: Code,
+  search: Search,
 };
 
 export function ToolTemplateCard({ template, onClick }: ToolTemplateCardProps) {

--- a/frontend/src/config/toolTemplates.json
+++ b/frontend/src/config/toolTemplates.json
@@ -46,6 +46,16 @@
       ]
     },
     {
+      "id": "web_search",
+      "name": "Web Search",
+      "description": "Search the web for live information via Google Programmable Search or Perplexity AI.",
+      "icon": "search",
+      "toolTypes": [
+        "Google Search",
+        "Perplexity Search"
+      ]
+    },
+    {
       "id": "run_agent",
       "name": "Run AI Agent",
       "description": "Delegate a task to another specialized AI Agent in your system.",

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -41,6 +41,8 @@ export type ToolType =
   | "Get Conversation Data"
   | "Set Conversation Data"
   | "Load Conversation Data"
+  | "Google Search"
+  | "Perplexity Search"
   | "Transcription"
   /**
    * @deprecated Legacy value kept for backward compatibility with saved docs.

--- a/huf/ai/app_seeding/loaders.py
+++ b/huf/ai/app_seeding/loaders.py
@@ -143,7 +143,8 @@ VALID_TYPES = [
     "Cancel Document", "Get Amended Document", "Custom Function", "App Provided",
     "Attach File to Document", "Get Report Result", "Get Value", "Set Value",
     "GET", "POST", "Run Agent", "Client Side Tool", "Get Conversation Data",
-    "Set Conversation Data", "Load Conversation Data"
+    "Set Conversation Data", "Load Conversation Data", "Google Search",
+    "Perplexity Search"
 ]
 
 def upsert_tool(data: dict, source_app: str, source_file: str) -> tuple:

--- a/huf/ai/flow_tool_executor.py
+++ b/huf/ai/flow_tool_executor.py
@@ -182,6 +182,8 @@ def _resolve_function_path(tool_doc: dict) -> str | None:
 		"Get Conversation Data": "huf.ai.sdk_tools.handle_get_conversation_data",
 		"Set Conversation Data": "huf.ai.sdk_tools.handle_set_conversation_data",
 		"Load Conversation Data": "huf.ai.sdk_tools.handle_load_conversation_data",
+		"Google Search": "huf.ai.sdk_tools.handle_google_search",
+		"Perplexity Search": "huf.ai.sdk_tools.handle_perplexity_search",
 	}
 
 	return type_to_handler.get(tool_type)

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -156,6 +156,10 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         function_path = "huf.ai.sdk_tools.handle_set_conversation_data"
                     elif function_doc.types == "Load Conversation Data":
                         function_path = "huf.ai.sdk_tools.handle_load_conversation_data"
+                    elif function_doc.types == "Google Search":
+                        function_path = "huf.ai.sdk_tools.handle_google_search"
+                    elif function_doc.types == "Perplexity Search":
+                        function_path = "huf.ai.sdk_tools.handle_perplexity_search"
 
                     else:
                         continue
@@ -2325,4 +2329,130 @@ async def handle_transcribe_audio(
     except Exception as e:
         # Hard transcription failure: retain Error Log for admin attention.
         frappe.log_error(f"Audio transcription error: {e!s}", "Audio Transcription Tool")
+        return {"success": False, "error": str(e)}
+
+def handle_google_search(query: str, max_results: int = 5, **kwargs):
+    """
+    Perform a web search using Google Programmable Search Engine.
+
+    Reads the API key and search engine ID from site_config
+    (``google_pse_api_key`` and ``google_pse_engine_id``).
+
+    Args:
+        query: The search query string
+        max_results: Maximum number of results to return (default: 5, max: 10)
+
+    Returns:
+        dict: {
+            "success": bool,
+            "query": str,
+            "results": list,        # [{"title", "link", "snippet"}, ...]
+            "total_results": int,
+            "error": str
+        }
+    """
+    site_config = frappe.get_site_config()
+    api_key = site_config.get("google_pse_api_key")
+    engine_id = site_config.get("google_pse_engine_id")
+
+    if not api_key:
+        frappe.throw(
+            _("Google Search is not configured. Please set 'google_pse_api_key' in site config.")
+        )
+    if not engine_id:
+        frappe.throw(
+            _("Google Search is not configured. Please set 'google_pse_engine_id' in site config.")
+        )
+
+    try:
+        num = max(1, min(int(max_results or 5), 10))
+
+        response = requests.get(
+            "https://www.googleapis.com/customsearch/v1",
+            params={"key": api_key, "cx": engine_id, "q": query, "num": num},
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        items = response.json().get("items", [])
+        results = [
+            {
+                "title": item.get("title"),
+                "link": item.get("link"),
+                "snippet": item.get("snippet"),
+            }
+            for item in items
+        ]
+
+        return {
+            "success": True,
+            "query": query,
+            "results": results,
+            "total_results": len(results),
+        }
+    except Exception as e:
+        logger.warning(f"handle_google_search failed: {e!s}")
+        return {"success": False, "error": str(e)}
+
+
+def handle_perplexity_search(query: str, **kwargs):
+    """
+    Perform a web search using a Perplexity sonar model via LiteLLM.
+
+    Reads the API key from the ``perplexity_api_key`` site_config value,
+    falling back to the ``PERPLEXITY_API_KEY`` environment variable.
+
+    Args:
+        query: The search query string
+
+    Returns:
+        dict: {
+            "success": bool,
+            "query": str,
+            "answer": str,          # Grounded answer text from the sonar model
+            "citations": list,      # Source URLs cited by the model
+            "model": str,
+            "error": str
+        }
+    """
+    import os
+
+    site_config = frappe.get_site_config()
+    api_key = site_config.get("perplexity_api_key") or os.environ.get("PERPLEXITY_API_KEY")
+
+    if not api_key:
+        frappe.throw(
+            _(
+                "Perplexity Search is not configured. Please set 'perplexity_api_key' "
+                "in site config or the PERPLEXITY_API_KEY environment variable."
+            )
+        )
+
+    try:
+        from litellm import completion
+
+        # LiteLLM routes Perplexity credentials via environment variable
+        os.environ["PERPLEXITY_API_KEY"] = api_key
+
+        response = completion(
+            model="perplexity/sonar",
+            messages=[{"role": "user", "content": query}],
+        )
+
+        message = response.choices[0].message
+        citations = (
+            getattr(response, "citations", None)
+            or getattr(message, "citations", None)
+            or []
+        )
+
+        return {
+            "success": True,
+            "query": query,
+            "answer": message.content,
+            "citations": citations,
+            "model": "perplexity/sonar",
+        }
+    except Exception as e:
+        logger.warning(f"handle_perplexity_search failed: {e!s}")
         return {"success": False, "error": str(e)}

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -52,7 +52,7 @@
    "fieldname": "types",
    "fieldtype": "Select",
    "label": "Types",
-   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nClient Side Tool\nGet Conversation Data\nSet Conversation Data\nLoad Conversation Data"
+   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nClient Side Tool\nGet Conversation Data\nSet Conversation Data\nLoad Conversation Data\nGoogle Search\nPerplexity Search"
   },
   {
    "depends_on": "eval: [\n  'Get Document',\n  'Get Multiple Documents',\n  'Get List',\n  'Create Document',\n  'Create Multiple Documents',\n  'Update Document',\n  'Update Multiple Documents',\n  'Delete Document',\n  'Delete Multiple Documents',\n  'Submit Document',\n  'Cancel Document',\n  'Get Amended Document',\n  'Attach File to Document',\n  'Get Report Result',\n  'Get Value',\n  'Set Value'\n].includes(doc.types)",
@@ -192,7 +192,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-22 22:21:36.079707",
+ "modified": "2026-07-26 04:48:07.000000",
  "modified_by": "Administrator",
  "module": "Huf",
  "name": "Agent Tool Function",

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -584,6 +584,37 @@ class AgentToolFunction(Document):
 				"additionalProperties": False
 			}
 
+		elif self.types == "Google Search":
+			params = {
+				"type": "object",
+				"properties": {
+					"query": {
+						"type": "string",
+						"description": "The search query string."
+					},
+					"max_results": {
+						"type": "integer",
+						"description": "Maximum number of results to return (default: 5).",
+						"default": 5
+					}
+				},
+				"required": ["query"],
+				"additionalProperties": False
+			}
+
+		elif self.types == "Perplexity Search":
+			params = {
+				"type": "object",
+				"properties": {
+					"query": {
+						"type": "string",
+						"description": "The search query string."
+					}
+				},
+				"required": ["query"],
+				"additionalProperties": False
+			}
+
 		else:
 			params = self.build_params_json_from_table()
 


### PR DESCRIPTION
## Summary

Re-implements the search-tool features from the stale PRs #4 and #5 against current `develop` (those PRs targeted the pre-rename `agentflo/` tree and were unmergeable). Supersedes/closes #4 and #5.

## Changes

- **Google Search** tool type: Google Programmable Search Engine via REST. Credentials from `site_config.json`: `google_pse_api_key` + `google_pse_engine_id`. Returns top-N `{title, link, snippet}` results.
- **Perplexity Search** tool type: via LiteLLM (`perplexity/sonar`). Key from `perplexity_api_key` in site_config, falling back to `PERPLEXITY_API_KEY` env (matches existing provider key routing in `huf/ai/providers/litellm.py`). Returns answer + citations.
- Types added to: Agent Tool Function `types` options, `prepare_function_params` branches, `sdk_tools.create_agent_tools` mapping, `flow_tool_executor` handler map, `app_seeding/loaders.py` VALID_TYPES, frontend `ToolType` union + `toolTemplates.json` (new "Web Search" template).

## Validation

- `python3 -m compileall` on edited modules; edited JSON files parse.
- Stubbed smoke tests: missing-key errors, Google result shape (mocked HTTP), Perplexity answer/citations (mocked litellm), env fallback, flow-executor mapping.
- `yarn typecheck` clean.