### PR TITLE
fix(agent): consolidate knowledge source add/create into single entry point

### DIFF
--- a/frontend/src/components/agent/AgentKnowledgeModal.tsx
+++ b/frontend/src/components/agent/AgentKnowledgeModal.tsx
@@ -33,6 +33,7 @@ interface AgentKnowledgeModalProps {
   onOpenChange: (open: boolean) => void;
   onSave: (row: AgentKnowledgeRow) => void;
   initialData?: AgentKnowledgeRow | null;
+  onCreateNew?: () => void;
 }
 
 export function AgentKnowledgeModal({
@@ -40,6 +41,7 @@ export function AgentKnowledgeModal({
   onOpenChange,
   onSave,
   initialData,
+  onCreateNew,
 }: AgentKnowledgeModalProps) {
   const [knowledgeSource, setKnowledgeSource] = useState('');
   const [mode, setMode] = useState<'Mandatory' | 'Optional'>('Optional');
@@ -108,15 +110,34 @@ export function AgentKnowledgeModal({
         <DialogScrollBody className="space-y-4 py-2">
           <div className="space-y-2">
             <Label>Knowledge Source *</Label>
-            <Combobox
-              options={sourceOptions}
-              value={knowledgeSource}
-              onValueChange={setKnowledgeSource}
-              placeholder="Select knowledge source..."
-              searchPlaceholder="Search knowledge sources..."
-              emptyText="No knowledge sources found."
-              linkTo={linkRoutes.knowledgeSource}
-            />
+            {sourceOptions.length === 0 && onCreateNew ? (
+              <div className="flex flex-col items-center gap-3 rounded-none border border-dashed py-6 text-center">
+                <p className="text-sm text-steel">No knowledge sources registered yet</p>
+                <Button type="button" variant="default" size="sm" onClick={onCreateNew}>
+                  Register your first knowledge source →
+                </Button>
+              </div>
+            ) : (
+              <Combobox
+                options={sourceOptions}
+                value={knowledgeSource}
+                onValueChange={setKnowledgeSource}
+                placeholder="Select knowledge source..."
+                searchPlaceholder="Search knowledge sources..."
+                emptyText="No knowledge sources found."
+                linkTo={linkRoutes.knowledgeSource}
+              />
+            )}
+            {sourceOptions.length > 0 && onCreateNew && (
+              <Button
+                type="button"
+                variant="link"
+                className="h-auto p-0 text-xs"
+                onClick={onCreateNew}
+              >
+                Don't see it? Create a new knowledge source →
+              </Button>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/frontend/src/components/agent/KnowledgeTab.tsx
+++ b/frontend/src/components/agent/KnowledgeTab.tsx
@@ -7,7 +7,6 @@ import type { AgentKnowledgeRow } from '@/types/agent.types';
 interface KnowledgeTabProps {
   knowledgeSources: AgentKnowledgeRow[];
   onAdd: () => void;
-  onCreate?: () => void;
   onEdit: (index: number) => void;
   onRemove: (index: number) => void;
 }
@@ -15,7 +14,6 @@ interface KnowledgeTabProps {
 export function KnowledgeTab({
   knowledgeSources,
   onAdd,
-  onCreate,
   onEdit,
   onRemove,
 }: KnowledgeTabProps) {
@@ -31,12 +29,6 @@ export function KnowledgeTab({
             <CardDescription>Knowledge sources this agent can access</CardDescription>
           </div>
           <div className="flex items-center gap-2">
-            {onCreate && (
-              <Button size="sm" variant="secondary" onClick={onCreate} type="button">
-                <Plus className="w-4 h-4 mr-2" />
-                Create Knowledge
-              </Button>
-            )}
             <Button size="sm" variant="outline" onClick={onAdd} type="button">
               <Plus className="w-4 h-4 mr-2" />
               Add Knowledge
@@ -52,12 +44,6 @@ export function KnowledgeTab({
               Link knowledge sources so this agent can retrieve relevant context from indexed documents.
             </p>
             <div className="flex items-center justify-center gap-2 flex-wrap">
-              {onCreate && (
-                <Button onClick={onCreate} variant="secondary" type="button">
-                  <Plus className="w-4 h-4 mr-2" />
-                  Create Knowledge
-                </Button>
-              )}
               <Button onClick={onAdd} variant="outline" type="button">
                 <Plus className="w-4 h-4 mr-2" />
                 Add Knowledge

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -2104,7 +2104,6 @@ export function AgentFormPage() {
                 <KnowledgeTab
                   knowledgeSources={knowledgeSources}
                   onAdd={handleAddKnowledge}
-                  onCreate={handleCreateKnowledge}
                   onEdit={handleEditKnowledge}
                   onRemove={handleRemoveKnowledge}
                 />
@@ -2181,6 +2180,7 @@ export function AgentFormPage() {
         onOpenChange={setShowKnowledgeModal}
         onSave={handleSaveKnowledge}
         initialData={editingKnowledgeIndex !== null ? knowledgeSources[editingKnowledgeIndex] : null}
+        onCreateNew={handleCreateKnowledge}
       />
 
       {/* Tool Form Modal (for editing) */}


### PR DESCRIPTION
## Summary
- Replace the separate "Create Knowledge" / "Add Knowledge" buttons on the agent Knowledge tab with a single "Add Knowledge" entry point
- The modal now offers registering a new knowledge source inline when none exist, or a "Create a new knowledge source" link alongside the existing-source picker, matching the MCP server connect flow

## Test plan
- [ ] Open an agent's Knowledge tab, confirm only one "Add Knowledge" button shows
- [ ] With no knowledge sources registered, confirm the modal shows the "Register your first knowledge source" CTA
- [ ] With sources registered, confirm the picker works and the "Create a new knowledge source" link navigates to the create flow