### PR TITLE
fix: allow Attach/Attach Image field types to be created on data tables

### DIFF
--- a/frontend/src/components/data-table/FieldTypeSelector.tsx
+++ b/frontend/src/components/data-table/FieldTypeSelector.tsx
@@ -18,6 +18,8 @@ import {
 	Folder,
 	Minus,
 	Columns,
+	Paperclip,
+	Image,
 	LucideIcon,
 } from 'lucide-react';
 import { useState } from 'react';
@@ -45,6 +47,8 @@ const ICON_MAP: Record<string, LucideIcon> = {
 	Folder,
 	Minus,
 	Columns,
+	Paperclip,
+	Image,
 };
 
 interface FieldTypeGroup {
@@ -96,6 +100,13 @@ const GROUPS: FieldTypeGroup[] = [
 		types: [
 			{ type: 'Color', label: 'Color', icon: 'Palette' },
 			{ type: 'Phone', label: 'Phone', icon: 'Phone' },
+		],
+	},
+	{
+		label: 'Media',
+		types: [
+			{ type: 'Attach', label: 'File', icon: 'Paperclip' },
+			{ type: 'Attach Image', label: 'Image', icon: 'Image' },
 		],
 	},
 	{

--- a/frontend/src/data/fieldTypes.ts
+++ b/frontend/src/data/fieldTypes.ts
@@ -160,6 +160,8 @@ export const FIELD_PROPERTIES: Record<string, string[]> = {
 	Rating: ['label', 'read_only', 'description', 'in_list_view'],
 	Color: ['label', 'reqd', 'read_only', 'description', 'in_list_view'],
 	Phone: ['label', 'reqd', 'unique', 'read_only', 'default', 'description', 'in_list_view'],
+	Attach: ['label', 'reqd', 'read_only', 'description', 'in_list_view'],
+	'Attach Image': ['label', 'reqd', 'read_only', 'description', 'in_list_view'],
 	'Section Break': ['label'],
 	'Column Break': [],
 };

--- a/frontend/src/data/fieldTypes.ts
+++ b/frontend/src/data/fieldTypes.ts
@@ -160,8 +160,9 @@ export const FIELD_PROPERTIES: Record<string, string[]> = {
 	Rating: ['label', 'read_only', 'description', 'in_list_view'],
 	Color: ['label', 'reqd', 'read_only', 'description', 'in_list_view'],
 	Phone: ['label', 'reqd', 'unique', 'read_only', 'default', 'description', 'in_list_view'],
-	Attach: ['label', 'reqd', 'read_only', 'description', 'in_list_view'],
-	'Attach Image': ['label', 'reqd', 'read_only', 'description', 'in_list_view'],
+	// Frappe does not permit `in_list_view` on Attach/Attach Image fields.
+	Attach: ['label', 'reqd', 'read_only', 'description'],
+	'Attach Image': ['label', 'reqd', 'read_only', 'description'],
 	'Section Break': ['label'],
 	'Column Break': [],
 };

--- a/frontend/src/pages/DataTableBuilderPage.tsx
+++ b/frontend/src/pages/DataTableBuilderPage.tsx
@@ -193,6 +193,8 @@ export function DataTableBuilderPage() {
 	const handleAddField = useCallback(
 		(type: DataTableFieldType) => {
 			const isLayout = type === 'Section Break' || type === 'Column Break';
+			// Frappe does not permit `in_list_view` on Attach/Attach Image fields.
+			const supportsListView = type !== 'Attach' && type !== 'Attach Image';
 			const baseName = isLayout
 				? type.toLowerCase().replace(/\s+/g, '_')
 				: 'new_field';
@@ -206,7 +208,7 @@ export function DataTableBuilderPage() {
 				fieldname,
 				fieldtype: type,
 				label: isLayout ? '' : '',
-				...(isLayout ? {} : { in_list_view: state.fields.filter(
+				...(isLayout || !supportsListView ? {} : { in_list_view: state.fields.filter(
 					(f) => f.fieldtype !== 'Section Break' && f.fieldtype !== 'Column Break'
 				).length < 4 ? 1 : 0 as 0 | 1 }),
 			};

--- a/frontend/src/types/dataTable.types.ts
+++ b/frontend/src/types/dataTable.types.ts
@@ -39,6 +39,8 @@ export type DataTableFieldType =
 	| 'Rating'
 	| 'Color'
 	| 'Phone'
+	| 'Attach'
+	| 'Attach Image'
 	| 'Tab Break'
 	| 'Section Break'
 	| 'Column Break';

--- a/huf/huf/doctype/huf_data_table/validators.py
+++ b/huf/huf/doctype/huf_data_table/validators.py
@@ -19,6 +19,8 @@ ALLOWED_FIELD_TYPES = {
 	"Rating",
 	"Color",
 	"Phone",
+	"Attach",
+	"Attach Image",
 	"Tab Break",
 	"Section Break",
 	"Column Break",


### PR DESCRIPTION
## Summary
This finishes off the file-upload feature from an earlier PR (#456) that never actually landed cleanly. Current `develop` already has full **rendering** support for `Attach`/`Attach Image` fields (upload widget, thumbnail preview, `/api/method/upload_file` integration in `DataRecordFormLayout.tsx`) — but the field type could never actually be **created**, because it was missing from three places:

1. `huf/huf/doctype/huf_data_table/validators.py` — `ALLOWED_FIELD_TYPES` didn't include `Attach`/`Attach Image`, so the backend rejected creating such a field.
2. `frontend/src/types/dataTable.types.ts` / `FieldTypeSelector.tsx` — the type wasn't selectable in the "Choose Field Type" dialog at all (added a "Media" group with File/Image options).
3. `frontend/src/data/fieldTypes.ts` (`FIELD_PROPERTIES`) — even after making the type selectable, the Field Properties panel had no `label` property registered for it, so the Label input never rendered and the field could never be named.

While verifying end-to-end, also caught and fixed a real Frappe-level validation error: `DataTableBuilderPage.tsx` defaults every new field's `in_list_view` to `1`, but Frappe does not permit `in_list_view` on Attach/Attach Image fields (`'In List View' not allowed for type Attach Image in row 1`). Fixed by excluding these two types from that default, and by removing `in_list_view` from their `FIELD_PROPERTIES` entry.

## Verification (live, on a fresh clean `develop` + this branch merged, full `bench migrate`)
- Created a table "Attach Verify" with an `Attach Image` field labeled "Photo" — table created successfully (no backend rejection).
- Uploaded a real image via the "Select File" button — thumbnail preview rendered correctly, `/api/method/upload_file` round-trip confirmed.
- Saved the record — "Record created" confirmed, value persisted and reloaded correctly (`/private/files/...` path shown on the read-only view).
- `yarn typecheck` / `yarn lint`: identical error/warning counts to bare `develop` (one pre-existing unrelated `GatewaysPage.tsx` typecheck error, 16 pre-existing lint errors/62 warnings) — this PR introduces zero new errors.
- Deleted the test table after verification; bench container's Python checkout (which is on an unrelated in-progress branch) was fully restored to its original state afterward.

## Test plan
- [x] Create a table with an Attach/Attach Image field via the UI — succeeds
- [x] Upload a real file/image — thumbnail renders, upload succeeds
- [x] Save the record — persists correctly
- [x] `yarn typecheck` / `yarn lint` — no new errors vs. bare `develop`