### PR TITLE
feat(gateway): add verified Discord interaction ingress

### DIFF
--- a/huf/ai/gateways/__init__.py
+++ b/huf/ai/gateways/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-specific, verified gateway ingress adapters."""

--- a/huf/ai/gateways/discord.py
+++ b/huf/ai/gateways/discord.py
@@ -1,0 +1,130 @@
+"""Discord Interactions ingress for Huf Gateways.
+
+Discord signs every Interaction using Ed25519 over the exact request timestamp
+concatenated with the unmodified request body.  This adapter verifies that
+signature before it acknowledges or stores anything.
+
+Discord requires a response within three seconds.  Non-ping interactions are
+therefore deferred and sent through the queue-first gateway service.  The
+existing Discord agent tools remain the outbound capability; a later generic
+agent-completion callback can use them to post an eventual answer.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+from frappe import _
+
+from huf.ai.gateway_service import ingest_gateway_event
+
+
+SIGNATURE_HEADER = "X-Signature-Ed25519"
+TIMESTAMP_HEADER = "X-Signature-Timestamp"
+PING = 1
+APPLICATION_COMMAND = 2
+DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5
+
+
+def _request_header(name: str) -> str:
+	return (frappe.request.headers.get(name) or "").strip() if frappe.request else ""
+
+
+def _request_body() -> bytes:
+	return frappe.request.get_data() if frappe.request else b""
+
+
+def _gateway_public_key(gateway) -> str:
+	"""Read Discord's public key from the Gateway's linked credentials only."""
+	if not gateway.integration_settings:
+		return ""
+	settings = frappe.get_doc("Integration Settings", gateway.integration_settings)
+	if settings.service != "discord" or not settings.is_active:
+		return ""
+	for credential in settings.credentials:
+		if credential.key == "interactions_public_key":
+			return credential.get_password("value") or ""
+	return ""
+
+
+def verify_interaction_signature(public_key: str, signature: str, timestamp: str, body: bytes) -> bool:
+	"""Return whether a Discord Ed25519 Interaction signature is valid."""
+	if not all([public_key, signature, timestamp, body]):
+		return False
+	try:
+		from cryptography.exceptions import InvalidSignature
+		from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+		key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key))
+		key.verify(bytes.fromhex(signature), timestamp.encode() + body)
+		return True
+	except (ImportError, InvalidSignature, ValueError, TypeError):
+		return False
+
+
+def _interaction_context(payload: dict) -> dict:
+	member = payload.get("member") or {}
+	user = member.get("user") or payload.get("user") or {}
+	data = payload.get("data") or {}
+	options = data.get("options") or []
+	option_text = " ".join(str(option.get("value", "")) for option in options if option.get("value") is not None)
+	command = str(data.get("name") or "interaction")
+	return {
+		"sender_id": str(user.get("id") or ""),
+		"conversation_id": str(payload.get("channel_id") or ""),
+		"thread_id": str((payload.get("message") or {}).get("id") or ""),
+		"message_text": " ".join(part for part in [command, option_text] if part),
+	}
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def handle_interaction(gateway_name: str | None = None) -> dict:
+	"""Verify and queue one Discord Interaction for a configured Gateway.
+
+	The endpoint is ``/api/method/huf.ai.gateways.discord.handle_interaction``
+	with a ``gateway_name`` query parameter.  It deliberately accepts only
+	Discord application interactions, rather than unsigned message events.
+	"""
+	if not gateway_name or not frappe.db.exists("Gateway", gateway_name):
+		return {"error": "Unknown gateway"}
+
+	gateway = frappe.get_doc("Gateway", gateway_name)
+	if gateway.provider != "Discord" or not gateway.is_enabled:
+		return {"error": "Gateway is inactive"}
+
+	body = _request_body()
+	if not verify_interaction_signature(
+		_gateway_public_key(gateway),
+		_request_header(SIGNATURE_HEADER),
+		_request_header(TIMESTAMP_HEADER),
+		body,
+	):
+		frappe.local.response.http_status_code = 401
+		return {"error": "Invalid Discord signature"}
+
+	try:
+		payload = json.loads(body)
+	except (TypeError, ValueError):
+		frappe.local.response.http_status_code = 400
+		return {"error": "Invalid JSON payload"}
+
+	if payload.get("type") == PING:
+		return {"type": PING}
+	if payload.get("type") != APPLICATION_COMMAND or not payload.get("id"):
+		frappe.local.response.http_status_code = 400
+		return {"error": "Unsupported Discord interaction"}
+
+	context = _interaction_context(payload)
+	if not context["sender_id"]:
+		frappe.local.response.http_status_code = 400
+		return {"error": "Discord interaction has no sender"}
+
+	ingest_gateway_event(
+		gateway.name,
+		str(payload["id"]),
+		context,
+		verified_sender=True,
+		raw_payload=payload,
+	)
+	return {"type": DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE}

--- a/huf/ai/tests/test_discord_gateway.py
+++ b/huf/ai/tests/test_discord_gateway.py
@@ -1,0 +1,48 @@
+"""Focused unit tests for the Discord Gateway ingress adapter."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from huf.ai.gateways import discord
+
+
+class TestDiscordGateway(unittest.TestCase):
+	def test_valid_ed25519_signature_is_accepted(self):
+		try:
+			from cryptography.hazmat.primitives import serialization
+			from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+		except ImportError:
+			self.skipTest("cryptography is not installed")
+		private_key = Ed25519PrivateKey.generate()
+		body = b'{"type":1}'
+		timestamp = "1234567890"
+		signature = private_key.sign(timestamp.encode() + body).hex()
+		public_key = private_key.public_key().public_bytes(
+			encoding=serialization.Encoding.Raw,
+			format=serialization.PublicFormat.Raw,
+		).hex()
+		self.assertTrue(discord.verify_interaction_signature(public_key, signature, timestamp, body))
+
+	def test_invalid_signature_is_rejected(self):
+		self.assertFalse(discord.verify_interaction_signature("00" * 32, "00" * 64, "1", b"{}"))
+
+	def test_interaction_context_normalizes_command(self):
+		self.assertEqual(
+			discord._interaction_context({"channel_id": "c1", "member": {"user": {"id": "u1"}}, "data": {"name": "ask", "options": [{"value": "hello"}]}}),
+			{"sender_id": "u1", "conversation_id": "c1", "thread_id": "", "message_text": "ask hello"},
+		)
+
+	@patch("huf.ai.gateways.discord.ingest_gateway_event")
+	@patch("huf.ai.gateways.discord.verify_interaction_signature", return_value=True)
+	@patch("huf.ai.gateways.discord._gateway_public_key", return_value="public-key")
+	@patch("huf.ai.gateways.discord._request_header", return_value="signature")
+	@patch("huf.ai.gateways.discord._request_body", return_value=b'{"id":"i1","type":2,"channel_id":"c1","member":{"user":{"id":"u1"}},"data":{"name":"ask"}}')
+	@patch("huf.ai.gateways.discord.frappe.get_doc")
+	@patch("huf.ai.gateways.discord.frappe.db.exists", return_value=True)
+	def test_command_is_ingested_then_deferred(self, _exists, get_doc, _body, _header, _key, _verify, ingest):
+		get_doc.return_value = MagicMock(name="gateway", provider="Discord", is_enabled=True)
+		get_doc.return_value.name = "discord-gateway"
+		self.assertEqual(discord.handle_interaction("discord-gateway"), {"type": 5})
+		ingest.assert_called_once()

--- a/huf/huf/doctype/gateway/gateway.json
+++ b/huf/huf/doctype/gateway/gateway.json
@@ -8,7 +8,7 @@
  "field_order": ["gateway_name", "provider", "is_enabled", "integration_settings", "execution_user", "description", "access_policy", "allowed_senders", "section_default_route", "default_target_type", "default_agent", "default_flow", "section_status", "last_event_at", "last_error"],
  "fields": [
   {"fieldname":"gateway_name","fieldtype":"Data","in_list_view":1,"label":"Gateway name","reqd":1,"unique":1},
-  {"fieldname":"provider","fieldtype":"Select","in_list_view":1,"label":"Channel","options":"Telegram\nSlack\nEmail\nWhatsApp","reqd":1},
+  {"fieldname":"provider","fieldtype":"Select","in_list_view":1,"label":"Channel","options":"Telegram\nSlack\nDiscord\nEmail\nWhatsApp","reqd":1},
   {"default":"1","fieldname":"is_enabled","fieldtype":"Check","in_list_view":1,"label":"Enabled"},
   {"description":"Optional existing integration that owns this channel's credentials. This keeps sending tools separate from inbound routing.","fieldname":"integration_settings","fieldtype":"Link","label":"Connected integration","options":"Integration Settings"},
   {"description":"The least-privileged Huf user used when this gateway starts an Agent or Flow. Never use Administrator.","fieldname":"execution_user","fieldtype":"Link","label":"Run as user","options":"User"},


### PR DESCRIPTION
## Summary
- adds a Discord Interaction gateway adapter, stacked on #441
- verifies the Discord Ed25519 signature against the exact timestamp + raw request body before accepting an event
- normalizes application commands into the queue-first Gateway ingress and returns Discord’s required deferred response
- adds Discord to the Gateway provider choice; existing Discord agent tools remain unchanged

## Intentional boundary
Discord requires an acknowledgement within three seconds. This PR does not pretend to send an eventual agent answer: gateway foundation queues work and currently returns an Agent Run ID, not a completion payload. A follow-up cross-provider completion/callback contract should post the eventual result through the existing `discord_send_message` tool/API.

## Credential setup
Link an active Discord Integration Settings record to the Gateway and add an encrypted `interactions_public_key` credential containing the Discord Application Public Key.

## Checks
- `python3 -m json.tool huf/huf/doctype/gateway/gateway.json`
- `python3 -m py_compile huf/ai/gateways/discord.py huf/ai/tests/test_discord_gateway.py`
- `git diff --check`

Focused unittest execution requires the Frappe app runtime; the isolated container-copy attempt could not import the copied app because of container ownership/import-path constraints, without modifying any bench.