### PR TITLE
feat: SerpApi integration tools (hotels, reviews, YouTube)

### DIFF
--- a/huf/ai/tests/test_serp_tools.py
+++ b/huf/ai/tests/test_serp_tools.py
@@ -1,0 +1,975 @@
+"""Tests for the SerpApi ("SERP") integration tools.
+
+All SerpApi calls are mocked at `huf.ai.tools.serp_common._client`; no live keys
+or DB access are required.
+"""
+
+import json
+import sys
+import types
+import unittest
+from typing import ClassVar
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import _registry, serp_common, serp_hotels, serp_reviews, serp_youtube
+from huf.ai.tools.credentials import _get_alt_env_names
+from huf.ai.tools.serp_common import SerpValidationError
+
+
+class SerpToolTestCase(unittest.TestCase):
+	"""Base class wiring a mocked SerpApi client that records search params."""
+
+	def setUp(self):
+		self.responses = {}
+		self.captured = []
+		self.client = MagicMock()
+		self.client.search.side_effect = self._record
+		patcher = patch("huf.ai.tools.serp_common._client", return_value=self.client)
+		self.mock_client_fn = patcher.start()
+		self.addCleanup(patcher.stop)
+
+	def _record(self, params):
+		params = dict(params)
+		self.captured.append(params)
+		resp = self.responses[params["engine"]]
+		if callable(resp):
+			return resp(params)
+		if isinstance(resp, Exception):
+			raise resp
+		return resp
+
+
+class TestSerpCommonHelpers(unittest.TestCase):
+	def test_safe_float(self):
+		self.assertEqual(serp_common._safe_float(None), 0.0)
+		self.assertEqual(serp_common._safe_float("bad"), 0.0)
+		self.assertEqual(serp_common._safe_float("4.5"), 4.5)
+		self.assertEqual(serp_common._safe_float(3), 3.0)
+
+	def test_as_int(self):
+		self.assertIsNone(serp_common._as_int(None, "x"))
+		self.assertIsNone(serp_common._as_int("", "x"))
+		self.assertEqual(serp_common._as_int("7", "x"), 7)
+		with self.assertRaises(SerpValidationError):
+			serp_common._as_int("abc", "x")
+
+	def test_as_bool(self):
+		self.assertTrue(serp_common._as_bool(True))
+		self.assertFalse(serp_common._as_bool(False))
+		for truthy in ("1", "true", "True", "yes", "on", 1):
+			self.assertTrue(serp_common._as_bool(truthy))
+		for falsy in ("0", "false", "no", "", None, 0):
+			self.assertFalse(serp_common._as_bool(falsy))
+
+	def test_as_csv(self):
+		self.assertIsNone(serp_common._as_csv(None))
+		self.assertIsNone(serp_common._as_csv(""))
+		self.assertEqual(serp_common._as_csv("4, 5"), "4,5")
+		self.assertEqual(serp_common._as_csv(["4", " 5 ", ""]), "4,5")
+		self.assertEqual(serp_common._as_csv(("a", "b")), "a,b")
+
+	def test_client_lazy_import_uses_credential(self):
+		fake_serpapi = types.ModuleType("serpapi")
+		fake_serpapi.Client = MagicMock()
+		with (
+			patch("huf.ai.tools.serp_common.require_credential", return_value="KEY-1") as mock_cred,
+			patch.dict(sys.modules, {"serpapi": fake_serpapi}),
+		):
+			serp_common._client()
+			fake_serpapi.Client.assert_called_once_with(api_key="KEY-1")
+			mock_cred.assert_called_once_with("serpapi", "api_key")
+
+			mock_cred.reset_mock()
+			serp_common._client(api_key="EXPLICIT")
+			mock_cred.assert_not_called()
+
+
+class TestHotelSearch(SerpToolTestCase):
+	BASE: ClassVar = {
+		"q": "Hotels in Bandra Mumbai",
+		"check_in_date": "2026-01-10",
+		"check_out_date": "2026-01-12",
+	}
+
+	def test_full_param_building(self):
+		self.responses = {"google_hotels": {"properties": [], "serpapi_pagination": {}}}
+		out = json.loads(
+			serp_hotels.handle_serp_hotel_search(
+				**self.BASE,
+				adults=2,
+				children=2,
+				children_ages="5, 8",
+				currency="USD",
+				gl="us",
+				hl="en",
+				sort_by=3,
+				min_price=100,
+				max_price=500,
+				rating=8,
+				hotel_class="4,5",
+				property_types="12,17",
+				amenities="1,2",
+				brands="33,44",
+				free_cancellation=True,
+				special_offers="yes",
+				eco_certified=1,
+				next_page_token="TOK0",
+			)
+		)
+		self.assertTrue(out["success"])
+		expected = {
+			"engine": "google_hotels",
+			"q": "Hotels in Bandra Mumbai",
+			"gl": "us",
+			"hl": "en",
+			"check_in_date": "2026-01-10",
+			"check_out_date": "2026-01-12",
+			"currency": "USD",
+			"adults": 2,
+			"children": 2,
+			"children_ages": "5,8",
+			"sort_by": 3,
+			"min_price": 100,
+			"max_price": 500,
+			"rating": 8,
+			"hotel_class": "4,5",
+			"property_types": "12,17",
+			"amenities": "1,2",
+			"brands": "33,44",
+			"free_cancellation": "true",
+			"special_offers": "true",
+			"eco_certified": "true",
+			"next_page_token": "TOK0",
+		}
+		self.assertEqual(self.captured, [expected])
+		self.assertEqual(out["applied_filters"], {k: v for k, v in expected.items() if k != "engine"})
+		self.assertEqual(out["search_query"], "Hotels in Bandra Mumbai")
+
+	def test_defaults_only_send_required_params(self):
+		self.responses = {"google_hotels": {}}
+		json.loads(serp_hotels.handle_serp_hotel_search(**self.BASE))
+		params = self.captured[0]
+		self.assertEqual(
+			params,
+			{
+				"engine": "google_hotels",
+				"q": "Hotels in Bandra Mumbai",
+				"gl": "in",
+				"hl": "en",
+				"check_in_date": "2026-01-10",
+				"check_out_date": "2026-01-12",
+				"currency": "INR",
+				"adults": 2,
+			},
+		)
+
+	def test_vacation_rentals_gates_brands_bedrooms(self):
+		self.responses = {"google_hotels": {}}
+		json.loads(
+			serp_hotels.handle_serp_hotel_search(
+				**self.BASE, vacation_rentals=True, bedrooms=2, bathrooms="1", brands="33"
+			)
+		)
+		params = self.captured[0]
+		self.assertEqual(params["vacation_rentals"], "true")
+		self.assertEqual(params["bedrooms"], 2)
+		self.assertEqual(params["bathrooms"], 1)
+		self.assertNotIn("brands", params)
+
+		json.loads(serp_hotels.handle_serp_hotel_search(**self.BASE, bedrooms=2, brands="33"))
+		params = self.captured[1]
+		self.assertNotIn("vacation_rentals", params)
+		self.assertNotIn("bedrooms", params)
+		self.assertNotIn("bathrooms", params)
+		self.assertEqual(params["brands"], "33")
+
+	def test_validation_errors_do_not_call_api(self):
+		cases = [
+			({}, "q is required"),
+			({"q": "x"}, "check_in_date"),
+			({**self.BASE, "adults": 0}, "At least 1 adult"),
+			({**self.BASE, "sort_by": 5}, "Invalid sort_by"),
+			({**self.BASE, "rating": 6}, "Invalid rating"),
+			({**self.BASE, "hotel_class": "4,6"}, "Invalid hotel_class"),
+			({**self.BASE, "min_price": 500, "max_price": 100}, "cannot be greater"),
+			({**self.BASE, "min_price": -5}, "cannot be negative"),
+			({**self.BASE, "adults": "two"}, "valid integer"),
+		]
+		for kwargs, fragment in cases:
+			out = json.loads(serp_hotels.handle_serp_hotel_search(**kwargs))
+			self.assertFalse(out["success"], kwargs)
+			self.assertIn(fragment, out["error"], kwargs)
+		self.assertEqual(self.captured, [])
+
+	def test_normalization_and_pagination(self):
+		self.responses = {
+			"google_hotels": {
+				"properties": [
+					{
+						"type": "hotel",
+						"name": "Hotel A",
+						"property_token": "tokA",
+						"extracted_hotel_class": 5,
+						"overall_rating": 4.6,
+						"reviews": 1234,
+						"rate_per_night": {"lowest": "$1,234"},
+						"gps_coordinates": {"latitude": 19.0, "longitude": 72.8},
+						"images": [{"thumbnail": "t.jpg", "original_image": "o.jpg"}, "plain.jpg"],
+						"nearby_places": [{"name": "Beach"}, "Market"],
+						"amenities": ["Wi-Fi", 42],
+						"free_cancellation": True,
+					},
+					{
+						"name": "Hotel B",
+						"property_token": "tokB",
+						"total_rate": {"extracted_lowest": 900},
+					},
+				],
+				"serpapi_pagination": {"next_page_token": "NEXT"},
+			}
+		}
+		out = json.loads(serp_hotels.handle_serp_hotel_search(**self.BASE))
+		self.assertTrue(out["success"])
+		self.assertEqual(out["next_page_token"], "NEXT")
+		a, b = out["properties"]
+		self.assertEqual(a["lowest_price"], 1234.0)
+		self.assertEqual(a["hotel_class"], "5")
+		self.assertEqual(a["reviews"], 1234.0)
+		self.assertTrue(a["free_cancellation"])
+		self.assertEqual(a["images"][1], {"thumbnail": "plain.jpg", "original_image": "plain.jpg"})
+		self.assertEqual(a["nearby_places"][1], {"name": "Market"})
+		self.assertEqual(a["amenities"], ["Wi-Fi"])
+		self.assertEqual(b["lowest_price"], 900.0)
+
+	def test_lowest_price_fallback_chain(self):
+		prop = {"total_rate": {"lowest": "₹2,500.50"}}
+		self.assertEqual(serp_hotels._extract_lowest_price(prop), 2500.5)
+		self.assertEqual(serp_hotels._extract_lowest_price({}), 0.0)
+		self.assertEqual(
+			serp_hotels._extract_lowest_price({"rate_per_night": {"extracted_lowest": None, "lowest": 75}}),
+			75.0,
+		)
+		# source quirk: a numeric zero short-circuits via the string-parsing path
+		self.assertEqual(
+			serp_hotels._extract_lowest_price({"rate_per_night": {"extracted_lowest": 0, "lowest": 75}}),
+			0.0,
+		)
+
+	def test_single_property_top_level_fallback(self):
+		self.responses = {
+			"google_hotels": {
+				"name": "Exact Hotel",
+				"property_token": "tokExact",
+				"rate_per_night": {"extracted_lowest": 300},
+			}
+		}
+		out = json.loads(serp_hotels.handle_serp_hotel_search(**self.BASE))
+		self.assertEqual(len(out["properties"]), 1)
+		self.assertEqual(out["properties"][0]["property_token"], "tokExact")
+		self.assertIsNone(out["next_page_token"])
+
+	@patch("huf.ai.tools.serp_hotels.update_last_error")
+	def test_error_envelope_updates_last_error(self, mock_update):
+		self.responses = {"google_hotels": RuntimeError("api down")}
+		out = json.loads(serp_hotels.handle_serp_hotel_search(**self.BASE))
+		self.assertFalse(out["success"])
+		self.assertEqual(out["error"], "api down")
+		mock_update.assert_called_once_with("serpapi", "api down")
+
+
+class TestHotelDetails(SerpToolTestCase):
+	def test_params_and_normalization(self):
+		self.responses = {
+			"google_hotels": {
+				"name": "Hotel A",
+				"type": "hotel",
+				"extracted_hotel_class": 4,
+				"overall_rating": 4.2,
+				"reviews": 500,
+				"link": "https://example.com",
+				"address": ["12 MG Road", "Mumbai"],
+				"phone": "+91 22 1234",
+				"gps_coordinates": {"latitude": 19.1, "longitude": 72.9},
+				"check_in_time": "2 PM",
+				"check_out_time": "11 AM",
+				"prices": [
+					{"source": "Booking.com", "rate_per_night": {"extracted_lowest": 120}},
+					{"source": "Agoda", "rate_per_night": {"extracted_lowest": 95}},
+					{"source": "NoRate"},
+				],
+				"amenities": ["Pool"],
+				"images": ["img.jpg"],
+				"nearby_places": ["Airport"],
+				"reviews_breakdown": [
+					{
+						"name": "Cleanliness",
+						"positive": 10,
+						"negative": 2,
+						"neutral": 1,
+						"total_mentioned": 13,
+					}
+				],
+			}
+		}
+		out = json.loads(
+			serp_hotels.handle_serp_hotel_details(
+				property_token="tok1", check_in_date="2026-01-10", check_out_date="2026-01-12"
+			)
+		)
+		self.assertTrue(out["success"])
+		params = self.captured[0]
+		self.assertEqual(params["engine"], "google_hotels")
+		self.assertEqual(params["property_token"], "tok1")
+		self.assertEqual(params["q"], "Hotels")
+		self.assertEqual(params["hl"], "en")
+		self.assertEqual(params["gl"], "in")
+		self.assertEqual(params["adults"], 2)
+		self.assertEqual(params["currency"], "INR")
+		self.assertEqual(out["lowest_rate_per_night"], 95.0)
+		self.assertEqual(out["address"], "12 MG Road, Mumbai")
+		self.assertEqual(out["hotel_class"], "4")
+		self.assertEqual(len(out["prices"]), 3)
+		self.assertEqual(out["prices"][2]["rate_per_night"], 0.0)
+		self.assertEqual(out["images"], [{"thumbnail": "img.jpg", "original_image": "img.jpg"}])
+		self.assertEqual(out["reviews_breakdown"][0]["name"], "Cleanliness")
+
+	def test_q_and_locale_overrides(self):
+		self.responses = {"google_hotels": {}}
+		json.loads(
+			serp_hotels.handle_serp_hotel_details(
+				property_token="tok1",
+				check_in_date="2026-01-10",
+				check_out_date="2026-01-12",
+				q="Hotels in Goa",
+				gl="us",
+				hl="fr",
+				currency="USD",
+				adults="3",
+			)
+		)
+		params = self.captured[0]
+		self.assertEqual(params["q"], "Hotels in Goa")
+		self.assertEqual(params["gl"], "us")
+		self.assertEqual(params["hl"], "fr")
+		self.assertEqual(params["adults"], 3)
+		self.assertEqual(params["currency"], "USD")
+
+	def test_validation(self):
+		out = json.loads(
+			serp_hotels.handle_serp_hotel_details(check_in_date="2026-01-10", check_out_date="2026-01-12")
+		)
+		self.assertFalse(out["success"])
+		self.assertIn("property_token", out["error"])
+		out = json.loads(serp_hotels.handle_serp_hotel_details(property_token="tok1"))
+		self.assertFalse(out["success"])
+		self.assertIn("check_in_date", out["error"])
+		self.assertEqual(self.captured, [])
+
+
+class TestHotelDetailsBatch(SerpToolTestCase):
+	def _details_router(self, params):
+		if params["property_token"] == "bad":
+			raise RuntimeError("fetch failed")
+		return {
+			"name": f"Hotel {params['property_token']}",
+			"property_token": params["property_token"],
+			"prices": [],
+		}
+
+	@patch("huf.ai.tools.serp_common.require_credential", return_value="KEY-BATCH")
+	def test_batch_success_dedupe_and_key_resolution(self, mock_cred):
+		self.responses = {"google_hotels": self._details_router}
+		out = json.loads(
+			serp_hotels.handle_serp_hotel_details_batch(
+				property_tokens="t1,t2,t1, ,t3",
+				check_in_date="2026-01-10",
+				check_out_date="2026-01-12",
+			)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(out["requested"], 3)
+		self.assertEqual(out["succeeded"], 3)
+		self.assertEqual(out["errors"], [])
+		self.assertEqual({h["property_token"] for h in out["hotels"]}, {"t1", "t2", "t3"})
+		mock_cred.assert_called_once_with("serpapi", "api_key")
+		# key resolved once on the calling thread, passed down to workers
+		for call in self.mock_client_fn.call_args_list:
+			self.assertEqual(call.kwargs["api_key"], "KEY-BATCH")
+
+	@patch("huf.ai.tools.serp_common.require_credential", return_value="KEY-BATCH")
+	def test_batch_json_tokens_and_errors(self, mock_cred):
+		self.responses = {"google_hotels": self._details_router}
+		out = json.loads(
+			serp_hotels.handle_serp_hotel_details_batch(
+				property_tokens='["t1", "bad"]',
+				check_in_date="2026-01-10",
+				check_out_date="2026-01-12",
+				max_workers=2,
+			)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(out["requested"], 2)
+		self.assertEqual(out["succeeded"], 1)
+		self.assertEqual(out["errors"], [{"property_token": "bad", "error": "fetch failed"}])
+
+	def test_batch_validation(self):
+		out = json.loads(serp_hotels.handle_serp_hotel_details_batch(property_tokens=""))
+		self.assertFalse(out["success"])
+		self.assertIn("property_token", out["error"])
+		out = json.loads(serp_hotels.handle_serp_hotel_details_batch(property_tokens="t1"))
+		self.assertFalse(out["success"])
+		self.assertIn("check_in_date", out["error"])
+
+
+class TestGoogleMapsReviews(SerpToolTestCase):
+	MAP_SEARCH: ClassVar = {
+		"local_results": [
+			{"place_id": "p0", "title": "No Data Id"},
+			{
+				"data_id": "0x1:0x2",
+				"place_id": "p1",
+				"title": "Leopold Cafe",
+				"address": "Colaba",
+				"rating": 4.2,
+				"reviews": 8000,
+				"gps_coordinates": {"latitude": 18.9, "longitude": 72.8},
+			},
+		]
+	}
+	REVIEWS: ClassVar = {
+		"place_info": {"title": "Leopold Cafe", "rating": 4.2, "reviews": 8000},
+		"reviews": [
+			{
+				"review_id": "r1",
+				"user": {"name": "Jane", "link": "l", "thumbnail": "t", "reviews": 10},
+				"rating": 5,
+				"date": "a week ago",
+				"iso_date": "2026-01-01",
+				"snippet": "Great",
+				"likes": 3,
+				"images": ["i.jpg"],
+				"response": {"snippet": "Thanks!"},
+			}
+		],
+		"serpapi_pagination": {"next_page_token": "MT"},
+	}
+
+	def test_two_step_resolution_and_matched_place(self):
+		self.responses = {"google_maps": self.MAP_SEARCH, "google_maps_reviews": self.REVIEWS}
+		out = json.loads(serp_reviews.handle_serp_google_maps_reviews(place_query="Leopold Cafe Mumbai"))
+		self.assertTrue(out["success"])
+		self.assertEqual(len(self.captured), 2)
+		search_params, review_params = self.captured
+		self.assertEqual(
+			search_params,
+			{"engine": "google_maps", "q": "Leopold Cafe Mumbai", "hl": "en", "gl": "in", "type": "search"},
+		)
+		self.assertEqual(review_params["engine"], "google_maps_reviews")
+		self.assertEqual(review_params["data_id"], "0x1:0x2")
+		self.assertNotIn("place_id", review_params)
+		self.assertEqual(out["data_id"], "0x1:0x2")
+		self.assertEqual(out["matched_place"], "Leopold Cafe")
+		self.assertEqual(out["next_page_token"], "MT")
+		self.assertEqual(out["place"]["title"], "Leopold Cafe")
+		review = out["reviews"][0]
+		self.assertEqual(review["author"], "Jane")
+		self.assertEqual(review["response"], "Thanks!")
+		self.assertEqual(review["likes"], 3.0)
+
+	def test_direct_id_skips_search(self):
+		self.responses = {"google_maps_reviews": self.REVIEWS}
+		out = json.loads(
+			serp_reviews.handle_serp_google_maps_reviews(
+				data_id="0x9:0x9", sort_by="newestFirst", next_page_token="PREV", hl="en", gl="us"
+			)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(len(self.captured), 1)
+		params = self.captured[0]
+		self.assertEqual(
+			params,
+			{
+				"engine": "google_maps_reviews",
+				"hl": "en",
+				"gl": "us",
+				"data_id": "0x9:0x9",
+				"sort_by": "newestFirst",
+				"next_page_token": "PREV",
+			},
+		)
+		self.assertEqual(out["matched_place"], "")
+		self.assertEqual(out["data_id"], "0x9:0x9")
+
+	def test_validation(self):
+		out = json.loads(serp_reviews.handle_serp_google_maps_reviews())
+		self.assertFalse(out["success"])
+		self.assertIn("place_query", out["error"])
+		out = json.loads(serp_reviews.handle_serp_google_maps_reviews(data_id="x", sort_by="bogus"))
+		self.assertFalse(out["success"])
+		self.assertIn("Invalid sort_by", out["error"])
+		self.assertEqual(self.captured, [])
+
+	def test_no_match(self):
+		self.responses = {"google_maps": {"local_results": []}}
+		out = json.loads(serp_reviews.handle_serp_google_maps_reviews(place_query="Nowhere"))
+		self.assertFalse(out["success"])
+		self.assertIn("No Google Maps place found", out["error"])
+
+	@patch("huf.ai.tools.serp_reviews.update_last_error")
+	def test_error_envelope_updates_last_error(self, mock_update):
+		self.responses = {"google_maps_reviews": RuntimeError("quota exceeded")}
+		out = json.loads(serp_reviews.handle_serp_google_maps_reviews(data_id="0x1:0x2"))
+		self.assertFalse(out["success"])
+		self.assertEqual(out["error"], "quota exceeded")
+		mock_update.assert_called_once_with("serpapi", "quota exceeded")
+
+
+class TestGoogleHotelReviews(SerpToolTestCase):
+	def _router(self, params):
+		if "property_token" in params:
+			return {
+				"name": "Taj Mahal Palace",
+				"overall_rating": 4.7,
+				"reviews": 9000,
+				"ratings": [{"stars": 5, "count": 7000}, {"stars": 4.0, "count": 1500}],
+				"reviews_breakdown": [
+					{"name": "Location", "positive": 50, "negative": 3, "neutral": 2, "total_mentioned": 55}
+				],
+			}
+		return {"properties": [{"name": "Taj Mahal Palace", "property_token": "tokTaj"}]}
+
+	def test_two_step_resolution(self):
+		self.responses = {"google_hotels": self._router}
+		out = json.loads(
+			serp_reviews.handle_serp_google_hotel_reviews(
+				hotel_query="Taj Mahal Palace Mumbai",
+				check_in_date="2026-01-10",
+				check_out_date="2026-01-12",
+			)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(len(self.captured), 2)
+		self.assertNotIn("property_token", self.captured[0])
+		self.assertEqual(self.captured[1]["property_token"], "tokTaj")
+		self.assertEqual(out["matched_hotel"], "Taj Mahal Palace")
+		self.assertEqual(out["property_token"], "tokTaj")
+		self.assertEqual(out["ratings"], [{"stars": 5, "count": 7000.0}, {"stars": 4, "count": 1500.0}])
+		self.assertEqual(out["reviews_count"], 9000.0)
+		self.assertEqual(out["reviews_breakdown"][0]["name"], "Location")
+
+	def test_direct_token(self):
+		self.responses = {"google_hotels": self._router}
+		out = json.loads(
+			serp_reviews.handle_serp_google_hotel_reviews(
+				property_token="tokTaj", check_in_date="2026-01-10", check_out_date="2026-01-12"
+			)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(len(self.captured), 1)
+		self.assertEqual(out["matched_hotel"], "")
+
+	def test_validation(self):
+		out = json.loads(serp_reviews.handle_serp_google_hotel_reviews(hotel_query="x"))
+		self.assertFalse(out["success"])
+		self.assertIn("check_in_date", out["error"])
+		out = json.loads(
+			serp_reviews.handle_serp_google_hotel_reviews(
+				check_in_date="2026-01-10", check_out_date="2026-01-12"
+			)
+		)
+		self.assertFalse(out["success"])
+		self.assertIn("hotel_query", out["error"])
+		self.assertEqual(self.captured, [])
+
+
+class TestTripadvisor(SerpToolTestCase):
+	SEARCH: ClassVar = {
+		"places": [
+			{
+				"location_id": "loc1",
+				"title": "Taj Mahal Palace",
+				"place_type": "hotel",
+				"link": "https://tripadvisor.com/x",
+				"rating": 4.5,
+				"reviews": 5000,
+				"location": "Mumbai",
+				"thumbnail": "t.jpg",
+			}
+		]
+	}
+
+	def test_search_params(self):
+		self.responses = {"tripadvisor": self.SEARCH}
+		out = json.loads(
+			serp_reviews.handle_serp_tripadvisor_search(
+				q="Taj Mumbai", ssrc="h", tripadvisor_domain="www.tripadvisor.in", offset=30, limit=10
+			)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(
+			self.captured[0],
+			{
+				"engine": "tripadvisor",
+				"q": "Taj Mumbai",
+				"ssrc": "h",
+				"tripadvisor_domain": "www.tripadvisor.in",
+				"offset": 30,
+				"limit": 10,
+			},
+		)
+		place = out["places"][0]
+		self.assertEqual(place["place_id"], "loc1")  # falls back to location_id
+		self.assertEqual(place["reviews_count"], 5000.0)
+
+	def test_search_validation(self):
+		out = json.loads(serp_reviews.handle_serp_tripadvisor_search(q=""))
+		self.assertFalse(out["success"])
+		out = json.loads(serp_reviews.handle_serp_tripadvisor_search(q="x", ssrc="z"))
+		self.assertFalse(out["success"])
+		self.assertIn("Invalid ssrc", out["error"])
+		self.assertEqual(self.captured, [])
+
+	def test_reviews_params_and_next_offset(self):
+		self.responses = {
+			"tripadvisor_reviews": {
+				"reviews": [
+					{
+						"review_id": "r1",
+						"title": "Amazing",
+						"snippet": "Loved it",
+						"rating": 5,
+						"author": {"display_name": "Bob", "contributions": 12, "hometown": "NYC"},
+						"trip_info": {"type": "Couples", "date": "Dec 2025"},
+						"additional_ratings": [{"label": "Service", "rating": 5}],
+						"response": {"snippet": "Come again"},
+					}
+				],
+				"serpapi_pagination": {"next": "https://serpapi.com/next"},
+			}
+		}
+		out = json.loads(
+			serp_reviews.handle_serp_tripadvisor_reviews(
+				place_id="loc1",
+				sort_by="most_recent",
+				rating="5,4",
+				language="en",
+				translate="true",
+				offset=30,
+				limit=20,
+			)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(
+			self.captured[0],
+			{
+				"engine": "tripadvisor_reviews",
+				"place_id": "loc1",
+				"offset": 30,
+				"sort_by": "most_recent",
+				"rating": "5,4",
+				"language": "en",
+				"translate": "true",
+				"limit": 20,
+			},
+		)
+		self.assertEqual(out["next_offset"], 50)
+		review = out["reviews"][0]
+		self.assertEqual(review["author"], "Bob")
+		self.assertEqual(review["trip_type"], "Couples")
+		self.assertEqual(review["additional_ratings"], [{"label": "Service", "rating": 5.0}])
+		self.assertEqual(review["response"], "Come again")
+
+	def test_reviews_no_next_page(self):
+		self.responses = {"tripadvisor_reviews": {"reviews": [], "serpapi_pagination": {}}}
+		out = json.loads(serp_reviews.handle_serp_tripadvisor_reviews(place_id="loc1"))
+		self.assertIsNone(out["next_offset"])
+		self.assertEqual(self.captured[0]["offset"], 0)
+
+	def test_reviews_limit_validation(self):
+		out = json.loads(serp_reviews.handle_serp_tripadvisor_reviews(place_id="loc1", limit=21))
+		self.assertFalse(out["success"])
+		self.assertIn("between 1 and 20", out["error"])
+		out = json.loads(serp_reviews.handle_serp_tripadvisor_reviews(place_id="loc1", sort_by="bogus"))
+		self.assertFalse(out["success"])
+		self.assertIn("Invalid sort_by", out["error"])
+		self.assertEqual(self.captured, [])
+
+	def test_two_step_resolution(self):
+		self.responses = {
+			"tripadvisor": self.SEARCH,
+			"tripadvisor_reviews": {"reviews": [], "serpapi_pagination": {}},
+		}
+		out = json.loads(serp_reviews.handle_serp_tripadvisor_reviews(place_query="Taj Mumbai"))
+		self.assertTrue(out["success"])
+		self.assertEqual(self.captured[0]["engine"], "tripadvisor")
+		self.assertEqual(self.captured[1]["place_id"], "loc1")
+		self.assertEqual(out["place_id"], "loc1")
+		self.assertEqual(out["matched_place"], "Taj Mahal Palace")
+
+
+class TestYelp(SerpToolTestCase):
+	SEARCH: ClassVar = {
+		"organic_results": [
+			{
+				"place_ids": ["yelp-1"],
+				"title": "Joe's Pizza",
+				"rating": 4.4,
+				"reviews": 300,
+				"price": "$$",
+				"categories": [{"title": "Pizza"}, "Italian"],
+				"neighborhoods": "Greenwich Village",
+				"phone": "212-555-1234",
+				"reviews_link": "https://yelp.com/r",
+			}
+		]
+	}
+
+	def test_search_params(self):
+		self.responses = {"yelp": self.SEARCH}
+		out = json.loads(
+			serp_reviews.handle_serp_yelp_search(find_desc="pizza", find_loc="New York, NY", start=10)
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(
+			self.captured[0],
+			{"engine": "yelp", "find_desc": "pizza", "find_loc": "New York, NY", "hl": "en", "start": 10},
+		)
+		biz = out["businesses"][0]
+		self.assertEqual(biz["place_id"], "yelp-1")
+		self.assertEqual(biz["categories"], ["Pizza", "Italian"])
+		self.assertEqual(biz["address"], "Greenwich Village")
+
+	def test_search_validation(self):
+		out = json.loads(serp_reviews.handle_serp_yelp_search(find_desc="", find_loc="x"))
+		self.assertFalse(out["success"])
+		out = json.loads(serp_reviews.handle_serp_yelp_search(find_desc="x", find_loc=""))
+		self.assertFalse(out["success"])
+		self.assertEqual(self.captured, [])
+
+	def test_reviews_sortby_quirk_and_total(self):
+		self.responses = {
+			"yelp_reviews": {
+				"reviews": [
+					{
+						"user": {"name": "Amy", "reviews": 7},
+						"rating": 4,
+						"date": "Jan 2026",
+						"comment": {"text": "Solid slice"},
+						"tags": ["elite"],
+					}
+				],
+				"search_information": {"total_results": 300},
+			}
+		}
+		out = json.loads(
+			serp_reviews.handle_serp_yelp_reviews(place_id="yelp-1", sort_by="date_desc", start=20, num=10)
+		)
+		self.assertTrue(out["success"])
+		params = self.captured[0]
+		# SerpApi Yelp Reviews engine takes the sort param as `sortby`, not `sort_by`
+		self.assertEqual(params["sortby"], "date_desc")
+		self.assertNotIn("sort_by", params)
+		self.assertEqual(params["start"], 20)
+		self.assertEqual(params["num"], 10)
+		self.assertEqual(out["total_reviews"], 300.0)
+		review = out["reviews"][0]
+		self.assertEqual(review["text"], "Solid slice")
+		self.assertEqual(review["tags"], ["elite"])
+
+	def test_reviews_validation(self):
+		out = json.loads(serp_reviews.handle_serp_yelp_reviews(place_id="y1", sort_by="bogus"))
+		self.assertFalse(out["success"])
+		self.assertIn("Invalid sort_by", out["error"])
+		out = json.loads(serp_reviews.handle_serp_yelp_reviews())
+		self.assertFalse(out["success"])
+		self.assertIn("business_name", out["error"])
+		self.assertEqual(self.captured, [])
+
+	def test_two_step_resolution(self):
+		self.responses = {
+			"yelp": self.SEARCH,
+			"yelp_reviews": {"reviews": [], "search_information": {"total_results": 300}},
+		}
+		out = json.loads(
+			serp_reviews.handle_serp_yelp_reviews(business_name="Joe's Pizza", location="New York, NY")
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(self.captured[0]["engine"], "yelp")
+		self.assertEqual(self.captured[1]["place_id"], "yelp-1")
+		self.assertEqual(out["place_id"], "yelp-1")
+		self.assertEqual(out["matched_business"], "Joe's Pizza")
+
+
+class TestYouTubeSearch(SerpToolTestCase):
+	def test_params_and_video_id_parsing(self):
+		self.responses = {
+			"youtube": {
+				"video_results": [
+					{
+						"title": "V1",
+						"link": "https://www.youtube.com/watch?v=abc123&t=10",
+						"channel": {"name": "Chan", "link": "cl"},
+						"published_date": "2 days ago",
+						"views": 1000,
+						"length": "10:01",
+						"description": "d",
+						"thumbnail": {"static": "th.jpg"},
+					},
+					{"title": "V2", "link": "https://youtu.be/def456?si=x"},
+					{"title": "V3", "link": "https://www.youtube.com/shorts/ghi789"},
+				]
+			}
+		}
+		out = json.loads(
+			serp_youtube.handle_serp_youtube_search(search_query="lofi", gl="us", hl="en", sp="CAI%3D")
+		)
+		self.assertTrue(out["success"])
+		self.assertEqual(
+			self.captured[0],
+			{"engine": "youtube", "search_query": "lofi", "gl": "us", "hl": "en", "sp": "CAI%3D"},
+		)
+		self.assertEqual(out["search_query"], "lofi")
+		v1, v2, v3 = out["videos"]
+		self.assertEqual(v1["video_id"], "abc123")
+		self.assertEqual(v1["channel"], "Chan")
+		self.assertEqual(v1["views"], 1000.0)
+		self.assertEqual(v1["thumbnail"], "th.jpg")
+		self.assertEqual(v2["video_id"], "def456")
+		self.assertEqual(v3["video_id"], "ghi789")
+
+	def test_validation(self):
+		out = json.loads(serp_youtube.handle_serp_youtube_search(search_query="  "))
+		self.assertFalse(out["success"])
+		self.assertIn("search_query", out["error"])
+		self.assertEqual(self.captured, [])
+
+
+class _FakeFetchedTranscript:
+	language_code = "hi"
+
+	def to_raw_data(self):
+		return [
+			{"text": "hello", "start": 0.0, "duration": 1.5},
+			{"text": "world", "start": 1.5, "duration": 2.0},
+		]
+
+
+class _FakeYouTubeTranscriptApi:
+	last_call = None
+
+	def fetch(self, video_id, languages=None):
+		type(self).last_call = (video_id, languages)
+		return _FakeFetchedTranscript()
+
+
+def _fake_transcript_module():
+	mod = types.ModuleType("youtube_transcript_api")
+	mod.YouTubeTranscriptApi = _FakeYouTubeTranscriptApi
+	return mod
+
+
+class TestYouTubeTranscript(unittest.TestCase):
+	def setUp(self):
+		_FakeYouTubeTranscriptApi.last_call = None
+
+	def test_video_id_url_variants(self):
+		extract = serp_youtube._extract_video_id
+		self.assertEqual(extract("https://www.youtube.com/watch?v=abc123&t=5"), "abc123")
+		self.assertEqual(extract("https://youtu.be/def456?si=x"), "def456")
+		self.assertEqual(extract("https://www.youtube.com/shorts/ghi789"), "ghi789")
+		self.assertEqual(extract("https://www.youtube.com/embed/jkl012?rel=0"), "jkl012")
+		self.assertEqual(extract("  plainid  "), "plainid")
+		self.assertEqual(extract(""), "")
+
+	def test_transcript_success_and_language_coercion(self):
+		with patch.dict(sys.modules, {"youtube_transcript_api": _fake_transcript_module()}):
+			out = json.loads(
+				serp_youtube.handle_youtube_transcript(
+					video="https://youtu.be/abc123?t=9", languages="en, hi"
+				)
+			)
+		self.assertTrue(out["success"])
+		self.assertEqual(out["video_id"], "abc123")
+		self.assertEqual(_FakeYouTubeTranscriptApi.last_call, ("abc123", ["en", "hi"]))
+		self.assertEqual(out["language"], "hi")
+		self.assertEqual(out["segment_count"], 2)
+		self.assertEqual(out["full_text"], "hello world")
+		self.assertEqual(out["segments"][1], {"text": "world", "start": 1.5, "duration": 2.0})
+
+	def test_transcript_default_language(self):
+		with patch.dict(sys.modules, {"youtube_transcript_api": _fake_transcript_module()}):
+			out = json.loads(serp_youtube.handle_youtube_transcript(video="abc123"))
+		self.assertTrue(out["success"])
+		self.assertEqual(_FakeYouTubeTranscriptApi.last_call, ("abc123", ["en"]))
+
+	def test_transcript_missing_video(self):
+		with patch.dict(sys.modules, {"youtube_transcript_api": _fake_transcript_module()}):
+			out = json.loads(serp_youtube.handle_youtube_transcript(video=""))
+		self.assertFalse(out["success"])
+		self.assertIn("video id or YouTube URL", out["error"])
+
+	def test_transcript_package_missing(self):
+		with patch.dict(sys.modules, {"youtube_transcript_api": None}):
+			out = json.loads(serp_youtube.handle_youtube_transcript(video="abc123"))
+		self.assertFalse(out["success"])
+		self.assertIn("youtube-transcript-api is not installed", out["error"])
+
+	def test_transcript_fetch_failure(self):
+		class _FailingApi:
+			def fetch(self, video_id, languages=None):
+				raise RuntimeError("TranscriptsDisabled")
+
+		mod = types.ModuleType("youtube_transcript_api")
+		mod.YouTubeTranscriptApi = _FailingApi
+		with patch.dict(sys.modules, {"youtube_transcript_api": mod}):
+			out = json.loads(serp_youtube.handle_youtube_transcript(video="abc123"))
+		self.assertFalse(out["success"])
+		self.assertIn("Could not fetch transcript", out["error"])
+
+
+class TestRegistryWiring(unittest.TestCase):
+	EXPECTED: ClassVar = {
+		"serp_hotel_search": "huf.ai.tools.serp_hotels.handle_serp_hotel_search",
+		"serp_hotel_details": "huf.ai.tools.serp_hotels.handle_serp_hotel_details",
+		"serp_hotel_details_batch": "huf.ai.tools.serp_hotels.handle_serp_hotel_details_batch",
+		"serp_google_maps_reviews": "huf.ai.tools.serp_reviews.handle_serp_google_maps_reviews",
+		"serp_google_hotel_reviews": "huf.ai.tools.serp_reviews.handle_serp_google_hotel_reviews",
+		"serp_tripadvisor_search": "huf.ai.tools.serp_reviews.handle_serp_tripadvisor_search",
+		"serp_tripadvisor_reviews": "huf.ai.tools.serp_reviews.handle_serp_tripadvisor_reviews",
+		"serp_yelp_search": "huf.ai.tools.serp_reviews.handle_serp_yelp_search",
+		"serp_yelp_reviews": "huf.ai.tools.serp_reviews.handle_serp_yelp_reviews",
+		"serp_youtube_search": "huf.ai.tools.serp_youtube.handle_serp_youtube_search",
+		"youtube_transcript": "huf.ai.tools.serp_youtube.handle_youtube_transcript",
+	}
+
+	def test_all_serp_tools_registered(self):
+		registered = {t["tool_name"]: t for t in _registry.ALL_INTEGRATION_TOOLS}
+		for tool_name, path in self.EXPECTED.items():
+			self.assertIn(tool_name, registered)
+			tool = registered[tool_name]
+			self.assertEqual(tool["category"], "SERP", tool_name)
+			self.assertEqual(tool["function_path"], path, tool_name)
+			self.assertTrue(tool["description"], tool_name)
+			# handlers actually exist at the registered paths
+			module_path, func_name = path.rsplit(".", 1)
+			module = __import__(module_path, fromlist=[func_name])
+			self.assertTrue(callable(getattr(module, func_name)), tool_name)
+
+	def test_registry_lists(self):
+		self.assertEqual(len(_registry.SERP_HOTEL_TOOLS), 3)
+		self.assertEqual(len(_registry.SERP_REVIEW_TOOLS), 6)
+		self.assertEqual(len(_registry.SERP_YOUTUBE_TOOLS), 2)
+
+	def test_required_params_flagged(self):
+		registered = {t["tool_name"]: t for t in _registry.ALL_INTEGRATION_TOOLS}
+		required = {p["fieldname"] for p in registered["serp_hotel_search"]["parameters"] if p["required"]}
+		self.assertEqual(required, {"q", "check_in_date", "check_out_date"})
+		required = {p["fieldname"] for p in registered["youtube_transcript"]["parameters"] if p["required"]}
+		self.assertEqual(required, {"video"})
+
+	def test_serpapi_env_fallback(self):
+		self.assertIn("SERPAPI_API_KEY", _get_alt_env_names("serpapi", "api_key"))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -652,6 +652,231 @@ GOOGLE_MEET_TOOLS = [
 
 
 # ---------------------------------------------------------------------------
+# SERP Tools (SerpApi) — hotels, reviews, YouTube
+# ---------------------------------------------------------------------------
+
+SERP_HOTEL_TOOLS = [
+	{
+		"tool_name": "serp_hotel_search",
+		"description": (
+			"Search hotels (or vacation rentals) via SerpApi Google Hotels with the full filter set: "
+			"guests, price budget, rating, star class, property types, amenities, brands, and boolean toggles. "
+			"Requires SERPAPI_API_KEY env var or serpapi Integration Settings. "
+			"Use property_token from each result with serp_hotel_details for full details."
+		),
+		"function_path": "huf.ai.tools.serp_hotels.handle_serp_hotel_search",
+		"category": "SERP",
+		"parameters": [
+			_p("q", required=True, description="Search query, e.g. 'Hotels in Bandra Mumbai'"),
+			_p("check_in_date", required=True, description="Check-in date (YYYY-MM-DD)"),
+			_p("check_out_date", required=True, description="Check-out date (YYYY-MM-DD)"),
+			_p("adults", type="integer", description="Number of adult guests (default 2, min 1)"),
+			_p("children", type="integer", description="Number of children"),
+			_p("children_ages", description="Ages of children, comma-separated, e.g. '5,8'"),
+			_p("currency", description="ISO currency code for prices (default INR)"),
+			_p("gl", description="Country code for the search, e.g. 'in', 'us' (default in)"),
+			_p("hl", description="Language code, e.g. 'en' (default en)"),
+			_p("sort_by", type="integer", description="Sort order: 3 (lowest price), 8 (highest rating), 13 (most reviewed). Omit for relevance."),
+			_p("min_price", type="integer", description="Minimum price per night"),
+			_p("max_price", type="integer", description="Maximum price per night"),
+			_p("rating", type="integer", description="Minimum guest rating bucket: 7 (3.5+), 8 (4.0+), 9 (4.5+)"),
+			_p("hotel_class", description="Star rating(s) 2-5, comma-separated, e.g. '4,5'"),
+			_p("property_types", description="SerpApi property-type ID(s), comma-separated"),
+			_p("amenities", description="SerpApi amenity ID(s), comma-separated"),
+			_p("brands", description="SerpApi hotel-brand ID(s), comma-separated (ignored when vacation_rentals is true)"),
+			_p("free_cancellation", type="boolean", description="Only results offering free cancellation"),
+			_p("special_offers", type="boolean", description="Only results with special offers"),
+			_p("eco_certified", type="boolean", description="Only eco-certified results"),
+			_p("vacation_rentals", type="boolean", description="Search vacation rentals instead of hotels"),
+			_p("bedrooms", type="integer", description="Minimum bedrooms (vacation rentals only)"),
+			_p("bathrooms", type="integer", description="Minimum bathrooms (vacation rentals only)"),
+			_p("next_page_token", description="Pagination token from a previous response"),
+		],
+	},
+	{
+		"tool_name": "serp_hotel_details",
+		"description": (
+			"Fetch full details for one hotel by property_token (from serp_hotel_search): per-OTA prices "
+			"for the stay, rating and review sentiment breakdown, amenities, images, location. "
+			"Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_hotels.handle_serp_hotel_details",
+		"category": "SERP",
+		"parameters": [
+			_p("property_token", required=True, description="Hotel token from a serp_hotel_search result"),
+			_p("check_in_date", required=True, description="Check-in date (YYYY-MM-DD); prices are quoted for this stay"),
+			_p("check_out_date", required=True, description="Check-out date (YYYY-MM-DD)"),
+			_p("q", description="Search query the token came from (improves accuracy; default 'Hotels')"),
+			_p("adults", type="integer", description="Number of adult guests (default 2)"),
+			_p("currency", description="ISO currency code for all prices (default INR)"),
+			_p("gl", description="Country code (default in)"),
+			_p("hl", description="Language code (default en)"),
+		],
+	},
+	{
+		"tool_name": "serp_hotel_details_batch",
+		"description": (
+			"Fetch details for several hotels in one call, concurrently. Pass the property_tokens returned "
+			"by serp_hotel_search. Returns {hotels, errors, requested, succeeded}. "
+			"Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_hotels.handle_serp_hotel_details_batch",
+		"category": "SERP",
+		"parameters": [
+			_p("property_tokens", required=True, description="Hotel tokens: JSON array, comma-separated string, or list"),
+			_p("check_in_date", required=True, description="Check-in date (YYYY-MM-DD)"),
+			_p("check_out_date", required=True, description="Check-out date (YYYY-MM-DD)"),
+			_p("q", description="Search query the tokens came from (improves accuracy)"),
+			_p("adults", type="integer", description="Number of adult guests (default 2)"),
+			_p("currency", description="ISO currency code for all prices (default INR)"),
+			_p("max_workers", type="integer", description="Thread pool size for parallel lookups (default 8)"),
+		],
+	},
+]
+
+SERP_REVIEW_TOOLS = [
+	{
+		"tool_name": "serp_google_maps_reviews",
+		"description": (
+			"Fetch reviews for a place on Google Maps. Pass a human-friendly place_query (e.g. 'Leopold Cafe "
+			"Mumbai') and the data_id is resolved internally, or pass data_id/place_id directly to skip search. "
+			"Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_reviews.handle_serp_google_maps_reviews",
+		"category": "SERP",
+		"parameters": [
+			_p("place_query", description="Place search query, e.g. 'Leopold Cafe Mumbai' (alternative to data_id/place_id)"),
+			_p("data_id", description="The place's data id, e.g. '0x...:0x...' (preferred if known)"),
+			_p("place_id", description="The place id (alternative to data_id)"),
+			_p("sort_by", description="Sort order: qualityScore (default), newestFirst, ratingHigh, ratingLow"),
+			_p("hl", description="Language code (default en)"),
+			_p("gl", description="Country code (default in)"),
+			_p("next_page_token", description="Pagination token from a previous response"),
+		],
+	},
+	{
+		"tool_name": "serp_google_hotel_reviews",
+		"description": (
+			"Fetch review data for a hotel: overall rating, star distribution, and per-topic sentiment "
+			"breakdown. Pass hotel_query plus stay dates (property_token resolved internally) or a "
+			"property_token directly. Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_reviews.handle_serp_google_hotel_reviews",
+		"category": "SERP",
+		"parameters": [
+			_p("hotel_query", description="Hotel search query, e.g. 'Taj Mahal Palace Mumbai' (alternative to property_token)"),
+			_p("property_token", description="Hotel token from a serp_hotel_search result (skips search)"),
+			_p("check_in_date", required=True, description="Check-in date (YYYY-MM-DD)"),
+			_p("check_out_date", required=True, description="Check-out date (YYYY-MM-DD)"),
+			_p("q", description="Search query the token came from (improves accuracy)"),
+			_p("adults", type="integer", description="Number of adult guests (default 2)"),
+			_p("currency", description="ISO currency code (default INR)"),
+		],
+	},
+	{
+		"tool_name": "serp_tripadvisor_search",
+		"description": (
+			"Search TripAdvisor to find a place and its place_id (for serp_tripadvisor_reviews). "
+			"Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_reviews.handle_serp_tripadvisor_search",
+		"category": "SERP",
+		"parameters": [
+			_p("q", required=True, description="Search terms, e.g. 'Taj Mahal Palace Mumbai'"),
+			_p("ssrc", description="Category filter: a (all), r (restaurants), A (things to do), h (hotels), g (destinations), v (rentals), f (forums)"),
+			_p("tripadvisor_domain", description="TripAdvisor domain, e.g. 'www.tripadvisor.in' (default .com)"),
+			_p("offset", type="integer", description="Pagination offset (increments of 30)"),
+			_p("limit", type="integer", description="Max results (default 30)"),
+		],
+	},
+	{
+		"tool_name": "serp_tripadvisor_reviews",
+		"description": (
+			"Fetch reviews for a TripAdvisor place. Pass a human-friendly place_query (place_id resolved "
+			"internally) or a place_id directly. Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_reviews.handle_serp_tripadvisor_reviews",
+		"category": "SERP",
+		"parameters": [
+			_p("place_query", description="Place search query (alternative to place_id)"),
+			_p("place_id", description="TripAdvisor place id from serp_tripadvisor_search (skips search)"),
+			_p("sort_by", description="Sort order: most_recent (default) or detailed_review"),
+			_p("rating", description="Filter by rating(s), comma-separated, e.g. '5' or '5,4'"),
+			_p("language", description="Language for reviews, e.g. 'en'"),
+			_p("tripadvisor_domain", description="TripAdvisor domain, e.g. 'www.tripadvisor.in'"),
+			_p("translate", type="boolean", description="Translate reviews to the selected language"),
+			_p("offset", type="integer", description="Reviews to skip (default 0)"),
+			_p("limit", type="integer", description="Max reviews per request (1-20, default 10)"),
+		],
+	},
+	{
+		"tool_name": "serp_yelp_search",
+		"description": (
+			"Find Yelp businesses and their place_id (for serp_yelp_reviews). "
+			"Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_reviews.handle_serp_yelp_search",
+		"category": "SERP",
+		"parameters": [
+			_p("find_desc", required=True, description="What to search for, e.g. 'pizza' or a business name"),
+			_p("find_loc", required=True, description="Location, e.g. 'New York, NY'"),
+			_p("hl", description="Language code (default en)"),
+			_p("start", type="integer", description="Result offset for pagination (0, 10, 20, ...)"),
+		],
+	},
+	{
+		"tool_name": "serp_yelp_reviews",
+		"description": (
+			"Fetch reviews for a Yelp business. Pass business_name + location (place_id resolved internally) "
+			"or a place_id directly. Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_reviews.handle_serp_yelp_reviews",
+		"category": "SERP",
+		"parameters": [
+			_p("business_name", description="Business name, e.g. \"Joe's Pizza\" (with location, alternative to place_id)"),
+			_p("location", description="Business location, e.g. 'New York, NY' (with business_name)"),
+			_p("place_id", description="Yelp place id from serp_yelp_search (skips search)"),
+			_p("sort_by", description="Sort order: relevance_desc (default), date_desc, date_asc, rating_desc, rating_asc, elites_desc"),
+			_p("start", type="integer", description="Result offset for pagination"),
+			_p("num", type="integer", description="Number of reviews to return"),
+			_p("hl", description="Language code (default en)"),
+		],
+	},
+]
+
+SERP_YOUTUBE_TOOLS = [
+	{
+		"tool_name": "serp_youtube_search",
+		"description": (
+			"Search YouTube videos via SerpApi. Returns videos with parsed video_id (usable with "
+			"youtube_transcript). Requires SERPAPI_API_KEY env var or serpapi Integration Settings."
+		),
+		"function_path": "huf.ai.tools.serp_youtube.handle_serp_youtube_search",
+		"category": "SERP",
+		"parameters": [
+			_p("search_query", required=True, description="YouTube search terms"),
+			_p("gl", description="Country code (default in)"),
+			_p("hl", description="Language code (default en)"),
+			_p("sp", description="SerpApi filter/sort token (advanced)"),
+		],
+	},
+	{
+		"tool_name": "youtube_transcript",
+		"description": (
+			"Fetch the transcript/captions for a YouTube video (no SerpApi key required). Accepts a video id "
+			"or any YouTube URL (watch, youtu.be, shorts, embed)."
+		),
+		"function_path": "huf.ai.tools.serp_youtube.handle_youtube_transcript",
+		"category": "SERP",
+		"parameters": [
+			_p("video", required=True, description="YouTube video id or URL (watch, youtu.be, shorts, embed)"),
+			_p("languages", description="Preferred language(s), comma-separated, e.g. 'en,hi' (default en); first available match is returned"),
+		],
+	},
+]
+
+
+# ---------------------------------------------------------------------------
 # Master list
 # ---------------------------------------------------------------------------
 
@@ -674,4 +899,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ GOOGLE_MAPS_TOOLS
 	+ GOOGLE_DRIVE_TOOLS
 	+ GOOGLE_MEET_TOOLS
+	+ SERP_HOTEL_TOOLS
+	+ SERP_REVIEW_TOOLS
+	+ SERP_YOUTUBE_TOOLS
 )

--- a/huf/ai/tools/credentials.py
+++ b/huf/ai/tools/credentials.py
@@ -4,8 +4,8 @@
 # TODO: Gmail OAuth2 stub - gmail.py only retrieves a static access token,
 #       no refresh-token flow is implemented yet. (gmail.py:15-19)
 # TODO: Optional deps (boto3, docker, duckduckgo-search, yfinance,
-#       pytube/pytubefix, youtube-transcript-api) are imported with
-#       ImportError fallbacks but not declared in pyproject.toml (by design).
+#       pytube/pytubefix) are imported with ImportError fallbacks but not
+#       declared in pyproject.toml (by design).
 # TODO: Some tool handlers use explicit positional params before **kwargs
 #       (discord, github, gmail, jira, slack, telegram). Works in practice
 #       since Frappe calls with kwargs, but is inconsistent with other tools.
@@ -115,7 +115,7 @@ def _get_alt_env_names(service: str, key: str) -> list:
 		"notion": ["NOTION_API_KEY", "NOTION_DATABASE_ID"],
 		"openweather": ["OPENWEATHER_API_KEY"],
 		"reddit": ["REDDIT_CLIENT_ID", "REDDIT_CLIENT_SECRET"],
-		"serpapi": ["SERP_API_KEY"],
+		"serpapi": ["SERP_API_KEY", "SERPAPI_API_KEY"],
 		"serper": ["SERPER_API_KEY"],
 		"shopify": ["SHOPIFY_SHOP_NAME", "SHOPIFY_ACCESS_TOKEN"],
 		"tavily": ["TAVILY_API_KEY"],

--- a/huf/ai/tools/serp_common.py
+++ b/huf/ai/tools/serp_common.py
@@ -1,0 +1,62 @@
+"""Shared helpers for the SerpApi ("SERP") integration tools.
+
+The `serpapi` package is imported lazily inside `_client()` so this module (and
+everything importing it) loads cleanly even when the package is not installed,
+which keeps tests and registry scans working without the optional dependency.
+"""
+
+from huf.ai.tools.credentials import require_credential
+
+SERVICE_NAME = "serpapi"
+
+
+class SerpValidationError(ValueError):
+	"""Invalid tool input. Surfaced as an error envelope without touching last_error."""
+
+
+def _client(api_key: str | None = None):
+	"""Build a SerpApi client, resolving the API key lazily per call."""
+	import serpapi
+
+	return serpapi.Client(api_key=api_key or require_credential(SERVICE_NAME, "api_key"))
+
+
+def _search(params: dict, api_key: str | None = None) -> dict:
+	"""Run a SerpApi search and return the raw result dict."""
+	return _client(api_key=api_key).search(params)
+
+
+def _safe_float(value) -> float:
+	if value is None:
+		return 0.0
+	try:
+		return float(value)
+	except (TypeError, ValueError):
+		return 0.0
+
+
+def _as_int(value, field: str):
+	"""Coerce an optional int input; None/'' -> None, bad value -> SerpValidationError."""
+	if value in (None, ""):
+		return None
+	try:
+		return int(value)
+	except (TypeError, ValueError):
+		raise SerpValidationError(f"{field} must be a valid integer.")
+
+
+def _as_bool(value) -> bool:
+	if isinstance(value, bool):
+		return value
+	return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _as_csv(value) -> str | None:
+	"""Accept a list or a comma string; return a clean comma-separated string."""
+	if value in (None, ""):
+		return None
+	if isinstance(value, list | tuple):
+		parts = [str(v).strip() for v in value if str(v).strip()]
+	else:
+		parts = [p.strip() for p in str(value).split(",") if p.strip()]
+	return ",".join(parts) or None

--- a/huf/ai/tools/serp_hotels.py
+++ b/huf/ai/tools/serp_hotels.py
@@ -1,0 +1,538 @@
+"""SerpApi Google Hotels tools: search, details, and batch details."""
+
+import concurrent.futures
+import json
+
+import frappe
+
+from huf.ai.tools import serp_common
+from huf.ai.tools.credentials import update_last_error
+from huf.ai.tools.serp_common import SerpValidationError, _as_bool, _as_csv, _as_int, _safe_float
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = serp_common.SERVICE_NAME
+
+# SerpApi Google Hotels filter value reference:
+# rating:      7 (3.5+), 8 (4.0+), 9 (4.5+)
+# sort_by:     3 (lowest price), 8 (highest rating), 13 (most reviewed); else relevance
+# hotel_class: 2, 3, 4, 5 (star ratings; comma-separated)
+VALID_RATINGS = (7, 8, 9)
+VALID_SORT_BY = (3, 8, 13)
+VALID_HOTEL_CLASS = (2, 3, 4, 5)
+
+
+def _extract_lowest_price(prop: dict) -> float:
+	for path_fn in (
+		lambda p: p.get("rate_per_night", {}).get("extracted_lowest"),
+		lambda p: p.get("rate_per_night", {}).get("lowest"),
+		lambda p: p.get("total_rate", {}).get("extracted_lowest"),
+		lambda p: p.get("total_rate", {}).get("lowest"),
+	):
+		raw = None
+		try:
+			raw = path_fn(prop)
+		except (TypeError, AttributeError):
+			continue
+		if raw is None:
+			continue
+		val = _safe_float(raw)
+		if val:
+			return val
+		cleaned = str(raw).replace(",", "").strip()
+		numeric = ""
+		for char in cleaned:
+			if char.isdigit() or char == ".":
+				numeric += char
+			elif numeric:
+				break
+		if numeric:
+			try:
+				return float(numeric)
+			except ValueError:
+				continue
+	return 0.0
+
+
+def _normalize_property(prop: dict) -> dict:
+	gps = prop.get("gps_coordinates") or {}
+
+	images = []
+	for img in prop.get("images") or []:
+		if isinstance(img, dict):
+			images.append(
+				{
+					"thumbnail": str(img.get("thumbnail", "")),
+					"original_image": str(img.get("original_image", "")),
+				}
+			)
+		elif isinstance(img, str):
+			images.append({"thumbnail": img, "original_image": img})
+
+	nearby = []
+	for place in prop.get("nearby_places") or []:
+		if isinstance(place, dict):
+			nearby.append({"name": str(place.get("name", ""))})
+		elif isinstance(place, str):
+			nearby.append({"name": place})
+
+	amenities = [a for a in (prop.get("amenities") or []) if isinstance(a, str)]
+
+	return {
+		"type": str(prop.get("type", "")),
+		"name": str(prop.get("name", "")),
+		"description": str(prop.get("description", "")),
+		"property_token": str(prop.get("property_token", "")),
+		"hotel_class": str(prop.get("extracted_hotel_class") or prop.get("hotel_class") or ""),
+		"overall_rating": _safe_float(prop.get("overall_rating")),
+		"reviews": _safe_float(prop.get("reviews")),
+		"lowest_price": _extract_lowest_price(prop),
+		"free_cancellation": bool(prop.get("free_cancellation")),
+		"gps_coordinates": {
+			"latitude": _safe_float(gps.get("latitude")),
+			"longitude": _safe_float(gps.get("longitude")),
+		},
+		"images": images,
+		"nearby_places": nearby,
+		"amenities": amenities,
+	}
+
+
+def _search_hotels(
+	q: str,
+	check_in_date: str,
+	check_out_date: str,
+	adults=2,
+	children=None,
+	children_ages=None,
+	currency: str = "INR",
+	gl: str = "in",
+	hl: str = "en",
+	sort_by=None,
+	min_price=None,
+	max_price=None,
+	rating=None,
+	hotel_class=None,
+	property_types=None,
+	amenities=None,
+	brands=None,
+	free_cancellation=False,
+	special_offers=False,
+	eco_certified=False,
+	vacation_rentals=False,
+	bedrooms=None,
+	bathrooms=None,
+	next_page_token=None,
+) -> dict:
+	"""Search hotels on the SerpApi Google Hotels engine with the full filter set."""
+	if not q or not str(q).strip():
+		raise SerpValidationError("q is required.")
+	if not check_in_date or not check_out_date:
+		raise SerpValidationError("Both check_in_date and check_out_date are required.")
+
+	# numeric guests / budget
+	adults_int = _as_int(adults, "adults")
+	if adults_int is None:
+		adults_int = 2
+	if adults_int < 1:
+		raise SerpValidationError("At least 1 adult is required.")
+	children_int = _as_int(children, "children")
+	min_price_int = _as_int(min_price, "min_price")
+	max_price_int = _as_int(max_price, "max_price")
+	bedrooms_int = _as_int(bedrooms, "bedrooms")
+	bathrooms_int = _as_int(bathrooms, "bathrooms")
+
+	if min_price_int is not None and min_price_int < 0:
+		raise SerpValidationError("min_price cannot be negative.")
+	if max_price_int is not None and max_price_int < 0:
+		raise SerpValidationError("max_price cannot be negative.")
+	if min_price_int is not None and max_price_int is not None and min_price_int > max_price_int:
+		raise SerpValidationError("min_price cannot be greater than max_price.")
+
+	# rating
+	rating_int = _as_int(rating, "rating")
+	if rating_int is not None and rating_int not in VALID_RATINGS:
+		raise SerpValidationError(f"Invalid rating '{rating_int}'. Must be 7 (3.5+), 8 (4.0+), or 9 (4.5+).")
+
+	# sort_by
+	sort_by_int = _as_int(sort_by, "sort_by")
+	if sort_by_int is not None and sort_by_int not in VALID_SORT_BY:
+		raise SerpValidationError(
+			f"Invalid sort_by '{sort_by_int}'. Must be 3 (lowest price), "
+			"8 (highest rating), or 13 (most reviewed)."
+		)
+
+	# hotel_class — validate each value
+	hotel_class_csv = _as_csv(hotel_class)
+	if hotel_class_csv:
+		for part in hotel_class_csv.split(","):
+			try:
+				hotel_class_int = int(part)
+			except (TypeError, ValueError):
+				raise SerpValidationError(f"Invalid hotel_class '{part}'. Allowed: 2, 3, 4, 5.")
+			if hotel_class_int not in VALID_HOTEL_CLASS:
+				raise SerpValidationError(f"Invalid hotel_class '{part}'. Allowed: 2, 3, 4, 5.")
+
+	children_ages_csv = _as_csv(children_ages)
+	property_types_csv = _as_csv(property_types)
+	amenities_csv = _as_csv(amenities)
+	brands_csv = _as_csv(brands)
+
+	is_vacation = _as_bool(vacation_rentals)
+
+	params = {
+		"engine": "google_hotels",
+		"q": str(q).strip(),
+		"gl": gl,
+		"hl": hl,
+		"check_in_date": check_in_date,
+		"check_out_date": check_out_date,
+		"currency": currency,
+		"adults": adults_int,
+	}
+
+	# optional numeric / list filters — only sent when provided
+	if children_int is not None:
+		params["children"] = children_int
+	if children_ages_csv:
+		params["children_ages"] = children_ages_csv
+	if sort_by_int is not None:
+		params["sort_by"] = sort_by_int
+	if min_price_int is not None:
+		params["min_price"] = min_price_int
+	if max_price_int is not None:
+		params["max_price"] = max_price_int
+	if rating_int is not None:
+		params["rating"] = rating_int
+	if hotel_class_csv:
+		params["hotel_class"] = hotel_class_csv
+	if property_types_csv:
+		params["property_types"] = property_types_csv
+	if amenities_csv:
+		params["amenities"] = amenities_csv
+
+	# boolean toggles — SerpApi expects the param present and "true"
+	if _as_bool(free_cancellation):
+		params["free_cancellation"] = "true"
+	if _as_bool(special_offers):
+		params["special_offers"] = "true"
+	if _as_bool(eco_certified):
+		params["eco_certified"] = "true"
+
+	if is_vacation:
+		params["vacation_rentals"] = "true"
+		if bedrooms_int is not None:
+			params["bedrooms"] = bedrooms_int
+		if bathrooms_int is not None:
+			params["bathrooms"] = bathrooms_int
+	elif brands_csv:
+		# brands are not supported for vacation rentals
+		params["brands"] = brands_csv
+
+	if next_page_token:
+		params["next_page_token"] = next_page_token
+
+	results = serp_common._search(params)
+
+	properties = [_normalize_property(p) for p in results.get("properties", [])]
+	# A specific-hotel query (e.g. an exact hotel name) makes Google Hotels resolve
+	# directly to one property at the top level instead of a `properties` array.
+	if not properties and results.get("property_token"):
+		properties = [_normalize_property(results)]
+	next_token = results.get("serpapi_pagination", {}).get("next_page_token") or None
+
+	applied = {k: v for k, v in params.items() if k != "engine"}
+	return {
+		"properties": properties,
+		"next_page_token": next_token,
+		"search_query": params["q"],
+		"applied_filters": applied,
+	}
+
+
+def handle_serp_hotel_search(**kwargs) -> str:
+	"""Search hotels with the full Google Hotels filter set."""
+	try:
+		result = _search_hotels(
+			q=kwargs.get("q"),
+			check_in_date=kwargs.get("check_in_date"),
+			check_out_date=kwargs.get("check_out_date"),
+			adults=kwargs.get("adults", 2),
+			children=kwargs.get("children"),
+			children_ages=kwargs.get("children_ages"),
+			currency=kwargs.get("currency", "INR"),
+			gl=kwargs.get("gl", "in"),
+			hl=kwargs.get("hl", "en"),
+			sort_by=kwargs.get("sort_by"),
+			min_price=kwargs.get("min_price"),
+			max_price=kwargs.get("max_price"),
+			rating=kwargs.get("rating"),
+			hotel_class=kwargs.get("hotel_class"),
+			property_types=kwargs.get("property_types"),
+			amenities=kwargs.get("amenities"),
+			brands=kwargs.get("brands"),
+			free_cancellation=kwargs.get("free_cancellation", False),
+			special_offers=kwargs.get("special_offers", False),
+			eco_certified=kwargs.get("eco_certified", False),
+			vacation_rentals=kwargs.get("vacation_rentals", False),
+			bedrooms=kwargs.get("bedrooms"),
+			bathrooms=kwargs.get("bathrooms"),
+			next_page_token=kwargs.get("next_page_token"),
+		)
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (Hotel Search): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def _normalize_featured_prices(result: dict) -> list:
+	"""Per-OTA rates (Booking.com, Agoda, etc.) for the requested stay."""
+	prices = []
+	for src in result.get("prices") or []:
+		if not isinstance(src, dict):
+			continue
+		prices.append(
+			{
+				"source": str(src.get("source", "")),
+				"logo": str(src.get("logo", "")),
+				"link": str(src.get("link", "")),
+				"rate_per_night": _safe_float((src.get("rate_per_night") or {}).get("extracted_lowest")),
+				"total_rate": _safe_float((src.get("total_rate") or {}).get("extracted_lowest")),
+			}
+		)
+	return prices
+
+
+def _normalize_images(result: dict) -> list:
+	images = []
+	for img in result.get("images") or []:
+		if isinstance(img, dict):
+			images.append(
+				{
+					"thumbnail": str(img.get("thumbnail", "")),
+					"original_image": str(img.get("original_image", "")),
+				}
+			)
+		elif isinstance(img, str):
+			images.append({"thumbnail": img, "original_image": img})
+	return images
+
+
+def _normalize_reviews_breakdown(result: dict) -> list:
+	breakdown = []
+	for row in result.get("reviews_breakdown") or []:
+		if isinstance(row, dict):
+			breakdown.append(
+				{
+					"name": str(row.get("name", "")),
+					"description": str(row.get("description", "")),
+					"total_mentioned": _safe_float(row.get("total_mentioned")),
+					"positive": _safe_float(row.get("positive")),
+					"negative": _safe_float(row.get("negative")),
+					"neutral": _safe_float(row.get("neutral")),
+				}
+			)
+	return breakdown
+
+
+def _coerce_adults(adults) -> int:
+	adults_int = _as_int(adults, "adults")
+	if adults_int is None:
+		adults_int = 2
+	if adults_int < 1:
+		raise SerpValidationError("At least 1 adult is required.")
+	return adults_int
+
+
+def _hotel_details(
+	property_token: str,
+	check_in_date: str,
+	check_out_date: str,
+	q: str | None = None,
+	adults=2,
+	currency: str = "INR",
+	gl: str = "in",
+	hl: str = "en",
+	api_key: str | None = None,
+) -> dict:
+	"""Fetch full details for a single hotel from the SerpApi Google Hotels engine."""
+	if not property_token or not str(property_token).strip():
+		raise SerpValidationError("property_token is required.")
+	if not check_in_date or not check_out_date:
+		raise SerpValidationError("Both check_in_date and check_out_date are required.")
+
+	result = serp_common._search(
+		{
+			"engine": "google_hotels",
+			"q": str(q).strip() if q and str(q).strip() else "Hotels",
+			"hl": hl,
+			"gl": gl,
+			"property_token": str(property_token).strip(),
+			"check_in_date": check_in_date,
+			"check_out_date": check_out_date,
+			"adults": _coerce_adults(adults),
+			"currency": currency,
+		},
+		api_key=api_key,
+	)
+
+	prices = _normalize_featured_prices(result)
+	rate_candidates = [p["rate_per_night"] for p in prices if p["rate_per_night"] > 0]
+	lowest_rate = (
+		min(rate_candidates)
+		if rate_candidates
+		else _safe_float((result.get("rate_per_night") or {}).get("extracted_lowest"))
+	)
+
+	gps = result.get("gps_coordinates") or {}
+	address = result.get("address")
+	if isinstance(address, list):
+		address = ", ".join(str(part) for part in address if part)
+
+	amenities = [str(a) for a in (result.get("amenities") or []) if isinstance(a, str)]
+
+	nearby = []
+	for place in result.get("nearby_places") or []:
+		if isinstance(place, dict):
+			nearby.append({"name": str(place.get("name", ""))})
+		elif isinstance(place, str):
+			nearby.append({"name": place})
+
+	return {
+		"name": str(result.get("name", "")),
+		"type": str(result.get("type", "")),
+		"description": str(result.get("description", "")),
+		"property_token": str(property_token).strip(),
+		"hotel_class": str(result.get("extracted_hotel_class") or result.get("hotel_class") or ""),
+		"overall_rating": _safe_float(result.get("overall_rating")),
+		"reviews": _safe_float(result.get("reviews")),
+		"link": str(result.get("link", "")),
+		"check_in_time": str(result.get("check_in_time", "")),
+		"check_out_time": str(result.get("check_out_time", "")),
+		"gps_coordinates": {
+			"latitude": _safe_float(gps.get("latitude")),
+			"longitude": _safe_float(gps.get("longitude")),
+		},
+		"address": str(address or ""),
+		"phone": str(result.get("phone", "")),
+		"lowest_rate_per_night": lowest_rate,
+		"prices": prices,
+		"amenities": amenities,
+		"images": _normalize_images(result),
+		"nearby_places": nearby,
+		"reviews_breakdown": _normalize_reviews_breakdown(result),
+	}
+
+
+def handle_serp_hotel_details(**kwargs) -> str:
+	"""Fetch full details for one hotel by property_token."""
+	try:
+		result = _hotel_details(
+			property_token=kwargs.get("property_token"),
+			check_in_date=kwargs.get("check_in_date"),
+			check_out_date=kwargs.get("check_out_date"),
+			q=kwargs.get("q"),
+			adults=kwargs.get("adults", 2),
+			currency=kwargs.get("currency", "INR"),
+			gl=kwargs.get("gl", "in"),
+			hl=kwargs.get("hl", "en"),
+		)
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (Hotel Details): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def _coerce_tokens(property_tokens) -> list:
+	"""Accept a list, a JSON array string, or a comma string -> list of tokens."""
+	if property_tokens in (None, ""):
+		return []
+	if isinstance(property_tokens, str):
+		raw = property_tokens.strip()
+		if raw.startswith("["):
+			try:
+				property_tokens = json.loads(raw)
+			except Exception:
+				property_tokens = raw.split(",")
+		else:
+			property_tokens = raw.split(",")
+	if not isinstance(property_tokens, list | tuple):
+		property_tokens = [property_tokens]
+
+	seen, tokens = set(), []
+	for tok in property_tokens:
+		tok = str(tok).strip()
+		if tok and tok not in seen:
+			seen.add(tok)
+			tokens.append(tok)
+	return tokens
+
+
+def handle_serp_hotel_details_batch(**kwargs) -> str:
+	"""Fetch details for several hotels in one call, concurrently.
+
+	The SerpApi key is resolved once on the calling thread and reused, since
+	worker threads have no Frappe DB context.
+	"""
+	try:
+		tokens = _coerce_tokens(kwargs.get("property_tokens"))
+		if not tokens:
+			raise SerpValidationError("At least one property_token is required.")
+		check_in_date = kwargs.get("check_in_date")
+		check_out_date = kwargs.get("check_out_date")
+		if not check_in_date or not check_out_date:
+			raise SerpValidationError("Both check_in_date and check_out_date are required.")
+
+		max_workers = _as_int(kwargs.get("max_workers"), "max_workers")
+		if max_workers is None or max_workers < 1:
+			max_workers = 8
+
+		api_key = serp_common.require_credential(SERVICE_NAME, "api_key")
+
+		def _fetch(token):
+			return _hotel_details(
+				property_token=token,
+				check_in_date=check_in_date,
+				check_out_date=check_out_date,
+				q=kwargs.get("q"),
+				adults=kwargs.get("adults", 2),
+				currency=kwargs.get("currency", "INR"),
+				gl=kwargs.get("gl", "in"),
+				hl=kwargs.get("hl", "en"),
+				api_key=api_key,
+			)
+
+		hotels, errors = [], []
+		with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+			future_map = {executor.submit(_fetch, t): t for t in tokens}
+			for future in concurrent.futures.as_completed(future_map):
+				token = future_map[future]
+				try:
+					hotels.append(future.result())
+				except Exception as exc:
+					errors.append({"property_token": token, "error": str(exc)})
+
+		for err in errors:
+			logger.warning(f"SerpApi Hotel Details Error ({err['property_token']}): {err['error']}")
+
+		return json.dumps(
+			{
+				"success": True,
+				"hotels": hotels,
+				"errors": errors,
+				"requested": len(tokens),
+				"succeeded": len(hotels),
+			}
+		)
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (Hotel Details Batch): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})

--- a/huf/ai/tools/serp_reviews.py
+++ b/huf/ai/tools/serp_reviews.py
@@ -1,0 +1,642 @@
+"""SerpApi review tools: Google Maps, Google Hotels, TripAdvisor, and Yelp."""
+
+import json
+
+import frappe
+
+from huf.ai.tools import serp_common, serp_hotels
+from huf.ai.tools.credentials import update_last_error
+from huf.ai.tools.serp_common import SerpValidationError, _as_bool, _as_int, _safe_float
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = serp_common.SERVICE_NAME
+
+# SerpApi Google Maps Reviews sort options
+MAPS_REVIEW_SORT_BY = ("qualityScore", "newestFirst", "ratingHigh", "ratingLow")
+
+# SerpApi TripAdvisor Reviews sort options
+TRIPADVISOR_SORT_BY = ("most_recent", "detailed_review")
+
+# TripAdvisor Search category filter (ssrc):
+# a = All, r = Restaurants, A = ThingsToDo, h = Hotels, g = Destinations, v = Rentals, f = Forums
+TRIPADVISOR_SSRC = ("a", "r", "A", "h", "g", "v", "f")
+
+# SerpApi Yelp Reviews sort options
+YELP_SORT_BY = (
+	"relevance_desc",
+	"date_desc",
+	"date_asc",
+	"rating_desc",
+	"rating_asc",
+	"elites_desc",
+)
+
+
+# ---------------------------------------------------------------------------
+# Google Maps reviews
+# ---------------------------------------------------------------------------
+
+
+def _normalize_maps_review(review: dict) -> dict:
+	user = review.get("user") or {}
+	return {
+		"review_id": str(review.get("review_id", "")),
+		"author": str(user.get("name", "")),
+		"author_link": str(user.get("link", "")),
+		"author_thumbnail": str(user.get("thumbnail", "")),
+		"author_reviews_count": _safe_float(user.get("reviews")),
+		"rating": _safe_float(review.get("rating")),
+		"date": str(review.get("date", "")),
+		"iso_date": str(review.get("iso_date", "")),
+		"snippet": str(review.get("snippet", "")),
+		"likes": _safe_float(review.get("likes")),
+		"images": [str(i) for i in (review.get("images") or []) if isinstance(i, str)],
+		"response": str((review.get("response") or {}).get("snippet", "")),
+	}
+
+
+def _search_google_maps(q: str, hl: str = "en", gl: str = "in") -> dict:
+	"""Search Google Maps for a place to obtain its data_id (needed for reviews)."""
+	if not q or not str(q).strip():
+		raise SerpValidationError("q is required.")
+
+	results = serp_common._search(
+		{"engine": "google_maps", "q": str(q).strip(), "hl": hl, "gl": gl, "type": "search"}
+	)
+
+	raw = results.get("local_results") or []
+	if not raw and results.get("place_results"):
+		raw = [results["place_results"]]
+
+	places = []
+	for p in raw:
+		if not isinstance(p, dict):
+			continue
+		gps = p.get("gps_coordinates") or {}
+		places.append(
+			{
+				"data_id": str(p.get("data_id", "")),
+				"place_id": str(p.get("place_id", "")),
+				"title": str(p.get("title", "")),
+				"address": str(p.get("address", "")),
+				"rating": _safe_float(p.get("rating")),
+				"reviews_count": _safe_float(p.get("reviews")),
+				"gps_coordinates": {
+					"latitude": _safe_float(gps.get("latitude")),
+					"longitude": _safe_float(gps.get("longitude")),
+				},
+			}
+		)
+	return {"results": places}
+
+
+def _google_maps_reviews(
+	data_id: str | None = None,
+	place_id: str | None = None,
+	sort_by: str | None = None,
+	hl: str = "en",
+	gl: str = "in",
+	next_page_token: str | None = None,
+) -> dict:
+	"""Fetch reviews for a place from the SerpApi Google Maps Reviews engine."""
+	if not (data_id and str(data_id).strip()) and not (place_id and str(place_id).strip()):
+		raise SerpValidationError("Either data_id or place_id is required.")
+
+	if sort_by and sort_by not in MAPS_REVIEW_SORT_BY:
+		raise SerpValidationError(f"Invalid sort_by '{sort_by}'. Allowed: {', '.join(MAPS_REVIEW_SORT_BY)}.")
+
+	params = {"engine": "google_maps_reviews", "hl": hl, "gl": gl}
+	if data_id:
+		params["data_id"] = str(data_id).strip()
+	if place_id:
+		params["place_id"] = str(place_id).strip()
+	if sort_by:
+		params["sort_by"] = sort_by
+	if next_page_token:
+		params["next_page_token"] = next_page_token
+
+	results = serp_common._search(params)
+
+	place = results.get("place_info") or {}
+	reviews = [_normalize_maps_review(r) for r in (results.get("reviews") or [])]
+	next_token = results.get("serpapi_pagination", {}).get("next_page_token") or None
+
+	return {
+		"place": {
+			"title": str(place.get("title", "")),
+			"rating": _safe_float(place.get("rating")),
+			"reviews_count": _safe_float(place.get("reviews")),
+		},
+		"reviews": reviews,
+		"next_page_token": next_token,
+	}
+
+
+def handle_serp_google_maps_reviews(**kwargs) -> str:
+	"""Reviews for a place on Google Maps — single self-contained tool.
+
+	Pass a human-friendly `place_query` (e.g. "Leopold Cafe Mumbai"); the data_id
+	is resolved internally via a Google Maps search, then its reviews are fetched.
+	If you already have a `data_id`/`place_id`, pass it to skip the search.
+	"""
+	try:
+		place_query = kwargs.get("place_query")
+		data_id = kwargs.get("data_id")
+		place_id = kwargs.get("place_id")
+		hl = kwargs.get("hl", "en")
+		gl = kwargs.get("gl", "in")
+
+		matched = ""
+		has_id = (data_id and str(data_id).strip()) or (place_id and str(place_id).strip())
+		if not has_id:
+			if not place_query or not str(place_query).strip():
+				raise SerpValidationError("Provide place_query (or a data_id/place_id).")
+			found = _search_google_maps(q=place_query, hl=hl, gl=gl)
+			match = next((r for r in found["results"] if r.get("data_id")), None)
+			if not match:
+				raise SerpValidationError(f"No Google Maps place found for '{place_query}'.")
+			data_id = match["data_id"]
+			matched = match["title"]
+
+		result = _google_maps_reviews(
+			data_id=data_id,
+			place_id=place_id,
+			sort_by=kwargs.get("sort_by"),
+			hl=hl,
+			gl=gl,
+			next_page_token=kwargs.get("next_page_token"),
+		)
+		result["data_id"] = data_id
+		result["matched_place"] = matched
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (Google Maps Reviews): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Google Hotel reviews
+# ---------------------------------------------------------------------------
+
+
+def _normalize_ratings(result: dict) -> list:
+	"""Star distribution, e.g. [{"stars": 5, "count": 800}, ...]."""
+	ratings = []
+	for row in result.get("ratings") or []:
+		if isinstance(row, dict):
+			ratings.append(
+				{
+					"stars": int(_safe_float(row.get("stars"))),
+					"count": _safe_float(row.get("count")),
+				}
+			)
+	return ratings
+
+
+def _google_hotel_reviews(
+	property_token: str,
+	check_in_date: str,
+	check_out_date: str,
+	q: str | None = None,
+	adults=2,
+	currency: str = "INR",
+) -> dict:
+	"""Fetch the review data for a single hotel from SerpApi Google Hotels."""
+	if not property_token or not str(property_token).strip():
+		raise SerpValidationError("property_token is required.")
+	if not check_in_date or not check_out_date:
+		raise SerpValidationError("Both check_in_date and check_out_date are required.")
+
+	result = serp_common._search(
+		{
+			"engine": "google_hotels",
+			"q": str(q).strip() if q and str(q).strip() else "Hotels",
+			"hl": "en",
+			"gl": "in",
+			"property_token": str(property_token).strip(),
+			"check_in_date": check_in_date,
+			"check_out_date": check_out_date,
+			"adults": serp_hotels._coerce_adults(adults),
+			"currency": currency,
+		}
+	)
+
+	return {
+		"name": str(result.get("name", "")),
+		"overall_rating": _safe_float(result.get("overall_rating")),
+		"reviews_count": _safe_float(result.get("reviews")),
+		"ratings": _normalize_ratings(result),
+		"reviews_breakdown": serp_hotels._normalize_reviews_breakdown(result),
+	}
+
+
+def handle_serp_google_hotel_reviews(**kwargs) -> str:
+	"""Review data for a hotel — single self-contained tool.
+
+	Pass a human-friendly `hotel_query` plus the stay dates; the property_token is
+	resolved internally via a Google Hotels search. If you already have a
+	`property_token`, pass it to skip the search.
+	"""
+	try:
+		hotel_query = kwargs.get("hotel_query")
+		property_token = kwargs.get("property_token")
+		check_in_date = kwargs.get("check_in_date")
+		check_out_date = kwargs.get("check_out_date")
+		adults = kwargs.get("adults", 2)
+		currency = kwargs.get("currency", "INR")
+
+		if not check_in_date or not check_out_date:
+			raise SerpValidationError("Both check_in_date and check_out_date are required.")
+
+		matched = ""
+		if not property_token or not str(property_token).strip():
+			if not hotel_query or not str(hotel_query).strip():
+				raise SerpValidationError("Provide hotel_query (or a property_token).")
+			found = serp_hotels._search_hotels(
+				q=hotel_query,
+				check_in_date=check_in_date,
+				check_out_date=check_out_date,
+				adults=adults,
+				currency=currency,
+			)
+			props = [p for p in found.get("properties", []) if p.get("property_token")]
+			if not props:
+				raise SerpValidationError(f"No hotel found for '{hotel_query}'.")
+			property_token = props[0]["property_token"]
+			matched = props[0]["name"]
+
+		result = _google_hotel_reviews(
+			property_token=property_token,
+			check_in_date=check_in_date,
+			check_out_date=check_out_date,
+			q=hotel_query,
+			adults=adults,
+			currency=currency,
+		)
+		result["property_token"] = property_token
+		result["matched_hotel"] = matched
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (Google Hotel Reviews): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# TripAdvisor
+# ---------------------------------------------------------------------------
+
+
+def _normalize_tripadvisor_place(place: dict) -> dict:
+	return {
+		"place_id": str(place.get("place_id") or place.get("location_id") or ""),
+		"title": str(place.get("title", "")),
+		"place_type": str(place.get("place_type", "")),
+		"link": str(place.get("link", "")),
+		"rating": _safe_float(place.get("rating")),
+		"reviews_count": _safe_float(place.get("reviews")),
+		"location": str(place.get("location", "")),
+		"thumbnail": str(place.get("thumbnail", "")),
+	}
+
+
+def _normalize_tripadvisor_review(review: dict) -> dict:
+	author = review.get("author") or {}
+	trip = review.get("trip_info") or {}
+	response = review.get("response") or {}
+
+	additional = []
+	for row in review.get("additional_ratings") or []:
+		if isinstance(row, dict):
+			additional.append(
+				{
+					"label": str(row.get("label", "")),
+					"rating": _safe_float(row.get("rating")),
+				}
+			)
+
+	return {
+		"review_id": str(review.get("review_id", "")),
+		"title": str(review.get("title", "")),
+		"snippet": str(review.get("snippet", "")),
+		"rating": _safe_float(review.get("rating")),
+		"date": str(review.get("date", "")),
+		"link": str(review.get("link", "")),
+		"language": str(review.get("language", "")),
+		"trip_type": str(trip.get("type", "")),
+		"trip_date": str(trip.get("date", "")),
+		"votes": _safe_float(review.get("votes")),
+		"images": [str(i) for i in (review.get("images") or []) if isinstance(i, str)],
+		"additional_ratings": additional,
+		"author": str(author.get("display_name") or author.get("username") or ""),
+		"author_contributions": _safe_float(author.get("contributions")),
+		"author_hometown": str(author.get("hometown", "")),
+		"response": str(response.get("snippet", "")),
+	}
+
+
+def _search_tripadvisor(
+	q: str,
+	ssrc: str | None = None,
+	tripadvisor_domain: str | None = None,
+	offset=None,
+	limit=None,
+) -> dict:
+	"""Search TripAdvisor to find a place and its place_id."""
+	if not q or not str(q).strip():
+		raise SerpValidationError("q is required.")
+	if ssrc and ssrc not in TRIPADVISOR_SSRC:
+		raise SerpValidationError(f"Invalid ssrc '{ssrc}'. Allowed: {', '.join(TRIPADVISOR_SSRC)}.")
+
+	params = {"engine": "tripadvisor", "q": str(q).strip()}
+	if ssrc:
+		params["ssrc"] = ssrc
+	if tripadvisor_domain:
+		params["tripadvisor_domain"] = tripadvisor_domain
+	off = _as_int(offset, "offset")
+	lim = _as_int(limit, "limit")
+	if off is not None:
+		params["offset"] = off
+	if lim is not None:
+		params["limit"] = lim
+
+	results = serp_common._search(params)
+	raw = results.get("places") or results.get("locations") or []
+	return {"places": [_normalize_tripadvisor_place(p) for p in raw]}
+
+
+def handle_serp_tripadvisor_search(**kwargs) -> str:
+	"""Find a TripAdvisor place (and its place_id)."""
+	try:
+		result = _search_tripadvisor(
+			q=kwargs.get("q"),
+			ssrc=kwargs.get("ssrc"),
+			tripadvisor_domain=kwargs.get("tripadvisor_domain"),
+			offset=kwargs.get("offset"),
+			limit=kwargs.get("limit"),
+		)
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (TripAdvisor Search): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def _tripadvisor_reviews(
+	place_id: str,
+	sort_by: str | None = None,
+	rating: str | None = None,
+	language: str | None = None,
+	tripadvisor_domain: str | None = None,
+	translate=False,
+	offset=None,
+	limit=None,
+) -> dict:
+	"""Fetch reviews for a TripAdvisor place via the tripadvisor_reviews engine."""
+	if not place_id or not str(place_id).strip():
+		raise SerpValidationError("place_id is required.")
+	if sort_by and sort_by not in TRIPADVISOR_SORT_BY:
+		raise SerpValidationError(f"Invalid sort_by '{sort_by}'. Allowed: {', '.join(TRIPADVISOR_SORT_BY)}.")
+
+	off = _as_int(offset, "offset") or 0
+	lim = _as_int(limit, "limit")
+	if lim is not None and (lim < 1 or lim > 20):
+		raise SerpValidationError("limit must be between 1 and 20.")
+
+	params = {
+		"engine": "tripadvisor_reviews",
+		"place_id": str(place_id).strip(),
+		"offset": off,
+	}
+	if sort_by:
+		params["sort_by"] = sort_by
+	if rating:
+		params["rating"] = str(rating).strip()
+	if language:
+		params["language"] = language
+	if tripadvisor_domain:
+		params["tripadvisor_domain"] = tripadvisor_domain
+	if _as_bool(translate):
+		params["translate"] = "true"
+	if lim is not None:
+		params["limit"] = lim
+
+	results = serp_common._search(params)
+	reviews = [_normalize_tripadvisor_review(r) for r in (results.get("reviews") or [])]
+
+	# tripadvisor_reviews paginates by offset; compute the next offset if a
+	# "next" page exists.
+	next_offset = None
+	if results.get("serpapi_pagination", {}).get("next"):
+		next_offset = off + (lim or len(reviews) or 10)
+
+	return {"reviews": reviews, "next_offset": next_offset}
+
+
+def handle_serp_tripadvisor_reviews(**kwargs) -> str:
+	"""Reviews for a TripAdvisor place — single self-contained tool.
+
+	Pass a human-friendly `place_query`; the TripAdvisor place_id is resolved
+	internally via search, then its reviews are fetched. If you already have a
+	`place_id`, pass it to skip the search.
+	"""
+	try:
+		place_query = kwargs.get("place_query")
+		place_id = kwargs.get("place_id")
+
+		matched = ""
+		if not place_id or not str(place_id).strip():
+			if not place_query or not str(place_query).strip():
+				raise SerpValidationError("Provide place_query (or a place_id).")
+			found = _search_tripadvisor(q=place_query)
+			if not found["places"]:
+				raise SerpValidationError(f"No TripAdvisor place found for '{place_query}'.")
+			top = found["places"][0]
+			place_id = top["place_id"]
+			matched = top["title"]
+
+		result = _tripadvisor_reviews(
+			place_id=place_id,
+			sort_by=kwargs.get("sort_by"),
+			rating=kwargs.get("rating"),
+			language=kwargs.get("language"),
+			tripadvisor_domain=kwargs.get("tripadvisor_domain"),
+			translate=kwargs.get("translate", False),
+			offset=kwargs.get("offset"),
+			limit=kwargs.get("limit"),
+		)
+		result["place_id"] = place_id
+		result["matched_place"] = matched
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (TripAdvisor Reviews): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Yelp
+# ---------------------------------------------------------------------------
+
+
+def _normalize_yelp_business(biz: dict) -> dict:
+	# categories arrive as dicts ({"title": "Pizza", "link": ...}) or plain strings
+	categories = []
+	for c in biz.get("categories") or []:
+		if isinstance(c, dict):
+			categories.append(str(c.get("title", "")))
+		elif isinstance(c, str):
+			categories.append(c)
+
+	return {
+		"place_id": str(biz.get("place_ids", [""])[0] if biz.get("place_ids") else biz.get("place_id", "")),
+		"title": str(biz.get("title", "")),
+		"link": str(biz.get("link", "")),
+		"rating": _safe_float(biz.get("rating")),
+		"reviews_count": _safe_float(biz.get("reviews")),
+		"price": str(biz.get("price", "")),
+		"categories": [c for c in categories if c],
+		"snippet": str(biz.get("snippet", "")),
+		"phone": str(biz.get("phone", "")),
+		"address": str(biz.get("neighborhoods", "") or biz.get("address", "")),
+		"thumbnail": str(biz.get("thumbnail", "")),
+		"reviews_link": str(biz.get("reviews_link", "")),
+	}
+
+
+def _normalize_yelp_review(review: dict) -> dict:
+	user = review.get("user") or {}
+	comment = review.get("comment") or {}
+	return {
+		"author": str(user.get("name", "")),
+		"author_link": str(user.get("link", "")),
+		"author_thumbnail": str(user.get("thumbnail", "")),
+		"author_reviews_count": _safe_float(user.get("reviews")),
+		"rating": _safe_float(review.get("rating")),
+		"date": str(review.get("date", "")),
+		"text": str(comment.get("text", "") or review.get("snippet", "")),
+		"tags": [str(t) for t in (review.get("tags") or []) if isinstance(t, str)],
+	}
+
+
+def _search_yelp(find_desc: str, find_loc: str, hl: str = "en", start=None) -> dict:
+	"""Find Yelp businesses (to obtain a place_id for reviews)."""
+	if not find_desc or not str(find_desc).strip():
+		raise SerpValidationError("find_desc is required.")
+	if not find_loc or not str(find_loc).strip():
+		raise SerpValidationError("find_loc is required.")
+
+	params = {
+		"engine": "yelp",
+		"find_desc": str(find_desc).strip(),
+		"find_loc": str(find_loc).strip(),
+		"hl": hl,
+	}
+	start_int = _as_int(start, "start")
+	if start_int is not None:
+		params["start"] = start_int
+
+	results = serp_common._search(params)
+	businesses = [_normalize_yelp_business(b) for b in (results.get("organic_results") or [])]
+	return {"businesses": businesses}
+
+
+def handle_serp_yelp_search(**kwargs) -> str:
+	"""Find Yelp businesses (and their place_id)."""
+	try:
+		result = _search_yelp(
+			find_desc=kwargs.get("find_desc"),
+			find_loc=kwargs.get("find_loc"),
+			hl=kwargs.get("hl", "en"),
+			start=kwargs.get("start"),
+		)
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (Yelp Search): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def _yelp_reviews(
+	place_id: str,
+	sort_by: str | None = None,
+	start=None,
+	num=None,
+	hl: str = "en",
+) -> dict:
+	"""Fetch reviews for a Yelp business via the SerpApi Yelp Reviews engine."""
+	if not place_id or not str(place_id).strip():
+		raise SerpValidationError("place_id is required.")
+	if sort_by and sort_by not in YELP_SORT_BY:
+		raise SerpValidationError(f"Invalid sort_by '{sort_by}'. Allowed: {', '.join(YELP_SORT_BY)}.")
+
+	params = {"engine": "yelp_reviews", "place_id": str(place_id).strip(), "hl": hl}
+	if sort_by:
+		# SerpApi quirk: the Yelp Reviews engine takes the sort param as `sortby`
+		params["sortby"] = sort_by
+	start_int = _as_int(start, "start")
+	if start_int is not None:
+		params["start"] = start_int
+	num_int = _as_int(num, "num")
+	if num_int is not None:
+		params["num"] = num_int
+
+	results = serp_common._search(params)
+	reviews = [_normalize_yelp_review(r) for r in (results.get("reviews") or [])]
+	total = _safe_float((results.get("search_information") or {}).get("total_results"))
+
+	return {"reviews": reviews, "total_reviews": total}
+
+
+def handle_serp_yelp_reviews(**kwargs) -> str:
+	"""Reviews for a Yelp business — single self-contained tool.
+
+	Pass a human-friendly `business_name` + `location`; the Yelp place_id is
+	resolved internally via search, then its reviews are fetched. If you already
+	have a `place_id`, pass it to skip the search.
+	"""
+	try:
+		business_name = kwargs.get("business_name")
+		location = kwargs.get("location")
+		place_id = kwargs.get("place_id")
+		hl = kwargs.get("hl", "en")
+
+		matched = ""
+		if not place_id or not str(place_id).strip():
+			if not (business_name and str(business_name).strip() and location and str(location).strip()):
+				raise SerpValidationError("Provide business_name and location (or a place_id).")
+			found = _search_yelp(find_desc=business_name, find_loc=location, hl=hl)
+			if not found["businesses"]:
+				raise SerpValidationError(f"No Yelp business found for '{business_name}' in '{location}'.")
+			top = found["businesses"][0]
+			place_id = top["place_id"]
+			matched = top["title"]
+
+		result = _yelp_reviews(
+			place_id=place_id,
+			sort_by=kwargs.get("sort_by"),
+			start=kwargs.get("start"),
+			num=kwargs.get("num"),
+			hl=hl,
+		)
+		result["place_id"] = place_id
+		result["matched_business"] = matched
+		return json.dumps({"success": True, **result})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (Yelp Reviews): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})

--- a/huf/ai/tools/serp_youtube.py
+++ b/huf/ai/tools/serp_youtube.py
@@ -1,0 +1,154 @@
+"""SerpApi YouTube search tool plus a YouTube transcript tool (no SerpApi key)."""
+
+import json
+
+import frappe
+
+from huf.ai.tools import serp_common
+from huf.ai.tools.credentials import update_last_error
+from huf.ai.tools.serp_common import SerpValidationError, _safe_float
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = serp_common.SERVICE_NAME
+
+
+def _video_id_from_link(link: str) -> str:
+	link = str(link or "")
+	if "watch?v=" in link:
+		return link.split("watch?v=", 1)[1].split("&", 1)[0]
+	if "youtu.be/" in link:
+		return link.split("youtu.be/", 1)[1].split("?", 1)[0]
+	if "/shorts/" in link:
+		return link.split("/shorts/", 1)[1].split("?", 1)[0]
+	return ""
+
+
+def _normalize_video(video: dict) -> dict:
+	channel = video.get("channel") or {}
+	thumb = video.get("thumbnail") or {}
+	link = str(video.get("link", ""))
+	return {
+		"title": str(video.get("title", "")),
+		"link": link,
+		"video_id": _video_id_from_link(link),
+		"channel": str(channel.get("name", "")),
+		"channel_link": str(channel.get("link", "")),
+		"published_date": str(video.get("published_date", "")),
+		"views": _safe_float(video.get("views")),
+		"length": str(video.get("length", "")),
+		"description": str(video.get("description", "")),
+		"thumbnail": str(thumb.get("static", "") if isinstance(thumb, dict) else thumb),
+	}
+
+
+def handle_serp_youtube_search(**kwargs) -> str:
+	"""Search YouTube videos via the SerpApi YouTube engine."""
+	try:
+		search_query = kwargs.get("search_query")
+		if not search_query or not str(search_query).strip():
+			raise SerpValidationError("search_query is required.")
+
+		params = {
+			"engine": "youtube",
+			"search_query": str(search_query).strip(),
+			"gl": kwargs.get("gl", "in"),
+			"hl": kwargs.get("hl", "en"),
+		}
+		if kwargs.get("sp"):
+			params["sp"] = kwargs.get("sp")
+
+		results = serp_common._search(params)
+		videos = [_normalize_video(v) for v in (results.get("video_results") or [])]
+
+		return json.dumps({"success": True, "videos": videos, "search_query": params["search_query"]})
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"SerpApi Error (YouTube Search): {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def _extract_video_id(video: str) -> str:
+	"""Accept a raw video id or any common YouTube URL and return the id."""
+	v = str(video or "").strip()
+	if not v:
+		return ""
+	if "watch?v=" in v:
+		return v.split("watch?v=", 1)[1].split("&", 1)[0]
+	if "youtu.be/" in v:
+		return v.split("youtu.be/", 1)[1].split("?", 1)[0]
+	if "/shorts/" in v:
+		return v.split("/shorts/", 1)[1].split("?", 1)[0]
+	if "/embed/" in v:
+		return v.split("/embed/", 1)[1].split("?", 1)[0]
+	return v  # already an id
+
+
+def _coerce_langs(languages) -> list:
+	if languages in (None, ""):
+		return ["en"]
+	if isinstance(languages, str):
+		parts = [p.strip() for p in languages.split(",") if p.strip()]
+	elif isinstance(languages, list | tuple):
+		parts = [str(p).strip() for p in languages if str(p).strip()]
+	else:
+		parts = []
+	return parts or ["en"]
+
+
+def handle_youtube_transcript(**kwargs) -> str:
+	"""Fetch the transcript/captions for a YouTube video.
+
+	Uses the youtube-transcript-api package (no SerpApi credit consumed).
+	`video` may be a video id or any YouTube URL (watch, youtu.be, shorts, embed).
+	`languages` may be a list or comma string (e.g. "en,hi"); the first available
+	match is returned.
+	"""
+	try:
+		# Imported lazily so the module loads even if the package is absent.
+		try:
+			from youtube_transcript_api import YouTubeTranscriptApi
+		except ImportError:
+			raise SerpValidationError(
+				"youtube-transcript-api is not installed. Run: bench pip install youtube-transcript-api"
+			)
+
+		video_id = _extract_video_id(kwargs.get("video"))
+		if not video_id:
+			raise SerpValidationError("A video id or YouTube URL is required.")
+
+		langs = _coerce_langs(kwargs.get("languages"))
+
+		try:
+			fetched = YouTubeTranscriptApi().fetch(video_id, languages=langs)
+		except Exception as exc:
+			# TranscriptsDisabled / NoTranscriptFound / VideoUnavailable, etc.
+			raise SerpValidationError(f"Could not fetch transcript for '{video_id}': {exc!s}")
+
+		segments = [
+			{
+				"text": str(row.get("text", "")),
+				"start": float(row.get("start", 0) or 0),
+				"duration": float(row.get("duration", 0) or 0),
+			}
+			for row in fetched.to_raw_data()
+		]
+
+		return json.dumps(
+			{
+				"success": True,
+				"video_id": video_id,
+				"language": getattr(fetched, "language_code", "") or langs[0],
+				"segments": segments,
+				"full_text": " ".join(s["text"] for s in segments).strip(),
+				"segment_count": len(segments),
+			}
+		)
+	except SerpValidationError as e:
+		return json.dumps({"success": False, "error": str(e)})
+	except Exception as e:
+		logger.warning(f"YouTube Transcript Error: {e!s}")
+		update_last_error(SERVICE_NAME, str(e))
+		return json.dumps({"success": False, "error": str(e)})

--- a/huf/install.py
+++ b/huf/install.py
@@ -888,6 +888,14 @@ def register_integration_services():
 				{"key": "refresh_token", "label": "OAuth Refresh Token", "required": True}
 			]
 		},
+		{
+			"service_name": "serpapi",
+			"category": "Google",
+			"description": "SerpApi search data: hotels, reviews (Google Maps, TripAdvisor, Yelp), and YouTube",
+			"required_credentials": [
+				{"key": "api_key", "label": "SerpApi API Key", "required": True}
+			]
+		},
 	]
 	
 	# Create or update each service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "beautifulsoup4",
     "aiohttp",
     "pypdfium2>=4.26.0",
+    "serpapi",
+    "youtube-transcript-api",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Ports the SerpApi integrations from [Travel-with-Genie-AI/google_services](https://github.com/Travel-with-Genie-AI/google_services)@develop into huf as first-class **App Provided** tools — with full parameter coverage and the source's normalized output shapes.

### Tools (11, category: SERP)

**Hotels (google_hotels engine)**
- `serp_hotel_search` — full filter set: dates, adults/children/ages, currency/gl/hl, sort_by (3|8|13), min/max price, rating (7|8|9), hotel_class, property_types, amenities, brands, free_cancellation/special_offers/eco_certified, vacation_rentals (+bedrooms/bathrooms), next_page_token
- `serp_hotel_details` — OTA price table, reviews_breakdown sentiment topics, amenities, images
- `serp_hotel_details_batch` — ThreadPool batch details (max_workers=8) with per-token error capture

**Reviews (two-step query → id resolution with `matched_*` echo)**
- `serp_google_maps_reviews` — data_id/place_id or query; sort qualityScore|newestFirst|ratingHigh|ratingLow; next_page_token
- `serp_google_hotel_reviews` — star distribution + reviews_breakdown
- `serp_tripadvisor_search` — ssrc categories, domain, offset/limit
- `serp_tripadvisor_reviews` — sort most_recent|detailed_review, rating csv, language, translate; next_offset
- `serp_yelp_search` / `serp_yelp_reviews` — find_desc/find_loc, full sortby enum, start/num

**YouTube**
- `serp_youtube_search` — youtube engine, gl/hl/sp, parsed video_ids
- `youtube_transcript` — no API key needed (youtube-transcript-api, lazy import), language preference list

### Design

- App Provided pattern: handlers in `huf/ai/tools/serp_{common,hotels,reviews,youtube}.py`, registered in `_registry.py`; no DocType/frontend changes.
- New **serpapi** Integration Service in `register_integration_services()` — config UI + Password credential out of the box; `SERPAPI_API_KEY` env fallback. Consolidates the 3 different key sources the source app used.
- `serpapi` + `youtube-transcript-api` added to dependencies; both imported lazily.
- Source bugs intentionally not ported: duplicated key helpers, `allow_guest` endpoints, hardcoded gl/hl (exposed as params), mid-request commits.

### Testing

- `huf/ai/tests/test_serp_tools.py` — 50 unit tests (param building incl. every enum and conditional gate, pagination shapes, two-step resolution, Yelp sortby quirk, video_id parsing, transcript language coercion, error envelopes, registry wiring), all passing with mocked serpapi client.
- `ruff check`/`format` clean on new files; no new findings in edited files; `compileall` clean.

Companion to the Google Places tools PR. Merge order-independent (disjoint files except `_registry.py`/`credentials.py`; will rebase if needed).
