### PR TITLE
feat(tools): add Perplexity Search

### DIFF
--- a/frontend/src/config/toolTemplates.json
+++ b/frontend/src/config/toolTemplates.json
@@ -48,10 +48,10 @@
     {
       "id": "web_search",
       "name": "Web Search",
-      "description": "Search the web for live information via Google Programmable Search.",
+      "description": "Search the web for live information via Perplexity AI.",
       "icon": "search",
       "toolTypes": [
-        "Google Search"
+        "Perplexity Search"
       ]
     },
     {

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -41,7 +41,7 @@ export type ToolType =
   | "Get Conversation Data"
   | "Set Conversation Data"
   | "Load Conversation Data"
-  | "Google Search"
+  | "Perplexity Search"
   | "Transcription"
   /**
    * @deprecated Legacy value kept for backward compatibility with saved docs.

--- a/huf/ai/app_seeding/loaders.py
+++ b/huf/ai/app_seeding/loaders.py
@@ -143,7 +143,7 @@ VALID_TYPES = [
     "Cancel Document", "Get Amended Document", "Custom Function", "App Provided",
     "Attach File to Document", "Get Report Result", "Get Value", "Set Value",
     "GET", "POST", "Run Agent", "Client Side Tool", "Get Conversation Data",
-    "Set Conversation Data", "Load Conversation Data", "Google Search"
+    "Set Conversation Data", "Load Conversation Data", "Perplexity Search"
 ]
 
 def upsert_tool(data: dict, source_app: str, source_file: str) -> tuple:

--- a/huf/ai/flow_tool_executor.py
+++ b/huf/ai/flow_tool_executor.py
@@ -182,7 +182,7 @@ def _resolve_function_path(tool_doc: dict) -> str | None:
 		"Get Conversation Data": "huf.ai.sdk_tools.handle_get_conversation_data",
 		"Set Conversation Data": "huf.ai.sdk_tools.handle_set_conversation_data",
 		"Load Conversation Data": "huf.ai.sdk_tools.handle_load_conversation_data",
-		"Google Search": "huf.ai.sdk_tools.handle_google_search",
+		"Perplexity Search": "huf.ai.sdk_tools.handle_perplexity_search",
 	}
 
 	return type_to_handler.get(tool_type)

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -156,8 +156,9 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                         function_path = "huf.ai.sdk_tools.handle_set_conversation_data"
                     elif function_doc.types == "Load Conversation Data":
                         function_path = "huf.ai.sdk_tools.handle_load_conversation_data"
-                    elif function_doc.types == "Google Search":
-                        function_path = "huf.ai.sdk_tools.handle_google_search"
+                    elif function_doc.types == "Perplexity Search":
+                        function_path = "huf.ai.sdk_tools.handle_perplexity_search"
+
                     else:
                         continue
 
@@ -2328,66 +2329,64 @@ async def handle_transcribe_audio(
         frappe.log_error(f"Audio transcription error: {e!s}", "Audio Transcription Tool")
         return {"success": False, "error": str(e)}
 
-def handle_google_search(query: str, max_results: int = 5, **kwargs):
+def handle_perplexity_search(query: str, **kwargs):
     """
-    Perform a web search using Google Programmable Search Engine.
+    Perform a web search using a Perplexity sonar model via LiteLLM.
 
-    Reads the API key and search engine ID from site_config
-    (``google_pse_api_key`` and ``google_pse_engine_id``).
+    Reads the API key from the ``perplexity_api_key`` site_config value,
+    falling back to the ``PERPLEXITY_API_KEY`` environment variable.
 
     Args:
         query: The search query string
-        max_results: Maximum number of results to return (default: 5, max: 10)
 
     Returns:
         dict: {
             "success": bool,
             "query": str,
-            "results": list,        # [{"title", "link", "snippet"}, ...]
-            "total_results": int,
+            "answer": str,          # Grounded answer text from the sonar model
+            "citations": list,      # Source URLs cited by the model
+            "model": str,
             "error": str
         }
     """
+    import os
+
     site_config = frappe.get_site_config()
-    api_key = site_config.get("google_pse_api_key")
-    engine_id = site_config.get("google_pse_engine_id")
+    api_key = site_config.get("perplexity_api_key") or os.environ.get("PERPLEXITY_API_KEY")
 
     if not api_key:
         frappe.throw(
-            _("Google Search is not configured. Please set 'google_pse_api_key' in site config.")
-        )
-    if not engine_id:
-        frappe.throw(
-            _("Google Search is not configured. Please set 'google_pse_engine_id' in site config.")
+            _(
+                "Perplexity Search is not configured. Please set 'perplexity_api_key' "
+                "in site config or the PERPLEXITY_API_KEY environment variable."
+            )
         )
 
     try:
-        num = max(1, min(int(max_results or 5), 10))
+        from litellm import completion
 
-        response = requests.get(
-            "https://www.googleapis.com/customsearch/v1",
-            params={"key": api_key, "cx": engine_id, "q": query, "num": num},
-            timeout=30,
+        # LiteLLM routes Perplexity credentials via environment variable
+        os.environ["PERPLEXITY_API_KEY"] = api_key
+
+        response = completion(
+            model="perplexity/sonar",
+            messages=[{"role": "user", "content": query}],
         )
-        response.raise_for_status()
 
-        items = response.json().get("items", [])
-        results = [
-            {
-                "title": item.get("title"),
-                "link": item.get("link"),
-                "snippet": item.get("snippet"),
-            }
-            for item in items
-        ]
+        message = response.choices[0].message
+        citations = (
+            getattr(response, "citations", None)
+            or getattr(message, "citations", None)
+            or []
+        )
 
         return {
             "success": True,
             "query": query,
-            "results": results,
-            "total_results": len(results),
+            "answer": message.content,
+            "citations": citations,
+            "model": "perplexity/sonar",
         }
     except Exception as e:
-        logger.warning(f"handle_google_search failed: {e!s}")
+        logger.warning(f"handle_perplexity_search failed: {e!s}")
         return {"success": False, "error": str(e)}
-

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -52,7 +52,7 @@
    "fieldname": "types",
    "fieldtype": "Select",
    "label": "Types",
-   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nClient Side Tool\nGet Conversation Data\nSet Conversation Data\nLoad Conversation Data\nGoogle Search"
+   "options": "\nGet Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nApp Provided\nAttach File to Document\nGet Report Result\nGet Value\nSet Value\nGET\nPOST\nRun Agent\nClient Side Tool\nGet Conversation Data\nSet Conversation Data\nLoad Conversation Data\nPerplexity Search"
   },
   {
    "depends_on": "eval: [\n  'Get Document',\n  'Get Multiple Documents',\n  'Get List',\n  'Create Document',\n  'Create Multiple Documents',\n  'Update Document',\n  'Update Multiple Documents',\n  'Delete Document',\n  'Delete Multiple Documents',\n  'Submit Document',\n  'Cancel Document',\n  'Get Amended Document',\n  'Attach File to Document',\n  'Get Report Result',\n  'Get Value',\n  'Set Value'\n].includes(doc.types)",

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -584,18 +584,13 @@ class AgentToolFunction(Document):
 				"additionalProperties": False
 			}
 
-		elif self.types == "Google Search":
+		elif self.types == "Perplexity Search":
 			params = {
 				"type": "object",
 				"properties": {
 					"query": {
 						"type": "string",
 						"description": "The search query string."
-					},
-					"max_results": {
-						"type": "integer",
-						"description": "Maximum number of results to return (default: 5).",
-						"default": 5
 					}
 				},
 				"required": ["query"],


### PR DESCRIPTION
## Consolidated scope

Extracts the Perplexity Search feature from the combined search implementation.

## Original PR

- #439: originally contained both Google Search and Perplexity Search; this PR contains only Perplexity Search

## Included functionality

- Perplexity Search tool type
- Agent tool schema and validation
- App seeding and flow execution registration
- Frontend tool template and type registration
- LiteLLM `perplexity/sonar` execution
- Site-configured or environment-provided Perplexity credentials
- Answer and citation response normalization

Google Search is tracked separately in #462. Targets `integration/huf-consolidation-2026-07`; included in final integration PR #468.