### PR TITLE
feat(gateway): add Microsoft Teams outgoing webhook adapter

### DIFF
--- a/huf/ai/tests/test_teams_webhook.py
+++ b/huf/ai/tests/test_teams_webhook.py
@@ -1,0 +1,59 @@
+"""Focused unit tests for the Teams Outgoing Webhook adapter."""
+
+import base64
+import hashlib
+import hmac
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import teams_webhook
+
+
+class TestTeamsWebhook(unittest.TestCase):
+	def test_valid_hmac_is_accepted(self):
+		key = base64.b64encode(b"teams-test-key").decode()
+		body = b'{"id":"activity-1"}'
+		signature = base64.b64encode(hmac.new(b"teams-test-key", body, hashlib.sha256).digest()).decode()
+		assert teams_webhook.verify_teams_hmac(key, body, f"HMAC {signature}")
+
+	def test_invalid_hmac_is_rejected(self):
+		key = base64.b64encode(b"teams-test-key").decode()
+		assert not teams_webhook.verify_teams_hmac(key, b"body", "HMAC invalid")
+		assert not teams_webhook.verify_teams_hmac("not-base64", b"body", "HMAC anything")
+
+	def test_activity_normalizes_to_gateway_context(self):
+		event_id, context = teams_webhook.teams_event_context(
+			{
+				"id": "activity-1",
+				"replyToId": "root-1",
+				"text": "@Huf help",
+				"from": {"id": "29:user"},
+				"conversation": {"id": "19:channel"},
+			}
+		)
+		assert event_id == "activity-1"
+		assert context == {
+			"sender_id": "29:user",
+			"conversation_id": "19:channel",
+			"thread_id": "root-1",
+			"message_text": "@Huf help",
+		}
+
+	@patch("huf.ai.tools.teams_webhook.ingest_gateway_event")
+	@patch("huf.ai.tools.teams_webhook._gateway_settings")
+	@patch("huf.ai.tools.teams_webhook.frappe")
+	def test_verified_message_is_ingested_and_acknowledged(self, mock_frappe, mock_settings, mock_ingest):
+		key_bytes = b"teams-test-key"
+		key = base64.b64encode(key_bytes).decode()
+		body = b'{"type":"message","id":"activity-1","text":"hello","from":{"id":"29:user"},"conversation":{"id":"19:channel"}}'
+		signature = base64.b64encode(hmac.new(key_bytes, body, hashlib.sha256).digest()).decode()
+		mock_settings.return_value.get_credential.return_value = key
+		mock_frappe.request.get_data.return_value = body
+		mock_frappe.get_request_header.return_value = f"HMAC {signature}"
+		mock_ingest.return_value = {"status": "Queued", "event_name": "GATEWAY-EVENT-1"}
+
+		response = teams_webhook.handle_teams_outgoing_webhook("Teams Support")
+
+		assert response == {"type": "message", "text": "Thanks — Huf has received your message."}
+		mock_ingest.assert_called_once()
+		assert mock_ingest.call_args.kwargs["verified_sender"] is True

--- a/huf/ai/tools/teams_webhook.py
+++ b/huf/ai/tools/teams_webhook.py
@@ -1,0 +1,108 @@
+"""Microsoft Teams Outgoing Webhook adapter for the Gateway foundation.
+
+This deliberately supports Teams *Outgoing Webhooks*, rather than pretending
+to be a full Bot Framework adapter.  Teams sends an HMAC-signed Activity when
+the webhook is @mentioned in a public channel; Huf verifies that signature,
+records/routes the event through the provider-neutral Gateway service, then
+returns a synchronous acknowledgement in the same Teams thread.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Any
+
+import frappe
+from frappe import _
+
+from huf.ai.gateway_service import ingest_gateway_event
+
+
+TEAMS_SERVICE = "microsoft_teams"
+HMAC_CREDENTIAL_KEY = "teams_outgoing_webhook_hmac_key"
+
+
+def verify_teams_hmac(signing_key: str, raw_body: bytes, authorization: str | None) -> bool:
+	"""Verify the `Authorization: HMAC <base64>` header from Teams.
+
+	The signing key shown once by Teams is base64-encoded.  It is kept in the
+	linked Integration Settings credential table, never in the Gateway Event.
+	"""
+	if not signing_key or not authorization:
+		return False
+	try:
+		scheme, supplied = authorization.split(" ", 1)
+		key = base64.b64decode(signing_key, validate=True)
+	except (ValueError, TypeError):
+		return False
+	if scheme.lower() != "hmac" or not supplied:
+		return False
+	expected = base64.b64encode(hmac.new(key, raw_body, hashlib.sha256).digest()).decode("utf-8")
+	return hmac.compare_digest(supplied.strip(), expected)
+
+
+def teams_event_context(activity: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+	"""Normalize the stable subset of a Teams Activity needed by Gateways."""
+	event_id = str(activity.get("id") or "")
+	if not event_id:
+		raise frappe.ValidationError(_("Microsoft Teams activity ID is required."))
+	conversation = activity.get("conversation") or {}
+	sender = activity.get("from") or {}
+	return event_id, {
+		"sender_id": str(sender.get("id") or ""),
+		"conversation_id": str(conversation.get("id") or ""),
+		"thread_id": str(activity.get("replyToId") or activity.get("id") or ""),
+		"message_text": str(activity.get("text") or ""),
+	}
+
+
+def _gateway_settings(gateway_name: str):
+	gateway = frappe.get_doc("Gateway", gateway_name)
+	if gateway.provider != "Microsoft Teams":
+		raise frappe.ValidationError(_("Gateway is not a Microsoft Teams gateway."))
+	if not gateway.integration_settings:
+		raise frappe.ValidationError(_("Microsoft Teams gateway needs a connected integration."))
+	settings = frappe.get_doc("Integration Settings", gateway.integration_settings)
+	if settings.service != TEAMS_SERVICE or not settings.is_active:
+		raise frappe.ValidationError(_("Connected Microsoft Teams integration is not active."))
+	return settings
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def handle_teams_outgoing_webhook(gateway_name: str) -> dict[str, str]:
+	"""Receive a verified Teams Outgoing Webhook Activity and acknowledge it.
+
+	This endpoint intentionally never runs a model inline: Microsoft gives an
+	Outgoing Webhook only a short synchronous response window.  Huf queues the
+	approved event and sends the fixed acknowledgement in the original thread.
+	"""
+	settings = _gateway_settings(gateway_name)
+	raw_body = frappe.request.get_data(as_text=False)
+	authorization = frappe.get_request_header("Authorization")
+	if not verify_teams_hmac(settings.get_credential(HMAC_CREDENTIAL_KEY), raw_body, authorization):
+		frappe.local.response["http_status_code"] = 401
+		return {"type": "message", "text": "Unauthorized webhook request."}
+	try:
+		activity = json.loads(raw_body.decode("utf-8"))
+	except (UnicodeDecodeError, json.JSONDecodeError):
+		frappe.local.response["http_status_code"] = 400
+		return {"type": "message", "text": "Invalid webhook payload."}
+
+	# Ignore installation and other non-message Activities; a successful empty
+	# response prevents Teams retrying an event that cannot start Huf work.
+	if activity.get("type") != "message":
+		return {"type": "message", "text": ""}
+	event_id, context = teams_event_context(activity)
+	result = ingest_gateway_event(
+		gateway_name,
+		event_id,
+		context,
+		verified_sender=True,
+		raw_payload=activity,
+	)
+	if result.get("status") == "Queued" or result.get("duplicate"):
+		return {"type": "message", "text": "Thanks — Huf has received your message."}
+	return {"type": "message", "text": "This gateway is not accepting messages from this sender."}

--- a/huf/huf/doctype/gateway/gateway.json
+++ b/huf/huf/doctype/gateway/gateway.json
@@ -8,7 +8,7 @@
  "field_order": ["gateway_name", "provider", "is_enabled", "integration_settings", "execution_user", "description", "access_policy", "allowed_senders", "section_default_route", "default_target_type", "default_agent", "default_flow", "section_status", "last_event_at", "last_error"],
  "fields": [
   {"fieldname":"gateway_name","fieldtype":"Data","in_list_view":1,"label":"Gateway name","reqd":1,"unique":1},
-  {"fieldname":"provider","fieldtype":"Select","in_list_view":1,"label":"Channel","options":"Telegram\nSlack\nEmail\nWhatsApp","reqd":1},
+  {"fieldname":"provider","fieldtype":"Select","in_list_view":1,"label":"Channel","options":"Telegram\nSlack\nEmail\nWhatsApp\nMicrosoft Teams","reqd":1},
   {"default":"1","fieldname":"is_enabled","fieldtype":"Check","in_list_view":1,"label":"Enabled"},
   {"description":"Optional existing integration that owns this channel's credentials. This keeps sending tools separate from inbound routing.","fieldname":"integration_settings","fieldtype":"Link","label":"Connected integration","options":"Integration Settings"},
   {"description":"The least-privileged Huf user used when this gateway starts an Agent or Flow. Never use Administrator.","fieldname":"execution_user","fieldtype":"Link","label":"Run as user","options":"User"},


### PR DESCRIPTION
## Dependency

Dependent on draft #441 (`feature/gateway-foundation`), which provides Gateway, Gateway Event, and the provider-neutral ingress service. This PR is intentionally based on that branch rather than `develop`.

## Scope

Adds the narrow Microsoft Teams **Outgoing Webhook** adapter:

- Adds Microsoft Teams to the Gateway channel picker.
- Verifies Teams `Authorization: HMAC <base64>` signatures against the base64 signing key stored as `teams_outgoing_webhook_hmac_key` in the linked active `microsoft_teams` Integration Settings record.
- Normalizes verified message Activities into `Gateway Event` ingress.
- Returns a synchronous fixed acknowledgement in the original Teams thread; gateway routing and policy remain responsible for agent/flow execution.

## Deliberately not included

This is not a full Azure Bot Framework adapter: no personal/private chats, JWT/app registration, proactive messaging, or model-generated synchronous replies. Those require a separately designed Bot Framework capability.

## Verification

- `python3 -m py_compile huf/ai/tools/teams_webhook.py huf/ai/tests/test_teams_webhook.py`
- In provisioned Frappe test environment: `PYTHONPATH=/tmp/huf-teams-test ./env/bin/python -m unittest huf.ai.tests.test_teams_webhook` (4 passed)
- `python3 -m json.tool huf/huf/doctype/gateway/gateway.json`
- `git diff --check`