### PR TITLE
fix: Frappe v16.27 compatibility imports and stubs

### DIFF
--- a/huf/ai/tools/code_execution.py
+++ b/huf/ai/tools/code_execution.py
@@ -39,7 +39,8 @@ from typing import Any
 from urllib.parse import urlparse
 
 import frappe
-from frappe.utils import add_to_date, get_files_path, now_datetime
+from frappe.utils import get_files_path
+from frappe.utils.data import add_to_date, now_datetime
 from frappe.utils.file_manager import save_file
 
 from huf.ai.http_handler import handle_http_request

--- a/huf/tests/test_chat_audio_upload.py
+++ b/huf/tests/test_chat_audio_upload.py
@@ -88,6 +88,9 @@ def _run_async_safely(coro):
 _get_or_create_stub(
     "huf.ai.agent_integration",
     _run_async_safely=_run_async_safely,
+    _is_truthy=lambda value: (
+        value.strip().lower() in ("1", "true", "yes") if isinstance(value, str) else bool(value)
+    ),
     run_agent_sync=MagicMock(),
 )
 conversation_manager_stub = _get_or_create_stub(


### PR DESCRIPTION
Rescued from bench `16_devuthere`.

- `huf/ai/tools/code_execution.py`: import `add_to_date` and `now_datetime` from `frappe.utils.data`, which is where they live in Frappe v16.27.
- `huf/tests/test_chat_audio_upload.py`: stub `_is_truthy` on the `huf.ai.agent_integration` mock so the test suite can import cleanly.

These changes are only needed when running against Frappe v16.27+; current `develop\'s target is v16.22.