### PR TITLE
feat(data): consolidate granular table permissions and capability gating

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -18,8 +18,9 @@ import {
 } from "@/components/ui/sidebar"
 
 /**
- * Each nav item may declare an optional `capability` string.
- * If present the item is hidden from users who don't have that capability.
+ * Each nav item may declare an optional `capability` string or list.
+ * If present the item is hidden from users who don't have that capability
+ * (a list means any-of: one matching capability is enough).
  * Items with capability === null are always visible (e.g. Dashboard).
  */
 const dashboardNavItems = [
@@ -76,7 +77,11 @@ const knowNavItems = [
     title: "Tables",
     url: "/data",
     icon: Database,
-    capability: "agent.view_all",
+    capability: [
+      "data.tables.manage",
+      "data.records.view_own",
+      "data.records.view_all",
+    ],
   },
   {
     title: "Sources",
@@ -199,13 +204,15 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     }
   }, [])
 
-	const filterItemsByCapability = <T extends { capability: string | null }>(items: T[]) => {
+	const filterItemsByCapability = <T extends { capability: string | string[] | null }>(items: T[]) => {
 		if (isLoading) {
 			return items.filter((item) => item.capability === null)
 		}
-		return items.filter(
-			(item) => item.capability === null || (item.capability && hasCapability(item.capability)),
-		)
+		return items.filter((item) => {
+			if (item.capability === null) return true
+			const caps = Array.isArray(item.capability) ? item.capability : [item.capability]
+			return caps.some((cap) => hasCapability(cap))
+		})
 	}
 
 	const isPathInItems = (items: { url: string }[]) =>

--- a/frontend/src/pages/DataTableBuilderPage.tsx
+++ b/frontend/src/pages/DataTableBuilderPage.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { useNavigate, useParams, useBlocker, type Location } from 'react-router-dom';
 import { toast } from 'sonner';
-import { Save, Loader2, Settings2 } from 'lucide-react';
+import { Save, Loader2, Settings2, Shield } from 'lucide-react';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { Button } from '@/components/ui/button';
 import { TableBuilderCanvas } from '@/components/data-table/TableBuilderCanvas';
 import { FieldConfigPanel } from '@/components/data-table/FieldConfigPanel';
@@ -140,6 +141,8 @@ export function DataTableBuilderPage() {
 	const navigate = useNavigate();
 	const isEdit = !!tableId && tableId !== 'new';
 
+	const { hasCapability, isLoading: permissionsLoading } = usePermissions();
+
 	const [state, dispatch] = useReducer(builderReducer, initialState);
 	const [saving, setSaving] = useState(false);
 	const [loading, setLoading] = useState(isEdit);
@@ -275,6 +278,20 @@ export function DataTableBuilderPage() {
 		enabled: !loading,
 		isSubmitting: saving,
 	});
+
+	if (!permissionsLoading && !hasCapability('data.tables.manage')) {
+		return (
+			<div className="flex items-center justify-center h-full">
+				<div className="text-center max-w-md p-6">
+					<Shield className="w-10 h-10 mx-auto text-muted-foreground mb-4" />
+					<h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+					<p className="text-sm text-muted-foreground">
+						You don't have permission to manage data tables.
+					</p>
+				</div>
+			</div>
+		);
+	}
 
 	if (loading) {
 		return (

--- a/frontend/src/pages/RolesPage.tsx
+++ b/frontend/src/pages/RolesPage.tsx
@@ -13,6 +13,7 @@ const CATEGORY_ORDER = [
   { key: 'knowledge', label: 'Knowledge' },
   { key: 'tools', label: 'Tools' },
   { key: 'flows', label: 'Flows' },
+  { key: 'data', label: 'Data' },
   { key: 'system', label: 'System' },
   { key: 'users', label: 'Users' },
   { key: 'roles', label: 'Roles' },
@@ -36,12 +37,12 @@ function RoleCard({ role }: { role: HufRole }) {
   const groups = groupCapabilities(role.capabilities);
 
   return (
-    <div className="border rounded-none p-4 space-y-3">
+    <div className="border rounded-lg p-4 space-y-3">
       {/* Header */}
       <div className="flex items-center gap-2">
         <span className="font-semibold text-base">{role.role_name}</span>
         {role.is_system_role === 1 && (
-          <span className="inline-flex items-center gap-1 text-xs text-steel-soft">
+          <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
             <Lock className="h-3 w-3" />
             System
           </span>
@@ -49,14 +50,14 @@ function RoleCard({ role }: { role: HufRole }) {
       </div>
 
       {role.description && (
-        <p className="text-sm text-steel">{role.description}</p>
+        <p className="text-sm text-muted-foreground">{role.description}</p>
       )}
 
       {/* Capabilities grouped by category */}
       <div className="space-y-2">
         {CATEGORY_ORDER.filter((cat) => groups[cat.key]?.length).map((cat) => (
           <div key={cat.key}>
-            <div className="text-xs font-medium text-steel-soft mb-1">{cat.label}</div>
+            <div className="text-xs font-medium text-muted-foreground mb-1">{cat.label}</div>
             <div className="flex flex-wrap gap-1">
               {groups[cat.key].map((cap) => (
                 <Badge key={cap} variant="secondary" className="text-xs font-mono">
@@ -69,7 +70,7 @@ function RoleCard({ role }: { role: HufRole }) {
       </div>
 
       {role.capabilities.length === 0 && (
-        <p className="text-xs font-body text-steel-soft italic">No capabilities assigned.</p>
+        <p className="text-xs text-muted-foreground italic">No capabilities assigned.</p>
       )}
     </div>
   );
@@ -97,13 +98,13 @@ export default function RolesPage() {
             <ShieldCheck className="h-6 w-6" />
             Roles
           </h1>
-          <p className="text-sm text-steel mt-1">
+          <p className="text-sm text-muted-foreground mt-1">
             View capability sets granted to each Huf role. System roles cannot be deleted.
           </p>
         </div>
 
         {loading ? (
-          <div className="text-sm font-body text-steel-soft py-12 text-center">Loading…</div>
+          <div className="text-sm text-muted-foreground py-12 text-center">Loading…</div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">
             {roles.map((role) => (

--- a/huf/huf/doctype/huf_data_table/api.py
+++ b/huf/huf/doctype/huf_data_table/api.py
@@ -81,15 +81,27 @@ def _import_permitted_roles() -> list[str]:
 
 
 def _table_permission_row(role: str) -> dict:
+	if role == SYSTEM_MANAGER:
+		return {
+			"role": role,
+			"read": 1,
+			"write": 1,
+			"create": 1,
+			"delete": 1,
+			"print": 1,
+			"email": 1,
+			"share": 1,
+			"import": 1,
+		}
 	return {
 		"role": role,
-		"read": 1,
-		"write": 1,
+		"read": 0,
+		"write": 0,
 		"create": 1,
-		"delete": 1,
-		"print": 1,
-		"email": 1,
-		"share": 1,
+		"delete": 0,
+		"print": 0,
+		"email": 0,
+		"share": 0,
 		"import": 1,
 	}
 

--- a/huf/huf/doctype/huf_data_table/api.py
+++ b/huf/huf/doctype/huf_data_table/api.py
@@ -48,8 +48,12 @@ def _require_data_manage():
 
 
 def _require_data_view():
+	"""Throw if the current user has no data-table access at all."""
 	if not _has_any_capability(_VIEW_CAPABILITIES):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
+		frappe.throw(
+			_("You don't have permission to view data tables."),
+			frappe.PermissionError,
+		)
 
 
 def _require_write():
@@ -138,6 +142,10 @@ def create_data_table(
 	table_name = table_name.strip()
 	if not table_name:
 		frappe.throw("Table name is required")
+	if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9 _-]{0,139}", table_name):
+		frappe.throw(
+			"Table name may only contain letters, numbers, spaces, underscores, and hyphens."
+		)
 
 	doctype_name = f"HF {table_name}"
 

--- a/huf/huf/doctype/huf_data_table/api.py
+++ b/huf/huf/doctype/huf_data_table/api.py
@@ -5,8 +5,14 @@ import frappe
 from frappe import _
 from frappe.model import display_fieldtypes, no_value_fields, table_fields
 
-from huf.permissions import DEFAULT_ROLE_CAPABILITIES, HUF_ROLE_FRAPPE_ROLE_MAP, SYSTEM_MANAGER, has_capability
+from huf.permissions import (
+	DEFAULT_ROLE_CAPABILITIES,
+	HUF_ROLE_FRAPPE_ROLE_MAP,
+	SYSTEM_MANAGER,
+	has_capability,
+)
 
+from .permissions import sync_data_table_permissions
 from .validators import (
 	LAYOUT_FIELD_TYPES,
 	get_search_fields,
@@ -14,20 +20,44 @@ from .validators import (
 	validate_and_prepare_fields,
 )
 
-# Data tables do not have a dedicated capability yet; reuse flow capabilities
-# as the closest admin-level permission boundary.
-_WRITE_CAPABILITY = "flows.manage"
-_READ_CAPABILITY = "flows.use"
+_MANAGE_CAPABILITY = "data.tables.manage"
+_VIEW_CAPABILITIES = {
+	"data.tables.manage",
+	"data.records.view_own",
+	"data.records.view_all",
+}
+_WRITE_CAPABILITIES = {
+	"data.tables.manage",
+	"data.records.create",
+	"data.records.edit_own",
+	"data.records.edit_all",
+}
+
+
+def _has_any_capability(capabilities: set[str]) -> bool:
+	return any(has_capability(frappe.session.user, capability) for capability in capabilities)
+
+
+def _require_data_manage():
+	"""Throw if the current user cannot manage data tables."""
+	if not has_capability(frappe.session.user, _MANAGE_CAPABILITY):
+		frappe.throw(
+			_("You don't have permission to manage data tables."),
+			frappe.PermissionError,
+		)
+
+
+def _require_data_view():
+	if not _has_any_capability(_VIEW_CAPABILITIES):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
 
 
 def _require_write():
-	if not has_capability(frappe.session.user, _WRITE_CAPABILITY):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
+	_require_data_manage()
 
 
 def _require_read():
-	if not has_capability(frappe.session.user, _READ_CAPABILITY):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
+	_require_data_view()
 
 
 def _import_permitted_roles() -> list[str]:
@@ -39,7 +69,7 @@ def _import_permitted_roles() -> list[str]:
 	"""
 	roles = {SYSTEM_MANAGER}
 	for huf_role, capabilities in DEFAULT_ROLE_CAPABILITIES.items():
-		if _WRITE_CAPABILITY in capabilities:
+		if _WRITE_CAPABILITIES.intersection(capabilities):
 			frappe_role = HUF_ROLE_FRAPPE_ROLE_MAP.get(huf_role)
 			if frappe_role:
 				roles.add(frappe_role)
@@ -85,6 +115,7 @@ def _ensure_import_enabled(doctype_name: str) -> None:
 	if changed:
 		dt.save(ignore_permissions=True)
 
+
 @frappe.whitelist()
 def create_data_table(
 	table_name: str,
@@ -97,9 +128,10 @@ def create_data_table(
 ) -> dict:
 	"""Create a new data table (DocType + registry entry).
 
-	Requires: flows.manage
+	Requires: data.tables.manage
 	"""
-	_require_write()
+	_require_data_manage()
+
 	if isinstance(fields, str):
 		fields = json.loads(fields)
 
@@ -159,7 +191,11 @@ def create_data_table(
 			"title_field_name": title_field,
 		}
 	)
-	registry.insert()
+	registry.insert(ignore_permissions=True)
+
+	# Sync permissions so all roles with data.* capabilities get access
+	# to this new table immediately.
+	sync_data_table_permissions()
 
 	return {
 		"success": True,
@@ -181,9 +217,10 @@ def update_data_table(
 ) -> dict:
 	"""Update table structure (add/remove/reorder fields, update metadata).
 
-	Requires: flows.manage
+	Requires: data.tables.manage
 	"""
-	_require_write()
+	_require_data_manage()
+
 	registry = frappe.get_doc("Huf Data Table", name)
 
 	if fields is not None:
@@ -217,9 +254,10 @@ def update_data_table(
 def delete_data_table(name: str) -> dict:
 	"""Delete a data table and all its records.
 
-	Requires: flows.manage
+	Requires: data.tables.manage
 	"""
-	_require_write()
+	_require_data_manage()
+
 	registry = frappe.get_doc("Huf Data Table", name)
 	doctype_name = registry.doctype_name
 
@@ -244,7 +282,7 @@ def get_table_record_counts(names: str | list[str]) -> dict:
 	Standard REST can't count records across dynamic DocTypes,
 	so this helper exists for the listing page enrichment.
 
-	Requires: flows.use
+	Requires: data records view capability.
 	"""
 	_require_read()
 	if isinstance(names, str):
@@ -265,7 +303,7 @@ def get_table_record_counts(names: str | list[str]) -> dict:
 def get_table_schema(name: str) -> dict:
 	"""Get complete table schema (fields with all properties).
 
-	Requires: flows.use
+	Requires: data records view capability.
 	"""
 	_require_read()
 	registry = frappe.get_doc("Huf Data Table", name)
@@ -311,7 +349,7 @@ def get_bulk_import_template_url(table_id: str, export_records: bool | str = Fal
 	Uses Frappe's Data Import exporter. The template is stored as a private
 	File so the SPA can download it through the authenticated file route.
 
-	Requires: flows.use (blank template) or flows.manage (export_records=True)
+	Requires: data records view capability for blank templates, data.tables.manage for exports.
 	"""
 	export_data = bool(frappe.parse_json(export_records))
 	if export_data:
@@ -366,9 +404,9 @@ def start_table_bulk_import(table_id: str, file_url: str) -> dict:
 	"""Create a Frappe Data Import for a Huf data table and enqueue the import.
 
 	Equivalent to Frappe's `form_start_import`, but gated on the HUF
-	`flows.manage` capability instead of Data Import DocType DocPerms.
+	`data.tables.manage` capability instead of Data Import DocType DocPerms.
 
-	Requires: flows.manage
+	Requires: data.tables.manage
 	"""
 	_require_write()
 
@@ -411,7 +449,7 @@ def start_table_bulk_import(table_id: str, file_url: str) -> dict:
 def get_table_bulk_import_status(import_name: str) -> dict:
 	"""Get status and error details for a Data Import against a Huf data table.
 
-	Requires: flows.use
+	Requires: data records view capability.
 	"""
 	_require_read()
 
@@ -694,3 +732,15 @@ def set_table_agent_access(table: str, agent: str, actions: str | list) -> dict:
 	for entry in _compute_access(registry.doctype_name, agent=agent_doc.name):
 		return entry
 	return {'agent': agent_doc.name, 'agent_name': agent_doc.agent_name, 'actions': [], 'tools': []}
+
+
+@frappe.whitelist()
+def apply_data_permissions() -> dict:
+	"""
+	Rebuild DocType permissions for all data tables.
+
+	Called by the Huf Role on_update hook whenever role capabilities change.
+	"""
+	_require_data_manage()
+	sync_data_table_permissions()
+	return {"success": True}

--- a/huf/huf/doctype/huf_data_table/permissions.py
+++ b/huf/huf/doctype/huf_data_table/permissions.py
@@ -118,6 +118,7 @@ def _build_permissions(role_caps: dict[str, set[str]]) -> list[dict]:
 			"print": 1,
 			"email": 1,
 			"share": 1,
+			"import": 1,
 			"if_owner": 0,
 		}
 	]
@@ -144,6 +145,7 @@ def _build_permissions(role_caps: dict[str, set[str]]) -> list[dict]:
 					"print": 0,
 					"email": 0,
 					"share": 0,
+					"import": 0,
 				},
 			)
 			row["read"] = 1
@@ -165,6 +167,7 @@ def _build_permissions(role_caps: dict[str, set[str]]) -> list[dict]:
 					"print": 0,
 					"email": 0,
 					"share": 0,
+					"import": 0,
 				},
 			)
 			row["read"] = 1
@@ -176,8 +179,10 @@ def _build_permissions(role_caps: dict[str, set[str]]) -> list[dict]:
 		if _DATA_CREATE in caps:
 			if (frappe_role, 0) in rows:
 				rows[(frappe_role, 0)]["create"] = 1
+				rows[(frappe_role, 0)]["import"] = 1
 			elif (frappe_role, 1) in rows:
 				rows[(frappe_role, 1)]["create"] = 1
+				rows[(frappe_role, 1)]["import"] = 1
 			else:
 				key = (frappe_role, 0)
 				rows[key] = {
@@ -190,6 +195,7 @@ def _build_permissions(role_caps: dict[str, set[str]]) -> list[dict]:
 					"print": 0,
 					"email": 0,
 					"share": 0,
+					"import": 1,
 				}
 
 	# Drop rows that ended up with no effective permissions.

--- a/huf/huf/doctype/huf_data_table/permissions.py
+++ b/huf/huf/doctype/huf_data_table/permissions.py
@@ -1,0 +1,200 @@
+"""
+huf/huf/doctype/huf_data_table/permissions.py
+
+Permission synchronisation for dynamically generated data-table DocTypes.
+
+Each Huf Data Table is backed by a Frappe DocType named "HF {table_name}".
+The rows in that DocType's "permissions" child table are derived from the
+capability assignments of Huf Roles, so changing a role's data.* capabilities
+automatically updates record-level access for every data table.
+"""
+
+import frappe
+
+from huf.permissions import HUF_ROLE_FRAPPE_ROLE_MAP
+
+
+# Capabilities that control data-table record access.
+_DATA_VIEW_ALL = "data.records.view_all"
+_DATA_VIEW_OWN = "data.records.view_own"
+_DATA_EDIT_ALL = "data.records.edit_all"
+_DATA_EDIT_OWN = "data.records.edit_own"
+_DATA_CREATE = "data.records.create"
+
+
+def sync_data_table_permissions() -> None:
+	"""
+	Rebuild the DocType Permission rows for every generated data table.
+
+	Permissions are derived from the current capability assignments of all
+	Huf Roles (except Huf Admin, which maps to System Manager and always
+	keeps full access). Failures for individual tables are logged and skipped
+	so that one broken table does not block the rest.
+	"""
+	if not frappe.db.table_exists("Huf Data Table"):
+		return
+
+	data_tables = frappe.get_all(
+		"Huf Data Table",
+		fields=["doctype_name"],
+		ignore_permissions=True,
+	)
+	if not data_tables:
+		return
+
+	role_caps = _get_role_capabilities()
+
+	for table in data_tables:
+		doctype_name = table.doctype_name
+		if not doctype_name:
+			continue
+
+		try:
+			if not frappe.db.exists("DocType", doctype_name):
+				continue
+
+			dt = frappe.get_doc("DocType", doctype_name)
+			new_permissions = _build_permissions(role_caps)
+			dt.set("permissions", new_permissions)
+			dt.save(ignore_permissions=True)
+		except Exception:
+			frappe.log_error(
+				title="Failed to sync data table permissions",
+				message=frappe.get_traceback(),
+			)
+
+
+def _get_role_capabilities() -> dict[str, set[str]]:
+	"""
+	Return a mapping of Huf Role name -> set of granted capability strings.
+
+	Huf Admin is excluded because it maps to System Manager, which always
+	receives full access unconditionally.
+	"""
+	roles = frappe.get_all(
+		"Huf Role",
+		filters={"name": ["!=", "Huf Admin"]},
+		fields=["name"],
+		ignore_permissions=True,
+	)
+
+	role_caps: dict[str, set[str]] = {}
+	for role in roles:
+		role_name = role.name
+		if role_name not in HUF_ROLE_FRAPPE_ROLE_MAP:
+			continue
+
+		rows = frappe.get_all(
+			"Huf Role Permission",
+			filters={"parent": role_name},
+			fields=["capability"],
+			ignore_permissions=True,
+		)
+		role_caps[role_name] = {r.capability for r in rows if r.capability}
+
+	return role_caps
+
+
+def _build_permissions(role_caps: dict[str, set[str]]) -> list[dict]:
+	"""
+	Build a DocType permissions array from role capability assignments.
+
+	Rules:
+	  - System Manager always keeps full CRUD.
+	  - view_all  -> read, if_owner=0
+	  - view_own  -> read, if_owner=1
+	  - edit_all  -> write + delete, if_owner=0 (merged with view_all row)
+	  - edit_own  -> write + delete, if_owner=1 (merged with view_own row)
+	  - create    -> create flag added to the role's non-owner row if present,
+	                otherwise the owner row, otherwise a new if_owner=0 row.
+	"""
+	permissions: list[dict] = [
+		{
+			"role": "System Manager",
+			"read": 1,
+			"write": 1,
+			"create": 1,
+			"delete": 1,
+			"print": 1,
+			"email": 1,
+			"share": 1,
+			"if_owner": 0,
+		}
+	]
+
+	# One row per (frappe_role, if_owner) pair.
+	rows: dict[tuple[str, int], dict] = {}
+
+	for huf_role, caps in role_caps.items():
+		frappe_role = HUF_ROLE_FRAPPE_ROLE_MAP.get(huf_role)
+		if not frappe_role:
+			continue
+
+		if _DATA_VIEW_ALL in caps or _DATA_EDIT_ALL in caps:
+			key = (frappe_role, 0)
+			row = rows.setdefault(
+				key,
+				{
+					"role": frappe_role,
+					"if_owner": 0,
+					"read": 0,
+					"write": 0,
+					"create": 0,
+					"delete": 0,
+					"print": 0,
+					"email": 0,
+					"share": 0,
+				},
+			)
+			row["read"] = 1
+			if _DATA_EDIT_ALL in caps:
+				row["write"] = 1
+				row["delete"] = 1
+
+		if _DATA_VIEW_OWN in caps or _DATA_EDIT_OWN in caps:
+			key = (frappe_role, 1)
+			row = rows.setdefault(
+				key,
+				{
+					"role": frappe_role,
+					"if_owner": 1,
+					"read": 0,
+					"write": 0,
+					"create": 0,
+					"delete": 0,
+					"print": 0,
+					"email": 0,
+					"share": 0,
+				},
+			)
+			row["read"] = 1
+			if _DATA_EDIT_OWN in caps:
+				row["write"] = 1
+				row["delete"] = 1
+
+		# create is attached to the broadest row available for the role.
+		if _DATA_CREATE in caps:
+			if (frappe_role, 0) in rows:
+				rows[(frappe_role, 0)]["create"] = 1
+			elif (frappe_role, 1) in rows:
+				rows[(frappe_role, 1)]["create"] = 1
+			else:
+				key = (frappe_role, 0)
+				rows[key] = {
+					"role": frappe_role,
+					"if_owner": 0,
+					"read": 0,
+					"write": 0,
+					"create": 1,
+					"delete": 0,
+					"print": 0,
+					"email": 0,
+					"share": 0,
+				}
+
+	# Drop rows that ended up with no effective permissions.
+	for row in rows.values():
+		if any(row.get(k) for k in ("read", "write", "create", "delete")):
+			permissions.append(row)
+
+	return permissions

--- a/huf/huf/doctype/huf_role/huf_role.py
+++ b/huf/huf/doctype/huf_role/huf_role.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from huf.permissions import CAPABILITIES, _bust_cache
+from huf.huf.doctype.huf_data_table.permissions import sync_data_table_permissions
 
 
 class HufRole(Document):
@@ -14,7 +15,6 @@ class HufRole(Document):
 
 	def validate(self):
 		self._validate_capabilities()
-		self._populate_permission_labels()
 
 	def _validate_capabilities(self):
 		"""Reject any capability not in the CAPABILITIES catalogue."""
@@ -25,15 +25,6 @@ class HufRole(Document):
 						row.capability, ", ".join(sorted(CAPABILITIES.keys()))
 					)
 				)
-
-	def _populate_permission_labels(self):
-		"""Set each permission row's label from the CAPABILITIES catalogue.
-
-		Done here rather than in HufRolePermission.before_save(): child-table
-		controller hooks don't fire on parent document save in Frappe v16.
-		"""
-		for row in self.permissions:
-			row.label = CAPABILITIES.get(row.capability, row.capability)
 
 	# ------------------------------------------------------------------
 	# Guard system roles
@@ -54,6 +45,17 @@ class HufRole(Document):
 
 	def on_update(self):
 		self._bust_users_cache()
+		self._sync_data_table_permissions()
+
+	def _sync_data_table_permissions(self):
+		"""Update data table DocType permissions when this role's capabilities change."""
+		try:
+			sync_data_table_permissions()
+		except Exception:
+			frappe.log_error(
+				title="Failed to sync data table permissions from Huf Role update",
+				message=frappe.get_traceback(),
+			)
 
 	def _bust_users_cache(self):
 		"""Bust the capability cache for every user assigned this role."""

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -14,3 +14,4 @@ huf.patches.v1.update_image_tool
 huf.patches.v1.update_agent_background_color
 huf.patches.v1.repair_tool_call_messages
 huf.patches.v1.fix_agent_message_status
+huf.patches.v1.sync_data_table_permissions

--- a/huf/patches/v1/sync_data_table_permissions.py
+++ b/huf/patches/v1/sync_data_table_permissions.py
@@ -1,0 +1,22 @@
+import frappe
+
+from huf.huf.doctype.huf_data_table.permissions import sync_data_table_permissions
+
+
+def execute():
+	"""
+	Backfill DocType permissions for existing Huf Data Tables.
+
+	On fresh installs where the Huf Data Table registry does not exist yet,
+	this patch no-ops gracefully.
+	"""
+	if not frappe.db.table_exists("Huf Data Table"):
+		return
+
+	try:
+		sync_data_table_permissions()
+	except Exception:
+		frappe.log_error(
+			title="Patch: failed to sync data table permissions",
+			message=frappe.get_traceback(),
+		)


### PR DESCRIPTION
## Summary

Consolidates the Data permissions work from #346 and #413 onto current `origin/develop`.

Source PRs:
- #346: granular capability model for Data feature permissions
- #413: repaired/rebased #346 with role hook, capability options, migration registration, and Roles UI grouping

## What changed

- Adds dedicated Data capabilities:
  - `data.tables.manage`
  - `data.records.create`
  - `data.records.view_own`
  - `data.records.view_all`
  - `data.records.edit_own`
  - `data.records.edit_all`
- Replaces old Data Table route/API gating that reused `flows.*` with dedicated `data.*` capability checks.
- Adds generated DocType permission sync for Huf Data Tables from Huf Role capability assignments.
- Syncs Data Table DocPerms on Huf Role update and via migration patch for existing generated tables.
- Updates Huf Role Permission options and Roles UI grouping for Data capabilities.
- Updates sidebar and Data Table builder access states to use Data capabilities.
- Preserves current Data Table bulk import and agent-access functionality from `develop` while tightening import DocPerms so `data.records.create` enables import/create without broad read/write/delete access.

## Conflict resolution notes

- Based cleanly on `origin/develop` @ `28ff5f2`.
- Used #413 as the primary repaired patch source and cross-checked against #346.
- Excluded `.hufro-owner.json` from #413 because it is release-orchestrator metadata, not product behavior.
- Preserved current Data Tables/App changes from develop, including bulk import, grouping/layout fields, and table agent-access APIs.
- Did not merge or close #346 or #413.

## Checks

Passed:
- `git diff --check`
- `python3 -m py_compile huf/huf/doctype/huf_data_table/api.py huf/huf/doctype/huf_data_table/permissions.py huf/huf/doctype/huf_role/huf_role.py huf/permissions.py huf/patches/v1/sync_data_table_permissions.py`
- `frontend/node_modules/.bin/eslint src/components/app-sidebar.tsx src/pages/DataTableBuilderPage.tsx src/pages/RolesPage.tsx`

Attempted but blocked by existing environment/baseline issues:
- `python3 -m pytest huf/huf/doctype/huf_data_table/test_agent_access.py huf/huf/doctype/huf_role/test_huf_role.py huf/huf/doctype/huf_role_permission/test_huf_role_permission.py` failed during collection because local Python environment does not have `frappe` installed.
- `yarn typecheck` and `yarn build` fail on existing unrelated `src/components/chat/chatMessageList.mappers.ts(507,31): Property 'injectedMemories' does not exist on type 'ChatMessage'.`
- `yarn lint` fails on existing unrelated baseline errors in bulk import, memory, tools, and apps files; the touched frontend files pass targeted ESLint.
