### PR TITLE
docs: add user-facing copy convention to agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2195,3 +2195,6 @@ HUF integrates prompt caching to save token costs on supported models:
 
 ### Frontend TypeScript Strictness
 The frontend project enforces strict TypeScript rules. Unused variables, unresolved imports, and unused functions will cause build failures (e.g., `error TS6133`). Always proactively remove unused variables, functions, and imports, especially after code refactorings, to ensure the frontend build succeeds without errors.
+
+### User-Facing Copy
+All labels, placeholders, empty states, and error messages shown to end users must read as plain product copy, not implementation detail. Never leak internal mechanics into UI text — e.g. write "Search records..." not "Search API records...", "Filter..." not "Filter columns locally...". If unsure whether a string is user-facing, write it assuming the reader has never heard of Frappe, DocTypes, REST, or SSE.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,9 +541,14 @@ Test files are located in:
 18. **Real-time**: Socket.io for live agent feedback (tool calls, new messages), SSE via fetch ReadableStream for streaming responses
 19. **Routing**: All routes are under `/huf` basename — use React Router `Link` and `useNavigate` for navigation
 20. **TypeScript Strictness**: The project enforces strict TypeScript settings. Always clean up and remove unused imports, variables, and functions to prevent build failures (e.g., TS6133).
+21. **User-facing copy**: Labels, placeholders, empty states, and error messages must read
+    as plain product copy, not implementation detail. Never expose internal mechanics in
+    UI text (e.g. "Search API records...", "Filter columns locally...", "Fetching via SSE").
+    Prefer "Search records...", "Filter...". If you're unsure whether a string is end-user
+    facing, write it as if the user has never heard of Frappe, doctypes, or REST/SSE.
 
 ### General
-21. **Docker Dev**: Use `docker/` for quick evaluation; use Frappe bench for full development
+22. **Docker Dev**: Use `docker/` for quick evaluation; use Frappe bench for full development
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary
- Prompted by a review finding on the data table list view: a search placeholder read "Search API records... (Press Enter)" and a filter read "Filter columns locally..." — both leak internal implementation detail into end-user copy.
- Adds a short convention to CLAUDE.md and AGENTS.md: UI labels/placeholders/empty-states/errors must read as plain product copy, never expose internal mechanics (Frappe, DocTypes, REST/SSE, "API", "locally").

No functional changes.