### PR TITLE
feat(gateway): add WeCom adapter contract

### DIFF
--- a/huf/ai/gateway_adapters/__init__.py
+++ b/huf/ai/gateway_adapters/__init__.py
@@ -17,6 +17,7 @@ from huf.ai.gateway_adapters.types import (
 	NormalizedGatewayEvent,
 	OutboundDelivery,
 )
+from huf.ai.gateway_adapters.wecom import WeComGatewayAdapter
 
 __all__ = [
 	"GatewayAdapter",
@@ -29,5 +30,6 @@ __all__ = [
 	"GatewayReply",
 	"NormalizedGatewayEvent",
 	"OutboundDelivery",
+	"WeComGatewayAdapter",
 	"assert_adapter_conforms",
 ]

--- a/huf/ai/gateway_adapters/wecom.py
+++ b/huf/ai/gateway_adapters/wecom.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+"""WeCom self-built-application callback and messaging adapter."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import struct
+import time
+import xml.etree.ElementTree as element_tree
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from huf.ai.gateway_adapters.adapter import GatewayAdapter
+from huf.ai.gateway_adapters.types import (
+	GatewayCapabilities,
+	GatewayCredentialField,
+	GatewayCredentialSchema,
+	GatewayInboundRequest,
+	GatewayReply,
+	NormalizedGatewayEvent,
+	OutboundDelivery,
+)
+
+
+WECOM_GET_TOKEN_URL = "https://qyapi.weixin.qq.com/cgi-bin/gettoken"
+WECOM_SEND_MESSAGE_URL = "https://qyapi.weixin.qq.com/cgi-bin/message/send"
+
+
+def _requests_get(url: str, *, params: Mapping[str, str], timeout: int) -> Any:
+	"""Lazily import requests so this package has no import-time HTTP dependency."""
+	import requests
+
+	return requests.get(url, params=params, timeout=timeout)
+
+
+def _requests_post(url: str, *, params: Mapping[str, str], json: Mapping[str, Any], timeout: int) -> Any:
+	"""Lazily import requests so this package has no import-time HTTP dependency."""
+	import requests
+
+	return requests.post(url, params=params, json=json, timeout=timeout)
+
+
+class WeComGatewayAdapter(GatewayAdapter):
+	"""Fail-closed WeCom encrypted callback adapter for a self-built app."""
+
+	provider_id = "wecom"
+	credential_schema = GatewayCredentialSchema(
+		(
+			GatewayCredentialField("corp_id", "Corporation ID", secret=False),
+			GatewayCredentialField("agent_id", "Application Agent ID", secret=False),
+			GatewayCredentialField("corp_secret", "Application Secret"),
+			GatewayCredentialField("callback_token", "Callback Token"),
+			GatewayCredentialField("encoding_aes_key", "Callback EncodingAESKey"),
+		)
+	)
+	capabilities = GatewayCapabilities(
+		frozenset({"webhook"}),
+		supports_thread_reply=False,
+		max_outbound_messages_per_second=0.5,
+	)
+
+	def __init__(
+		self,
+		credentials: Mapping[str, str],
+		*,
+		http_get: Callable[..., Any] = _requests_get,
+		http_post: Callable[..., Any] = _requests_post,
+		clock: Callable[[], float] = time.monotonic,
+	) -> None:
+		missing = self.credential_schema.missing_required(credentials)
+		if missing:
+			raise ValueError(f"WeCom adapter is missing required credentials: {', '.join(missing)}")
+		self._corp_id = credentials["corp_id"]
+		self._agent_id = credentials["agent_id"]
+		self._corp_secret = credentials["corp_secret"]
+		self._callback_token = credentials["callback_token"]
+		self._aes_key = self._decode_aes_key(credentials["encoding_aes_key"])
+		self._http_get = http_get
+		self._http_post = http_post
+		self._clock = clock
+		self._access_token: str | None = None
+		self._access_token_expires_at = 0.0
+
+	def verify_url(self, request: GatewayInboundRequest) -> str:
+		"""Verify a WeCom GET callback challenge and return its plaintext echo."""
+		encrypted = request.query.get("echostr", "")
+		if not encrypted or not self._valid_signature(request.query, encrypted):
+			raise ValueError("WeCom callback URL verification failed")
+		return self._decrypt(encrypted).decode("utf-8")
+
+	def verify_inbound(self, request: GatewayInboundRequest) -> bool:
+		"""Return true only for signed, decryptable callbacks addressed to this corp."""
+		try:
+			encrypted = self._encrypted_body(request.body)
+			if not encrypted or not self._valid_signature(request.query, encrypted):
+				return False
+			self._decrypt(encrypted)
+			return True
+		except (ValueError, UnicodeDecodeError, element_tree.ParseError):
+			return False
+
+	def normalize_inbound(self, request: GatewayInboundRequest) -> NormalizedGatewayEvent:
+		"""Normalize a verified WeCom text callback; reject unsupported events."""
+		if not self.verify_inbound(request):
+			raise ValueError("WeCom callback was not verified")
+		xml_body = self._decrypt(self._encrypted_body(request.body) or "")
+		root = element_tree.fromstring(xml_body)
+		if self._xml_text(root, "MsgType") != "text":
+			raise ValueError("WeCom callback is not a text message")
+		message_id = self._xml_text(root, "MsgId")
+		sender_id = self._xml_text(root, "FromUserName")
+		if not message_id or not sender_id:
+			raise ValueError("WeCom text callback is missing message or sender identifier")
+		return NormalizedGatewayEvent(
+			provider_event_id=message_id,
+			sender_id=sender_id,
+			conversation_id=sender_id,
+			message_text=self._xml_text(root, "Content") or "",
+			raw_payload={"xml": xml_body.decode("utf-8")},
+		)
+
+	def send_reply(self, reply: GatewayReply) -> OutboundDelivery:
+		"""Send an application text message to the reply's WeCom recipient."""
+		access_token = self._get_access_token()
+		payload = {
+			"touser": reply.conversation_id,
+			"msgtype": "text",
+			"agentid": self._agent_id,
+			"text": {"content": reply.text},
+		}
+		response = self._http_post(
+			WECOM_SEND_MESSAGE_URL,
+			params={"access_token": access_token},
+			json=payload,
+			timeout=10,
+		)
+		if hasattr(response, "raise_for_status"):
+			response.raise_for_status()
+		body = response.json() if hasattr(response, "json") else response
+		if not isinstance(body, Mapping):
+			raise ValueError("WeCom message send returned an invalid response")
+		if body.get("errcode", 0) != 0:
+			raise ValueError(f"WeCom message send failed with errcode {body.get('errcode')}")
+		message_id = body.get("msgid")
+		if not message_id:
+			raise ValueError("WeCom message send response did not include a message id")
+		return OutboundDelivery(str(message_id), provider_response=body)
+
+	def _get_access_token(self) -> str:
+		if self._access_token and self._clock() < self._access_token_expires_at:
+			return self._access_token
+		response = self._http_get(
+			WECOM_GET_TOKEN_URL,
+			params={"corpid": self._corp_id, "corpsecret": self._corp_secret},
+			timeout=10,
+		)
+		if hasattr(response, "raise_for_status"):
+			response.raise_for_status()
+		body = response.json() if hasattr(response, "json") else response
+		if not isinstance(body, Mapping) or body.get("errcode", 0) != 0 or not body.get("access_token"):
+			raise ValueError("WeCom access token request failed")
+		self._access_token = str(body["access_token"])
+		expires_in = int(body.get("expires_in") or 0)
+		self._access_token_expires_at = self._clock() + max(0, expires_in - 60)
+		return self._access_token
+
+	def _valid_signature(self, query: Mapping[str, str], encrypted: str) -> bool:
+		timestamp = query.get("timestamp", "")
+		nonce = query.get("nonce", "")
+		provided = query.get("msg_signature", "")
+		if not timestamp or not nonce or not provided:
+			return False
+		candidate = hashlib.sha1("".join(sorted((self._callback_token, timestamp, nonce, encrypted))).encode()).hexdigest()
+		return hmac.compare_digest(candidate, provided)
+
+	def _decrypt(self, encrypted: str) -> bytes:
+		try:
+			ciphertext = base64.b64decode(encrypted)
+		except Exception as exc:
+			raise ValueError("WeCom callback ciphertext is invalid") from exc
+		decryptor = Cipher(algorithms.AES(self._aes_key), modes.CBC(self._aes_key[:16])).decryptor()
+		plain = decryptor.update(ciphertext) + decryptor.finalize()
+		if not plain:
+			raise ValueError("WeCom callback plaintext is empty")
+		padding = plain[-1]
+		if padding < 1 or padding > 32 or plain[-padding:] != bytes([padding]) * padding:
+			raise ValueError("WeCom callback padding is invalid")
+		content = plain[:-padding]
+		if len(content) < 20:
+			raise ValueError("WeCom callback plaintext is malformed")
+		xml_length = struct.unpack("!I", content[16:20])[0]
+		xml_end = 20 + xml_length
+		if xml_end > len(content):
+			raise ValueError("WeCom callback XML length is invalid")
+		receive_id = content[xml_end:].decode("utf-8")
+		if not hmac.compare_digest(receive_id, self._corp_id):
+			raise ValueError("WeCom callback receive-id does not match corporation")
+		return content[20:xml_end]
+
+	@staticmethod
+	def _decode_aes_key(value: str) -> bytes:
+		try:
+			key = base64.b64decode(f"{value}=")
+		except Exception as exc:
+			raise ValueError("WeCom EncodingAESKey is invalid") from exc
+		if len(key) != 32:
+			raise ValueError("WeCom EncodingAESKey must decode to 32 bytes")
+		return key
+
+	@staticmethod
+	def _encrypted_body(body: bytes) -> str | None:
+		root = element_tree.fromstring(body)
+		return WeComGatewayAdapter._xml_text(root, "Encrypt")
+
+	@staticmethod
+	def _xml_text(root: element_tree.Element, tag: str) -> str | None:
+		element = root.find(tag)
+		return element.text if element is not None else None

--- a/huf/ai/tests/test_wecom_gateway_adapter.py
+++ b/huf/ai/tests/test_wecom_gateway_adapter.py
@@ -1,0 +1,111 @@
+"""Cryptographic fixtures for the WeCom self-built-app adapter."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import struct
+import unittest
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from huf.ai.gateway_adapters import GatewayInboundRequest, GatewayReply, assert_adapter_conforms
+from huf.ai.gateway_adapters.wecom import WECOM_GET_TOKEN_URL, WECOM_SEND_MESSAGE_URL, WeComGatewayAdapter
+
+
+class FakeResponse:
+	def __init__(self, body):
+		self.body = body
+
+	def raise_for_status(self):
+		return None
+
+	def json(self):
+		return self.body
+
+
+class TestWeComGatewayAdapter(unittest.TestCase):
+	def setUp(self):
+		self.key = b"0123456789abcdef0123456789abcdef"
+		self.encoding_key = base64.b64encode(self.key).decode().rstrip("=")
+		self.get_calls = []
+		self.post_calls = []
+		self.now = 1000.0
+		self.adapter = WeComGatewayAdapter(
+			{
+				"corp_id": "wx-corp",
+				"agent_id": "100001",
+				"corp_secret": "corp-secret",
+				"callback_token": "callback-token",
+				"encoding_aes_key": self.encoding_key,
+			},
+			http_get=self._get,
+			http_post=self._post,
+			clock=lambda: self.now,
+		)
+
+	def _get(self, url, *, params, timeout):
+		self.get_calls.append({"url": url, "params": params, "timeout": timeout})
+		return FakeResponse({"errcode": 0, "access_token": "access-token", "expires_in": 7200})
+
+	def _post(self, url, *, params, json, timeout):
+		self.post_calls.append({"url": url, "params": params, "json": json, "timeout": timeout})
+		return FakeResponse({"errcode": 0, "msgid": "message-1"})
+
+	def _encrypt(self, plaintext: bytes, receive_id: str = "wx-corp") -> str:
+		content = b"R" * 16 + struct.pack("!I", len(plaintext)) + plaintext + receive_id.encode()
+		padding = 32 - len(content) % 32
+		content += bytes([padding]) * padding
+		encryptor = Cipher(algorithms.AES(self.key), modes.CBC(self.key[:16])).encryptor()
+		return base64.b64encode(encryptor.update(content) + encryptor.finalize()).decode()
+
+	def _request(self, plaintext: bytes, *, receive_id: str = "wx-corp", challenge: bool = False):
+		encrypted = self._encrypt(plaintext, receive_id)
+		timestamp, nonce = "1700000000", "nonce-1"
+		signature = hashlib.sha1("".join(sorted(("callback-token", timestamp, nonce, encrypted))).encode()).hexdigest()
+		query = {"msg_signature": signature, "timestamp": timestamp, "nonce": nonce}
+		if challenge:
+			query["echostr"] = encrypted
+			return GatewayInboundRequest(b"", query=query, method="GET")
+		return GatewayInboundRequest(f"<xml><Encrypt><![CDATA[{encrypted}]]></Encrypt></xml>".encode(), query=query)
+
+	def test_signed_encrypted_callback_normalizes_a_text_message(self):
+		xml = b"<xml><ToUserName><![CDATA[bot]]></ToUserName><FromUserName><![CDATA[user-1]]></FromUserName><CreateTime>1</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[hello]]></Content><MsgId>msg-1</MsgId></xml>"
+		request = self._request(xml)
+		self.assertTrue(self.adapter.verify_inbound(request))
+		event = self.adapter.normalize_inbound(request)
+		self.assertEqual((event.provider_event_id, event.sender_id, event.conversation_id, event.message_text), ("msg-1", "user-1", "user-1", "hello"))
+
+	def test_url_verification_and_wrong_signature_or_receive_id_fail_closed(self):
+		challenge = self._request(b"echo-value", challenge=True)
+		self.assertEqual(self.adapter.verify_url(challenge), "echo-value")
+		bad_signature = GatewayInboundRequest(challenge.body, query={**challenge.query, "msg_signature": "wrong"}, method="GET")
+		with self.assertRaises(ValueError):
+			self.adapter.verify_url(bad_signature)
+		wrong_corp = self._request(b"<xml><MsgType>text</MsgType></xml>", receive_id="other-corp")
+		self.assertFalse(self.adapter.verify_inbound(wrong_corp))
+
+	def test_outbound_reply_fetches_and_caches_access_token(self):
+		first = self.adapter.send_reply(GatewayReply("user-1", "hello"))
+		self.now += 1
+		second = self.adapter.send_reply(GatewayReply("user-2", "again"))
+		self.assertEqual((first.provider_message_id, second.provider_message_id), ("message-1", "message-1"))
+		self.assertEqual(len(self.get_calls), 1)
+		self.assertEqual(self.get_calls[0]["url"], WECOM_GET_TOKEN_URL)
+		self.assertEqual(self.post_calls[0], {
+			"url": WECOM_SEND_MESSAGE_URL,
+			"params": {"access_token": "access-token"},
+			"json": {"touser": "user-1", "msgtype": "text", "agentid": "100001", "text": {"content": "hello"}},
+			"timeout": 10,
+		})
+
+	def test_conformance_runner_uses_real_encryption_fixture(self):
+		xml = b"<xml><FromUserName><![CDATA[user-1]]></FromUserName><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[hello]]></Content><MsgId>msg-1</MsgId></xml>"
+		event = assert_adapter_conforms(self.adapter, self._request(xml), GatewayReply("user-1", "reply"))
+		self.assertEqual(event.provider_event_id, "msg-1")
+
+	def test_non_text_events_are_not_normalized(self):
+		xml = b"<xml><FromUserName><![CDATA[user-1]]></FromUserName><MsgType><![CDATA[image]]></MsgType><MsgId>msg-1</MsgId></xml>"
+		with self.assertRaisesRegex(ValueError, "not a text"):
+			self.adapter.normalize_inbound(self._request(xml))


### PR DESCRIPTION
## Summary

Adds a WeCom self-built-application adapter to the Gateway Adapter SDK.

- Verifies native callbacks fail-closed using WeCom’s sorted SHA-1 signature, AES-CBC/PKCS#7 decrypt, and corporation receive-ID check.
- Handles the GET URL-verification `echostr` flow separately from message ingestion.
- Normalizes only verified text callbacks.
- Fetches and caches application access tokens, then sends outbound text through the documented app message endpoint.
- Uses injected HTTP transports for deterministic tests.

## Scope boundary

This is a provider adapter only. It does not add an endpoint, DocType, credential UI, or Gateway foundation routing integration; those remain a later slice behind #441.

## Verification

- `python3 -m py_compile huf/ai/gateway_adapters/*.py huf/ai/tests/test_gateway_adapter_sdk.py huf/ai/tests/test_wecom_gateway_adapter.py`
- Disposable Frappe-environment clone: `11/11` unit tests passing across SDK + WeCom fixtures, including actual AES encrypt/decrypt fixtures.

## Dependency note

The supported Frappe environment already provides `cryptography` (verified: 49.0.0); this PR adds no dependency metadata.

## Related PRs

- **Stacked on:** #446 (Gateway Adapter SDK). Merge this PR after #446.
- Sibling adapter: #447 (VK), also stacked on #446.
- Runtime endpoint/routing integration remains separately dependent on Gateway foundation #441.

## Runtime bridge

- #449 connects the Gateway foundation and installed adapter packages for verified VK/WeCom webhooks and Agent reply delivery.