### PR TITLE
feat(gateway): add adapter SDK contract

### DIFF
--- a/huf/ai/gateway_adapters/__init__.py
+++ b/huf/ai/gateway_adapters/__init__.py
@@ -1,0 +1,33 @@
+"""Provider-neutral contracts for Huf messaging gateway adapters.
+
+The SDK deliberately contains no Frappe persistence, HTTP endpoint, or provider
+implementation.  Provider packages use these contracts before handing verified,
+normalized events to Huf's Gateway service.
+"""
+
+from huf.ai.gateway_adapters.adapter import GatewayAdapter
+from huf.ai.gateway_adapters.conformance import GatewayAdapterConformanceError, assert_adapter_conforms
+from huf.ai.gateway_adapters.registry import GatewayAdapterRegistry
+from huf.ai.gateway_adapters.types import (
+	GatewayCapabilities,
+	GatewayCredentialField,
+	GatewayCredentialSchema,
+	GatewayInboundRequest,
+	GatewayReply,
+	NormalizedGatewayEvent,
+	OutboundDelivery,
+)
+
+__all__ = [
+	"GatewayAdapter",
+	"GatewayAdapterConformanceError",
+	"GatewayAdapterRegistry",
+	"GatewayCapabilities",
+	"GatewayCredentialField",
+	"GatewayCredentialSchema",
+	"GatewayInboundRequest",
+	"GatewayReply",
+	"NormalizedGatewayEvent",
+	"OutboundDelivery",
+	"assert_adapter_conforms",
+]

--- a/huf/ai/gateway_adapters/adapter.py
+++ b/huf/ai/gateway_adapters/adapter.py
@@ -1,0 +1,33 @@
+"""The provider contract implemented by each messaging gateway adapter."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from huf.ai.gateway_adapters.types import (
+	GatewayCapabilities,
+	GatewayCredentialSchema,
+	GatewayInboundRequest,
+	GatewayReply,
+	NormalizedGatewayEvent,
+	OutboundDelivery,
+)
+
+
+class GatewayAdapter(ABC):
+	"""Fail-closed contract for one provider's inbound and outbound transport."""
+
+	provider_id: str
+	credential_schema: GatewayCredentialSchema
+	capabilities: GatewayCapabilities
+
+	@abstractmethod
+	def verify_inbound(self, request: GatewayInboundRequest) -> bool:
+		"""Return true only when the provider has authenticated this request."""
+
+	@abstractmethod
+	def normalize_inbound(self, request: GatewayInboundRequest) -> NormalizedGatewayEvent:
+		"""Convert an already verified provider request into a Huf event."""
+
+	@abstractmethod
+	def send_reply(self, reply: GatewayReply) -> OutboundDelivery:
+		"""Send an outbound reply and return the provider delivery receipt."""

--- a/huf/ai/gateway_adapters/conformance.py
+++ b/huf/ai/gateway_adapters/conformance.py
@@ -1,0 +1,40 @@
+"""Reusable contract checks for provider gateway adapter implementations."""
+
+from __future__ import annotations
+
+from huf.ai.gateway_adapters.adapter import GatewayAdapter
+from huf.ai.gateway_adapters.types import GatewayInboundRequest, GatewayReply, NormalizedGatewayEvent
+
+
+class GatewayAdapterConformanceError(ValueError):
+	"""Raised when an adapter violates the minimum Huf gateway contract."""
+
+
+def assert_adapter_conforms(
+	adapter: GatewayAdapter,
+	verified_request: GatewayInboundRequest,
+	reply: GatewayReply,
+) -> NormalizedGatewayEvent:
+	"""Exercise the mandatory verified-inbound and outbound-reply contract.
+
+	Provider packages call this from their own fixture tests. It deliberately does
+	not make network calls or persist data; it verifies only the adapter boundary.
+	"""
+	if not isinstance(getattr(adapter, "provider_id", None), str) or not adapter.provider_id.strip():
+		raise GatewayAdapterConformanceError("Adapter provider_id is required")
+	if not adapter.credential_schema.fields:
+		raise GatewayAdapterConformanceError("Adapter must declare a credential schema")
+	if not adapter.capabilities.ingress_transports:
+		raise GatewayAdapterConformanceError("Adapter must declare an ingress transport")
+	if not adapter.capabilities.supports_text_reply:
+		raise GatewayAdapterConformanceError("MVP adapters must support text replies")
+	if not adapter.verify_inbound(verified_request):
+		raise GatewayAdapterConformanceError("Verified fixture was rejected")
+
+	event = adapter.normalize_inbound(verified_request)
+	if not isinstance(event, NormalizedGatewayEvent):
+		raise GatewayAdapterConformanceError("Adapter did not return a NormalizedGatewayEvent")
+	delivery = adapter.send_reply(reply)
+	if not delivery.accepted:
+		raise GatewayAdapterConformanceError("Adapter rejected the outbound reply")
+	return event

--- a/huf/ai/gateway_adapters/registry.py
+++ b/huf/ai/gateway_adapters/registry.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+"""Deterministic registry of gateway adapters, keyed by ``provider_id``."""
+
+from __future__ import annotations
+
+from huf.ai.gateway_adapters.adapter import GatewayAdapter
+
+
+class GatewayAdapterRegistry:
+	"""Deterministic registry of gateway adapters.
+
+	Registration is idempotent for the identical class; listing is always
+	sorted by ``provider_id`` so lookups and iteration are deterministic
+	regardless of registration order.
+	"""
+
+	def __init__(self) -> None:
+		self._adapters: dict[str, type[GatewayAdapter]] = {}
+
+	def register(self, adapter_cls: type[GatewayAdapter]) -> type[GatewayAdapter]:
+		"""Register an adapter class under its ``provider_id``.
+
+		Raises ``TypeError`` for non-adapters and ``ValueError`` when a
+		different class already owns the ``provider_id``. Returns the class
+		so it can be used as a decorator.
+		"""
+		if not isinstance(adapter_cls, type) or not issubclass(adapter_cls, GatewayAdapter):
+			raise TypeError(f"{adapter_cls!r} is not a GatewayAdapter subclass")
+		provider_id = getattr(adapter_cls, "provider_id", None)
+		if not isinstance(provider_id, str) or not provider_id.strip():
+			raise ValueError(f"Adapter {adapter_cls!r} must define a non-empty 'provider_id'")
+		existing = self._adapters.get(provider_id)
+		if existing is not None and existing is not adapter_cls:
+			raise ValueError(
+				f"Gateway provider_id '{provider_id}' is already registered "
+				f"({existing.__module__}.{existing.__qualname__})"
+			)
+		self._adapters[provider_id] = adapter_cls
+		return adapter_cls
+
+	def get(self, provider_id: str) -> type[GatewayAdapter]:
+		"""Return the adapter class registered under ``provider_id``.
+
+		Raises ``KeyError`` listing the known provider ids when not found.
+		"""
+		try:
+			return self._adapters[provider_id]
+		except KeyError:
+			known = ", ".join(self.names()) or "<none>"
+			raise KeyError(
+				f"Unknown gateway adapter '{provider_id}'. Registered: {known}"
+			) from None
+
+	def names(self) -> list[str]:
+		"""All registered provider ids, sorted ascending."""
+		return sorted(self._adapters)
+
+	def adapters(self) -> tuple[type[GatewayAdapter], ...]:
+		"""All registered adapter classes, in ascending ``provider_id`` order."""
+		return tuple(self._adapters[name] for name in self.names())
+
+	def __contains__(self, provider_id: str) -> bool:
+		return provider_id in self._adapters
+
+	def __len__(self) -> int:
+		return len(self._adapters)

--- a/huf/ai/gateway_adapters/types.py
+++ b/huf/ai/gateway_adapters/types.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+"""Immutable value objects shared by every gateway adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayCredentialField:
+	"""One provider configuration field that a gateway administrator supplies."""
+
+	key: str
+	label: str
+	required: bool = True
+	secret: bool = True
+	description: str = ""
+
+	def __post_init__(self) -> None:
+		if not self.key.strip():
+			raise ValueError("Credential field key is required")
+		if not self.label.strip():
+			raise ValueError("Credential field label is required")
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayCredentialSchema:
+	"""Ordered, validated credential schema declared by one adapter."""
+
+	fields: tuple[GatewayCredentialField, ...]
+
+	def __post_init__(self) -> None:
+		keys = [field.key for field in self.fields]
+		if len(keys) != len(set(keys)):
+			raise ValueError("Credential field keys must be unique")
+
+	def missing_required(self, credentials: Mapping[str, Any]) -> tuple[str, ...]:
+		"""Return required keys absent or empty from a supplied credential mapping."""
+		return tuple(field.key for field in self.fields if field.required and not credentials.get(field.key))
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayCapabilities:
+	"""Explicitly declared transport and outbound capabilities of an adapter."""
+
+	ingress_transports: frozenset[str]
+	supports_text_reply: bool = True
+	supports_thread_reply: bool = False
+	supports_media_reply: bool = False
+	max_outbound_messages_per_second: float | None = None
+
+	def __post_init__(self) -> None:
+		if not self.ingress_transports:
+			raise ValueError("At least one ingress transport is required")
+		if any(not transport.strip() for transport in self.ingress_transports):
+			raise ValueError("Ingress transport names must not be blank")
+		if self.max_outbound_messages_per_second is not None and self.max_outbound_messages_per_second <= 0:
+			raise ValueError("Outbound message rate limit must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayInboundRequest:
+	"""Transport-neutral request data received from a provider."""
+
+	body: bytes
+	headers: Mapping[str, str] = field(default_factory=dict)
+	query: Mapping[str, str] = field(default_factory=dict)
+	method: str = "POST"
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedGatewayEvent:
+	"""A verified provider event in the shape consumed by Huf Gateway ingress."""
+
+	provider_event_id: str
+	sender_id: str
+	conversation_id: str
+	message_text: str
+	thread_id: str | None = None
+	is_room: bool = False
+	mentioned: bool = False
+	raw_payload: Mapping[str, Any] = field(default_factory=dict)
+
+	def __post_init__(self) -> None:
+		for name in ("provider_event_id", "sender_id", "conversation_id"):
+			if not getattr(self, name).strip():
+				raise ValueError(f"{name} is required")
+
+
+@dataclass(frozen=True, slots=True)
+class GatewayReply:
+	"""A provider-neutral outbound text reply to a normalized event."""
+
+	conversation_id: str
+	text: str
+	thread_id: str | None = None
+	reply_to_provider_message_id: str | None = None
+
+	def __post_init__(self) -> None:
+		if not self.conversation_id.strip():
+			raise ValueError("conversation_id is required")
+		if not self.text.strip():
+			raise ValueError("Reply text is required")
+
+
+@dataclass(frozen=True, slots=True)
+class OutboundDelivery:
+	"""The provider receipt returned after a reply has been accepted."""
+
+	provider_message_id: str
+	accepted: bool = True
+	provider_response: Mapping[str, Any] = field(default_factory=dict)
+
+	def __post_init__(self) -> None:
+		if not self.provider_message_id.strip():
+			raise ValueError("provider_message_id is required")

--- a/huf/ai/tests/test_gateway_adapter_sdk.py
+++ b/huf/ai/tests/test_gateway_adapter_sdk.py
@@ -1,0 +1,100 @@
+"""Contract tests for the provider-neutral Gateway Adapter SDK."""
+
+from __future__ import annotations
+
+import unittest
+
+from huf.ai.gateway_adapters import (
+	GatewayAdapter,
+	GatewayAdapterConformanceError,
+	GatewayAdapterRegistry,
+	GatewayCapabilities,
+	GatewayCredentialField,
+	GatewayCredentialSchema,
+	GatewayInboundRequest,
+	GatewayReply,
+	NormalizedGatewayEvent,
+	OutboundDelivery,
+	assert_adapter_conforms,
+)
+
+
+class FakeAdapter(GatewayAdapter):
+	provider_id = "fake"
+	credential_schema = GatewayCredentialSchema((GatewayCredentialField("secret", "Secret"),))
+	capabilities = GatewayCapabilities(frozenset({"webhook"}), supports_thread_reply=True)
+
+	def verify_inbound(self, request: GatewayInboundRequest) -> bool:
+		return request.headers.get("X-Fake-Signature") == "valid"
+
+	def normalize_inbound(self, request: GatewayInboundRequest) -> NormalizedGatewayEvent:
+		if not self.verify_inbound(request):
+			raise ValueError("Inbound request was not verified")
+		return NormalizedGatewayEvent(
+			provider_event_id="event-1",
+			sender_id="sender-1",
+			conversation_id="conversation-1",
+			message_text=request.body.decode(),
+			thread_id="thread-1",
+		)
+
+	def send_reply(self, reply: GatewayReply) -> OutboundDelivery:
+		if not reply.text:
+			raise ValueError("Reply text is required")
+		return OutboundDelivery("message-1", provider_response={"conversation": reply.conversation_id})
+
+
+class TestGatewayAdapterSdk(unittest.TestCase):
+	def test_credential_schema_rejects_duplicate_keys_and_finds_missing_required(self):
+		field = GatewayCredentialField("token", "Token")
+		with self.assertRaises(ValueError):
+			GatewayCredentialSchema((field, field))
+		self.assertEqual(
+			GatewayCredentialSchema((field,)).missing_required({}),
+			("token",),
+		)
+
+	def test_value_types_reject_missing_required_fields(self):
+		with self.assertRaises(ValueError):
+			GatewayCapabilities(frozenset())
+		with self.assertRaises(ValueError):
+			NormalizedGatewayEvent("", "sender", "conversation", "hello")
+		with self.assertRaises(ValueError):
+			GatewayReply("conversation", "")
+		with self.assertRaises(ValueError):
+			OutboundDelivery("")
+
+	def test_registry_is_deterministic_and_rejects_duplicates(self):
+		registry = GatewayAdapterRegistry()
+		registry.register(FakeAdapter)
+		self.assertIs(registry.get("fake"), FakeAdapter)
+		self.assertEqual(registry.names(), ["fake"])
+		with self.assertRaises(ValueError):
+			registry.register(type("DuplicateAdapter", (FakeAdapter,), {"provider_id": "fake"}))
+		with self.assertRaises(KeyError):
+			registry.get("missing")
+
+	def test_verified_inbound_normalizes_and_sends_reply(self):
+		adapter = FakeAdapter()
+		request = GatewayInboundRequest(b"hello", headers={"X-Fake-Signature": "valid"})
+		self.assertTrue(adapter.verify_inbound(request))
+		event = adapter.normalize_inbound(request)
+		self.assertEqual(event.provider_event_id, "event-1")
+		delivery = adapter.send_reply(GatewayReply(event.conversation_id, "hi", thread_id=event.thread_id))
+		self.assertTrue(delivery.accepted)
+		self.assertEqual(delivery.provider_message_id, "message-1")
+
+	def test_conformance_runner_exercises_the_minimum_adapter_contract(self):
+		adapter = FakeAdapter()
+		request = GatewayInboundRequest(b"hello", headers={"X-Fake-Signature": "valid"})
+		event = assert_adapter_conforms(adapter, request, GatewayReply("conversation-1", "hi"))
+		self.assertEqual(event.sender_id, "sender-1")
+		with self.assertRaises(GatewayAdapterConformanceError):
+			assert_adapter_conforms(adapter, GatewayInboundRequest(b"hello"), GatewayReply("conversation-1", "hi"))
+
+	def test_unverified_request_cannot_be_normalized_by_conforming_adapter(self):
+		adapter = FakeAdapter()
+		request = GatewayInboundRequest(b"hello", headers={"X-Fake-Signature": "invalid"})
+		self.assertFalse(adapter.verify_inbound(request))
+		with self.assertRaises(ValueError):
+			adapter.normalize_inbound(request)


### PR DESCRIPTION
## Summary

Adds a pure-Python Gateway Adapter SDK, independently mergeable from the draft Gateway foundation.

- Defines credential schema, capabilities, verified inbound request, normalized event, outbound reply/delivery types.
- Adds a fail-closed adapter protocol, deterministic provider registry, and reusable conformance runner.
- Adds focused fake-adapter contract tests.

## Boundary

This does not add a public endpoint, provider adapter, Frappe DocType, or Integration Settings fields. Provider adapters remain separate follow-up PRs and must validate native input before calling the Gateway foundation.

## Verification

- `python3 -m py_compile huf/ai/gateway_adapters/*.py huf/ai/tests/test_gateway_adapter_sdk.py`
- Isolated Frappe-environment test from a disposable clone: `6/6` passing (`huf.ai.tests.test_gateway_adapter_sdk`).

## Regional readiness

- Feishu/Lark is the first candidate once #441 and this SDK have landed; implementation must select and fixture-test one official ingress transport.
- WeCom, DingTalk, and VK remain evidence-gated.
- Kakao requires CS Talk/Business approval; consumer/channel APIs are not treated as two-way support.
- MAX remains gated on privacy, deployment, and legal review.

## Related PRs

- Stacked provider adapters: #447 (VK) and #448 (WeCom), both target this SDK branch.
- Runtime endpoint/routing integration remains separately dependent on Gateway foundation #441.

## Runtime bridge

- #449 connects the Gateway foundation and installed adapter packages for verified VK/WeCom webhooks and Agent reply delivery.