### PR TITLE
fix(agent): re-enable delete and duplicate actions in agent form

### DIFF
--- a/frontend/src/components/agent/AgentHeader.tsx
+++ b/frontend/src/components/agent/AgentHeader.tsx
@@ -1,4 +1,4 @@
-import { Clock, Play, Save, MessageSquare, MoreVertical, FileText, Lock } from 'lucide-react';
+import { Clock, Play, Save, MessageSquare, MoreVertical, FileText, Lock, Copy, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -36,6 +36,7 @@ interface AgentHeaderProps {
   onDuplicate: () => void;
   onViewLogs: () => void;
   onDelete: () => void;
+  duplicating?: boolean;
   agentId?: string;
   allowChat: boolean;
   lastRun?: string | null;
@@ -56,9 +57,10 @@ export function AgentHeader({
   runningTest = false,
   onSave,
   onRunTest,
-  // onDuplicate,
+  onDuplicate,
   onViewLogs,
-  // onDelete,
+  onDelete,
+  duplicating = false,
   agentId,
   allowChat,
   lastRun,
@@ -170,18 +172,18 @@ export function AgentHeader({
             {!isNew && (
               <>
                 <DropdownMenuSeparator />
-                {/* <DropdownMenuItem onClick={onDuplicate}>
+                <DropdownMenuItem onClick={onDuplicate} disabled={duplicating || locked}>
                   <Copy className="w-4 h-4 mr-2" />
-                  Duplicate
-                </DropdownMenuItem> */}
+                  {duplicating ? 'Duplicating...' : 'Duplicate'}
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={onViewLogs}>
                   <FileText className="w-4 h-4 mr-2" />
                   View Logs
                 </DropdownMenuItem>
-                {/* <DropdownMenuItem onClick={onDelete} className="text-destructive">
+                <DropdownMenuItem onClick={onDelete} disabled={locked} className="text-destructive">
                   <Trash2 className="w-4 h-4 mr-2" />
                   Delete
-                </DropdownMenuItem> */}
+                </DropdownMenuItem>
               </>
             )}
           </DropdownMenuContent>

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -11,7 +11,7 @@ import { usePermissions } from '../contexts/PermissionsContext';
 import { AIProvider, AIModel, AgentToolFunctionRef, type ToolType } from '../types/agent.types';
 import type { AgentSkillRow } from '../types/skill.types';
 import { getSkillOptions } from '../services/skillApi';
-import { getAgent, updateAgent, createAgent, getAgentTriggers, getAgentTrigger, createAgentTrigger, updateAgentTrigger, getDocTypes, getTriggerTypes, type AgentTriggerListItem, type AgentTriggerDoc, type AgentTriggerAttachmentRow, type TriggerTypeOption, deleteAgentTrigger, runAgentTest } from '../services/agentApi';
+import { getAgent, updateAgent, createAgent, getAgentTriggers, getAgentTrigger, createAgentTrigger, updateAgentTrigger, getDocTypes, getTriggerTypes, type AgentTriggerListItem, type AgentTriggerDoc, type AgentTriggerAttachmentRow, type TriggerTypeOption, deleteAgentTrigger, runAgentTest, deleteAgent, duplicateAgent } from '../services/agentApi';
 import { getAgentPrompt } from '../services/agentPromptApi';
 import { getAgentSummaryPrompt } from '../services/agentSummaryPromptApi';
 import { getProviders, getModels } from '../services/providerApi';
@@ -25,6 +25,7 @@ import { TriggerModal } from '../components/agent/TriggerModal';
 import { getFrappeErrorMessage } from '../lib/frappe-error';
 import { db } from '../lib/frappe-sdk';
 import { AgentHeader } from '../components/agent/AgentHeader';
+import { DeleteAgentDialog } from '../components/agent/DeleteAgentDialog';
 import { GeneralTab } from '../components/agent/GeneralTab';
 import { BehaviorTab } from '../components/agent/BehaviorTab';
 import { TriggersTab } from '../components/agent/TriggersTab';
@@ -301,6 +302,9 @@ export function AgentFormPage() {
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
   const [deletingTrigger, setDeletingTrigger] = useState(false);
+  const [duplicating, setDuplicating] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [providers, setProviders] = useState<AIProvider[]>([]);
   const [models, setModels] = useState<AIModel[]>([]);
   const [allModels, setAllModels] = useState<AIModel[]>([]);
@@ -1624,13 +1628,39 @@ export function AgentFormPage() {
     }
   };
 
-  const handleDuplicate = () => {
-    toast.info('Coming Soon!');
+  const handleDuplicate = async () => {
+    if (!id || isNew) return;
+    setDuplicating(true);
+    try {
+      const copy = await duplicateAgent(id);
+      toast.success('Agent duplicated');
+      navigate(`/agents/${copy.name}`);
+    } catch (error) {
+      const errorMessage = getFrappeErrorMessage(error);
+      toast.error(errorMessage || 'Failed to duplicate agent');
+    } finally {
+      setDuplicating(false);
+    }
   };
 
   const handleDelete = () => {
-    toast.info('Deleting agent...');
-    navigate('/agents');
+    setShowDeleteDialog(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!id || isNew) return;
+    setDeleting(true);
+    try {
+      await deleteAgent(id);
+      toast.success('Agent deleted');
+      navigate('/agents');
+    } catch (error) {
+      const errorMessage = getFrappeErrorMessage(error);
+      toast.error(errorMessage || 'Failed to delete agent');
+    } finally {
+      setDeleting(false);
+      setShowDeleteDialog(false);
+    }
   };
 
   const handleViewLogs = () => {
@@ -1986,12 +2016,21 @@ export function AgentFormPage() {
           onSave={handleFormSubmit}
           onRunTest={handleRunTest}
           onDuplicate={handleDuplicate}
+          duplicating={duplicating}
           onViewLogs={handleViewLogs}
           onDelete={handleDelete}
           agentId={!isNew && id ? id : undefined}
           allowChat={allowChat}
           lastRun={agentStats.last_run}
           totalRun={agentStats.total_run}
+        />
+
+        <DeleteAgentDialog
+          open={showDeleteDialog}
+          onOpenChange={setShowDeleteDialog}
+          agentName={form.watch('agent_name') || id || ''}
+          onConfirm={handleConfirmDelete}
+          loading={deleting}
         />
 
         <Form {...form}>

--- a/frontend/src/services/agentApi.ts
+++ b/frontend/src/services/agentApi.ts
@@ -432,6 +432,68 @@ export async function updateAgent(name: string, data: Partial<AgentDoc>): Promis
   }
 }
 
+/**
+ * Delete an agent document
+ */
+export async function deleteAgent(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype.Agent, name);
+  } catch (error) {
+    handleFrappeError(error, `Error deleting agent ${name}`);
+  }
+}
+
+/**
+ * Duplicate an agent document (copies all fields except identity/stats fields).
+ * Ensures the duplicated name is unique by appending "(Copy)", "(Copy 2)", etc.
+ */
+export async function duplicateAgent(name: string): Promise<AgentDoc> {
+  try {
+    const source = await db.getDoc(doctype.Agent, name);
+    const excludedFields = [
+      'name',
+      'owner',
+      'creation',
+      'modified',
+      'modified_by',
+      'last_run',
+      'total_run',
+      'idx',
+      'docstatus',
+    ];
+    const rest = Object.fromEntries(
+      Object.entries(source as Record<string, unknown>).filter(
+        ([key]) => !excludedFields.includes(key)
+      )
+    );
+
+    const baseName = (source as AgentDoc).agent_name;
+    const nameExists = async (candidate: string): Promise<boolean> => {
+      const matches = await db.getDocList(doctype.Agent, {
+        filters: [['agent_name', '=', candidate]] as any,
+        fields: ['name'],
+        limit: 1,
+      });
+      return matches.length > 0;
+    };
+
+    let candidateName = `${baseName} (Copy)`;
+    let suffix = 2;
+    while (await nameExists(candidateName)) {
+      candidateName = `${baseName} (Copy ${suffix})`;
+      suffix += 1;
+    }
+
+    const copy = await db.createDoc(doctype.Agent, {
+      ...rest,
+      agent_name: candidateName,
+    });
+    return copy as AgentDoc;
+  } catch (error) {
+    handleFrappeError(error, `Error duplicating agent ${name}`);
+  }
+}
+
 type AgentMcpServerChildRow = {
   name?: string;
   mcp_server: string;


### PR DESCRIPTION
Restores the agent delete/duplicate actions that were merged in PR #343 but later reverted by the design-system merge.

## What changed
- Re-added `deleteAgent()` and `duplicateAgent()` to `frontend/src/services/agentApi.ts` with the `(Copy 2)`, `(Copy 3)`, … uniqueness fix.
- Re-enabled **Duplicate** and **Delete** menu items in `AgentHeader.tsx`.
- Wired real handlers in `AgentFormPage.tsx` with loading states and the existing `DeleteAgentDialog`.
- Respects the existing system-agent `locked` state: actions are disabled for non-admin users on protected system agents.

## Notes
- `frontend/src/components/agent/DeleteAgentDialog.tsx` already contained the corrected copy from the original follow-up commit and is now used again.
- Frontend typecheck/build have a pre-existing unrelated error in `GatewaysPage.tsx` and `vite.config.ts`; the changed agent files are clean.