### PR TITLE
fix(gateway): align frontend schema, hide incomplete UI, add TODO shame list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2196,6 +2196,18 @@ HUF integrates prompt caching to save token costs on supported models:
 - **Model Check**: Checks model support by checking the LiteLLM pricing metadata for the field `cache_read_input_token_cost`.
 - **Toggle**: Users can toggle `enable_prompt_caching` in `Agent` settings to automatically apply prompt caching block headers on supported providers (Anthropic, Deepseek, OpenAI, Bedrock).
 
+## Known Incomplete Features / TODO
+
+The Gateways feature (channel inbound adapters) is merged into `develop` but is not yet
+user-ready. The UI navigation and Flow Run trigger are temporarily disabled while the
+provider adapters and connection forms are finished. See:
+
+- `docs/gateway-todo.md` — detailed shame list and restoration checklist.
+- `#473-followup` comments in `frontend/src/services/gatewayApi.ts`,
+  `frontend/src/pages/GatewaysPage.tsx`, `frontend/src/components/app-sidebar.tsx`,
+  `frontend/src/App.tsx`, `huf/huf/doctype/flow_run/flow_run.json`, and
+  `huf/ai/gateway_service.py`.
+
 ## Development and Coding Guidelines
 
 ### Frontend TypeScript Strictness

--- a/docs/gateway-todo.md
+++ b/docs/gateway-todo.md
@@ -1,0 +1,54 @@
+# Gateway TODO / Shame List
+
+The channel gateway foundation and adapters were consolidated into `develop` via PR #473,
+but the end-to-end feature is **not ready for users**. This file tracks what is missing,
+what was disabled, and what must be restored before Gateways can be shipped.
+
+## What works
+
+- Backend DocTypes exist: `Gateway`, `Gateway Binding`, `Gateway Access Entry`, `Gateway Event`.
+- Provider-neutral ingress, admission, idempotency, routing, queueing, and execution service
+  (`huf/ai/gateway_service.py`) has unit tests.
+- Adapter SDK contracts, runtime bridge, VK/WeCom contracts, Teams outgoing webhook, and
+  Discord Interaction ingress are merged.
+
+## What is disabled / shameful
+
+- **UI navigation**: Gateways is hidden from the app sidebar and the `/gateways` route is
+  commented out in `frontend/src/App.tsx` and `frontend/src/components/app-sidebar.tsx`.
+- **Flow Run trigger**: `Gateway` is removed from `Flow Run.trigger_type` options in
+  `huf/huf/doctype/flow_run/flow_run.json`.
+- **Frontend create form**: `GatewaysPage.tsx` only creates a minimal draft with
+  `direct_policy: 'Disabled'`. The full admission and routing forms are not implemented.
+- **Provider adapters**: no live inbound adapters are wired to the runtime (webhooks,
+  long-polling bots, etc.). The SDK contracts exist but are not connected end-to-end.
+
+## TODOs before re-enabling
+
+1. Implement live provider adapters for at least one channel (Telegram bot webhook is the
+   planned first adapter) and add integration tests.
+2. Build the in-app gateway connection form: choose integration, map credentials, test
+   connectivity, and enable/disable.
+3. Build the admission-policy UI (`direct_policy`, `room_policy`, `room_sender_policy`,
+   `mention_required`, `pairing_ttl_minutes`) instead of hard-coding `Disabled`.
+4. Build binding/routing UI so a gateway can target an Agent or Flow.
+5. Re-enable the sidebar item, `/gateways` route, and `Gateway` Flow Run trigger type.
+6. Add end-to-end smoke test that creates a gateway, sends a test event, and verifies the
+   resulting Agent/Flow run.
+
+## Files with `#473-followup` TODOs
+
+- `frontend/src/services/gatewayApi.ts`
+- `frontend/src/pages/GatewaysPage.tsx`
+- `frontend/src/components/app-sidebar.tsx`
+- `frontend/src/App.tsx`
+- `huf/huf/doctype/flow_run/flow_run.json`
+- `huf/ai/gateway_service.py`
+
+## History
+
+- Original PRs: #441 (foundation), #446 (adapter SDK), #449 (runtime bridge), #447 (VK),
+  #448 (WeCom), #442 (Teams), #443 (Discord).
+- Consolidated PR: #473.
+- Quick-fix commit that hid the incomplete UI and fixed the `access_policy` frontend bug:
+  see commit message for the follow-up change on `develop`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,7 +65,9 @@ const IntegrationServiceFormPageWrapper = lazy(
   () => import('./pages/IntegrationServiceFormPageWrapper'),
 );
 const HubSimplePage = lazy(() => import('./pages/HubSimplePage'));
-const GatewaysPage = lazy(() => import('./pages/GatewaysPage'));
+// TODO(#473-followup): Gateways page is kept in source but unlinked from routes
+// while the feature is incomplete. See docs/gateway-todo.md.
+// const GatewaysPage = lazy(() => import('./pages/GatewaysPage'));
 const AgentSettingsPage = lazy(() => import('./pages/AgentSettingsPage'));
 
 import { useEffect } from 'react';
@@ -487,7 +489,9 @@ function AppShell() {
               </ProtectedRoute>
             }
           />
-          <Route
+          {/* TODO(#473-followup): Gateways route is disabled while the feature is
+              incomplete. Restore once docs/gateway-todo.md items are resolved. */}
+          {/* <Route
             path="/gateways"
             element={
               <ProtectedRoute>
@@ -498,7 +502,7 @@ function AppShell() {
                 </UnifiedLayout>
               </ProtectedRoute>
             }
-          />
+          /> */}
           <Route
             path="/integration-services"
             element={

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -155,12 +155,15 @@ const settingsNavItems = [
     icon: Terminal,
     capability: "agent.use",
   },
-  {
-    title: "Gateways",
-    url: "/gateways",
-    icon: MessageSquare,
-    capability: "system.integrations.manage",
-  },
+  // TODO(#473-followup): Gateways navigation is hidden while the feature is
+  // incomplete (no live provider adapters, no in-app connection form). Restore
+  // once the items in docs/gateway-todo.md are resolved.
+  // {
+  //   title: "Gateways",
+  //   url: "/gateways",
+  //   icon: MessageSquare,
+  //   capability: "system.integrations.manage",
+  // },
   {
     title: "Integrations",
     url: "/integrations",

--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -1,24 +1,39 @@
 import { FormEvent, useEffect, useState } from 'react';
-import { Link2, Mail, MessageCircle, Send, Settings, ShieldCheck, Slack } from 'lucide-react';
+import {
+  Link2,
+  Mail,
+  MessageCircle,
+  Send,
+  Settings,
+  ShieldCheck,
+  Slack,
+} from 'lucide-react';
 import { PageLayout, GridView, ItemCard } from '@/components/dashboard';
-import { getGateways, type GatewayDoc } from '@/services/gatewayApi';
+import { getGateways, type GatewayDoc, type GatewayProvider } from '@/services/gatewayApi';
 import { db } from '@/lib/frappe-sdk';
 import { doctype } from '@/data/doctypes';
 import { Button } from '@/components/ui/button';
 
-const providerIcons = {
+// TODO(#473-followup): Add real icons/names for Discord, VK, WeCom, Microsoft Teams
+// once the provider adapters are wired up. For now we fall back to a generic icon.
+const providerIcons: Partial<Record<GatewayProvider, React.ComponentType<{ className?: string }>>> = {
   Telegram: Send,
   Slack,
   Email: Mail,
   WhatsApp: MessageCircle,
-} as const;
+};
 
-const providerNames = {
+const providerNames: Partial<Record<GatewayProvider, string>> = {
   Telegram: 'Telegram bot',
   Slack: 'Slack workspace',
   Email: 'Shared inbox',
   WhatsApp: 'WhatsApp business number',
-} as const;
+};
+
+// TODO(#473-followup): The UI only exposes the four originally-supported providers
+// while the backend schema already accepts Discord, VK, WeCom, and Microsoft Teams.
+// Expand this list when adapters and connection forms are ready.
+const uiProviders: GatewayProvider[] = ['Telegram', 'Slack', 'Email', 'WhatsApp'];
 
 export default function GatewaysPage() {
   const [gateways, setGateways] = useState<GatewayDoc[]>([]);
@@ -75,11 +90,13 @@ export default function GatewaysPage() {
             setCreating(true);
             setError('');
             try {
+              // TODO(#473-followup): The create form is intentionally minimal. A full
+              // admission + routing form should replace this once the UI is ready.
               const created = await db.createDoc(doctype.Gateway, {
                 gateway_name: gatewayName.trim(),
                 provider,
                 is_enabled: 0,
-                access_policy: 'Deny by default',
+                direct_policy: 'Disabled',
               }) as GatewayDoc;
               setGateways((current) => [created, ...current]);
               setGatewayName('');
@@ -108,10 +125,9 @@ export default function GatewaysPage() {
               value={provider}
               onChange={(event) => setProvider(event.target.value as GatewayDoc['provider'])}
             >
-              <option value="Telegram">Telegram</option>
-              <option value="Slack">Slack</option>
-              <option value="Email">Email</option>
-              <option value="WhatsApp">WhatsApp</option>
+              {uiProviders.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
             </select>
           </label>
           <Button type="submit" disabled={creating}>{creating ? 'Creating…' : 'Create safe draft'}</Button>
@@ -134,21 +150,21 @@ export default function GatewaysPage() {
           </div>
         }
         renderItem={(gateway) => {
-          const Icon = providerIcons[gateway.provider];
+          const Icon = providerIcons[gateway.provider] ?? MessageCircle;
           const target = gateway.default_target_type === 'Agent'
             ? gateway.default_agent
             : gateway.default_target_type === 'Flow' ? gateway.default_flow : 'No default route';
           return (
             <ItemCard
               title={gateway.gateway_name}
-              description={gateway.description || providerNames[gateway.provider]}
+              description={gateway.description || providerNames[gateway.provider] || `${gateway.provider} channel`}
               status={{
                 label: gateway.is_enabled ? 'ready' : 'not receiving messages',
                 variant: gateway.is_enabled ? 'default' : 'secondary',
               }}
               metadata={[
                 { label: 'Channel', value: gateway.provider, icon: Icon },
-                { label: 'Access', value: gateway.access_policy },
+                { label: 'Access', value: gateway.direct_policy },
                 { label: 'Default route', value: target || 'No default route' },
               ]}
               actions={[

--- a/frontend/src/services/gatewayApi.ts
+++ b/frontend/src/services/gatewayApi.ts
@@ -1,14 +1,34 @@
 import { db } from '@/lib/frappe-sdk';
 import { doctype } from '@/data/doctypes';
 
-export type GatewayProvider = 'Telegram' | 'Slack' | 'Email' | 'WhatsApp';
+// TODO(#473-followup): The consolidated gateway DocType uses per-channel admission
+// fields (direct_policy, room_policy, room_sender_policy, mention_required,
+// pairing_ttl_minutes) instead of the older access_policy. Keep this file in sync
+// with huf/huf/doctype/gateway/gateway.json. See docs/gateway-todo.md.
+export type GatewayProvider =
+  | 'Telegram'
+  | 'Slack'
+  | 'Discord'
+  | 'Email'
+  | 'WhatsApp'
+  | 'VK'
+  | 'WeCom'
+  | 'Microsoft Teams';
+
+export type GatewayPolicy = 'Disabled' | 'Pairing' | 'Allow list' | 'Open';
 
 export interface GatewayDoc {
   name: string;
   gateway_name: string;
   provider: GatewayProvider;
   is_enabled: 0 | 1;
-  access_policy: 'Deny by default' | 'Allow list' | 'Pairing';
+  // TODO(#473-followup): admission UI is incomplete; direct_policy is shown as a
+  // placeholder until the full admission form is built.
+  direct_policy: GatewayPolicy;
+  room_policy?: GatewayPolicy;
+  room_sender_policy?: GatewayPolicy;
+  mention_required?: 0 | 1;
+  pairing_ttl_minutes?: number;
   description?: string;
   default_target_type?: '' | 'Agent' | 'Flow';
   default_agent?: string;
@@ -20,7 +40,9 @@ export interface GatewayDoc {
 export async function getGateways(): Promise<GatewayDoc[]> {
   return (await db.getDocList(doctype.Gateway, {
     fields: [
-      'name', 'gateway_name', 'provider', 'is_enabled', 'access_policy', 'description',
+      'name', 'gateway_name', 'provider', 'is_enabled',
+      'direct_policy', 'room_policy', 'room_sender_policy',
+      'mention_required', 'pairing_ttl_minutes', 'description',
       'default_target_type', 'default_agent', 'default_flow', 'last_event_at', 'last_error',
     ],
     orderBy: { field: 'modified', order: 'desc' },

--- a/huf/ai/gateway_service.py
+++ b/huf/ai/gateway_service.py
@@ -262,6 +262,9 @@ def process_gateway_event(event_name: str) -> dict:
         if event.target_type == "Flow":
             from huf.ai.flow_engine import create_flow_run
 
+            # TODO(#473-followup): Gateway trigger_type is temporarily removed from
+            # Flow Run options because the feature is incomplete. Re-enable once
+            # docs/gateway-todo.md checklist is done and adapters are live.
             flow_run = create_flow_run(
                 flow_id=event.target_flow,
                 payload={"gateway_event": event.name, "message": event.message_text},

--- a/huf/huf/doctype/flow_run/flow_run.json
+++ b/huf/huf/doctype/flow_run/flow_run.json
@@ -87,7 +87,7 @@
    "fieldname": "trigger_type",
    "fieldtype": "Select",
    "label": "Trigger Type",
-   "options": "Manual\nWebhook\nSchedule\nDoc Event\nGateway",
+   "options": "Manual\nWebhook\nSchedule\nDoc Event",
    "read_only": 1
   },
   {


### PR DESCRIPTION
Fixes the "Could not load gateways" error on the Gateways page and hides the incomplete feature from the UI and execution path until adapters are ready.

Changes:
- `frontend/src/services/gatewayApi.ts`: replace stale `access_policy` with the real admission fields (`direct_policy`, `room_policy`, `room_sender_policy`, `mention_required`, `pairing_ttl_minutes`).
- `frontend/src/pages/GatewaysPage.tsx`: use `direct_policy`, add TODOs, fallback for unimplemented providers.
- `frontend/src/App.tsx` / `frontend/src/components/app-sidebar.tsx`: comment out the `/gateways` route and sidebar item.
- `huf/huf/doctype/flow_run/flow_run.json`: remove `Gateway` from `trigger_type` options.
- `huf/ai/gateway_service.py`: add TODO where the Gateway trigger is used.
- New `docs/gateway-todo.md` shame list / restoration checklist.
- `AGENTS.md`: links to the gateway TODO list.

Refs #473, #441, #442, #443, #446, #447, #448, #449.
