### PR TITLE
fix(security): consolidate artifact isolation and permission boundaries

### DIFF
--- a/frontend/src/components/chat/ArtifactRenderer.tsx
+++ b/frontend/src/components/chat/ArtifactRenderer.tsx
@@ -192,7 +192,7 @@ export function ArtifactRenderer({
 					<div className="flex flex-col gap-2">
 						<iframe
 							srcDoc={artifact.content}
-							sandbox="allow-scripts"
+							sandbox=""
 							className="w-full h-96 border rounded bg-white"
 							title={artifact.title || 'HTML Preview'}
 						/>

--- a/huf/__init__.py
+++ b/huf/__init__.py
@@ -9,8 +9,8 @@ try:
 	_huf_logger = frappe.logger("huf")
 	if _huf_logger.level > logging.INFO:
 		_huf_logger.setLevel(logging.INFO)
-except Exception:
-	pass
+except (frappe.FrappeException, Exception) as exc:  # best-effort non-critical cleanup
+        frappe.logger("huf").debug(f"Ignored non-critical failure: {exc!s}")
 
 # Use pysqlite3 (loadable extensions) instead of stdlib sqlite3 for sqlite_vec
 try:

--- a/huf/__init__.py
+++ b/huf/__init__.py
@@ -9,8 +9,8 @@ try:
 	_huf_logger = frappe.logger("huf")
 	if _huf_logger.level > logging.INFO:
 		_huf_logger.setLevel(logging.INFO)
-except (frappe.FrappeException, Exception) as exc:  # best-effort non-critical cleanup
-        frappe.logger("huf").debug(f"Ignored non-critical failure: {exc!s}")
+except Exception:  # best-effort non-critical cleanup
+	pass
 
 # Use pysqlite3 (loadable extensions) instead of stdlib sqlite3 for sqlite_vec
 try:

--- a/huf/ai/agent_chat.py
+++ b/huf/ai/agent_chat.py
@@ -95,7 +95,7 @@ def upload_audio_and_transcribe(filename: str, b64data: str, docname: str = None
                     },
                 )
             except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError) as e:
-                logger.warning(f"Error checking tool permission for {tool_link.tool}: {e!s}")
+                logger.warning(f"Create audio user message failed: {e!s}")
     except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"Audio transcription failed: {e!s}")
         frappe.db.set_value("Agent Message", msg.name, "status", "Failed")

--- a/huf/ai/agent_chat.py
+++ b/huf/ai/agent_chat.py
@@ -96,7 +96,7 @@ def upload_audio_and_transcribe(filename: str, b64data: str, docname: str = None
                 )
             except Exception as e:
                 logger.warning(f"Create audio user message failed: {e!s}")
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"Audio transcription failed: {e!s}")
         frappe.db.set_value("Agent Message", msg.name, "status", "Failed")
         return {"success": False, "error": str(e)}
@@ -193,7 +193,7 @@ def upload_audio_and_transcribe_web(
             attached_to_name=msg.name,
             is_private=0,
         )
-    except Exception as e:
+    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
         logger.warning(f"Save audio upload failed (web): {e}")
         return {"success": False, "error": str(e)}
 
@@ -210,7 +210,7 @@ def upload_audio_and_transcribe_web(
             file_id=file_id,
             agent_name=agent,
         )
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"Audio transcription failed (web): {e!s}")
         frappe.db.set_value("Agent Message", msg.name, "status", "Failed")
         return {"success": False, "error": str(e)}
@@ -365,7 +365,7 @@ def create_conversation(agent: str, channel: str = "Chat"):
             "success": True,
             "conversation_id": conversation.name,
         }
-    except Exception:
+    except Exception:  # boundary exception handler: API endpoint
         # API boundary: log unexpected failure with traceback, then re-raise.
         frappe.log_error(
             message=f"create_conversation error: {frappe.get_traceback()}",
@@ -409,7 +409,7 @@ def new_conversation(agent: str, message: str, skip_user_message=0, files=None):
             "run": run_result
         }
 
-    except Exception as e:
+    except Exception as e:  # boundary exception handler: API endpoint
         # API boundary: log unexpected failure with traceback, then re-raise.
         frappe.log_error(message=f"new_conversation error: {frappe.get_traceback()}", title="Huf API")
         raise
@@ -451,7 +451,7 @@ def send_message_to_conversation(conversation: str, message: str, skip_user_mess
 
         return result
 
-    except Exception as e:
+    except Exception as e:  # boundary exception handler: API endpoint
         # API boundary: log unexpected failure with traceback, then re-raise.
         frappe.log_error(message=f"send_message_to_conversation error: {frappe.get_traceback()}", title="Huf API")
         raise
@@ -510,7 +510,7 @@ def upload_file_and_process(docname: str, filename: str, b64data: str, agent: st
             msg.name, 
             is_private=False
         )
-    except Exception as e:
+    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
         logger.warning(f"File save failed: {e!s}")
         frappe.throw(_("Failed to save file"))
 
@@ -536,7 +536,7 @@ def upload_file_and_process(docname: str, filename: str, b64data: str, agent: st
 
         return result
 
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"File processing failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -631,7 +631,7 @@ def upload_file_and_process_web(
 
     try:
         saved_file = save_file(filename, file_bytes, "Agent Message", msg.name, is_private=True)
-    except Exception as e:
+    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
         logger.warning(f"Save file failed (web): {e}")
         return {"success": False, "error": "Could not save file to database."}
 
@@ -655,7 +655,7 @@ def upload_file_and_process_web(
                     conversation_id=conversation_id,
                 )
             )
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"File processing failed (web): {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -752,7 +752,7 @@ def upload_file_attachment_web(filename: str, b64data: str, agent: str):
 
     try:
         saved_file = save_file(filename, file_bytes, "Agent", agent, is_private=True)
-    except Exception as e:
+    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
         logger.warning(f"Attachment upload failed (web): {e}")
         return {"success": False, "error": "Could not save file to database."}
 
@@ -935,7 +935,7 @@ def prepare_message_with_file_web(
                     create_message=False,
                 )
             )
-        except Exception as e:
+        except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
             logger.warning(f"OCR processing failed (web prepare): {e!s}")
             return {"success": False, "error": str(e)}
 
@@ -1011,7 +1011,7 @@ def add_message(
             "success": True,
             "message_id": msg.name
         }
-    except Exception as e:
+    except Exception as e:  # boundary exception handler: API endpoint
         # API boundary: log unexpected failure with traceback, then re-raise.
         frappe.log_error(message=f"add_message API error: {frappe.get_traceback()}", title="Huf API")
         raise

--- a/huf/ai/agent_chat.py
+++ b/huf/ai/agent_chat.py
@@ -51,7 +51,7 @@ def upload_audio_and_transcribe(filename: str, b64data: str, docname: str = None
         "user": frappe.session.user,
         "session_id": session_id,
     })
-    msg.insert(ignore_permissions=True)
+    msg.insert()
 
     try:
         saved_file = audio_service.save_audio_upload(
@@ -61,7 +61,7 @@ def upload_audio_and_transcribe(filename: str, b64data: str, docname: str = None
             attached_to_name=msg.name,
             is_private=0,
         )
-    except Exception as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, OSError, ValueError, KeyError, TypeError) as e:
         logger.warning(f"Save audio upload failed: {e}")
         return {"success": False, "error": str(e)}
 
@@ -94,9 +94,9 @@ def upload_audio_and_transcribe(filename: str, b64data: str, docname: str = None
                         "status": "Completed",
                     },
                 )
-            except Exception as e:
-                logger.warning(f"Create audio user message failed: {e!s}")
-    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
+            except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError) as e:
+                logger.warning(f"Error checking tool permission for {tool_link.tool}: {e!s}")
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"Audio transcription failed: {e!s}")
         frappe.db.set_value("Agent Message", msg.name, "status", "Failed")
         return {"success": False, "error": str(e)}
@@ -182,7 +182,7 @@ def upload_audio_and_transcribe_web(
         "user": frappe.session.user,
         "session_id": conv.session_id,
     })
-    msg.insert(ignore_permissions=True)
+    msg.insert()
 
     # Save file attached to Agent Message
     try:
@@ -193,7 +193,7 @@ def upload_audio_and_transcribe_web(
             attached_to_name=msg.name,
             is_private=0,
         )
-    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, OSError, ValueError, KeyError) as e:
         logger.warning(f"Save audio upload failed (web): {e}")
         return {"success": False, "error": str(e)}
 
@@ -210,7 +210,7 @@ def upload_audio_and_transcribe_web(
             file_id=file_id,
             agent_name=agent,
         )
-    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"Audio transcription failed (web): {e!s}")
         frappe.db.set_value("Agent Message", msg.name, "status", "Failed")
         return {"success": False, "error": str(e)}
@@ -235,7 +235,7 @@ def upload_audio_and_transcribe_web(
                 "status": "Completed",
             },
         )
-    except Exception as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError) as e:
         logger.warning(f"Create audio user message failed (web): {e!s}")
 
     # Ensure the transcript is stored even if message update failed above
@@ -349,6 +349,7 @@ def render_markdown(content: str = "") -> str:
         return md(content or "")
     except Exception:
         # Broad boundary: any markdown failure should fall back to escaped HTML safely.
+        logger.warning(f"render_markdown failed: {frappe.get_traceback()}")
         return frappe.utils.escape_html(content or "")
 
 
@@ -399,8 +400,8 @@ def new_conversation(agent: str, message: str, skip_user_message=0, files=None):
         if run_result.get("conversation_id"):
             try:
                 frappe.db.set_value("Agent Conversation", conversation.name, "name", conversation.name)
-            except Exception:
-                # Best-effort defensive update; ignore failures.
+            except (frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError, frappe.TimestampMismatchError):
+                # Best-effort defensive update; ignore known validation failures.
                 pass
 
         return {
@@ -510,7 +511,7 @@ def upload_file_and_process(docname: str, filename: str, b64data: str, agent: st
             msg.name, 
             is_private=False
         )
-    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, OSError, ValueError, KeyError) as e:
         logger.warning(f"File save failed: {e!s}")
         frappe.throw(_("Failed to save file"))
 
@@ -536,7 +537,7 @@ def upload_file_and_process(docname: str, filename: str, b64data: str, agent: st
 
         return result
 
-    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"File processing failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -631,7 +632,7 @@ def upload_file_and_process_web(
 
     try:
         saved_file = save_file(filename, file_bytes, "Agent Message", msg.name, is_private=True)
-    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, OSError, ValueError, KeyError) as e:
         logger.warning(f"Save file failed (web): {e}")
         return {"success": False, "error": "Could not save file to database."}
 
@@ -655,7 +656,7 @@ def upload_file_and_process_web(
                     conversation_id=conversation_id,
                 )
             )
-    except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, RuntimeError) as e:
         logger.warning(f"File processing failed (web): {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -752,7 +753,7 @@ def upload_file_attachment_web(filename: str, b64data: str, agent: str):
 
     try:
         saved_file = save_file(filename, file_bytes, "Agent", agent, is_private=True)
-    except (frappe.FrappeException, OSError, ValueError, KeyError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, OSError, ValueError, KeyError) as e:
         logger.warning(f"Attachment upload failed (web): {e}")
         return {"success": False, "error": "Could not save file to database."}
 
@@ -846,7 +847,7 @@ def prepare_message_with_file_web(
         "user": frappe.session.user,
         "session_id": conv.session_id,
     })
-    msg.insert(ignore_permissions=True)
+    msg.insert()
 
     if file_id:
         frappe.db.set_value(
@@ -860,7 +861,7 @@ def prepare_message_with_file_web(
     else:
         try:
             saved_file = save_file(resolved_filename, file_bytes, "Agent Message", msg.name, is_private=True)
-        except Exception as e:
+        except (frappe.DoesNotExistError, frappe.ValidationError, OSError, ValueError, KeyError) as e:
             logger.warning(f"Save file failed (web): {e}")
             return {"success": False, "error": "Could not save file to database."}
 
@@ -935,7 +936,7 @@ def prepare_message_with_file_web(
                     create_message=False,
                 )
             )
-        except (frappe.FrappeException, ValueError, KeyError, RuntimeError) as e:
+        except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, RuntimeError) as e:
             logger.warning(f"OCR processing failed (web prepare): {e!s}")
             return {"success": False, "error": str(e)}
 

--- a/huf/ai/agent_hooks.py
+++ b/huf/ai/agent_hooks.py
@@ -10,8 +10,15 @@ CACHE_KEY = "huf:doc_event_agents"
 
 
 def get_doc_event_agents(event: str):
-    """Fetch & cache Doc Event triggers (Agent Trigger doctype)."""
+    """Fetch & cache Doc Event triggers (Agent Trigger doctype).
+
+    Permission checks are enforced so agents only fire for triggers the current
+    user is allowed to read.
+    """
     if not frappe.db.exists("DocType", "Agent Trigger"):
+        return []
+
+    if not frappe.has_permission("Agent Trigger", "read"):
         return []
 
     cached = frappe.cache().hget(CACHE_KEY, f"doc_event:{event}")
@@ -25,45 +32,38 @@ def get_doc_event_agents(event: str):
             "disabled": 0,
             "doc_event": event
         },
-        fields=["name", "agent", "reference_doctype", "doc_event", "condition", "prompt_field"],
-        ignore_permissions=True
+        fields=["name", "agent", "reference_doctype", "doc_event", "condition", "prompt_field"]
     )
 
     result = []
-    
-    original_ignore_permissions = frappe.flags.ignore_permissions
-    frappe.flags.ignore_permissions = True
-    
-    try:
-        for t in triggers:
-            try:
-                trigger_doc = frappe.get_doc("Agent Trigger", t["name"])
-                agent_doc = frappe.get_doc("Agent", t["agent"])
-                from huf.ai.prompt_resolver import resolve_prompt
-                prompt = resolve_prompt(agent_doc)
-                
-                result.append({
-                    "name": t["name"],
-                    "agent": t["agent"],
-                    "reference_doctype": t.get("reference_doctype"),
-                    "doc_event": t.get("doc_event"),
-                    "condition": t.get("condition"),
-                    "prompt_field": t.get("prompt_field"), 
-                    "file_attachments": [
-                        {
-                            "source_type": a.source_type,
-                            "child_table": a.child_table,
-                            "field_name": a.field_name
-                        } for a in (trigger_doc.get("file_attachments") or [])
-                    ],
-                    "instructions": prompt,
-                    "provider": getattr(agent_doc, "provider", None),
-                    "model": getattr(agent_doc, "model", None),
-                })
-            except Exception as e:
-                frappe.logger("huf").error(f"Agent Trigger load failed: {t.get('name')} - {str(e)}")
-    finally:
-        frappe.flags.ignore_permissions = original_ignore_permissions
+
+    for t in triggers:
+        try:
+            trigger_doc = frappe.get_doc("Agent Trigger", t["name"])
+            agent_doc = frappe.get_doc("Agent", t["agent"])
+            from huf.ai.prompt_resolver import resolve_prompt
+            prompt = resolve_prompt(agent_doc)
+
+            result.append({
+                "name": t["name"],
+                "agent": t["agent"],
+                "reference_doctype": t.get("reference_doctype"),
+                "doc_event": t.get("doc_event"),
+                "condition": t.get("condition"),
+                "prompt_field": t.get("prompt_field"),
+                "file_attachments": [
+                    {
+                        "source_type": a.source_type,
+                        "child_table": a.child_table,
+                        "field_name": a.field_name
+                    } for a in (trigger_doc.get("file_attachments") or [])
+                ],
+                "instructions": prompt,
+                "provider": getattr(agent_doc, "provider", None),
+                "model": getattr(agent_doc, "model", None),
+            })
+        except Exception as e:
+            frappe.logger("huf").error(f"Agent Trigger load failed: {t.get('name')} - {str(e)}")
 
     frappe.cache().hset(CACHE_KEY, f"doc_event:{event}", frappe.as_json(result))
     return result
@@ -148,7 +148,8 @@ def run_agent_for_doc(doc, agent_name, instructions, event_name, provider, model
         if initiating_user and frappe.session.user != initiating_user:
             try:
                 frappe.set_user(initiating_user)
-            except Exception:
+            except frappe.DoesNotExistError:
+                # Initiating user no longer exists; continue as current session user
                 pass
 
         custom_instruction = None
@@ -202,8 +203,8 @@ def run_agent_for_doc(doc, agent_name, instructions, event_name, provider, model
                 {json_string}
                 ```
                 """
-            except Exception:
-                pass
+            except (TypeError, ValueError, json.JSONDecodeError) as e:
+                frappe.log_error(f"Agent hook document JSON serialization failed: {e}")
 
             external_id = None
             channel = channel_id or "doc_event"
@@ -214,7 +215,7 @@ def run_agent_for_doc(doc, agent_name, instructions, event_name, provider, model
                     external_id = initiating_user or doc.get("owner") or doc.get("modified_by") or "unknown_user"
                 else:
                     external_id = f"shared:{agent_name}"
-            except Exception:
+            except frappe.DoesNotExistError:
                 external_id = initiating_user or f"shared:{agent_name}"
 
             # File attachments logic

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -351,8 +351,8 @@ def _emit_run_lifecycle_event(run_doc, conversation, status, extra=None):
             message=message,
             user=frappe.session.user,
         )
-    except Exception:
-        pass
+    except Exception as exc:  # non-critical UI notification
+        frappe.logger("huf").debug(f"Realtime publish failed: {exc!s}")
 
 
 def _emit_conversation_title_updated(conversation_name, title):
@@ -370,8 +370,8 @@ def _emit_conversation_title_updated(conversation_name, title):
             },
             user=owner,
         )
-    except Exception:
-        pass
+    except Exception as exc:  # non-critical UI notification
+        frappe.logger("huf").debug(f"Realtime title update publish failed: {exc!s}")
 
 
 def _parse_prompt_cache_options(prompt_cache_options):
@@ -916,8 +916,8 @@ def run_agent_sync(
     if _has_queued_runs(conversation.name, exclude_run_id=run_doc.name):
         try:
             frappe.cache().delete(lock_key)
-        except Exception:
-            pass
+        except Exception as exc:  # best-effort cache cleanup
+            frappe.logger("huf").debug(f"Cache lock delete failed: {exc!s}")
         frappe.throw(
             _(
                 "This conversation has queued runs pending. Wait for them to complete before using the direct-execution override."
@@ -941,14 +941,14 @@ def run_agent_sync(
         heartbeat.stop()
         try:
             frappe.cache().delete(lock_key)
-        except Exception:
-            pass
+        except Exception as exc:  # best-effort cache cleanup
+            frappe.logger("huf").debug(f"Cache lock delete failed: {exc!s}")
         # A queued run may have arrived while we held the lock; wake a drainer.
         try:
             if _has_queued_runs(conversation.name):
                 _enqueue_drain(conversation.name)
-        except Exception:
-            pass
+        except Exception as exc:  # best-effort drain enqueue
+            frappe.logger("huf").warning(f"Drain enqueue failed: {exc!s}")
 
 
 def _is_truthy(value):
@@ -1520,7 +1520,11 @@ def _execute_agent_run(
                     channel_id=channel_id,
                     external_id=external_id,
                 )
-            except Exception as hook_err:
+            except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
+
+                frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
+
+            except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
                 frappe.log_error(f"Error in Sub-Agent Success Hook: {str(hook_err)}", "Agent Integration Error")
 
             # 3. Real-Time UI Notification
@@ -1647,7 +1651,11 @@ def _execute_agent_run(
                     channel_id=channel_id,
                     external_id=external_id,
                 )
-            except Exception as hook_err:
+            except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
+
+                frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
+
+            except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
                 frappe.log_error(f"Error in Sub-Agent Failure Hook: {str(hook_err)}", "Agent Integration Error")
 
             # 3. Real-Time UI Notification
@@ -1733,8 +1741,8 @@ def _reset_run_to_queued(run_id: str, error_message: str = None):
             values["error_message"] = error_message
         frappe.db.set_value("Agent Run", run_id, values, update_modified=True)
         frappe.db.commit()
-    except Exception:
-        pass
+    except (frappe.FrappeException, Exception) as exc:  # best-effort recovery cleanup
+        frappe.logger("huf").debug(f"Failed to reset run {run_id} to queued: {exc!s}")
 
 
 class _RunHeartbeat:
@@ -1759,8 +1767,8 @@ class _RunHeartbeat:
         while not self._stop.wait(self.interval):
             try:
                 frappe.cache().expire(self.lock_key, _QUEUE_LOCK_TTL)
-            except Exception:
-                pass
+            except (frappe.FrappeException, Exception) as exc:  # best-effort heartbeat renewal
+                frappe.logger("huf").debug(f"Lock heartbeat renewal failed for {self.lock_key}: {exc!s}")
 
 
 def _run_queued_agent(lock_attempt=0, **kwargs):
@@ -1799,15 +1807,15 @@ def _run_queued_agent(lock_attempt=0, **kwargs):
     finally:
         try:
             frappe.cache().delete(lock_key)
-        except Exception:
-            pass
+        except Exception as exc:  # best-effort cache cleanup
+            frappe.logger("huf").debug(f"Cache lock delete failed: {exc!s}")
         # Re-check after releasing lock. If a submit happened between our last
         # SELECT and the delete, enqueue a sweeper so the run is not orphaned.
         try:
             if _has_queued_runs(conversation_id):
                 _enqueue_drain(conversation_id)
-        except Exception:
-            pass
+        except (frappe.FrappeException, Exception) as exc:  # best-effort post-release drain enqueue
+            frappe.logger("huf").warning(f"Post-release drain enqueue failed for {conversation_id}: {exc!s}")
 
 
 def _drain_run(run_doc, lock_key: str):
@@ -1856,8 +1864,8 @@ def _drain_run(run_doc, lock_key: str):
                 "failed",
                 {"error": str(e)},
             )
-        except Exception:
-            pass
+        except (frappe.FrappeException, Exception) as exc:  # non-critical lifecycle event notification
+            frappe.logger("huf").debug(f"Failed-run lifecycle event emission failed for {run_doc.name}: {exc!s}")
         frappe.log_error(f"Queued agent run failed: {frappe.get_traceback()}", "Huf")
     finally:
         heartbeat.stop()
@@ -1895,8 +1903,8 @@ def _fail_queued_run(run_id, error_message):
                 "error_message": error_message,
             }, update_modified=True)
             frappe.db.commit()
-    except Exception:
-        pass
+    except (frappe.FrappeException, Exception) as exc:  # best-effort failure status update
+        frappe.logger("huf").warning(f"Failed to mark run {run_id} as Failed: {exc!s}")
 
 
 def recover_stalled_agent_runs():
@@ -2421,7 +2429,11 @@ async def run_agent_stream(
                                 channel_id=channel_id,
                                 external_id=external_id
                             )
-                        except Exception as hook_err:
+                        except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
+
+                            frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
+
+                        except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
                             frappe.log_error(f"Error in Sub-Agent Success Hook: {str(hook_err)}", "Agent Integration Error")
 
                         frappe.publish_realtime(
@@ -2548,7 +2560,11 @@ async def run_agent_stream(
                                 channel_id=channel_id,
                                 external_id=external_id
                             )
-                        except Exception as hook_err:
+                        except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
+
+                            frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
+
+                        except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
                             frappe.log_error(f"Error in Sub-Agent Failure Hook: {str(hook_err)}", "Agent Integration Error")
 
                         frappe.publish_realtime(
@@ -2637,7 +2653,11 @@ async def run_agent_stream(
                         channel_id=channel_id,
                         external_id=external_id
                     )
-                except Exception as hook_err:
+                except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
+
+                    frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
+
+                except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
                     frappe.log_error(f"Error in Sub-Agent Failure Hook: {str(hook_err)}", "Agent Integration Error")
 
                 frappe.publish_realtime(

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -50,9 +50,9 @@ class AgentManager:
             agent_tools = create_agent_tools(self.agent_doc)
             if agent_tools:
                 self.tools.extend(agent_tools)
-        except Exception as e:
+        except (ImportError, AttributeError, TypeError, ValueError, RuntimeError) as e:
             logger.warning(f"Failed to load agent tools: {e!s}")
-        
+
         # Add knowledge_search tool and get_knowledge_sources tool if agent has knowledge
         try:
             from huf.ai.knowledge.tool import (
@@ -86,7 +86,7 @@ class AgentManager:
                     return handle_get_knowledge_sources(agent_name=self.agent_doc.agent_name)
                 self.tools.append(get_knowledge_sources_tool)
 
-        except Exception as e:
+        except (ImportError, AttributeError, TypeError, ValueError, RuntimeError) as e:
             logger.warning(f"Failed to load knowledge tools: {e!s}")
 
     def _setup_client(self):
@@ -351,7 +351,9 @@ def _emit_run_lifecycle_event(run_doc, conversation, status, extra=None):
             message=message,
             user=frappe.session.user,
         )
-    except Exception as exc:  # non-critical UI notification
+    except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+            frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as exc:
+        # Non-critical UI notification; do not fail the run.
         frappe.logger("huf").debug(f"Realtime publish failed: {exc!s}")
 
 
@@ -370,7 +372,9 @@ def _emit_conversation_title_updated(conversation_name, title):
             },
             user=owner,
         )
-    except Exception as exc:  # non-critical UI notification
+    except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+            frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as exc:
+        # Non-critical UI notification; do not fail the title update.
         frappe.logger("huf").debug(f"Realtime title update publish failed: {exc!s}")
 
 
@@ -472,7 +476,12 @@ def process_tool_call(agent_run, conversation, name=None, args=None, result=None
                     update_data["status"] = "Completed"
 
                 doc.update(update_data)
-                doc.save(ignore_permissions=True)
+                if not frappe.has_permission("Agent Tool Call", "write", doc=doc):
+                    frappe.throw(
+                        _("Not permitted to update Agent Tool Call records."),
+                        frappe.PermissionError,
+                    )
+                doc.save()
                 return doc.name
             else:
                 return None
@@ -506,14 +515,24 @@ def process_tool_call(agent_run, conversation, name=None, args=None, result=None
                 "tool_result": result_val,
                 "error_message": error,
                 "status": "Queued",
-                "call_id": tool_call_id 
+                "call_id": tool_call_id
             })
-            doc.insert(ignore_permissions=True)
+            if not frappe.has_permission("Agent Tool Call", "create"):
+                frappe.throw(
+                    _("Not permitted to create Agent Tool Call records."),
+                    frappe.PermissionError,
+                )
+            doc.insert()
             return doc.name
 
+    except frappe.PermissionError:
+        raise
     except Exception as e:
         # Tool-call persistence boundary: any failure here corrupts run audit state.
-        frappe.log_error(f"Error processing tool call: {str(e)}", "Agent Tool Call Error")
+        frappe.log_error(
+            f"Error processing tool call: {str(e)}\n{frappe.get_traceback()}",
+            "Agent Tool Call Error"
+        )
         return None
 
 def log_tool_call(run_doc, conversation, raw_call, tool_result=None, error=None, is_output=False):
@@ -617,9 +636,14 @@ def run_background_summarization(conversation_name, agent_name):
         if new_summary_text:
             conv_manager.update_stored_summary(conversation_name, new_summary_text)
             frappe.db.commit()  # nosemgrep: justified background-job commit
-            
+
     except Exception as e:
+        # Background job entry point: log full traceback for observability.
         logger.warning(f"Background summarization failed: {e!s}")
+        frappe.log_error(
+            f"Background summarization failed: {e!s}\n{frappe.get_traceback()}",
+            "Agent Background Summarization Error"
+        )
 
 @frappe.whitelist()
 def generate_conversation_title(conversation_name, agent_name):
@@ -634,7 +658,7 @@ def generate_conversation_title(conversation_name, agent_name):
 
         conv_manager = ConversationManager(agent_name=agent_name)
         history = conv_manager.get_conversation_history(conversation_name, limit=5)
-        
+
         if not history:
             return
 
@@ -645,15 +669,15 @@ def generate_conversation_title(conversation_name, agent_name):
         Conversation:
         {json.dumps(history)}
         """
-        
+
         agent_doc = frappe.get_doc("Agent", agent_name)
         provider = agent_doc.provider
         model = agent_doc.model
-        
+
         from huf.ai.providers.litellm import get_simple_completion
-        
+
         messages = [{"role": "user", "content": prompt}]
-        
+
         title = _run_async_safely(
             get_simple_completion(model, messages, provider)
         )
@@ -663,7 +687,12 @@ def generate_conversation_title(conversation_name, agent_name):
             frappe.db.commit()  # nosemgrep: justified background-job commit
             _emit_conversation_title_updated(conversation_name, title)
     except Exception as e:
+        # Background job entry point: log full traceback for observability.
         logger.warning(f"Conversation title generation failed: {e!s}")
+        frappe.log_error(
+            f"Conversation title generation failed: {e!s}\n{frappe.get_traceback()}",
+            "Agent Conversation Title Error"
+        )
 
 def _history_without_pending_user_turn(history, skip_user_message: bool):
 	"""When the user message was already persisted (e.g. file prepare), drop it from history.
@@ -829,8 +858,14 @@ def run_agent_sync(
         if flow_id:
             run_doc_data["flow_id"] = flow_id
 
+    if not frappe.has_permission("Agent Run", "create"):
+        frappe.throw(
+            _("You do not have permission to create an Agent Run."),
+            frappe.PermissionError
+        )
+
     run_doc = frappe.get_doc(run_doc_data)
-    run_doc.insert(ignore_permissions=True)
+    run_doc.insert()
 
     execution_kwargs = {
         "agent_name": agent_name,
@@ -916,7 +951,8 @@ def run_agent_sync(
     if _has_queued_runs(conversation.name, exclude_run_id=run_doc.name):
         try:
             frappe.cache().delete(lock_key)
-        except Exception as exc:  # best-effort cache cleanup
+        except Exception as exc:
+            # Defensive cleanup: must not mask the queued-runs validation error.
             frappe.logger("huf").debug(f"Cache lock delete failed: {exc!s}")
         frappe.throw(
             _(
@@ -941,13 +977,15 @@ def run_agent_sync(
         heartbeat.stop()
         try:
             frappe.cache().delete(lock_key)
-        except Exception as exc:  # best-effort cache cleanup
+        except Exception as exc:
+            # Defensive finally cleanup: must not suppress the original exception.
             frappe.logger("huf").debug(f"Cache lock delete failed: {exc!s}")
         # A queued run may have arrived while we held the lock; wake a drainer.
         try:
             if _has_queued_runs(conversation.name):
                 _enqueue_drain(conversation.name)
-        except Exception as exc:  # best-effort drain enqueue
+        except Exception as exc:
+            # Defensive finally cleanup: must not suppress the original exception.
             frappe.logger("huf").warning(f"Drain enqueue failed: {exc!s}")
 
 
@@ -1120,13 +1158,14 @@ def _execute_agent_run(
         knowledge_context = None
         try:
             from huf.ai.knowledge.context_builder import build_knowledge_context, inject_knowledge_context
-            
+
             knowledge_context = build_knowledge_context(
                 agent_name=agent_name,
                 user_query=prompt,
                 max_tokens=agent_doc.max_knowledge_tokens or 4000
             )
-        except Exception:
+        except (ImportError, ValueError, TypeError, KeyError, AttributeError, RuntimeError,
+                frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError):
             # Abort the run instead of continuing with partial state.
             # Mandatory knowledge context is required for this agent; failing here
             # prevents inconsistent tool-call messages from being committed later.
@@ -1445,7 +1484,7 @@ def _execute_agent_run(
                         cached_tokens=cached_tokens,
                         litellm_response=mock_response
                     )
-            except Exception as e:
+            except (ImportError, AttributeError, TypeError, ValueError, KeyError, RuntimeError) as e:
                 frappe.logger("huf").warning(
                     f"Cost calculation failed for {resolved_model} in sync: {e}"
                 )
@@ -1453,17 +1492,18 @@ def _execute_agent_run(
 
             try:
                 total_tokens = getattr(usage, "total_tokens", (input_tokens + output_tokens)) if usage else (input_tokens + output_tokens)
-                
+
                 frappe.db.sql("""
                     UPDATE `tabAgent Conversation`
-                    SET 
+                    SET
                         total_input_tokens = total_input_tokens + %s,
                         total_output_tokens = total_output_tokens + %s,
                         total_tokens = total_tokens + %s,
                         total_cost = total_cost + %s
                     WHERE name = %s
                 """, (input_tokens, output_tokens, total_tokens, cost, conversation.name))
-            except Exception as e:
+            except (RuntimeError, TypeError, ValueError,
+                    frappe.ValidationError, frappe.PermissionError) as e:
                 frappe.logger("huf").warning(
                     f"Failed to update conversation metrics: {str(e)}"
                 )
@@ -1520,12 +1560,16 @@ def _execute_agent_run(
                     channel_id=channel_id,
                     external_id=external_id,
                 )
-            except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
-
+            except (ValueError, KeyError, TypeError, AttributeError,
+                    frappe.DoesNotExistError, frappe.ValidationError,
+                    frappe.PermissionError, frappe.TimestampMismatchError) as hook_err:
                 frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
 
             except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
-                frappe.log_error(f"Error in Sub-Agent Success Hook: {str(hook_err)}", "Agent Integration Error")
+                frappe.log_error(
+                    f"Error in Sub-Agent Success Hook: {str(hook_err)}\n{frappe.get_traceback()}",
+                    "Agent Integration Error"
+                )
 
             # 3. Real-Time UI Notification
             frappe.publish_realtime(
@@ -1588,41 +1632,43 @@ def _execute_agent_run(
             try:
                 frappe.db.set_value("Agent Conversation", conversation.name, "is_active", 0)
                 transaction_checkpoint(reason="agent_streaming_progress")
-                
+
                 error_msg = _("This conversation has exceeded the maximum token limit. Please start a new conversation to continue.")
-                
+
                 conv_manager.add_message(
-                    conversation=conversation, 
-                    role="agent", 
-                    content=error_msg, 
-                    provider=resolved_provider, 
-                    model=resolved_model, 
-                    agent=agent_name, 
+                    conversation=conversation,
+                    role="agent",
+                    content=error_msg,
+                    provider=resolved_provider,
+                    model=resolved_model,
+                    agent=agent_name,
                     run_name=run_doc.name,
                     kind="Error"
                 )
                 transaction_checkpoint(reason="agent_streaming_progress")
-            except Exception as inner_e:
+            except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+                    frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as inner_e:
                 frappe.logger("huf").warning(
                     f"Failed to handle context window error in sync: {str(inner_e)}"
                 )
-                
+
         elif "RateLimitError" in error_msg:
             try:
                 error_msg = _("You have reached the API rate limit (requests/tokens per minute). Please wait a moment and try again.")
-                
+
                 conv_manager.add_message(
-                    conversation=conversation, 
-                    role="agent", 
-                    content=error_msg, 
-                    provider=resolved_provider, 
-                    model=resolved_model, 
-                    agent=agent_name, 
+                    conversation=conversation,
+                    role="agent",
+                    content=error_msg,
+                    provider=resolved_provider,
+                    model=resolved_model,
+                    agent=agent_name,
                     run_name=run_doc.name,
                     kind="Error"
                 )
                 transaction_checkpoint(reason="agent_streaming_progress")
-            except Exception as inner_e:
+            except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+                    frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as inner_e:
                 frappe.logger("huf").warning(
                     f"Failed to handle rate limit error in sync: {str(inner_e)}"
                 )
@@ -1651,12 +1697,16 @@ def _execute_agent_run(
                     channel_id=channel_id,
                     external_id=external_id,
                 )
-            except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
-
+            except (ValueError, KeyError, TypeError, AttributeError,
+                    frappe.DoesNotExistError, frappe.ValidationError,
+                    frappe.PermissionError, frappe.TimestampMismatchError) as hook_err:
                 frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
 
             except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
-                frappe.log_error(f"Error in Sub-Agent Failure Hook: {str(hook_err)}", "Agent Integration Error")
+                frappe.log_error(
+                    f"Error in Sub-Agent Failure Hook: {str(hook_err)}\n{frappe.get_traceback()}",
+                    "Agent Integration Error"
+                )
 
             # 3. Real-Time UI Notification
             frappe.publish_realtime(
@@ -1699,8 +1749,8 @@ def _next_run_sequence(conversation_id: str) -> int:
     seq_key = f"agent_run_seq:{conversation_id}"
     try:
         return int(frappe.cache().incr(seq_key))
-    except Exception:
-        # Redis unavailable: gaps are acceptable; 0 lets the drain loop fall
+    except (RuntimeError, TypeError, ValueError, AttributeError):
+        # Redis/cache unavailable: gaps are acceptable; 0 lets the drain loop fall
         # back to creation-time ordering.
         return 0
 
@@ -1741,7 +1791,7 @@ def _reset_run_to_queued(run_id: str, error_message: str = None):
             values["error_message"] = error_message
         frappe.db.set_value("Agent Run", run_id, values, update_modified=True)
         frappe.db.commit()
-    except (frappe.FrappeException, Exception) as exc:  # best-effort recovery cleanup
+    except Exception as exc:  # top-level recovery helper
         frappe.logger("huf").debug(f"Failed to reset run {run_id} to queued: {exc!s}")
 
 
@@ -1767,7 +1817,7 @@ class _RunHeartbeat:
         while not self._stop.wait(self.interval):
             try:
                 frappe.cache().expire(self.lock_key, _QUEUE_LOCK_TTL)
-            except (frappe.FrappeException, Exception) as exc:  # best-effort heartbeat renewal
+            except Exception as exc:  # worker-thread heartbeat: must never kill the heartbeat thread
                 frappe.logger("huf").debug(f"Lock heartbeat renewal failed for {self.lock_key}: {exc!s}")
 
 
@@ -1803,18 +1853,21 @@ def _run_queued_agent(lock_attempt=0, **kwargs):
             last_result = _drain_run(run_doc, lock_key)
         return last_result
     except Exception:
+        # Background queue drainer boundary: log full traceback.
         frappe.log_error(f"Conversation drainer failed: {frappe.get_traceback()}", "Huf")
     finally:
         try:
             frappe.cache().delete(lock_key)
-        except Exception as exc:  # best-effort cache cleanup
+        except Exception as exc:
+            # Defensive finally cleanup: must not suppress the original exception.
             frappe.logger("huf").debug(f"Cache lock delete failed: {exc!s}")
         # Re-check after releasing lock. If a submit happened between our last
         # SELECT and the delete, enqueue a sweeper so the run is not orphaned.
         try:
             if _has_queued_runs(conversation_id):
                 _enqueue_drain(conversation_id)
-        except (frappe.FrappeException, Exception) as exc:  # best-effort post-release drain enqueue
+        except Exception as exc:
+            # Defensive finally cleanup: must not suppress the original exception.
             frappe.logger("huf").warning(f"Post-release drain enqueue failed for {conversation_id}: {exc!s}")
 
 
@@ -1856,6 +1909,7 @@ def _drain_run(run_doc, lock_key: str):
         result = _execute_agent_run(**execution_kwargs)
         return result
     except Exception as e:
+        # Worker thread boundary: ensure the queued run is marked failed and logged.
         _fail_queued_run(run_doc.name, str(e))
         try:
             _emit_run_lifecycle_event(
@@ -1864,7 +1918,9 @@ def _drain_run(run_doc, lock_key: str):
                 "failed",
                 {"error": str(e)},
             )
-        except (frappe.FrappeException, Exception) as exc:  # non-critical lifecycle event notification
+        except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+                frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as exc:
+            # Non-critical lifecycle event notification.
             frappe.logger("huf").debug(f"Failed-run lifecycle event emission failed for {run_doc.name}: {exc!s}")
         frappe.log_error(f"Queued agent run failed: {frappe.get_traceback()}", "Huf")
     finally:
@@ -1903,7 +1959,7 @@ def _fail_queued_run(run_id, error_message):
                 "error_message": error_message,
             }, update_modified=True)
             frappe.db.commit()
-    except (frappe.FrappeException, Exception) as exc:  # best-effort failure status update
+    except Exception as exc:  # top-level recovery helper
         frappe.logger("huf").warning(f"Failed to mark run {run_id} as Failed: {exc!s}")
 
 
@@ -1935,7 +1991,7 @@ def recover_stalled_agent_runs():
             lock_key = _conversation_lock_key(conversation)
             try:
                 ttl = frappe.cache().ttl(lock_key)
-            except Exception:
+            except (RuntimeError, TypeError, ValueError, AttributeError):
                 ttl = None
             if ttl and ttl > 0:
                 continue
@@ -1960,13 +2016,14 @@ def recover_stalled_agent_runs():
             lock_key = _conversation_lock_key(run.conversation)
             try:
                 ttl = frappe.cache().ttl(lock_key)
-            except Exception:
+            except (RuntimeError, TypeError, ValueError, AttributeError):
                 ttl = None
             if ttl and ttl > 0:
                 continue
             _enqueue_drain(run.conversation)
             drained_conversations.add(run.conversation)
     except Exception:
+        # Scheduler entry point / top-level recovery helper: log full traceback.
         frappe.log_error(f"Agent run recovery failed: {frappe.get_traceback()}", "Huf")
 
 
@@ -2101,6 +2158,13 @@ async def run_agent_stream(
         history = _history_without_pending_user_turn(history, skip_user_message)
         
         # Create Agent Run document
+        if not frappe.has_permission("Agent Run", "create"):
+            yield {
+                "type": "error",
+                "error": "You do not have permission to create an Agent Run."
+            }
+            return
+
         run_doc = frappe.get_doc({
             "doctype": "Agent Run",
             "agent": agent_name,
@@ -2111,7 +2175,7 @@ async def run_agent_stream(
             "model": resolved_model,
             "provider": resolved_provider
         })
-        run_doc.insert(ignore_permissions=True)
+        run_doc.insert()
         if not skip_user_message:
             conv_manager.add_message(conversation, "user", prompt, resolved_provider, resolved_model, agent_name, run_doc.name)
         else:
@@ -2195,13 +2259,13 @@ async def run_agent_stream(
 
         knowledge_context = None
         try:
-            
             knowledge_context = build_knowledge_context(
                 agent_name=agent_name,
                 user_query=prompt,
                 max_tokens=agent_doc.max_knowledge_tokens or 4000
             )
-        except Exception:
+        except (ImportError, ValueError, TypeError, KeyError, AttributeError, RuntimeError,
+                frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError):
             # Abort the stream instead of continuing with partial state.
             # Mandatory knowledge context is required for this agent; failing here
             # prevents inconsistent tool-call messages from being committed later.
@@ -2338,11 +2402,11 @@ async def run_agent_stream(
                             input_tokens = token_counter(model=pricing_model, messages=msgs_for_count)
                             output_tokens = token_counter(model=pricing_model, text=full_response)
                             total_tokens = input_tokens + output_tokens
-                        except Exception as e:
+                        except (ImportError, AttributeError, TypeError, ValueError, KeyError, RuntimeError) as e:
                             frappe.logger("huf").warning(
                                 f"Fallback token counting failed: {e}"
                             )
-                            
+
                     try:
                         # Prefer cost directly from the chunk (calculated by provider)
                         cost = chunk.get("cost")
@@ -2350,7 +2414,7 @@ async def run_agent_stream(
                             from huf.ai.cost_calculator import calculate_cost
 
                             pricing_model = _normalize_model_name(resolved_model, resolved_provider)
-                            
+
                             mock_response = {
                                 "usage": {
                                     "prompt_tokens": input_tokens,
@@ -2359,10 +2423,10 @@ async def run_agent_stream(
                                 },
                                 "model": pricing_model
                             }
-                            
+
                             if cached_tokens > 0:
                                 mock_response["usage"]["prompt_tokens_details"] = {"cached_tokens": cached_tokens}
-                                
+
                             cost, _source = calculate_cost(
                                 model_name=resolved_model,
                                 input_tokens=input_tokens,
@@ -2371,7 +2435,7 @@ async def run_agent_stream(
                                 litellm_response=mock_response
                             )
 
-                    except Exception as e:
+                    except (ImportError, AttributeError, TypeError, ValueError, KeyError, RuntimeError) as e:
                         frappe.logger("huf").warning(
                             f"Cost calculation failed for {resolved_model}: {e}"
                         )
@@ -2381,14 +2445,15 @@ async def run_agent_stream(
                     try:
                         frappe.db.sql("""
                             UPDATE `tabAgent Conversation`
-                            SET 
+                            SET
                                 total_input_tokens = total_input_tokens + %s,
                                 total_output_tokens = total_output_tokens + %s,
                                 total_tokens = total_tokens + %s,
                                 total_cost = total_cost + %s
                             WHERE name = %s
                         """, (input_tokens, output_tokens, total_tokens, cost, conversation.name))
-                    except Exception as e:
+                    except (RuntimeError, TypeError, ValueError,
+                            frappe.ValidationError, frappe.PermissionError) as e:
                         frappe.logger("huf").warning(
                             f"Failed to update conv metrics stream: {str(e)}"
                         )
@@ -2429,12 +2494,16 @@ async def run_agent_stream(
                                 channel_id=channel_id,
                                 external_id=external_id
                             )
-                        except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
-
+                        except (ValueError, KeyError, TypeError, AttributeError,
+                                frappe.DoesNotExistError, frappe.ValidationError,
+                                frappe.PermissionError, frappe.TimestampMismatchError) as hook_err:
                             frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
 
                         except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
-                            frappe.log_error(f"Error in Sub-Agent Success Hook: {str(hook_err)}", "Agent Integration Error")
+                            frappe.log_error(
+                                f"Error in Sub-Agent Success Hook: {str(hook_err)}\n{frappe.get_traceback()}",
+                                "Agent Integration Error"
+                            )
 
                         frappe.publish_realtime(
                             event=f"conversation:{parent_conversation_id}",
@@ -2458,7 +2527,8 @@ async def run_agent_stream(
                                     conversation_name=conversation.name,
                                     agent_name=agent_name
                                 )
-                    except Exception:
+                    except (RuntimeError, TypeError, ValueError, AttributeError,
+                            frappe.ValidationError, frappe.PermissionError):
                         # Best-effort auto-naming enqueue; ignore failures.
                         pass
                         
@@ -2493,23 +2563,24 @@ async def run_agent_stream(
                         try:
                             frappe.db.set_value("Agent Conversation", conversation.name, "is_active", 0)
                             transaction_checkpoint(reason="agent_streaming_progress")
-                            
+
                             user_error_msg = _("This conversation has exceeded the maximum token limit. Please start a new conversation to continue.")
-                            
+
                             conv_manager.add_message(
-                                conversation=conversation, 
-                                role="agent", 
-                                content=user_error_msg, 
-                                provider=resolved_provider, 
-                                model=resolved_model, 
-                                agent=agent_name, 
+                                conversation=conversation,
+                                role="agent",
+                                content=user_error_msg,
+                                provider=resolved_provider,
+                                model=resolved_model,
+                                agent=agent_name,
                                 run_name=run_doc.name,
                                 kind="Error"
                             )
                             transaction_checkpoint(reason="agent_streaming_progress")
                             chunk["error"] = user_error_msg # override so the client sees the same message
                             error_msg = user_error_msg
-                        except Exception as inner_e:
+                        except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+                                frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as inner_e:
                             frappe.logger("huf").warning(
                                 f"Failed to handle context window error in stream inner block: {str(inner_e)}"
                             )
@@ -2517,21 +2588,22 @@ async def run_agent_stream(
                     elif "RateLimitError" in error_msg:
                         try:
                             user_error_msg = _("You have reached the API rate limit (requests/tokens per minute). Please wait a moment and try again.")
-                            
+
                             conv_manager.add_message(
-                                conversation=conversation, 
-                                role="agent", 
-                                content=user_error_msg, 
-                                provider=resolved_provider, 
-                                model=resolved_model, 
-                                agent=agent_name, 
+                                conversation=conversation,
+                                role="agent",
+                                content=user_error_msg,
+                                provider=resolved_provider,
+                                model=resolved_model,
+                                agent=agent_name,
                                 run_name=run_doc.name,
                                 kind="Error"
                             )
                             transaction_checkpoint(reason="agent_streaming_progress")
                             chunk["error"] = user_error_msg # override so the client sees the same message
                             error_msg = user_error_msg
-                        except Exception as inner_e:
+                        except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+                                frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as inner_e:
                             frappe.logger("huf").warning(
                                 f"Failed to handle rate limit in stream inner block: {str(inner_e)}"
                             )
@@ -2560,12 +2632,16 @@ async def run_agent_stream(
                                 channel_id=channel_id,
                                 external_id=external_id
                             )
-                        except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
-
+                        except (ValueError, KeyError, TypeError, AttributeError,
+                                frappe.DoesNotExistError, frappe.ValidationError,
+                                frappe.PermissionError, frappe.TimestampMismatchError) as hook_err:
                             frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
 
                         except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
-                            frappe.log_error(f"Error in Sub-Agent Failure Hook: {str(hook_err)}", "Agent Integration Error")
+                            frappe.log_error(
+                                f"Error in Sub-Agent Failure Hook: {str(hook_err)}\n{frappe.get_traceback()}",
+                                "Agent Integration Error"
+                            )
 
                         frappe.publish_realtime(
                             event=f"conversation:{parent_conversation_id}",
@@ -2589,21 +2665,22 @@ async def run_agent_stream(
                 try:
                     frappe.db.set_value("Agent Conversation", conversation.name, "is_active", 0)
                     transaction_checkpoint(reason="agent_streaming_progress")
-                    
+
                     error_msg = _("This conversation has exceeded the maximum token limit. Please start a new conversation to continue.")
-                    
+
                     conv_manager.add_message(
-                        conversation=conversation, 
-                        role="agent", 
-                        content=error_msg, 
-                        provider=resolved_provider, 
-                        model=resolved_model, 
-                        agent=agent_name, 
+                        conversation=conversation,
+                        role="agent",
+                        content=error_msg,
+                        provider=resolved_provider,
+                        model=resolved_model,
+                        agent=agent_name,
                         run_name=run_doc.name,
                         kind="Error"
                     )
                     transaction_checkpoint(reason="agent_streaming_progress")
-                except Exception as inner_e:
+                except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+                        frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as inner_e:
                     frappe.logger("huf").warning(
                         f"Failed to handle context window error in stream inner block: {str(inner_e)}"
                     )
@@ -2611,31 +2688,31 @@ async def run_agent_stream(
             elif "RateLimitError" in error_msg:
                 try:
                     error_msg = _("You have reached the API rate limit (requests/tokens per minute). Please wait a moment and try again.")
-                    
+
                     conv_manager.add_message(
-                        conversation=conversation, 
-                        role="agent", 
-                        content=error_msg, 
-                        provider=resolved_provider, 
-                        model=resolved_model, 
-                        agent=agent_name, 
+                        conversation=conversation,
+                        role="agent",
+                        content=error_msg,
+                        provider=resolved_provider,
+                        model=resolved_model,
+                        agent=agent_name,
                         run_name=run_doc.name,
                         kind="Error"
                     )
                     transaction_checkpoint(reason="agent_streaming_progress")
-                except Exception as inner_e:
+                except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+                        frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as inner_e:
                     frappe.logger("huf").warning(
                         f"Failed to handle rate limit in stream inner block: {str(inner_e)}"
                     )
 
-            
             frappe.db.set_value("Agent Run", run_doc.name, {
                 "status": "Failed",
                 "error_message": error_msg,
                 "end_time": now_datetime()
             }, update_modified=True)
             transaction_checkpoint(reason="agent_streaming_progress")
-            
+
             # Handle Sub-Agent Failure Lifecycle Hook
             if parent_conversation_id and invoked_by_agent:
                 # Silent Auto-Awaken Trigger
@@ -2653,12 +2730,16 @@ async def run_agent_stream(
                         channel_id=channel_id,
                         external_id=external_id
                     )
-                except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as hook_err:
-
+                except (ValueError, KeyError, TypeError, AttributeError,
+                        frappe.DoesNotExistError, frappe.ValidationError,
+                        frappe.PermissionError, frappe.TimestampMismatchError) as hook_err:
                     frappe.logger("huf").warning(f"Agent hook dispatch failure: {hook_err!s}")
 
                 except Exception as hook_err:  # boundary exception handler: agent hook dispatcher
-                    frappe.log_error(f"Error in Sub-Agent Failure Hook: {str(hook_err)}", "Agent Integration Error")
+                    frappe.log_error(
+                        f"Error in Sub-Agent Failure Hook: {str(hook_err)}\n{frappe.get_traceback()}",
+                        "Agent Integration Error"
+                    )
 
                 frappe.publish_realtime(
                     event=f"conversation:{parent_conversation_id}",
@@ -2714,7 +2795,10 @@ async def run_agent_stream(
                         }, update_modified=True)
                     safe_commit()
             except Exception as clean_err:
-                frappe.logger("huf").warning(f"Error in stream disconnect response recovery: {clean_err}")
+                # Defensive finally cleanup: must not suppress the original exception.
+                frappe.logger("huf").warning(
+                    f"Error in stream disconnect response recovery: {clean_err}\n{frappe.get_traceback()}"
+                )
 
 # ---------------------------------------------------------------------------
 # Permission query conditions — used by hooks.py permission_query_conditions

--- a/huf/ai/agent_scheduler.py
+++ b/huf/ai/agent_scheduler.py
@@ -49,7 +49,7 @@ def run_scheduled_agents():
                 years=interval if si == "yearly" else 0,
             )
 
-            doc.save(ignore_permissions=True)
+            doc.save()
             frappe.db.commit()
 
         except Exception:

--- a/huf/ai/agent_stream_renderer.py
+++ b/huf/ai/agent_stream_renderer.py
@@ -49,7 +49,7 @@ class AgentStreamRenderer(BaseRenderer):
 		if agent_name:
 			try:
 				agent_name = urllib.parse.unquote(agent_name)
-			except Exception:
+			except (ValueError, TypeError):
 				pass
 			return self._render_agent_stream(agent_name)
 			
@@ -97,9 +97,9 @@ class AgentStreamRenderer(BaseRenderer):
 					if not prompt_template: prompt_template = body.get("prompt_template")
 					if not prompt_version: prompt_version = body.get("prompt_version")
 					if not prompt_cache_options: prompt_cache_options = body.get("prompt_cache_options")
-			except Exception:
+			except (json.JSONDecodeError, TypeError, ValueError):
 				pass
-		
+
 		if not prompt:
 			def error_generator() -> Generator[str, None, None]:
 				error_data = {"type": "error", "error": "Prompt parameter required"}
@@ -138,10 +138,11 @@ class AgentStreamRenderer(BaseRenderer):
 				},
 			)
 		except Exception as e:
+			frappe.log_error(frappe.get_traceback(), "Agent Stream Renderer Error")
 			def error_generator() -> Generator[str, None, None]:
 				error_data = {"type": "error", "error": f"Error loading agent: {str(e)}"}
 				yield f"data: {json.dumps(error_data)}\n\n"
-			
+
 			return Response(
 				error_generator(),
 				mimetype="text/event-stream",
@@ -151,7 +152,7 @@ class AgentStreamRenderer(BaseRenderer):
 					"X-Accel-Buffering": "no",
 				},
 			)
-		
+
 		# Queue-first policy: streaming is a direct-execution compatibility path,
 		# allowed only when the agent opts in via the 'Run Immediately' policy.
 		if not getattr(agent_doc, "run_immediately", 0):
@@ -176,7 +177,7 @@ class AgentStreamRenderer(BaseRenderer):
 				create_new = body.get("create_new", create_new)
 				skip_user_message = body.get("skip_user_message", skip_user_message)
 				files = body.get("files")
-		except Exception:
+		except (json.JSONDecodeError, TypeError, ValueError):
 			pass
 
 		create_new = bool(create_new)
@@ -241,10 +242,12 @@ class AgentStreamRenderer(BaseRenderer):
 					except StopAsyncIteration:
 						break
 					except Exception as e:
+						frappe.log_error(frappe.get_traceback(), "Agent Stream Chunk Error")
 						error_data = {"type": "error", "error": str(e)}
 						yield f"data: {json.dumps(error_data)}\n\n"
 						break
 			except Exception as e:
+				frappe.log_error(frappe.get_traceback(), "Agent Stream Setup Error")
 				error_data = {"type": "error", "error": f"Stream setup error: {str(e)}"}
 				yield f"data: {json.dumps(error_data)}\n\n"
 			finally:
@@ -258,7 +261,7 @@ class AgentStreamRenderer(BaseRenderer):
 						if pending:
 							loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
 						loop.close()
-					except Exception:
+					except (RuntimeError, ValueError, TypeError, AttributeError, KeyError):
 						pass
 					finally:
 						asyncio.set_event_loop(None)

--- a/huf/ai/audio_service.py
+++ b/huf/ai/audio_service.py
@@ -186,7 +186,7 @@ def save_audio_upload(
             attached_to_name,
             is_private=is_private,
         )
-    except Exception as e:
+    except (OSError, ValueError, frappe.ValidationError) as e:
         frappe.log_error(message=f"Save File Failed: {e}", title="Save File Failed")
         frappe.throw(_("Could not save audio file to database."))
 
@@ -336,7 +336,7 @@ def _find_transcription_model(provider: str) -> str:
             order_by="modified desc",
             limit=1,
         )
-    except Exception:
+    except frappe.DoesNotExistError:
         return None
 
     return models[0].model_name if models else None
@@ -457,7 +457,7 @@ def _resolve_file_doc(file_id: str = None, file_url: str = None):
     if file_url:
         try:
             file_doc = frappe.get_doc("File", {"file_url": file_url})
-        except Exception:
+        except (frappe.DoesNotExistError, frappe.DataError):
             # Try alternative lookup
             file_name = file_url.replace("/files/", "")
             file_doc = frappe.get_doc("File", {"file_name": file_name})
@@ -738,7 +738,15 @@ def create_audio_user_message(
             message_doc.status = message_status
         if file_doc and file_doc.file_url:
             message_doc.voice_message = file_doc.file_url
-        message_doc.insert(ignore_permissions=True)
+        # Audio user messages are created during agent/chat execution.
+        # Authenticated users require Agent Message create permission;
+        # Guest agents rely on the system-level bypass.
+        if frappe.session.user == "Guest":
+            message_doc.insert(ignore_permissions=True)
+        else:
+            if not frappe.has_permission("Agent Message", "create", doc=message_doc):
+                frappe.throw(_("Not permitted to create Agent Message"), frappe.PermissionError)
+            message_doc.insert()
 
     # Check if file is already attached to this message
     if file_doc and message_doc:

--- a/huf/ai/conversation_manager.py
+++ b/huf/ai/conversation_manager.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.utils import now
 import json
 from collections import defaultdict
@@ -133,7 +134,7 @@ def _synthesize_assistant_tool_call(tool_call_id: str, conversation_name: str | 
                 }
             ],
         }
-    except Exception:
+    except (frappe.DoesNotExistError, frappe.DataError):
         return None
 
 
@@ -163,7 +164,7 @@ def update_tool_call_message(
 
     try:
         msg_doc = frappe.get_doc("Agent Message", message_name)
-    except Exception as e:
+    except (frappe.DoesNotExistError, frappe.DataError) as e:
         frappe.log_error(
             f"Could not load Agent Message '{message_name}' for tool result update: {e}",
             "Tool Call Message Update"
@@ -182,7 +183,7 @@ def update_tool_call_message(
         if agent_doc:
             try:
                 max_context_chars = int(getattr(agent_doc, "max_context_chars", 2000) or 2000)
-            except Exception:
+            except (ValueError, TypeError):
                 max_context_chars = 2000
         max_context_chars = max(max_context_chars, 500)
 
@@ -207,9 +208,17 @@ def update_tool_call_message(
                 else tool_call
             )
 
-        msg_doc.save(ignore_permissions=True)
+        # Only users who can write Agent Messages should be able to mutate a
+        # persisted tool-call row. Standard permissions cover authenticated
+        # Huf users; system callers must run as a user with this permission.
+        if not frappe.has_permission("Agent Message", "write", doc=msg_doc):
+            frappe.throw(
+                _("Not permitted to update Agent Message {0}").format(msg_doc.name),
+                frappe.PermissionError,
+            )
+        msg_doc.save()
         return True
-    except Exception as e:
+    except (frappe.ValidationError, frappe.PermissionError, frappe.TimestampMismatchError) as e:
         frappe.log_error(
             f"Error updating tool call message '{message_name}': {e}",
             "Tool Call Message Update"
@@ -348,7 +357,12 @@ class ConversationManager:
             "is_active": 1,
             "model": frappe.db.get_value("Agent", self.agent_name, "model")
         })
-        conv.insert(ignore_permissions=True)
+        if not frappe.has_permission("Agent Conversation", "create"):
+            frappe.throw(
+                _("Not permitted to create Agent Conversation"),
+                frappe.PermissionError,
+            )
+        conv.insert()
         return conv
 
     def get_or_create_conversation(self, title=None, conversation_id=None):
@@ -390,7 +404,12 @@ class ConversationManager:
             "is_active": 1,
             "model": frappe.db.get_value("Agent", self.agent_name, "model")
         })
-        conv.insert(ignore_permissions=True)
+        if not frappe.has_permission("Agent Conversation", "create"):
+            frappe.throw(
+                _("Not permitted to create Agent Conversation"),
+                frappe.PermissionError,
+            )
+        conv.insert()
         return conv
 
     def add_message(
@@ -478,7 +497,12 @@ class ConversationManager:
                 doc_data["token_estimate"] = token_estimate
 
             message = frappe.get_doc(doc_data)
-            message.insert(ignore_permissions=True)
+            if not frappe.has_permission("Agent Message", "create"):
+                frappe.throw(
+                    _("Not permitted to create Agent Message"),
+                    frappe.PermissionError,
+                )
+            message.insert()
 
             frappe.db.set_value("Agent Conversation", conversation.name, {
                 "total_messages": last_index + 1,
@@ -600,7 +624,7 @@ class ConversationManager:
                     )
                     if isinstance(parsed, list):
                         tool_calls = parsed
-                except Exception:
+                except (json.JSONDecodeError, TypeError):
                     tool_calls = []
 
             if not tool_calls and (stored_tool_call_id or tool_call_link):

--- a/huf/ai/cost_calculator.py
+++ b/huf/ai/cost_calculator.py
@@ -58,7 +58,7 @@ def get_model_pricing(model_name: str) -> dict | None:
         if cached is not None:
             # Sentinel: empty dict means "we checked, no custom pricing"
             return cached if cached else None
-    except (frappe.FrappeException, Exception) as exc:  # best-effort pricing cache operation
+    except Exception as exc:  # best-effort pricing cache operation
         frappe.logger("huf").debug(f"Model pricing cache operation failed: {exc!s}")
 
     try:
@@ -111,7 +111,7 @@ def get_model_pricing(model_name: str) -> dict | None:
 
     try:
         frappe.cache().set_value(cache_key, pricing, expires_in_sec=_PRICING_CACHE_TTL)
-    except (frappe.FrappeException, Exception) as exc:  # best-effort pricing cache operation
+    except Exception as exc:  # best-effort pricing cache operation
         frappe.logger("huf").debug(f"Model pricing cache operation failed: {exc!s}")
 
     return pricing
@@ -223,5 +223,5 @@ def invalidate_model_pricing_cache(model_name: str):
         return
     try:
         frappe.cache().delete_key(f"huf_model_pricing:{model_name}")
-    except (frappe.FrappeException, Exception) as exc:  # best-effort pricing cache operation
+    except Exception as exc:  # best-effort pricing cache operation
         frappe.logger("huf").debug(f"Model pricing cache operation failed: {exc!s}")

--- a/huf/ai/cost_calculator.py
+++ b/huf/ai/cost_calculator.py
@@ -58,8 +58,8 @@ def get_model_pricing(model_name: str) -> dict | None:
         if cached is not None:
             # Sentinel: empty dict means "we checked, no custom pricing"
             return cached if cached else None
-    except Exception:
-        pass
+    except (frappe.FrappeException, Exception) as exc:  # best-effort pricing cache operation
+        frappe.logger("huf").debug(f"Model pricing cache operation failed: {exc!s}")
 
     try:
         model_doc = frappe.db.get_value(
@@ -111,8 +111,8 @@ def get_model_pricing(model_name: str) -> dict | None:
 
     try:
         frappe.cache().set_value(cache_key, pricing, expires_in_sec=_PRICING_CACHE_TTL)
-    except Exception:
-        pass
+    except (frappe.FrappeException, Exception) as exc:  # best-effort pricing cache operation
+        frappe.logger("huf").debug(f"Model pricing cache operation failed: {exc!s}")
 
     return pricing
 
@@ -223,5 +223,5 @@ def invalidate_model_pricing_cache(model_name: str):
         return
     try:
         frappe.cache().delete_key(f"huf_model_pricing:{model_name}")
-    except Exception:
-        pass
+    except (frappe.FrappeException, Exception) as exc:  # best-effort pricing cache operation
+        frappe.logger("huf").debug(f"Model pricing cache operation failed: {exc!s}")

--- a/huf/ai/flow_api.py
+++ b/huf/ai/flow_api.py
@@ -391,8 +391,9 @@ def flow_webhook(flow_id: str, webhook_key: str | None = None) -> dict:
 			raw = frappe.request.get_data(as_text=True)
 			if raw:
 				payload = frappe.parse_json(raw)
-		except Exception:
-			pass
+		except (json.JSONDecodeError, TypeError):
+			frappe.log_error(frappe.get_traceback(), "Flow Webhook Payload Parse Error")
+			payload = {}
 
 		if not payload:
 			if frappe.request.form:
@@ -603,7 +604,10 @@ def execute_scheduled_flow(flow_id: str) -> dict:
 		}
 	except Exception as e:
 		error_msg = str(e)
-		frappe.log_error(f"Error executing scheduled flow '{flow_id}': {error_msg}", "Flow Scheduler")
+		frappe.log_error(
+			frappe.get_traceback(),
+			f"Scheduled Flow Execution Error: {flow_id}",
+		)
 		return {"status": "error", "error": error_msg, "flow_id": flow_id}
 
 
@@ -806,9 +810,9 @@ def handle_run_flow(flow_id: str, payload: str | dict | None = None, mode: str |
 		if isinstance(payload, str):
 			try:
 				payload = json.loads(payload)
-			except Exception:
+			except (json.JSONDecodeError, TypeError):
 				payload = {}
-				
+
 		from huf.ai.flow_engine import create_flow_run, run_flow as engine_run_flow
 
 		flow_run = create_flow_run(flow_id=flow_id, payload=payload or {}, mode=mode)
@@ -825,6 +829,7 @@ def handle_run_flow(flow_id: str, payload: str | dict | None = None, mode: str |
 			"current_node_id": flow_run.current_node_id,
 		}
 	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), "Run Flow Tool Error")
 		return {"success": False, "error": str(e)}
 
 
@@ -861,6 +866,7 @@ def handle_get_flow_run(flow_run_id: str, **kwargs) -> dict:
 			"waiting": waiting,
 		}
 	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), "Get Flow Run Tool Error")
 		return {"success": False, "error": str(e)}
 
 
@@ -888,6 +894,7 @@ def handle_resume_flow_run(flow_run_id: str, input: dict | None = None, **kwargs
 			"current_node_id": doc.current_node_id,
 		}
 	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), "Resume Flow Run Tool Error")
 		return {"success": False, "error": str(e)}
 
 
@@ -916,6 +923,7 @@ def handle_approve_flow_run(flow_run_id: str, decision: str = "approved", commen
 			"current_node_id": doc.current_node_id,
 		}
 	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), "Approve Flow Run Tool Error")
 		return {"success": False, "error": str(e)}
 
 

--- a/huf/ai/flow_engine.py
+++ b/huf/ai/flow_engine.py
@@ -108,7 +108,15 @@ def create_flow_run(
 			"started_at": now_datetime(),
 		}
 	)
-	flow_run.insert(ignore_permissions=True)
+	# Authenticated callers are already verified by the public API.
+	# Webhook triggers run as Guest after HMAC validation, so the internal
+	# Flow Run record must be created on behalf of the system.
+	if frappe.session.user == "Guest":
+		flow_run.insert(ignore_permissions=True)
+	else:
+		if not frappe.has_permission("Flow Run", "create", doc=flow_run):
+			frappe.throw(_("Not permitted to create Flow Run"), frappe.PermissionError)
+		flow_run.insert()
 	commit_if_background()
 
 	return flow_run
@@ -1286,7 +1294,15 @@ def _create_flow_agent_run(flow_run, node: dict, run_kind: str, prompt: str = ""
 			"start_time": now_datetime(),
 		}
 	)
-	run_doc.insert(ignore_permissions=True)
+	# Agent Run records are internal execution logs. Authenticated users
+	# create them through normal permission checks; Guest/webhook paths are
+	# allowed because the engine is acting on behalf of the system.
+	if frappe.session.user == "Guest":
+		run_doc.insert(ignore_permissions=True)
+	else:
+		if not frappe.has_permission("Agent Run", "create", doc=run_doc):
+			frappe.throw(_("Not permitted to create Agent Run"), frappe.PermissionError)
+		run_doc.insert()
 	commit_if_background()
 	return run_doc
 
@@ -1303,7 +1319,14 @@ def _create_flow_conversation(flow_id: str, entry_node_id: str) -> "frappe.Docum
 			"is_active": 1,
 		}
 	)
-	conv.insert(ignore_permissions=True)
+	# Flow conversations are created by the engine. Authenticated callers
+	# use standard permissions; Guest/webhook triggers rely on the system.
+	if frappe.session.user == "Guest":
+		conv.insert(ignore_permissions=True)
+	else:
+		if not frappe.has_permission("Agent Conversation", "create", doc=conv):
+			frappe.throw(_("Not permitted to create Agent Conversation"), frappe.PermissionError)
+		conv.insert()
 	commit_if_background()
 	return conv
 

--- a/huf/ai/knowledge/tool.py
+++ b/huf/ai/knowledge/tool.py
@@ -111,13 +111,14 @@ def handle_knowledge_search(
 	if not knowledge_source:
 		return "Error: No knowledge sources available for this agent."
 
-	# Perform search (ignore_permissions=True: agent has explicit knowledge linkage)
+	# Perform search respecting the current user's permissions on the
+	# Knowledge Source; the agent linkage alone is not sufficient to bypass
+	# permission checks.
 	try:
 		results = knowledge_search(
 			query=query,
 			knowledge_source=knowledge_source,
 			top_k=top_k,
-			ignore_permissions=True,
 		)
 
 		if not results:

--- a/huf/ai/mcp_client.py
+++ b/huf/ai/mcp_client.py
@@ -69,7 +69,7 @@ def create_mcp_tools(agent_doc) -> list[FunctionTool]:
                 # Reconstruct tool definition from child table
                 try:
                     parameters = json.loads(tool_row.parameters) if tool_row.parameters else {}
-                except Exception:
+                except json.JSONDecodeError:
                     parameters = {}
                     
                 tool_def = {
@@ -84,8 +84,8 @@ def create_mcp_tools(agent_doc) -> list[FunctionTool]:
                     
         except Exception as e:
             frappe.log_error(
-                f"Error loading MCP tools from {mcp_link.mcp_server}: {str(e)}",
-                "MCP Client Error"
+                message=f"Error loading MCP tools from {mcp_link.mcp_server}: {str(e)}\n\n{frappe.get_traceback()}",
+                title="MCP Client Error"
             )
     
     return tools
@@ -169,8 +169,8 @@ def _create_mcp_function_tool(mcp_server, tool_def: dict) -> FunctionTool:
                 
             except Exception as e:
                 frappe.log_error(
-                    f"Error executing MCP tool '{display_name}': {str(e)}",
-                    "MCP Tool Execution Error"
+                    message=f"Error executing MCP tool '{display_name}': {str(e)}\n\n{frappe.get_traceback()}",
+                    title="MCP Tool Execution Error"
                 )
                 return json.dumps({"error": str(e)})
         
@@ -192,8 +192,8 @@ def _create_mcp_function_tool(mcp_server, tool_def: dict) -> FunctionTool:
         
     except Exception as e:
         frappe.log_error(
-            f"Error creating MCP tool from {tool_def}: {str(e)}",
-            "MCP Client Error"
+            message=f"Error creating MCP tool from {tool_def}: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP Client Error"
         )
         return None
 
@@ -228,8 +228,8 @@ async def execute_mcp_tool(
             
     except Exception as e:
         frappe.log_error(
-            f"Error executing MCP tool {tool_name} on {server_name}: {str(e)}",
-            "MCP Tool Execution Error"
+            message=f"Error executing MCP tool {tool_name} on {server_name}: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP Tool Execution Error"
         )
         return {"error": str(e), "success": False}
 
@@ -254,7 +254,7 @@ def _format_mcp_error(exc) -> str:
         try:
             if hasattr(exc.response, "text") and exc.response.text:
                 msg += f" (Response: {exc.response.text})"
-        except Exception:
+        except (AttributeError, ValueError, RuntimeError):
             pass # Ignore if streaming response not read
         return msg
     return str(exc)
@@ -278,8 +278,15 @@ async def execute_with_mcp_session(mcp_server, operation: Callable[[Any], Any]):
                 headers = _build_mcp_headers(mcp_server)
                 return await _do_execute_mcp_session(mcp_server, headers, operation)
             except Exception as refresh_exc:
-                frappe.log_error(f"OAuth retry failed: {refresh_exc}", "MCP OAuth Retry")
+                frappe.log_error(
+                    message=f"OAuth retry failed: {refresh_exc}\n\n{frappe.get_traceback()}",
+                    title="MCP OAuth Retry"
+                )
                 raise Exception("OAuth token invalid or expired. Reconnect via the MCP Server form.")
+        frappe.log_error(
+            message=f"MCP session error: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP Session Error"
+        )
         raise Exception(_format_mcp_error(e))
 
 async def _do_execute_mcp_session(mcp_server, headers, operation):
@@ -322,6 +329,10 @@ async def _execute_mcp_tool_via_sdk(mcp_server, tool_name: str, arguments: dict)
             return result.model_dump()
         return {"content": [{"type": "text", "text": str(result)}], "isError": getattr(result, "isError", False)}
     except Exception as e:
+        frappe.log_error(
+            message=f"Error executing MCP tool via SDK: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP Tool Execution Error"
+        )
         return {"error": str(e), "success": False}
 
 
@@ -349,7 +360,10 @@ def _build_mcp_headers(mcp_server) -> dict:
                 token = get_valid_access_token(mcp_server.name)
                 headers["Authorization"] = f"Bearer {token}"
             except Exception as exc:
-                frappe.log_error(str(exc), "MCP OAuth Header Error")
+                frappe.log_error(
+                    message=f"{str(exc)}\n\n{frappe.get_traceback()}",
+                    title="MCP OAuth Header Error"
+                )
                 # Proceed without auth header; server will return 401
         else:
             auth_value = mcp_server.get_password("auth_header_value")
@@ -426,6 +440,7 @@ def sync_mcp_server_tools(server_name: str) -> dict:
                     "enabled": 1
                 })
         
+        # Whitelisted sync endpoint updates server metadata after permission check; bypass is required because non-admin users may trigger sync.
         mcp_server.save(ignore_permissions=True)
         commit_if_background()
         
@@ -437,8 +452,8 @@ def sync_mcp_server_tools(server_name: str) -> dict:
         
     except Exception as e:
         frappe.log_error(
-            f"Error syncing MCP tools from {server_name}: {str(e)}",
-            "MCP Sync Error"
+            message=f"Error syncing MCP tools from {server_name}: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP Sync Error"
         )
         return {
             "success": False,
@@ -527,6 +542,10 @@ def test_mcp_connection(server_name: str) -> dict:
     except requests.exceptions.ConnectionError as e:
         return {"success": False, "error": f"Connection failed: {str(e)}"}
     except Exception as e:
+        frappe.log_error(
+            message=f"MCP connection test failed: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP Connection Test Error"
+        )
         return {"success": False, "error": str(e)}
 
 
@@ -555,7 +574,7 @@ def get_agent_mcp_servers(agent_name: str) -> list:
                     try:
                         tools = json.loads(mcp_server.available_tools)
                         tool_count = len(tools) if isinstance(tools, list) else 0
-                    except Exception:
+                    except json.JSONDecodeError:
                         pass
                 
                 result.append({
@@ -569,13 +588,20 @@ def get_agent_mcp_servers(agent_name: str) -> list:
                     "tool_count": tool_count,
                     "last_sync": mcp_server.last_sync
                 })
-            except Exception:
+            except Exception as e:
+                frappe.log_error(
+                    message=f"Error loading MCP server {mcp_link.mcp_server}: {str(e)}\n\n{frappe.get_traceback()}",
+                    title="MCP Agent Server Load Error"
+                )
                 continue
         
         return result
         
     except Exception as e:
-        frappe.log_error(f"Error getting agent MCP servers: {str(e)}", "MCP API Error")
+        frappe.log_error(
+            message=f"Error getting agent MCP servers: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP API Error"
+        )
         return []
 
 
@@ -604,7 +630,7 @@ def get_available_mcp_servers() -> list:
                 if available_tools:
                     tools = json.loads(available_tools)
                     tool_count = len(tools) if isinstance(tools, list) else 0
-            except Exception:
+            except json.JSONDecodeError:
                 pass
             
             result.append({
@@ -615,7 +641,10 @@ def get_available_mcp_servers() -> list:
         return result
         
     except Exception as e:
-        frappe.log_error(f"Error getting available MCP servers: {str(e)}", "MCP API Error")
+        frappe.log_error(
+            message=f"Error getting available MCP servers: {str(e)}\n\n{frappe.get_traceback()}",
+            title="MCP API Error"
+        )
         return []
 
 @frappe.whitelist()
@@ -639,4 +668,7 @@ def auto_sync_mcp_server_tools():
                 frappe.log_error(f"Auto-syncing MCP Tools: {server.name}", "MCP Tools Auto Synced")
                 sync_mcp_server_tools(server.name)
         except Exception as e:
-            frappe.log_error(f"Error auto-syncing {server.name}: {str(e)}", "MCP Tools Auto Sync Error")
+            frappe.log_error(
+                message=f"Error auto-syncing {server.name}: {str(e)}\n\n{frappe.get_traceback()}",
+                title="MCP Tools Auto Sync Error"
+            )

--- a/huf/ai/mcp_connection_resolver.py
+++ b/huf/ai/mcp_connection_resolver.py
@@ -185,7 +185,7 @@ def discover_mcp_server(server_name: str) -> dict:
         if result.get("discovery_status") != "Ready":
             server.oauth_discovery_status = result.get("discovery_status", "Failed")
             server.oauth_discovery_error = result.get("discovery_error")
-            server.save(ignore_permissions=True)
+            server.save()
             return result
 
         # Persist discovered metadata
@@ -213,7 +213,7 @@ def discover_mcp_server(server_name: str) -> dict:
         if not server.oauth_scope and result.get("scopes_supported"):
             server.oauth_scope = " ".join(result["scopes_supported"])
 
-        server.save(ignore_permissions=True)
+        server.save()
 
         # Return a sanitized version (no full metadata dump to frontend)
         return {

--- a/huf/ai/mcp_oauth.py
+++ b/huf/ai/mcp_oauth.py
@@ -93,13 +93,16 @@ def start_oauth_flow(server_name: str) -> dict:
                 extra_params = json.loads(config["extra_authorize_params"])
                 if isinstance(extra_params, dict):
                     params.update(extra_params)
-            except Exception as e:
-                frappe.log_error("MCP OAuth", message=f"Invalid JSON in oauth_extra_authorize_params for {server_name}: {e}")
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                frappe.logger("huf").warning(f"Invalid JSON in oauth_extra_authorize_params for {server_name}: {e!s}")
 
         auth_url = config["authorization_endpoint"] + "?" + urllib.parse.urlencode(params)
         return {"auth_url": auth_url}
 
-    except Exception as exc:
+    except (frappe.PermissionError, ValueError, KeyError) as exc:
+        frappe.logger("huf").warning(f"OAuth start_flow validation error for {server_name}: {exc!s}")
+        return {"error": str(exc)}
+    except Exception as exc:  # boundary exception handler: OAuth start_flow endpoint
         frappe.log_error("MCP OAuth", message=f"MCP OAuth start_flow error for {server_name}: {exc}")
         return {"error": str(exc)}
 
@@ -136,7 +139,10 @@ def resolve_and_start_oauth_flow(server_name: str) -> dict:
 
         return start_oauth_flow(server_name)
 
-    except Exception as exc:
+    except (frappe.PermissionError, ValueError, KeyError) as exc:
+        frappe.logger("huf").warning(f"OAuth resolve error for {server_name}: {exc!s}")
+        return {"error": str(exc)}
+    except Exception as exc:  # boundary exception handler: OAuth resolve_and_start endpoint
         frappe.log_error("MCP OAuth", message=f"MCP OAuth resolve_and_start error for {server_name}: {exc}")
         return {"error": str(exc)}
 
@@ -184,7 +190,10 @@ def handle_oauth_callback(server_name: str, code: str, state: str) -> dict:
 
         return {"success": True}
 
-    except Exception as exc:
+    except (frappe.PermissionError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        frappe.logger("huf").warning(f"OAuth callback validation error for {server_name}: {exc!s}")
+        return {"error": str(exc)}
+    except Exception as exc:  # boundary exception handler: OAuth callback endpoint
         frappe.log_error("MCP OAuth", message=f"MCP OAuth callback error for {server_name}: {exc}")
         return {"error": str(exc)}
 
@@ -203,7 +212,10 @@ def disconnect_oauth(server_name: str) -> dict:
         server.oauth_status = "Not Connected"
         server.save(ignore_permissions=True)
         return {"success": True}
-    except Exception as exc:
+    except (frappe.FrappeException, ValueError, KeyError) as exc:
+        frappe.logger("huf").warning(f"Disconnect OAuth warning for {server_name}: {exc!s}")
+        return {"error": str(exc)}
+    except Exception as exc:  # boundary exception handler: disconnect_oauth endpoint
         return {"error": str(exc)}
 
 
@@ -235,7 +247,7 @@ def get_valid_access_token(server_name: str) -> str:
     if _is_token_expiring_soon(server):
         try:
             access_token = refresh_oauth_token(server_name)
-        except Exception as exc:
+        except Exception as exc:  # boundary exception handler: proactive refresh fallback
             frappe.log_error("MCP OAuth", message=f"MCP OAuth proactive refresh failed for {server_name}: {exc}")
             # Return existing token — it may still work for a few minutes
             # (executor will get a 401 and retry once)
@@ -255,7 +267,7 @@ def refresh_oauth_token(server_name: str) -> str:
 
     try:
         refresh_token = server.get_password("oauth_refresh_token")
-    except Exception:
+    except (frappe.FrappeException, KeyError, AttributeError):  # optional refresh token lookup
         refresh_token = None
 
     if not refresh_token:
@@ -275,8 +287,8 @@ def refresh_oauth_token(server_name: str) -> str:
         client_secret = None
         try:
             client_secret = server.get_password("oauth_client_secret")
-        except Exception:
-            pass
+        except (frappe.FrappeException, KeyError, AttributeError):  # PKCE public clients may omit client_secret
+            client_secret = None
         if client_secret:
             payload["client_secret"] = client_secret
 
@@ -295,7 +307,7 @@ def refresh_oauth_token(server_name: str) -> str:
         _save_tokens(server, token_data)
         return server.get_password("oauth_access_token")
 
-    except Exception as exc:
+    except Exception as exc:  # boundary exception handler: token refresh endpoint call
         _set_expired_status(server)
         raise
 
@@ -314,7 +326,7 @@ def auto_refresh_oauth_tokens():
         if _is_token_expiring_soon(s, buffer_minutes=65):
             try:
                 refresh_oauth_token(s.name)
-            except Exception as exc:
+            except Exception as exc:  # boundary exception handler: scheduled auto-refresh job
                 frappe.log_error("MCP OAuth Auto Refresh", message=f"Auto refresh failed for {s.name}: {exc}")
 
 
@@ -360,8 +372,8 @@ def _exchange_code_for_tokens(server, config: dict, code: str, code_verifier: st
     client_secret = None
     try:
         client_secret = server.get_password("oauth_client_secret")
-    except Exception:
-        pass
+    except (frappe.FrappeException, AttributeError, KeyError) as exc:  # non-critical cleanup
+        frappe.logger("huf").debug(f"Helper exception ignored: {exc!s}")
     if client_secret:
         payload["client_secret"] = client_secret
 
@@ -427,8 +439,8 @@ def _set_expired_status(server):
     try:
         server.oauth_status = "Token Expired"
         server.save(ignore_permissions=True)
-    except Exception:
-        pass
+    except (frappe.FrappeException, AttributeError, KeyError) as exc:  # non-critical cleanup
+        frappe.logger("huf").debug(f"Helper exception ignored: {exc!s}")
 
 
 def _get_effective_oauth_config(server) -> dict:

--- a/huf/ai/mcp_oauth.py
+++ b/huf/ai/mcp_oauth.py
@@ -181,6 +181,9 @@ def handle_oauth_callback(server_name: str, code: str, state: str) -> dict:
 
         redirect_uri = _get_redirect_uri(server)
 
+        if not frappe.has_permission("MCP Server", "write", server_name):
+            return {"error": "Not permitted to update MCP Server."}
+
         token_data = _exchange_code_for_tokens(server, config, code, code_verifier, redirect_uri)
         _save_tokens(server, token_data)
 
@@ -210,9 +213,9 @@ def disconnect_oauth(server_name: str) -> dict:
         server.oauth_refresh_token = ""
         server.oauth_token_expires_at = None
         server.oauth_status = "Not Connected"
-        server.save(ignore_permissions=True)
+        server.save()
         return {"success": True}
-    except (frappe.FrappeException, ValueError, KeyError) as exc:
+    except (frappe.AuthenticationError, frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError) as exc:
         frappe.logger("huf").warning(f"Disconnect OAuth warning for {server_name}: {exc!s}")
         return {"error": str(exc)}
     except Exception as exc:  # boundary exception handler: disconnect_oauth endpoint
@@ -267,15 +270,15 @@ def refresh_oauth_token(server_name: str) -> str:
 
     try:
         refresh_token = server.get_password("oauth_refresh_token")
-    except (frappe.FrappeException, KeyError, AttributeError):  # optional refresh token lookup
+    except (frappe.AuthenticationError, frappe.DoesNotExistError, KeyError, AttributeError):  # optional refresh token lookup
         refresh_token = None
 
     if not refresh_token:
-        _set_expired_status(server)
+        _set_expired_status(server, ignore_permissions=True)
         raise ValueError(f"No refresh token stored for MCP Server '{server_name}'.")
 
     if not config.get("token_endpoint") or not config.get("client_id"):
-        _set_expired_status(server)
+        _set_expired_status(server, ignore_permissions=True)
         raise ValueError(f"OAuth configuration missing for MCP Server '{server_name}'.")
 
     try:
@@ -287,7 +290,7 @@ def refresh_oauth_token(server_name: str) -> str:
         client_secret = None
         try:
             client_secret = server.get_password("oauth_client_secret")
-        except (frappe.FrappeException, KeyError, AttributeError):  # PKCE public clients may omit client_secret
+        except (frappe.AuthenticationError, frappe.DoesNotExistError, KeyError, AttributeError):  # PKCE public clients may omit client_secret
             client_secret = None
         if client_secret:
             payload["client_secret"] = client_secret
@@ -304,11 +307,11 @@ def refresh_oauth_token(server_name: str) -> str:
         if "error" in token_data:
             raise ValueError(token_data.get("error_description", token_data["error"]))
 
-        _save_tokens(server, token_data)
+        _save_tokens(server, token_data, ignore_permissions=True)
         return server.get_password("oauth_access_token")
 
     except Exception as exc:  # boundary exception handler: token refresh endpoint call
-        _set_expired_status(server)
+        _set_expired_status(server, ignore_permissions=True)
         raise
 
 
@@ -372,7 +375,7 @@ def _exchange_code_for_tokens(server, config: dict, code: str, code_verifier: st
     client_secret = None
     try:
         client_secret = server.get_password("oauth_client_secret")
-    except (frappe.FrappeException, AttributeError, KeyError) as exc:  # non-critical cleanup
+    except (frappe.AuthenticationError, frappe.DoesNotExistError, AttributeError, KeyError) as exc:  # non-critical cleanup
         frappe.logger("huf").debug(f"Helper exception ignored: {exc!s}")
     if client_secret:
         payload["client_secret"] = client_secret
@@ -398,7 +401,7 @@ def _exchange_code_for_tokens(server, config: dict, code: str, code_verifier: st
     return data
 
 
-def _save_tokens(server, token_data: dict):
+def _save_tokens(server, token_data: dict, ignore_permissions: bool = False):
     """Persist access_token, refresh_token, expiry and status to the server doc."""
     expires_in = token_data.get("expires_in")
     expires_at = add_to_date(now_datetime(), seconds=int(expires_in)) if expires_in else None
@@ -423,7 +426,10 @@ def _save_tokens(server, token_data: dict):
         server.oauth_refresh_token = token_data["refresh_token"]
     server.oauth_token_expires_at = expires_at
     server.oauth_status = "Connected"
-    server.save(ignore_permissions=True)
+    # ignore_permissions is used only for automatic system-level token refresh
+    # (scheduled job or proactive refresh during MCP tool execution) where no
+    # end-user is directly editing the MCP Server document.
+    server.save(ignore_permissions=ignore_permissions)
 
 
 def _is_token_expiring_soon(server_or_row, buffer_minutes: int = 5) -> bool:
@@ -435,11 +441,14 @@ def _is_token_expiring_soon(server_or_row, buffer_minutes: int = 5) -> bool:
     return get_datetime(expires_at) <= get_datetime(threshold)
 
 
-def _set_expired_status(server):
+def _set_expired_status(server, ignore_permissions: bool = False):
     try:
         server.oauth_status = "Token Expired"
-        server.save(ignore_permissions=True)
-    except (frappe.FrappeException, AttributeError, KeyError) as exc:  # non-critical cleanup
+        # ignore_permissions is kept for automatic refresh failures in system
+        # contexts (scheduler or tool execution) where the current user may not
+        # have write access to the MCP Server configuration document.
+        server.save(ignore_permissions=ignore_permissions)
+    except (frappe.AuthenticationError, frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError, AttributeError, KeyError) as exc:  # non-critical cleanup
         frappe.logger("huf").debug(f"Helper exception ignored: {exc!s}")
 
 

--- a/huf/ai/ocr_engine.py
+++ b/huf/ai/ocr_engine.py
@@ -67,8 +67,8 @@ class ExtractionResult:
 def _log_error(message: str, title: str = "OCR Engine"):
     try:
         frappe.log_error(message, title)
-    except Exception:
-        pass
+    except (frappe.FrappeException, Exception) as exc:  # fallback logging protection
+        frappe.logger("huf").warning(f"Error logging failed: {exc!s}")
 
 
 def _file_hash(file_path: str, algorithm: str = "sha256") -> str:
@@ -322,7 +322,7 @@ async def _process_with_ocr_endpoint(
                 page_list = [int(p.strip()) for p in str(pages).split(",") if p.strip()]
                 if page_list:
                     ocr_params["pages"] = page_list
-            except Exception:
+            except (ValueError, AttributeError, TypeError):  # optional page list parsing fallback
                 pass
 
         if include_images:
@@ -547,7 +547,7 @@ async def extract_document(
                 file_id=file_doc.name,
                 file_name=file_doc.file_name,
             )
-    except Exception:
+    except (OSError, frappe.FrappeException, AttributeError):  # path resolution fallback
         pass
 
     if not os.path.exists(file_path):

--- a/huf/ai/ocr_engine.py
+++ b/huf/ai/ocr_engine.py
@@ -67,7 +67,7 @@ class ExtractionResult:
 def _log_error(message: str, title: str = "OCR Engine"):
     try:
         frappe.log_error(message, title)
-    except (frappe.FrappeException, Exception) as exc:  # fallback logging protection
+    except Exception as exc:  # fallback logging protection
         frappe.logger("huf").warning(f"Error logging failed: {exc!s}")
 
 
@@ -98,7 +98,7 @@ def _resolve_file_doc(file_id: str | None = None, file_url: str | None = None):
             return frappe.get_doc("File", file_id)
         except frappe.DoesNotExistError:
             raise ValueError(f"File document '{file_id}' not found")
-        except Exception as e:
+        except (frappe.DoesNotExistError, frappe.DataError) as e:
             raise ValueError(f"Error loading File '{file_id}': {e}")
 
     if file_url:
@@ -547,7 +547,7 @@ async def extract_document(
                 file_id=file_doc.name,
                 file_name=file_doc.file_name,
             )
-    except (OSError, frappe.FrappeException, AttributeError):  # path resolution fallback
+    except (OSError, frappe.DoesNotExistError, frappe.ValidationError, AttributeError):  # path resolution fallback
         pass
 
     if not os.path.exists(file_path):
@@ -700,7 +700,15 @@ async def extract_document(
                     "user": "Agent",
                 }
             )
-            message_doc.insert(ignore_permissions=True)
+            # OCR messages are created during agent execution. Authenticated
+            # users must have Agent Message create permission; Guest agents
+            # (allow_guest) create the internal message on behalf of the system.
+            if frappe.session.user == "Guest":
+                message_doc.insert(ignore_permissions=True)
+            else:
+                if not frappe.has_permission("Agent Message", "create", doc=message_doc):
+                    frappe.throw(_("Not permitted to create Agent Message"), frappe.PermissionError)
+                message_doc.insert()
 
             frappe.db.sql(
                 """

--- a/huf/ai/orchestration/orchestrator.py
+++ b/huf/ai/orchestration/orchestrator.py
@@ -154,7 +154,7 @@ def execute_next_step(orch=None, orch_name=None):
     if not next_step:
         orch.status = "Completed"
         orch.last_run_at = now_datetime()
-        orch.save(ignore_permissions=True)
+        orch.save()
         if orch.parent_run:
             frappe.db.set_value("Agent Run", orch.parent_run, {
                 "status": "Success",
@@ -170,7 +170,7 @@ def execute_next_step(orch=None, orch_name=None):
     next_step.status = "in_progress"
     orch.current_step = next_step.step_index
     orch.last_run_at = now_datetime()
-    orch.save(ignore_permissions=True)
+    orch.save()
     frappe.db.commit()
 
     try:
@@ -216,7 +216,7 @@ def execute_next_step(orch=None, orch_name=None):
         orch.status = "Failed"
         frappe.log_error(frappe.get_traceback(), "Orchestration Step Error")
 
-    orch.save(ignore_permissions=True)
+    orch.save()
     frappe.db.commit()
 
     return "ok" if next_step.status == "done" else "failed"

--- a/huf/ai/orchestration/scheduler.py
+++ b/huf/ai/orchestration/scheduler.py
@@ -38,7 +38,7 @@ def process_orchestrations():
                         step.status = "failed"
                         orch.error_log = (orch.error_log or "") + f"\nStep {step.step_index} timed out (stuck for > 15m)."
                         orch.status = "Failed"
-                        orch.save(ignore_permissions=True)
+                        orch.save()
                         frappe.db.commit()
                         timed_out = True
                     else:

--- a/huf/ai/providers/elevenlabs_convai_api.py
+++ b/huf/ai/providers/elevenlabs_convai_api.py
@@ -194,6 +194,7 @@ def handle_elevenlabs_webhook(type=None, data=None, event_timestamp=None):
             "total_cost": metadata.get("cost", 0),
         }
     )
+    # Guest webhook runs after signature validation; internal audit record created on behalf of the system.
     run_doc.insert(ignore_permissions=True)
     if api_key and conversation_id:
         try:

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -132,10 +132,10 @@ def _file_dict_to_data_image_url(file_dict: dict) -> dict | None:
         with open(file_path, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("utf-8")
         return {"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{encoded}"}}
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
-        logger.warning(f"Failed to embed image for LLM: {e}")
+        logger.warning(f"Failed to embed image for LLM: {e}\n{frappe.get_traceback()}")
         return None
 
 
@@ -379,7 +379,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
         if enable_prompt_caching:
             try:
                 model_supports_caching = model_supports_prompt_caching(model, provider)
-            except Exception:
+            except (ImportError, AttributeError, ValueError, TypeError, RuntimeError):
                 # Prompt-caching check failed; disable caching and log for investigation.
                 model_supports_caching = False
                 frappe.log_error(
@@ -482,7 +482,9 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             try:
                 messages = trim_messages(messages=messages, model=normalized_model)
             except Exception as e:
-                logger.warning(f"Failed to trim messages: {e!s}; continuing with untrimmed messages")
+                logger.warning(
+                    f"Failed to trim messages: {e!s}; continuing with untrimmed messages\n{frappe.get_traceback()}"
+                )
                 # Continue with untrimmed messages if trimming fails
                 pass
 
@@ -580,7 +582,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                         litellm_response=response,
                     )
                     total_cost += round_cost
-                except Exception:
+                except (ValueError, TypeError, AttributeError, KeyError):
                     # Cost calculation is best-effort; ignore rounding failures.
                     pass
 
@@ -597,7 +599,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
                 try:
                     full_trace = frappe.get_traceback()
-                except Exception:
+                except (AttributeError, TypeError, RuntimeError):
                     full_trace = str(e)
 
                 frappe.log_error(message=full_trace, title=title)
@@ -614,7 +616,10 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
             except Exception as e:
                 msg = f"LiteLLM error for model '{normalized_model}': {str(e)}"
-                frappe.log_error(message=msg, title="LiteLLM Provider")
+                frappe.log_error(
+                    message=f"{msg}\n\n{frappe.get_traceback()}",
+                    title="LiteLLM Provider"
+                )
                 
                 if "ContextWindowExceededError" in str(e) or "RateLimitError" in str(e):
                     raise e
@@ -696,6 +701,10 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                             tool_to_run, tool_args, context, tool_call.id
                         )
                     except Exception as e:
+                        frappe.log_error(
+                            message=f"Error executing tool {tool_name}: {str(e)}\n\n{frappe.get_traceback()}",
+                            title="LiteLLM Tool Execution Error"
+                        )
                         result_content = f"Error executing tool {tool_name}: {str(e)}"
                 else:
                     result_content = f"Tool '{tool_name}' not found."
@@ -728,7 +737,10 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
     except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError) as e:
         frappe.logger("huf").warning(f"Expected failure: {e!s}")
     except Exception as e:  # boundary exception handler: unexpected system error boundary
-        frappe.log_error(message=f"LiteLLM Provider Error: {str(e)}", title="LiteLLM Provider")
+        frappe.log_error(
+            message=f"LiteLLM Provider Error: {str(e)}\n\n{frappe.get_traceback()}",
+            title="LiteLLM Provider"
+        )
         
         if "ContextWindowExceededError" in str(e) or "RateLimitError" in str(e):
             raise e
@@ -770,10 +782,10 @@ async def get_simple_completion(model: str, messages: list, provider: str) -> st
         
         return response.choices[0].message.content
         
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
-        logger.warning(f"LiteLLM simple completion failed: {e!s}")
+        logger.warning(f"LiteLLM simple completion failed: {e!s}\n{frappe.get_traceback()}")
         return ""
 
 
@@ -847,7 +859,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         if enable_prompt_caching:
             try:
                 model_supports_caching = model_supports_prompt_caching(model, provider)
-            except Exception:
+            except (ImportError, AttributeError, ValueError, TypeError, RuntimeError):
                 # Prompt-caching check failed; disable caching and log for investigation.
                 model_supports_caching = False
                 frappe.log_error(
@@ -944,7 +956,9 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         try:
             messages = trim_messages(messages=messages, model=normalized_model)
         except Exception as e:
-            logger.warning(f"Failed to trim messages: {e!s}; continuing with untrimmed messages")
+            logger.warning(
+                f"Failed to trim messages: {e!s}; continuing with untrimmed messages\n{frappe.get_traceback()}"
+            )
             pass
 
         messages = repair_message_sequence(
@@ -1090,6 +1104,10 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                             tool_to_run, tool_args, context, tool_call.get("id")
                                         )
                                     except Exception as e:
+                                        frappe.log_error(
+                                            message=f"Error executing tool {tool_name}: {str(e)}\n\n{frappe.get_traceback()}",
+                                            title="LiteLLM Streaming Tool Execution Error"
+                                        )
                                         result_content = f"Error executing tool {tool_name}: {str(e)}"
 
                                     # Update Agent Tool Call with result (runs even if tool raised)
@@ -1111,7 +1129,15 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                     tc_doc.tool_result = result_content
                                                 else:
                                                     tc_doc.tool_result = {"output": str(result_content)[:140000]}
-                                                tc_doc.save(ignore_permissions=True)
+                                                # Tool-call audit records are updated by the provider
+                                                # during execution. Authenticated users use standard
+                                                # permissions; Guest/system paths bypass permissions.
+                                                if frappe.session.user == "Guest":
+                                                    tc_doc.save(ignore_permissions=True)
+                                                else:
+                                                    if not frappe.has_permission("Agent Tool Call", "write", doc=tc_doc):
+                                                        frappe.throw(_("Not permitted to update Agent Tool Call"), frappe.PermissionError)
+                                                    tc_doc.save()
 
                                                 # Find the Agent Message to update. Prefer the in-memory
                                                 # map passed via context, then fall back to DB lookups.
@@ -1189,8 +1215,8 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                 transaction_checkpoint(reason="agent_streaming_progress")
                                         except Exception as e:
                                             frappe.log_error(
-                                                f"Error updating tool call result for call_id={call_id}: {e}",
-                                                "Tool Call Message Update"
+                                                message=f"Error updating tool call result for call_id={call_id}: {e}\n\n{frappe.get_traceback()}",
+                                                title="Tool Call Message Update"
                                             )
                                 else:
                                     result_content = f"Tool '{tool_name}' not found."
@@ -1238,6 +1264,10 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                 yield {"type": "error", "error": f"API error: {str(e)}"}
                 return
             except Exception as e:
+                frappe.log_error(
+                    message=f"LiteLLM streaming round error: {str(e)}\n\n{frappe.get_traceback()}",
+                    title="LiteLLM Streaming"
+                )
                 yield {"type": "error", "error": f"LiteLLM error: {str(e)}"}
                 return
 
@@ -1263,7 +1293,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                     output_tokens=s_output,
                     cached_tokens=s_cached,
                 )
-            except Exception:
+            except (ValueError, TypeError, AttributeError, KeyError):
                 # Stream cost calculation is best-effort; ignore failures.
                 pass
 
@@ -1278,5 +1308,8 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
     except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError) as e:
         frappe.logger("huf").warning(f"Expected failure: {e!s}")
     except Exception as e:  # boundary exception handler: unexpected system error boundary
-        frappe.log_error(message=f"LiteLLM Streaming Error: {str(e)}", title="LiteLLM Streaming")
-        yield {"type": "error", "error": f"LiteLLM Streaming Error: {str(e)}"}
+        frappe.log_error(
+            message=f"LiteLLM Streaming Error: {str(e)}\n\n{frappe.get_traceback()}",
+            title="LiteLLM Streaming"
+        )
+        yield {"type": "error", "error": f"LiteLLM Streaming Error: {str(e)}",}

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -132,7 +132,9 @@ def _file_dict_to_data_image_url(file_dict: dict) -> dict | None:
         with open(file_path, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("utf-8")
         return {"type": "image_url", "image_url": {"url": f"data:{mime_type};base64,{encoded}"}}
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Failed to embed image for LLM: {e}")
         return None
 
@@ -723,7 +725,9 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             cost=total_cost,
         )
 
-    except Exception as e:
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError) as e:
+        frappe.logger("huf").warning(f"Expected failure: {e!s}")
+    except Exception as e:  # boundary exception handler: unexpected system error boundary
         frappe.log_error(message=f"LiteLLM Provider Error: {str(e)}", title="LiteLLM Provider")
         
         if "ContextWindowExceededError" in str(e) or "RateLimitError" in str(e):
@@ -766,7 +770,9 @@ async def get_simple_completion(model: str, messages: list, provider: str) -> st
         
         return response.choices[0].message.content
         
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"LiteLLM simple completion failed: {e!s}")
         return ""
 
@@ -1269,6 +1275,8 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         }
 
 
-    except Exception as e:
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError) as e:
+        frappe.logger("huf").warning(f"Expected failure: {e!s}")
+    except Exception as e:  # boundary exception handler: unexpected system error boundary
         frappe.log_error(message=f"LiteLLM Streaming Error: {str(e)}", title="LiteLLM Streaming")
         yield {"type": "error", "error": f"LiteLLM Streaming Error: {str(e)}"}

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -90,7 +90,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
             from huf.ai.mcp_client import create_mcp_tools
             mcp_tools = create_mcp_tools(agent)
             tools.extend(mcp_tools)
-        except Exception as e:
+        except (ImportError, frappe.FrappeException, ValueError, KeyError) as e:
             frappe.logger("huf").warning(
                 f"Error loading MCP tools for agent: {e!s}"
             )
@@ -211,7 +211,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                     if tool:
                         tools.append(tool)
 
-            except Exception as e:
+            except (frappe.FrappeException, ValueError, KeyError, AttributeError) as e:
                 frappe.logger("huf").debug(
                     f"Error processing function {function_doc.name}: {e!s}"
                 )
@@ -751,7 +751,10 @@ def handle_create_document(reference_doctype=None, ignore_permissions=False, **k
         result_dict = {"name": doc.name, "creation": str(doc.creation)}
 
         return {"success": True, "result": result_dict, "message": f"{reference_doctype} created"}
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_create_document failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -789,7 +792,10 @@ def handle_delete_document(document_id=None, reference_doctype=None, ignore_perm
         frappe.delete_doc(reference_doctype, document_id, ignore_permissions=ignore_permissions)
 
         return {"success": True, "message": f"{reference_doctype} {document_id} deleted"}
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_delete_document failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -960,7 +966,10 @@ def handle_update_document(document_id=None, data=None, reference_doctype=None, 
             "result": result_dict,
             "message": f"{reference_doctype} {document_id} updated successfully.",
         }
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_update_document failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1011,7 +1020,10 @@ def handle_get_document(document_id=None, reference_doctype=None, **filters):
             "message": f"{reference_doctype} '{doc_name}' fetched successfully",
         }
 
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_get_document failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1143,7 +1155,10 @@ def handle_set_value(doctype: str = None, filters: dict = None, fieldname: str =
             "new_value": doc.get(fieldname)
         }
 
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_set_value failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1198,7 +1213,10 @@ def handle_run_agent(target_agent_name: str, prompt: str, **kwargs):
             "message": "The task is currently being processed in the background. IMPORTANT: DO NOT tell the user that the task is completed or successful yet. Inform the user that you are working on it and will provide an update shortly. Do not mention the terms 'sub-agent' or 'background queue' explicitly, keep it natural (e.g., 'I am processing this for you now...').",
             "job_id": job.id
         }
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_run_agent failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1228,7 +1246,10 @@ def handle_attach_file_to_document(reference_doctype, document_id, **kwargs):
             **normalized_kwargs,
         )
         return {"success": True, "result": result}
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_attach_file_to_document failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1277,7 +1298,10 @@ def handle_get_conversation_data(name: str, default: Any = None, conversation_id
                 break
 
         return {"success": True, "value": value}
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_get_conversation_data failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1360,7 +1384,10 @@ def handle_set_conversation_data(
 
         return {"success": True, "message": f"Set '{name}' match successfully"}
 
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_set_conversation_data failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1433,7 +1460,10 @@ def handle_get_result_context(reference_doctype: str, reference_name: str, **kwa
 
         # Unreachable because of the allow-list, but kept as defense-in-depth.
         return {"success": False, "error": "Unexpected DocType."}
+    except (frappe.DoesNotExistError, frappe.PermissionError, frappe.ValidationError, ValueError, KeyError) as e:
+        return {"success": False, "error": str(e)}
     except Exception as e:
+        # Boundary exception handler: tool contract requires returning JSON error to LLM
         logger.warning(f"handle_get_result_context failed: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -1553,7 +1583,7 @@ async def handle_generate_image(
                 """, (conversation_id,), as_dict=1)
 
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
-            except Exception:
+            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException):
                 # Hard failure: message ordering is required; abort and alert admin.
                 frappe.log_error(
                     frappe.get_traceback(),
@@ -1637,7 +1667,7 @@ async def handle_generate_image(
                             "user": "Agent"
                         })
                         message_doc.insert(ignore_permissions=True)
-                    except Exception as e:
+                    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
                         logger.warning(f"Create image message failed: {e!s}")
                         # Continue even if message creation fails
 
@@ -1692,7 +1722,7 @@ async def handle_generate_image(
                             user=frappe.session.user,
                             after_commit=False
                         )
-                    except Exception as e:
+                    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
                         frappe.logger("huf").debug(
                             f"Error emitting new_agent_message socket event: {e!s}"
                         )
@@ -1711,7 +1741,7 @@ async def handle_generate_image(
                     SET total_messages = %s, last_activity = NOW()
                     WHERE name = %s
                 """, (final_index, conversation_id))
-            except Exception as e:
+            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
                 frappe.logger("huf").debug(
                     f"Error updating conversation total_messages: {e!s}"
                 )
@@ -1728,7 +1758,7 @@ async def handle_generate_image(
             "message": f"Generated {len(images)} image(s) successfully"
         }
 
-    except Exception as e:
+    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
         # Hard provider/tool failure: retain Error Log for admin attention.
         frappe.log_error(f"Image generation error: {e!s}", "Image Generation Tool")
         return {"success": False, "error": str(e)}
@@ -1799,7 +1829,7 @@ async def handle_ocr_document(
 
         return result.as_dict()
 
-    except Exception as e:
+    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
         # Hard OCR failure: retain Error Log for admin attention.
         frappe.log_error(f"OCR error: {e!s}", "OCR Tool")
         return {"success": False, "error": str(e)}
@@ -2101,7 +2131,7 @@ async def handle_generate_audio(
                 """, (conversation_id,), as_dict=1)
 
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
-            except Exception:
+            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException):
                 # Hard failure: message ordering is required; abort and alert admin.
                 frappe.log_error(
                     frappe.get_traceback(),
@@ -2149,7 +2179,7 @@ async def handle_generate_audio(
                     )
                     message_doc.tts_model = agent_doc.tts_model
 
-            except Exception as e:
+            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
                 logger.warning(f"Create audio message failed: {e!s}")
                 message_doc = None
 
@@ -2202,7 +2232,7 @@ async def handle_generate_audio(
                     user=frappe.session.user,
                     after_commit=False
                 )
-            except Exception as e:
+            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
                 frappe.logger("huf").debug(
                     f"Error emitting new_agent_message socket event: {e!s}"
                 )
@@ -2215,7 +2245,7 @@ async def handle_generate_audio(
                     SET total_messages = %s, last_activity = NOW()
                     WHERE name = %s
                 """, (conversation_index, conversation_id))
-            except Exception as e:
+            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
                 frappe.logger("huf").debug(
                     f"Error updating conversation total_messages: {e!s}"
                 )
@@ -2238,7 +2268,7 @@ async def handle_generate_audio(
             "conversation_id": conversation_id
         }
 
-    except Exception as e:
+    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
         # Hard provider/tool failure: retain Error Log for admin attention.
         frappe.log_error(title="Audio Generation Tool", message=f"Audio generation error: {e!s}")
         return {"success": False, "error": str(e)}
@@ -2322,7 +2352,7 @@ async def handle_transcribe_audio(
             "provider": result.get("provider"),
         }
 
-    except Exception as e:
+    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
         # Hard transcription failure: retain Error Log for admin attention.
         frappe.log_error(f"Audio transcription error: {e!s}", "Audio Transcription Tool")
         return {"success": False, "error": str(e)}

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -90,7 +90,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
             from huf.ai.mcp_client import create_mcp_tools
             mcp_tools = create_mcp_tools(agent)
             tools.extend(mcp_tools)
-        except (ImportError, frappe.FrappeException, ValueError, KeyError) as e:
+        except (ImportError, frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError) as e:
             frappe.logger("huf").warning(
                 f"Error loading MCP tools for agent: {e!s}"
             )
@@ -211,7 +211,7 @@ def create_agent_tools(agent) -> list[FunctionTool]:
                     if tool:
                         tools.append(tool)
 
-            except (frappe.FrappeException, ValueError, KeyError, AttributeError) as e:
+            except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, AttributeError) as e:
                 frappe.logger("huf").debug(
                     f"Error processing function {function_doc.name}: {e!s}"
                 )
@@ -400,7 +400,7 @@ def create_function_tool(
 
             except Exception as e:
                 frappe.logger("huf").debug(
-                    f"Error in on_invoke_tool for tool '{name}': {e!s}"
+                    f"Error in on_invoke_tool for tool '{name}': {e!s}\n{frappe.get_traceback()}"
                 )
                 return json.dumps({"error": str(e)})
 
@@ -421,9 +421,9 @@ def create_function_tool(
 
         return tool
 
-    except Exception as e:
+    except (TypeError, ValueError, AttributeError) as e:
         frappe.logger("huf").debug(
-            f"Error creating FunctionTool for {name}: {e!s}"
+            f"Error creating FunctionTool for {name}: {e!s}\n{frappe.get_traceback()}"
         )
         return None
 
@@ -470,9 +470,9 @@ def get_function_from_name(tool_name: str) -> Callable:
 
 		return function
 
-	except Exception as e:
+	except (ImportError, AttributeError, TypeError, ValueError) as e:
 		frappe.logger("huf").debug(
-			f"Unexpected error getting function {tool_name}: {e!s}"
+			f"Unexpected error getting function {tool_name}: {e!s}\n{frappe.get_traceback()}"
 		)
 		return None
 
@@ -502,7 +502,7 @@ def wrap_frappe_function(func: Callable) -> Callable:
 
 			return {"success": True, "result": result}
 		except Exception as e:
-			logger.warning(f"Wrapped function {func.__name__} failed: {e}")
+			logger.warning(f"Wrapped function {func.__name__} failed: {e!s}\n{frappe.get_traceback()}")
 			return {"success": False, "error": str(e)}
 
 
@@ -536,7 +536,7 @@ def _sanitize_for_doctype(doctype: str, data: dict) -> dict:
                 cleaned[key] = value
 
         return cleaned
-    except Exception:
+    except (frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError, ValueError, KeyError, TypeError):
         # Defensive fallback: if meta lookup fails, return original data unchanged.
         return data or {}
 
@@ -755,7 +755,7 @@ def handle_create_document(reference_doctype=None, ignore_permissions=False, **k
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_create_document failed: {e!s}")
+        logger.warning(f"handle_create_document failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 
@@ -796,7 +796,7 @@ def handle_delete_document(document_id=None, reference_doctype=None, ignore_perm
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_delete_document failed: {e!s}")
+        logger.warning(f"handle_delete_document failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 
@@ -916,7 +916,7 @@ def handle_get_list(
 
 		return response
 	except Exception as e:
-		logger.warning(f"handle_get_list failed: {e!s}")
+		logger.warning(f"handle_get_list failed: {e!s}\n{frappe.get_traceback()}")
 		return {"success": False, "error": str(e)}
 
 
@@ -970,7 +970,7 @@ def handle_update_document(document_id=None, data=None, reference_doctype=None, 
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_update_document failed: {e!s}")
+        logger.warning(f"handle_update_document failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 
@@ -1024,7 +1024,7 @@ def handle_get_document(document_id=None, reference_doctype=None, **filters):
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_get_document failed: {e!s}")
+        logger.warning(f"handle_get_document failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 def handle_create_documents(reference_doctype: str, documents: list = None, data: list = None, **kwargs):
@@ -1113,6 +1113,7 @@ def handle_get_value(doctype: str = None, filters: dict = None, fieldname=None, 
             "value": value,
         }
     except Exception as e:
+        logger.warning(f"handle_get_value failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 
@@ -1159,7 +1160,7 @@ def handle_set_value(doctype: str = None, filters: dict = None, fieldname: str =
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_set_value failed: {e!s}")
+        logger.warning(f"handle_set_value failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 
@@ -1217,7 +1218,7 @@ def handle_run_agent(target_agent_name: str, prompt: str, **kwargs):
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_run_agent failed: {e!s}")
+        logger.warning(f"handle_run_agent failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 def handle_attach_file_to_document(reference_doctype, document_id, **kwargs):
@@ -1250,7 +1251,7 @@ def handle_attach_file_to_document(reference_doctype, document_id, **kwargs):
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_attach_file_to_document failed: {e!s}")
+        logger.warning(f"handle_attach_file_to_document failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 
@@ -1302,7 +1303,7 @@ def handle_get_conversation_data(name: str, default: Any = None, conversation_id
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_get_conversation_data failed: {e!s}")
+        logger.warning(f"handle_get_conversation_data failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 def handle_set_conversation_data(
@@ -1388,7 +1389,7 @@ def handle_set_conversation_data(
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_set_conversation_data failed: {e!s}")
+        logger.warning(f"handle_set_conversation_data failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 def handle_load_conversation_data(conversation_id: str = None, **kwargs):
@@ -1400,6 +1401,7 @@ def handle_load_conversation_data(conversation_id: str = None, **kwargs):
         state = _load_state(data_json)
         return {"success": True, "data": state}
     except Exception as e:
+        logger.warning(f"handle_load_conversation_data failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 
@@ -1464,7 +1466,7 @@ def handle_get_result_context(reference_doctype: str, reference_name: str, **kwa
         return {"success": False, "error": str(e)}
     except Exception as e:
         # Boundary exception handler: tool contract requires returning JSON error to LLM
-        logger.warning(f"handle_get_result_context failed: {e!s}")
+        logger.warning(f"handle_get_result_context failed: {e!s}\n{frappe.get_traceback()}")
         return {"success": False, "error": str(e)}
 
 def _get_default_image_model(provider_name: str) -> str:
@@ -1583,7 +1585,7 @@ async def handle_generate_image(
                 """, (conversation_id,), as_dict=1)
 
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
-            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException):
+            except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError):
                 # Hard failure: message ordering is required; abort and alert admin.
                 frappe.log_error(
                     frappe.get_traceback(),
@@ -1646,30 +1648,35 @@ async def handle_generate_image(
                 # Create Agent Message first (we'll attach the file to it)
                 message_doc = None
                 if conversation_id and conversation_index is not None:
-                    try:
-                        # Get provider and model from agent
-                        provider = agent_doc.provider
-                        model = agent_doc.model
+                    if frappe.has_permission("Agent Message", "create"):
+                        try:
+                            # Get provider and model from agent
+                            provider = agent_doc.provider
+                            model = agent_doc.model
 
-                        # Create Agent Message with kind "Image" first (without image)
-                        message_doc = frappe.get_doc({
-                            "doctype": "Agent Message",
-                            "conversation": conversation_id,
-                            "role": "agent",
-                            "content": f"Generated image: {prompt}",
-                            "kind": "Image",
-                            "agent": agent_name,
-                            "provider": provider,
-                            "model": model,  # Link to AI Model
-                            "agent_run": kwargs.get("agent_run_id"),
-                            "conversation_index": conversation_index + idx,  # Increment for each image
-                            "is_agent_message": 1,
-                            "user": "Agent"
-                        })
-                        message_doc.insert(ignore_permissions=True)
-                    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
-                        logger.warning(f"Create image message failed: {e!s}")
-                        # Continue even if message creation fails
+                            # Create Agent Message with kind "Image" first (without image)
+                            message_doc = frappe.get_doc({
+                                "doctype": "Agent Message",
+                                "conversation": conversation_id,
+                                "role": "agent",
+                                "content": f"Generated image: {prompt}",
+                                "kind": "Image",
+                                "agent": agent_name,
+                                "provider": provider,
+                                "model": model,  # Link to AI Model
+                                "agent_run": kwargs.get("agent_run_id"),
+                                "conversation_index": conversation_index + idx,  # Increment for each image
+                                "is_agent_message": 1,
+                                "user": "Agent"
+                            })
+                            message_doc.insert()
+                        except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
+                            logger.warning(f"Create image message failed: {e!s}")
+                            # Continue even if message creation fails
+                    else:
+                        frappe.logger("huf").warning(
+                            f"User {frappe.session.user} does not have permission to create Agent Message; attaching image to conversation instead."
+                        )
 
                 # Save file attached to the Agent Message (or conversation if message creation failed)
                 if message_doc:
@@ -1722,7 +1729,7 @@ async def handle_generate_image(
                             user=frappe.session.user,
                             after_commit=False
                         )
-                    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+                    except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
                         frappe.logger("huf").debug(
                             f"Error emitting new_agent_message socket event: {e!s}"
                         )
@@ -1741,7 +1748,7 @@ async def handle_generate_image(
                     SET total_messages = %s, last_activity = NOW()
                     WHERE name = %s
                 """, (final_index, conversation_id))
-            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+            except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
                 frappe.logger("huf").debug(
                     f"Error updating conversation total_messages: {e!s}"
                 )
@@ -1758,7 +1765,7 @@ async def handle_generate_image(
             "message": f"Generated {len(images)} image(s) successfully"
         }
 
-    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
         # Hard provider/tool failure: retain Error Log for admin attention.
         frappe.log_error(f"Image generation error: {e!s}", "Image Generation Tool")
         return {"success": False, "error": str(e)}
@@ -1829,7 +1836,7 @@ async def handle_ocr_document(
 
         return result.as_dict()
 
-    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
         # Hard OCR failure: retain Error Log for admin attention.
         frappe.log_error(f"OCR error: {e!s}", "OCR Tool")
         return {"success": False, "error": str(e)}
@@ -2131,7 +2138,7 @@ async def handle_generate_audio(
                 """, (conversation_id,), as_dict=1)
 
                 conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
-            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException):
+            except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError):
                 # Hard failure: message ordering is required; abort and alert admin.
                 frappe.log_error(
                     frappe.get_traceback(),
@@ -2148,40 +2155,45 @@ async def handle_generate_audio(
         # Create Agent Message first (we'll attach the file to it)
         message_doc = None
         if conversation_id and conversation_index is not None:
-            try:
-                # Get provider and model from agent
-                provider = agent_doc.provider
-                model_name = agent_doc.model
+            if frappe.has_permission("Agent Message", "create"):
+                try:
+                    # Get provider and model from agent
+                    provider = agent_doc.provider
+                    model_name = agent_doc.model
 
-                # Create Agent Message with kind "Audio"
-                message_doc = frappe.get_doc({
-                    "doctype": "Agent Message",
-                    "conversation": conversation_id,
-                    "role": "agent",
-                    "content": f"Generated audio: {input[:100]}{'...' if len(input) > 100 else ''}",
-                    "kind": "Audio",
-                    "agent": agent_name,
-                    "provider": provider,
-                    "model": model_name,
-                    "agent_run": kwargs.get("agent_run_id"),
-                    "conversation_index": conversation_index,
-                    "is_agent_message": 1,
-                    "user": "Agent",
-                    "tts_voice": voice
-                })
-                message_doc.insert(ignore_permissions=True)
+                    # Create Agent Message with kind "Audio"
+                    message_doc = frappe.get_doc({
+                        "doctype": "Agent Message",
+                        "conversation": conversation_id,
+                        "role": "agent",
+                        "content": f"Generated audio: {input[:100]}{'...' if len(input) > 100 else ''}",
+                        "kind": "Audio",
+                        "agent": agent_name,
+                        "provider": provider,
+                        "model": model_name,
+                        "agent_run": kwargs.get("agent_run_id"),
+                        "conversation_index": conversation_index,
+                        "is_agent_message": 1,
+                        "user": "Agent",
+                        "tts_voice": voice
+                    })
+                    message_doc.insert()
 
-                if tts_source == "agent_config" and getattr(agent_doc, "tts_model", None):
-                    frappe.db.set_value(
-                        "Agent Message", message_doc.name,
-                        "tts_model", agent_doc.tts_model,
-                        update_modified=False
-                    )
-                    message_doc.tts_model = agent_doc.tts_model
+                    if tts_source == "agent_config" and getattr(agent_doc, "tts_model", None):
+                        frappe.db.set_value(
+                            "Agent Message", message_doc.name,
+                            "tts_model", agent_doc.tts_model,
+                            update_modified=False
+                        )
+                        message_doc.tts_model = agent_doc.tts_model
 
-            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
-                logger.warning(f"Create audio message failed: {e!s}")
-                message_doc = None
+                except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
+                    logger.warning(f"Create audio message failed: {e!s}")
+                    message_doc = None
+            else:
+                frappe.logger("huf").warning(
+                    f"User {frappe.session.user} does not have permission to create Agent Message; attaching audio to conversation instead."
+                )
 
         # Save file attached to the Agent Message
         if message_doc:
@@ -2232,7 +2244,7 @@ async def handle_generate_audio(
                     user=frappe.session.user,
                     after_commit=False
                 )
-            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+            except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
                 frappe.logger("huf").debug(
                     f"Error emitting new_agent_message socket event: {e!s}"
                 )
@@ -2245,7 +2257,7 @@ async def handle_generate_audio(
                     SET total_messages = %s, last_activity = NOW()
                     WHERE name = %s
                 """, (conversation_index, conversation_id))
-            except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+            except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
                 frappe.logger("huf").debug(
                     f"Error updating conversation total_messages: {e!s}"
                 )
@@ -2268,7 +2280,7 @@ async def handle_generate_audio(
             "conversation_id": conversation_id
         }
 
-    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
         # Hard provider/tool failure: retain Error Log for admin attention.
         frappe.log_error(title="Audio Generation Tool", message=f"Audio generation error: {e!s}")
         return {"success": False, "error": str(e)}
@@ -2352,7 +2364,7 @@ async def handle_transcribe_audio(
             "provider": result.get("provider"),
         }
 
-    except (frappe.DoesNotExistError, AttributeError, KeyError, ValueError, frappe.FrappeException) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError, ValueError) as e:
         # Hard transcription failure: retain Error Log for admin attention.
         frappe.log_error(f"Audio transcription error: {e!s}", "Audio Transcription Tool")
         return {"success": False, "error": str(e)}

--- a/huf/ai/tool_functions.py
+++ b/huf/ai/tool_functions.py
@@ -1,3 +1,4 @@
+import json
 import os
 from urllib.parse import urlparse
 
@@ -71,9 +72,9 @@ def create_documents(doctype: str, data: list, function=None):
         try:
             res = create_document(doctype, item, function)
             if not res or not res.get("document_id"):
-                raise Exception("Create returned no document_id")
+                raise ValueError("Create returned no document_id")
             created_ids.append(res["document_id"])
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
             errors.append({"index": idx, "error": str(e)})
 
     return {
@@ -131,7 +132,7 @@ def update_document(doctype: str, document_id: str, data: dict, tool=None):
             "message": f"{doctype} {document_id} updated successfully",
             "document": result_dict
         }
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
         frappe.log_error(f"Error updating {doctype} {document_id}: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -148,13 +149,13 @@ def update_documents(doctype: str, data: list, function=None):
             payload = dict(doc or {})
             document_id = payload.pop("document_id", None) or payload.pop("name", None)
             if not document_id:
-                raise Exception("Missing 'document_id' (or 'name') in item")
+                raise ValueError("Missing 'document_id' (or 'name') in item")
 
             res = update_document(doctype, document_id, payload, function)
             if not res or not res.get("success"):
-                raise Exception((res or {}).get("error") or "Unknown error")
+                raise ValueError((res or {}).get("error") or "Unknown error")
             updated_ids.append(res["document"]["name"])
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
             errors.append({"index": idx, "error": str(e)})
 
     return {
@@ -192,7 +193,7 @@ def delete_document(doctype: str, document_id: str):
 
         frappe.delete_doc(doctype, document_id)
         return {"success": True, "message": f"{doctype} {document_id} deleted successfully"}
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
         frappe.log_error(f"Error deleting {doctype} {document_id}: {e!s}")
         return {"success": False, "error": str(e)}
 
@@ -224,7 +225,7 @@ def delete_documents(doctype: str, document_ids: list):
 				"error": str(e),
 				"permission_denied": True,
 			})
-		except Exception as e:
+		except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
 			failed.append({"name": document_id, "error": str(e)})
 
 	return {
@@ -494,7 +495,7 @@ def _process_single_attachment(doctype, document_id, file_path):
              return f"/files/{file_doc.file_name}"
         return clean_url
 
-    except Exception as e:
+    except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
         frappe.log_error(f"Attachment failed for {file_path}: {e!s}")
         return None
 
@@ -507,12 +508,9 @@ def attach_file_to_document(doctype: str, document_id: str, **kwargs):
     if not frappe.db.exists(doctype, document_id):
         return {"success": False, "error": f"{doctype} {document_id} not found", "document_id": document_id}
 
-    try:
-        doc = frappe.get_doc(doctype, document_id)
-        if not frappe.has_permission(doctype, ptype="write", doc=doc):
-            return {"success": False, "error": "No write permission on target document"}
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+    doc = frappe.get_doc(doctype, document_id)
+    if not frappe.has_permission(doctype, ptype="write", doc=doc):
+        return {"success": False, "error": "No write permission on target document"}
 
     updates = {}
     attached_files = []
@@ -538,7 +536,7 @@ def attach_file_to_document(doctype: str, document_id: str, **kwargs):
         try:
             frappe.db.set_value(doctype, document_id, updates)
             commit_if_background()
-        except Exception as e:
+        except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
             return {
                 "success": True,
                 "message": "Files attached but field update failed",

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -53,8 +53,8 @@ class PermissionAwareToolRegistry:
                 if cls._can_use_tool(tool_doc, user):
                     all_tools.append(tool_doc)
 
-            except Exception as e:
-                logger.warning(f"Error checking tool permission for {tool_link.tool}: {e}")
+            except (frappe.FrappeException, AttributeError, KeyError) as e:
+                logger.warning(f"Error checking tool permission for {tool_link.tool}: {e!s}")
         
         return all_tools
     
@@ -113,8 +113,8 @@ def _get_app_modified_time(app_name):
         if os.path.exists(hooks_path):
             mtime = os.path.getmtime(hooks_path)
             return datetime.fromtimestamp(mtime)
-    except Exception:
-        # Cache probe is best-effort; ignore failures.
+    except (OSError, frappe.FrappeException, AttributeError, ValueError):
+        # Cache probe is best-effort; fail silently
         pass
     return None
 
@@ -130,8 +130,8 @@ def _get_cached_scans():
             settings = frappe.get_single(CACHE_DOCTYPE)
             if hasattr(settings, "last_app_scans") and settings.last_app_scans:
                 return json.loads(settings.last_app_scans)
-    except Exception:
-        # Cache may not exist yet; fail silently.
+    except (json.JSONDecodeError, frappe.FrappeException, AttributeError, TypeError):
+        # Cache may not exist yet; fail silently
         pass
     return {}
 
@@ -160,8 +160,8 @@ def _update_cached_scans(apps_scanned):
         
         settings.last_app_scans = json.dumps(cache)
         settings.save(ignore_permissions=True)
-    except Exception:
-        # Cache update is non-critical; fail silently.
+    except (frappe.FrappeException, TypeError, ValueError, json.JSONDecodeError):
+        # Cache update is non-critical; fail silently
         pass
 
 def _get_apps_to_scan():
@@ -289,7 +289,7 @@ def sync_discovered_tools(apps_to_scan=None, use_cache=True):
             for d in tools:
                 if d:  # Skip None/empty tools
                     tools_to_process.append((app, d))
-        except Exception as e:
+        except (frappe.FrappeException, ValueError, KeyError, AttributeError, TypeError) as e:
             errors.append(f"App '{app}': Failed to process tools list: {str(e)}")
             logger.warning(f"Failed to process tools for app '{app}': {e!s}")
             continue
@@ -343,7 +343,7 @@ def sync_discovered_tools(apps_to_scan=None, use_cache=True):
                 validated_tools.append((app, d))
             else:
                 errors.append(f"App '{app}': Tool '{tool_name}': Function '{func_path}' is not callable")
-        except Exception as e:
+        except (frappe.FrappeException, ValueError, KeyError, AttributeError, TypeError) as e:
             errors.append(f"App '{app}': Error processing tool: {str(e)}")
             logger.warning(f"Error processing tool in app '{app}': {e!s}")
             continue
@@ -404,7 +404,7 @@ def sync_discovered_tools(apps_to_scan=None, use_cache=True):
             else:
                 payload["doctype"] = "Agent Tool Function"
                 to_create.append(payload)
-        except Exception as e:
+        except (frappe.FrappeException, ValueError, KeyError, AttributeError, TypeError) as e:
             errors.append(f"App '{app}': Failed to prepare tool '{d.get('tool_name', 'unknown')}': {str(e)}")
             logger.warning(f"Failed to prepare tool in app '{app}': {e!s}")
             continue
@@ -479,5 +479,7 @@ def sync_app_tools(app_name=None):
     try:
         result = sync_discovered_tools(apps_to_scan=[app_name])
         logger.info(f"Synced tools for app '{app_name}': {result.get('total_tools', 0)} tools")
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Failed to sync tools for app '{app_name}': {e!s}")

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -53,7 +53,7 @@ class PermissionAwareToolRegistry:
                 if cls._can_use_tool(tool_doc, user):
                     all_tools.append(tool_doc)
 
-            except (frappe.FrappeException, AttributeError, KeyError) as e:
+            except (frappe.DoesNotExistError, frappe.ValidationError, AttributeError, KeyError) as e:
                 logger.warning(f"Error checking tool permission for {tool_link.tool}: {e!s}")
         
         return all_tools
@@ -113,7 +113,7 @@ def _get_app_modified_time(app_name):
         if os.path.exists(hooks_path):
             mtime = os.path.getmtime(hooks_path)
             return datetime.fromtimestamp(mtime)
-    except (OSError, frappe.FrappeException, AttributeError, ValueError):
+    except (OSError, frappe.DoesNotExistError, frappe.ValidationError, AttributeError, ValueError):
         # Cache probe is best-effort; fail silently
         pass
     return None
@@ -130,7 +130,7 @@ def _get_cached_scans():
             settings = frappe.get_single(CACHE_DOCTYPE)
             if hasattr(settings, "last_app_scans") and settings.last_app_scans:
                 return json.loads(settings.last_app_scans)
-    except (json.JSONDecodeError, frappe.FrappeException, AttributeError, TypeError):
+    except (json.JSONDecodeError, frappe.DoesNotExistError, frappe.ValidationError, AttributeError, TypeError):
         # Cache may not exist yet; fail silently
         pass
     return {}
@@ -160,7 +160,7 @@ def _update_cached_scans(apps_scanned):
         
         settings.last_app_scans = json.dumps(cache)
         settings.save(ignore_permissions=True)
-    except (frappe.FrappeException, TypeError, ValueError, json.JSONDecodeError):
+    except (frappe.DoesNotExistError, frappe.ValidationError, TypeError, ValueError, json.JSONDecodeError):
         # Cache update is non-critical; fail silently
         pass
 
@@ -289,7 +289,7 @@ def sync_discovered_tools(apps_to_scan=None, use_cache=True):
             for d in tools:
                 if d:  # Skip None/empty tools
                     tools_to_process.append((app, d))
-        except (frappe.FrappeException, ValueError, KeyError, AttributeError, TypeError) as e:
+        except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, AttributeError, TypeError) as e:
             errors.append(f"App '{app}': Failed to process tools list: {str(e)}")
             logger.warning(f"Failed to process tools for app '{app}': {e!s}")
             continue
@@ -343,7 +343,7 @@ def sync_discovered_tools(apps_to_scan=None, use_cache=True):
                 validated_tools.append((app, d))
             else:
                 errors.append(f"App '{app}': Tool '{tool_name}': Function '{func_path}' is not callable")
-        except (frappe.FrappeException, ValueError, KeyError, AttributeError, TypeError) as e:
+        except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, AttributeError, TypeError) as e:
             errors.append(f"App '{app}': Error processing tool: {str(e)}")
             logger.warning(f"Error processing tool in app '{app}': {e!s}")
             continue
@@ -404,7 +404,7 @@ def sync_discovered_tools(apps_to_scan=None, use_cache=True):
             else:
                 payload["doctype"] = "Agent Tool Function"
                 to_create.append(payload)
-        except (frappe.FrappeException, ValueError, KeyError, AttributeError, TypeError) as e:
+        except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, AttributeError, TypeError) as e:
             errors.append(f"App '{app}': Failed to prepare tool '{d.get('tool_name', 'unknown')}': {str(e)}")
             logger.warning(f"Failed to prepare tool in app '{app}': {e!s}")
             continue
@@ -479,7 +479,7 @@ def sync_app_tools(app_name=None):
     try:
         result = sync_discovered_tools(apps_to_scan=[app_name])
         logger.info(f"Synced tools for app '{app_name}': {result.get('total_tools', 0)} tools")
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Failed to sync tools for app '{app_name}': {e!s}")

--- a/huf/ai/tools/credentials.py
+++ b/huf/ai/tools/credentials.py
@@ -173,8 +173,13 @@ def update_last_error(service: str, error: str):
 		if settings:
 			doc = frappe.get_doc("Integration Settings", settings[0].name)
 			doc.last_error = error[:140]  # Truncate to field length
-			doc.save(ignore_permissions=True)
-			commit_if_background()
+			if frappe.has_permission("Integration Settings", "write", doc=doc):
+				doc.save()
+				commit_if_background()
+			else:
+				frappe.logger("huf").error(
+					f"Not permitted to persist last_error on Integration Settings {doc.name}: {doc.last_error}"
+				)
 	except Exception:
 		# Silently fail - don't break tool execution for logging errors
 		pass

--- a/huf/ai/tools/erpnext.py
+++ b/huf/ai/tools/erpnext.py
@@ -82,7 +82,9 @@ def _handle_get_sales_invoices(**kwargs) -> str:
             inv["docstatus_label"] = _docstatus_label(inv.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(invoices), "results": invoices}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Sales Invoices Error: {e}")
         return _error(str(e))
 
@@ -103,7 +105,9 @@ def _handle_get_sales_invoice(**kwargs) -> str:
         result = doc.as_dict()
         result["docstatus_label"] = _docstatus_label(result.get("docstatus"))
         return json.dumps({"success": True, "results": result}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Sales Invoice Error: {e}")
         return _error(str(e))
 
@@ -140,7 +144,9 @@ def _handle_create_sales_invoice(**kwargs) -> str:
         return json.dumps(
             {"success": True, "results": {"name": doc.name, "customer": doc.customer}}
         )
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Sales Invoice Error: {e}")
         return _error(str(e))
 
@@ -206,7 +212,9 @@ def _handle_get_purchase_invoices(**kwargs) -> str:
             inv["docstatus_label"] = _docstatus_label(inv.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(invoices), "results": invoices}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Purchase Invoices Error: {e}")
         return _error(str(e))
 
@@ -227,7 +235,9 @@ def _handle_get_purchase_invoice(**kwargs) -> str:
         result = doc.as_dict()
         result["docstatus_label"] = _docstatus_label(result.get("docstatus"))
         return json.dumps({"success": True, "results": result}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Purchase Invoice Error: {e}")
         return _error(str(e))
 
@@ -282,7 +292,9 @@ def _handle_get_payments(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(payments), "results": payments}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Payments Error: {e}")
         return _error(str(e))
 
@@ -335,7 +347,9 @@ def _handle_create_payment(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Payment Error: {e}")
         return _error(str(e))
 
@@ -393,7 +407,9 @@ def _handle_get_quotations(**kwargs) -> str:
             q["docstatus_label"] = _docstatus_label(q.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(quotes), "results": quotes}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Quotations Error: {e}")
         return _error(str(e))
 
@@ -433,7 +449,9 @@ def _handle_create_quotation(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Quotation Error: {e}")
         return _error(str(e))
 
@@ -488,7 +506,9 @@ def _handle_get_customers(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(customers), "results": customers}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Customers Error: {e}")
         return _error(str(e))
 
@@ -539,7 +559,9 @@ def _handle_get_customer(**kwargs) -> str:
             result["contacts"].append(contact.as_dict())
 
         return json.dumps({"success": True, "results": result}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Customer Error: {e}")
         return _error(str(e))
 
@@ -602,7 +624,9 @@ def _handle_get_account_ledger(**kwargs) -> str:
             entry["running_balance"] = running_balance
 
         return json.dumps({"success": True, "count": len(entries), "results": entries}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Account Ledger Error: {e}")
         return _error(str(e))
 
@@ -641,7 +665,9 @@ def _handle_create_journal_entry(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Journal Entry Error: {e}")
         return _error(str(e))
 
@@ -680,7 +706,9 @@ def _handle_get_rfqs(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(rfqs), "results": rfqs}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get RFQs Error: {e}")
         return _error(str(e))
 

--- a/huf/ai/tools/erpnext.py
+++ b/huf/ai/tools/erpnext.py
@@ -82,7 +82,7 @@ def _handle_get_sales_invoices(**kwargs) -> str:
             inv["docstatus_label"] = _docstatus_label(inv.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(invoices), "results": invoices}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Sales Invoices Error: {e}")
@@ -105,7 +105,7 @@ def _handle_get_sales_invoice(**kwargs) -> str:
         result = doc.as_dict()
         result["docstatus_label"] = _docstatus_label(result.get("docstatus"))
         return json.dumps({"success": True, "results": result}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Sales Invoice Error: {e}")
@@ -144,7 +144,7 @@ def _handle_create_sales_invoice(**kwargs) -> str:
         return json.dumps(
             {"success": True, "results": {"name": doc.name, "customer": doc.customer}}
         )
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Sales Invoice Error: {e}")
@@ -212,7 +212,7 @@ def _handle_get_purchase_invoices(**kwargs) -> str:
             inv["docstatus_label"] = _docstatus_label(inv.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(invoices), "results": invoices}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Purchase Invoices Error: {e}")
@@ -235,7 +235,7 @@ def _handle_get_purchase_invoice(**kwargs) -> str:
         result = doc.as_dict()
         result["docstatus_label"] = _docstatus_label(result.get("docstatus"))
         return json.dumps({"success": True, "results": result}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Purchase Invoice Error: {e}")
@@ -292,7 +292,7 @@ def _handle_get_payments(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(payments), "results": payments}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Payments Error: {e}")
@@ -347,7 +347,7 @@ def _handle_create_payment(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Payment Error: {e}")
@@ -407,7 +407,7 @@ def _handle_get_quotations(**kwargs) -> str:
             q["docstatus_label"] = _docstatus_label(q.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(quotes), "results": quotes}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Quotations Error: {e}")
@@ -449,7 +449,7 @@ def _handle_create_quotation(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Quotation Error: {e}")
@@ -506,7 +506,7 @@ def _handle_get_customers(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(customers), "results": customers}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Customers Error: {e}")
@@ -559,7 +559,7 @@ def _handle_get_customer(**kwargs) -> str:
             result["contacts"].append(contact.as_dict())
 
         return json.dumps({"success": True, "results": result}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Customer Error: {e}")
@@ -624,7 +624,7 @@ def _handle_get_account_ledger(**kwargs) -> str:
             entry["running_balance"] = running_balance
 
         return json.dumps({"success": True, "count": len(entries), "results": entries}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Account Ledger Error: {e}")
@@ -665,7 +665,7 @@ def _handle_create_journal_entry(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create Journal Entry Error: {e}")
@@ -706,7 +706,7 @@ def _handle_get_rfqs(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(rfqs), "results": rfqs}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get RFQs Error: {e}")

--- a/huf/ai/tools/erpnext_inventory.py
+++ b/huf/ai/tools/erpnext_inventory.py
@@ -75,7 +75,9 @@ def _handle_get_items(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(items), "results": items}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Items Error: {e}")
         return _error(str(e))
 
@@ -95,7 +97,9 @@ def _handle_get_item(**kwargs) -> str:
         doc = frappe.get_doc("Item", name)
         result = doc.as_dict()
         return json.dumps({"success": True, "results": result}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Item Error: {e}")
         return _error(str(e))
 
@@ -143,7 +147,9 @@ def _handle_get_item_prices(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(prices), "results": prices}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Item Prices Error: {e}")
         return _error(str(e))
 
@@ -196,7 +202,9 @@ def _handle_get_boms(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(boms), "results": boms}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get BOMs Error: {e}")
         return _error(str(e))
 
@@ -216,7 +224,9 @@ def _handle_get_bom(**kwargs) -> str:
         doc = frappe.get_doc("BOM", name)
         result = doc.as_dict()
         return json.dumps({"success": True, "results": result}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get BOM Error: {e}")
         return _error(str(e))
 
@@ -255,7 +265,9 @@ def _handle_create_bom(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name, "item": doc.item}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create BOM Error: {e}")
         return _error(str(e))
 
@@ -316,7 +328,9 @@ def _handle_get_stock_balance(**kwargs) -> str:
             })
 
         return json.dumps({"success": True, "count": len(results), "results": results}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Stock Balance Error: {e}")
         return _error(str(e))
 
@@ -369,7 +383,9 @@ def _handle_get_stock_movements(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(entries), "results": entries}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Stock Movements Error: {e}")
         return _error(str(e))
 
@@ -416,7 +432,9 @@ def _handle_get_stock_entries(**kwargs) -> str:
             entry["docstatus_label"] = _docstatus_label(entry.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(entries), "results": entries}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Stock Entries Error: {e}")
         return _error(str(e))
 
@@ -455,7 +473,9 @@ def _handle_get_warehouses(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(warehouses), "results": warehouses}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Warehouses Error: {e}")
         return _error(str(e))
 
@@ -503,7 +523,9 @@ def _handle_get_delivery_notes(**kwargs) -> str:
             note["docstatus_label"] = _docstatus_label(note.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(notes), "results": notes}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Delivery Notes Error: {e}")
         return _error(str(e))
 
@@ -551,7 +573,9 @@ def _handle_get_purchase_receipts(**kwargs) -> str:
             receipt["docstatus_label"] = _docstatus_label(receipt.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(receipts), "results": receipts}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Purchase Receipts Error: {e}")
         return _error(str(e))
 

--- a/huf/ai/tools/erpnext_inventory.py
+++ b/huf/ai/tools/erpnext_inventory.py
@@ -75,7 +75,7 @@ def _handle_get_items(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(items), "results": items}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Items Error: {e}")
@@ -97,7 +97,7 @@ def _handle_get_item(**kwargs) -> str:
         doc = frappe.get_doc("Item", name)
         result = doc.as_dict()
         return json.dumps({"success": True, "results": result}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Item Error: {e}")
@@ -147,7 +147,7 @@ def _handle_get_item_prices(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(prices), "results": prices}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Item Prices Error: {e}")
@@ -202,7 +202,7 @@ def _handle_get_boms(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(boms), "results": boms}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get BOMs Error: {e}")
@@ -224,7 +224,7 @@ def _handle_get_bom(**kwargs) -> str:
         doc = frappe.get_doc("BOM", name)
         result = doc.as_dict()
         return json.dumps({"success": True, "results": result}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get BOM Error: {e}")
@@ -265,7 +265,7 @@ def _handle_create_bom(**kwargs) -> str:
 
         doc.insert()
         return json.dumps({"success": True, "results": {"name": doc.name, "item": doc.item}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Create BOM Error: {e}")
@@ -328,7 +328,7 @@ def _handle_get_stock_balance(**kwargs) -> str:
             })
 
         return json.dumps({"success": True, "count": len(results), "results": results}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Stock Balance Error: {e}")
@@ -383,7 +383,7 @@ def _handle_get_stock_movements(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(entries), "results": entries}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Stock Movements Error: {e}")
@@ -432,7 +432,7 @@ def _handle_get_stock_entries(**kwargs) -> str:
             entry["docstatus_label"] = _docstatus_label(entry.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(entries), "results": entries}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Stock Entries Error: {e}")
@@ -473,7 +473,7 @@ def _handle_get_warehouses(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(warehouses), "results": warehouses}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Warehouses Error: {e}")
@@ -523,7 +523,7 @@ def _handle_get_delivery_notes(**kwargs) -> str:
             note["docstatus_label"] = _docstatus_label(note.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(notes), "results": notes}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Delivery Notes Error: {e}")
@@ -573,7 +573,7 @@ def _handle_get_purchase_receipts(**kwargs) -> str:
             receipt["docstatus_label"] = _docstatus_label(receipt.get("docstatus"))
 
         return json.dumps({"success": True, "count": len(receipts), "results": receipts}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"ERPNext Get Purchase Receipts Error: {e}")

--- a/huf/ai/tools/helpdesk.py
+++ b/huf/ai/tools/helpdesk.py
@@ -80,7 +80,9 @@ def _handle_get_tickets(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(tickets), "results": tickets}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Tickets Error: {e}")
         return _error(str(e))
 
@@ -109,7 +111,9 @@ def _handle_get_ticket(**kwargs) -> str:
         result = doc.as_dict()
         result["comments"] = comments
         return json.dumps({"success": True, "results": result}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Ticket Error: {e}")
         return _error(str(e))
 
@@ -136,7 +140,9 @@ def _handle_create_ticket(**kwargs) -> str:
         doc.insert()
 
         return json.dumps({"success": True, "results": {"name": doc.name, "subject": doc.subject}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Create Ticket Error: {e}")
         return _error(str(e))
 
@@ -179,7 +185,9 @@ def _handle_update_ticket(**kwargs) -> str:
             doc.assign_agent(assigned_to)
 
         return json.dumps({"success": True, "results": {"name": doc.name, "subject": doc.subject}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Update Ticket Error: {e}")
         return _error(str(e))
 
@@ -204,7 +212,9 @@ def _handle_add_comment(**kwargs) -> str:
         comment.insert()
 
         return json.dumps({"success": True, "results": {"name": comment.name}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Add Comment Error: {e}")
         return _error(str(e))
 
@@ -244,7 +254,9 @@ def _handle_get_agents(**kwargs) -> str:
             order_by="modified desc",
         )
         return json.dumps({"success": True, "count": len(agents), "results": agents}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Agents Error: {e}")
         return _error(str(e))
 
@@ -273,7 +285,9 @@ def _handle_get_teams(**kwargs) -> str:
             order_by="modified desc",
         )
         return json.dumps({"success": True, "count": len(teams), "results": teams}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Teams Error: {e}")
         return _error(str(e))
 
@@ -297,7 +311,9 @@ def _handle_assign_ticket(**kwargs) -> str:
         doc.assign_agent(agent_id)
 
         return json.dumps({"success": True, "results": {"name": doc.name, "assigned_to": agent_id}}, default=str)
-    except Exception as e:
+    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+        logger.warning(f"Validation/Operation warning: {e!s}")
+    except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Assign Ticket Error: {e}")
         return _error(str(e))
 

--- a/huf/ai/tools/helpdesk.py
+++ b/huf/ai/tools/helpdesk.py
@@ -80,7 +80,7 @@ def _handle_get_tickets(**kwargs) -> str:
         )
 
         return json.dumps({"success": True, "count": len(tickets), "results": tickets}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Tickets Error: {e}")
@@ -111,7 +111,7 @@ def _handle_get_ticket(**kwargs) -> str:
         result = doc.as_dict()
         result["comments"] = comments
         return json.dumps({"success": True, "results": result}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Ticket Error: {e}")
@@ -140,7 +140,7 @@ def _handle_create_ticket(**kwargs) -> str:
         doc.insert()
 
         return json.dumps({"success": True, "results": {"name": doc.name, "subject": doc.subject}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Create Ticket Error: {e}")
@@ -185,7 +185,7 @@ def _handle_update_ticket(**kwargs) -> str:
             doc.assign_agent(assigned_to)
 
         return json.dumps({"success": True, "results": {"name": doc.name, "subject": doc.subject}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Update Ticket Error: {e}")
@@ -212,7 +212,7 @@ def _handle_add_comment(**kwargs) -> str:
         comment.insert()
 
         return json.dumps({"success": True, "results": {"name": comment.name}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Add Comment Error: {e}")
@@ -254,7 +254,7 @@ def _handle_get_agents(**kwargs) -> str:
             order_by="modified desc",
         )
         return json.dumps({"success": True, "count": len(agents), "results": agents}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Agents Error: {e}")
@@ -285,7 +285,7 @@ def _handle_get_teams(**kwargs) -> str:
             order_by="modified desc",
         )
         return json.dumps({"success": True, "count": len(teams), "results": teams}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Get Teams Error: {e}")
@@ -311,7 +311,7 @@ def _handle_assign_ticket(**kwargs) -> str:
         doc.assign_agent(agent_id)
 
         return json.dumps({"success": True, "results": {"name": doc.name, "assigned_to": agent_id}}, default=str)
-    except (frappe.FrappeException, ValueError, KeyError, TypeError, AttributeError) as e:
+    except (frappe.DoesNotExistError, frappe.ValidationError, ValueError, KeyError, TypeError, AttributeError) as e:
         logger.warning(f"Validation/Operation warning: {e!s}")
     except Exception as e:  # boundary exception handler: external provider/tool boundary
         logger.warning(f"Helpdesk Assign Ticket Error: {e}")

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -63,14 +63,11 @@ def _check_model_supports_caching(model_name: str, provider_name: str) -> bool:
 def _get_cacheable_models_for_provider(
     provider_doc_name: str, provider_name: str, exclude_model: str = None
 ) -> list:
-    try:
-        all_models = frappe.get_all(
-            "AI Model",
-            filters={"provider": provider_doc_name},
-            fields=["name", "model_name"],
-        )
-    except Exception:
-        return []
+    all_models = frappe.get_all(
+        "AI Model",
+        filters={"provider": provider_doc_name},
+        fields=["name", "model_name"],
+    )
 
     cacheable = []
     for m in all_models:
@@ -131,14 +128,14 @@ class Agent(Document):
         for row in self.agent_mcp_server:
             if not row.mcp_server:
                 continue
-            try:
-                mcp_doc = frappe.get_doc("MCP Server", row.mcp_server)
-                if mcp_doc.available_tools:
+            mcp_doc = frappe.get_doc("MCP Server", row.mcp_server)
+            if mcp_doc.available_tools:
+                try:
                     tools = json.loads(mcp_doc.available_tools)
-                    row.tool_count = len(tools) if isinstance(tools, list) else 0
-                else:
-                    row.tool_count = 0
-            except Exception:
+                except json.JSONDecodeError:
+                    tools = None
+                row.tool_count = len(tools) if isinstance(tools, list) else 0
+            else:
                 row.tool_count = 0
 
     def _validate_advanced_models(self):
@@ -177,19 +174,12 @@ class Agent(Document):
     def _validate_prompt_caching(self):
         if not self.model:
             frappe.throw(_("A model must be selected before enabling prompt caching."))
-        try:
-            model_doc = frappe.get_doc("AI Model", self.model)
-            model_name = model_doc.model_name or model_doc.name
-            provider_name = (
-                frappe.db.get_value("AI Provider", self.provider, "provider_name")
-                or self.provider
-            )
-        except Exception as e:
-            frappe.log_error(
-                f"Error loading model/provider for caching validation: {e}",
-                "Agent Prompt Caching Validation",
-            )
-            return
+        model_doc = frappe.get_doc("AI Model", self.model)
+        model_name = model_doc.model_name or model_doc.name
+        provider_name = (
+            frappe.db.get_value("AI Provider", self.provider, "provider_name")
+            or self.provider
+        )
         if _check_model_supports_caching(model_name, provider_name):
             return  
         alternatives = _get_cacheable_models_for_provider(
@@ -342,8 +332,8 @@ class Agent(Document):
                 self.flags.ignore_recursion = False
             
             return planning_run_id, steps
-                
-        except Exception as e:
+
+        except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
             frappe.log_error(f"Plan Generation Failed: {str(e)}", "Agent Plan Error")
             return None
 
@@ -383,8 +373,8 @@ class Agent(Document):
                         parent_run_id=planning_run_id,
                         override_plan=steps
                     )
-                
-            except Exception as e:
+
+            except (ValueError, TypeError, KeyError, AttributeError, json.JSONDecodeError, ImportError) as e:
                 frappe.log_error(f"Multi-Run Setup Failed: {str(e)}", "Agent Creation Error")
 
     

--- a/huf/huf/doctype/agent_run/agent_run.json
+++ b/huf/huf/doctype/agent_run/agent_run.json
@@ -317,7 +317,7 @@
    "write": 1
   },
   {
-   "create": 0,
+   "create": 1,
    "delete": 0,
    "email": 1,
    "export": 1,
@@ -326,10 +326,10 @@
    "report": 1,
    "role": "Huf Manager",
    "share": 1,
-   "write": 0
+   "write": 1
   },
   {
-   "create": 0,
+   "create": 1,
    "delete": 0,
    "email": 1,
    "export": 1,
@@ -338,7 +338,7 @@
    "report": 1,
    "role": "Huf User",
    "share": 1,
-   "write": 0
+   "write": 1
   },
   {
    "create": 0,

--- a/huf/huf/doctype/agent_tool_call/agent_tool_call.json
+++ b/huf/huf/doctype/agent_tool_call/agent_tool_call.json
@@ -104,6 +104,30 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "share": 1,
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/huf/huf/doctype/agent_trigger/agent_trigger.py
+++ b/huf/huf/doctype/agent_trigger/agent_trigger.py
@@ -30,7 +30,7 @@ class AgentTrigger(Document):
 		temp_doc = frappe.new_doc(self.reference_doctype)
 		try:
 			frappe.safe_eval(self.condition, None, get_context(temp_doc.as_dict()))
-		except Exception:
+		except (SyntaxError, NameError, TypeError, ValueError):
 			frappe.throw(_("The Condition '{0}' is invalid").format(self.condition))
 		
 	

--- a/huf/huf/doctype/flow_run/flow_run.json
+++ b/huf/huf/doctype/flow_run/flow_run.json
@@ -211,7 +211,7 @@
    "write": 1
   },
   {
-   "create": 0,
+   "create": 1,
    "delete": 0,
    "email": 1,
    "export": 1,
@@ -223,7 +223,7 @@
    "write": 1
   },
   {
-   "create": 0,
+   "create": 1,
    "delete": 0,
    "email": 1,
    "export": 1,
@@ -232,7 +232,7 @@
    "report": 1,
    "role": "Huf User",
    "share": 1,
-   "write": 0
+   "write": 1
   }
  ],
  "sort_field": "modified",

--- a/huf/huf/doctype/huf_data_table/api.py
+++ b/huf/huf/doctype/huf_data_table/api.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model import display_fieldtypes, no_value_fields, table_fields
 
-from huf.permissions import has_capability
+from huf.permissions import DEFAULT_ROLE_CAPABILITIES, HUF_ROLE_FRAPPE_ROLE_MAP, SYSTEM_MANAGER, has_capability
 
 from .validators import (
 	LAYOUT_FIELD_TYPES,

--- a/huf/huf/doctype/huf_data_table/api.py
+++ b/huf/huf/doctype/huf_data_table/api.py
@@ -176,8 +176,8 @@ def delete_data_table(name: str) -> dict:
 	record_count = 0
 	try:
 		record_count = frappe.db.count(doctype_name)
-	except Exception:
-		pass
+	except (frappe.DoesNotExistError, frappe.DataError):
+		record_count = 0
 
 	if frappe.db.exists("DocType", doctype_name):
 		frappe.delete_doc("DocType", doctype_name, force=True)
@@ -205,7 +205,7 @@ def get_table_record_counts(names: str | list[str]) -> dict:
 		try:
 			registry = frappe.get_doc("Huf Data Table", name)
 			counts[name] = frappe.db.count(registry.doctype_name)
-		except Exception:
+		except (frappe.DoesNotExistError, frappe.DataError):
 			counts[name] = 0
 
 	return counts

--- a/huf/huf/doctype/huf_data_table/huf_data_table.py
+++ b/huf/huf/doctype/huf_data_table/huf_data_table.py
@@ -10,4 +10,5 @@ class HufDataTable(Document):
 	def on_trash(self):
 		"""Clean up the associated DocType when registry entry is deleted."""
 		if self.doctype_name and frappe.db.exists("DocType", self.doctype_name):
+			# System-level cleanup during DocType deletion; permissions were already verified by Frappe controller lifecycle.
 			frappe.delete_doc("DocType", self.doctype_name, force=True, ignore_permissions=True)

--- a/huf/huf/doctype/huf_role/huf_role.py
+++ b/huf/huf/doctype/huf_role/huf_role.py
@@ -61,6 +61,7 @@ class HufRole(Document):
 			"Huf User Role",
 			filters={"huf_role": self.name, "enabled": 1},
 			fields=["user"],
+			# Reading role assignments to bust affected users' capability cache; the caller already holds permission to modify this role.
 			ignore_permissions=True,
 		)
 		for row in users:

--- a/huf/huf/doctype/huf_user_role/huf_user_role.py
+++ b/huf/huf/doctype/huf_user_role/huf_user_role.py
@@ -64,6 +64,7 @@ class HufUserRole(Document):
 		# Grant the target Frappe role if not already present.
 		if self.enabled and target_frappe_role not in current_roles:
 			user_doc.append("roles", {"role": target_frappe_role})
+			# Synchronizing Frappe role membership on behalf of the system; the controller validates the operation.
 			user_doc.save(ignore_permissions=True)
 		elif not self.enabled:
 			# Disabled Huf User Role → remove the Frappe role too.

--- a/huf/huf/doctype/knowledge_input/knowledge_input.py
+++ b/huf/huf/doctype/knowledge_input/knowledge_input.py
@@ -65,7 +65,7 @@ class KnowledgeInput(Document):
 				file_doc = frappe.get_doc("File", {"file_url": self.file})
 				self.file_name = file_doc.file_name
 				self.file_type = file_doc.file_type or self.get_file_type_from_name(file_doc.file_name)
-			except Exception:
+			except (frappe.DoesNotExistError, AttributeError):
 				pass
 	
 	def get_file_type_from_name(self, filename):

--- a/huf/huf/doctype/knowledge_source/knowledge_source.py
+++ b/huf/huf/doctype/knowledge_source/knowledge_source.py
@@ -45,6 +45,7 @@ class KnowledgeSource(Document):
 		if self.sqlite_file:
 			try:
 				file_doc = frappe.get_doc("File", {"file_url": self.sqlite_file})
+				# System-level cleanup during knowledge source deletion; permissions were already verified by Frappe controller lifecycle.
 				file_doc.delete(ignore_permissions=True)
 			except Exception:
 				pass

--- a/huf/permissions.py
+++ b/huf/permissions.py
@@ -195,6 +195,7 @@ def get_user_capabilities(user: str | None = None) -> list[str]:
 		"Huf Role Permission",
 		filters={"parent": huf_role},
 		fields=["capability"],
+		# Capability lookup must read its own permission table without requiring the caller to hold role-permission read rights.
 		ignore_permissions=True,
 	)
 	result = [r.capability for r in rows if r.capability in CAPABILITIES]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ select = [
     "UP",
     "B",
     "RUF",
+    "BLE",
+    "S",
+    "TRY",
 ]
 ignore = [
     "B017", # assertRaises(Exception) - should be more specific


### PR DESCRIPTION
## Summary
Consolidates the two security PRs into one review/test surface without merging into `develop` and without closing the source PRs.

Source PRs:
- #425: fix(chat): remove allow-scripts sandbox from HTML artifact iframe
- #426: fix: harden exception handling and permission boundaries across HUF

## Preserved Scope
- Artifact iframe sandbox hardening: HTML artifact previews now match the SVG branch by using a fully restricted iframe sandbox, preventing script execution in LLM-generated `srcDoc` content while preserving HTML/CSS rendering.
- Exception handling hardening: replaces broad or invalid exception boundaries across AI, MCP, flow, provider, tool, and DocType code with narrower Frappe/runtime exception tuples where the original PR did so.
- Permission boundaries: removes unnecessary `ignore_permissions=True` usage, adds explicit permission checks for agent/flow run creation paths, and documents legitimate system-level permission bypasses.
- DocType permission matrix: preserves create/write permission updates for `Agent Run`, `Agent Tool Call`, and `Flow Run` so non-admin HUF users can execute runs through the hardened path.
- Source documentation: keeps the security rationale from #425 and the categorized implementation notes from #426 represented here and linked for full history.

## Source Documentation
### #425 Artifact Sandbox Rationale
`ArtifactRenderer.tsx` rendered AI-generated HTML artifacts inside an iframe with `sandbox="allow-scripts"`. Since artifact content can be influenced by prompts, tool output, uploaded/shared content, and knowledge sources, script execution inside the preview surface is an avoidable CWE-79 sink. The consolidated branch removes `allow-scripts`; markup and inline CSS still render, but scripts become inert. Interactive HTML artifacts should be introduced later only behind an explicit opt-in policy.

### #426 Security Hardening Rationale
The original PR hardens exception boundaries across HUF AI execution, MCP resolution/OAuth, tools/providers, flow execution, and DocType controllers. It also standardizes traceback logging at API/execution boundaries, removes unnecessary permission bypasses, and enables Ruff `BLE`, `S`, and `TRY` rule families to prevent blind exception/security regressions in future work.

## Conflict Resolution Notes
Merged from fresh `origin/develop` in this order:
1. `origin/pr-425` clean merge.
2. `origin/pr-426` with conflicts resolved in:
   - `huf/ai/agent_integration.py`: kept current develop flow/knowledge behavior and retained #426 targeted exception handling / failed-run updates.
   - `huf/ai/knowledge/tool.py`: preserved develop filter parsing, removed the knowledge-search `ignore_permissions=True` bypass from #426.
   - `huf/ai/providers/litellm.py`: preserved develop prompt-cache unsupported-model tracking and narrowed exceptions from #426.

Additional consolidation fixes:
- Corrected an introduced undefined `tool_link` reference in `huf/ai/agent_chat.py` logging.
- Added missing explicit permission-constant imports in `huf/huf/doctype/huf_data_table/api.py` so touched-file undefined-name lint passes.

## Validation
Passed:
- `python3 -m compileall -q huf/ai huf/huf/doctype huf/permissions.py huf/__init__.py`
- `uvx ruff check --select F821 huf/ai/agent_chat.py huf/huf/doctype/huf_data_table/api.py`

Attempted / not clean:
- `uvx ruff check <touched python files>` runs but reports the new project-wide `BLE/S/TRY/RUF/I/W` backlog introduced/enabled by #426 across touched files; this branch fixes the concrete `F821` regressions found during that run.
- `cd frontend && yarn install --frozen-lockfile && yarn typecheck` installs dependencies but typecheck fails on an existing app-wide issue: `src/components/chat/chatMessageList.mappers.ts(507,31): Property injectedMemories does not exist on type ChatMessage`. The sandbox change in `ArtifactRenderer.tsx` is an attribute-only change.

## Operational Notes
- Do not merge this PR yet unless explicitly approved.
- Do not close #425 or #426 yet; they remain source PRs for traceability until this umbrella PR is accepted.
