### PR TITLE
feat(home): add 'Get started with AI' empty-state card with quick-start paths

### DIFF
--- a/frontend/src/pages/AiProvidersPage.tsx
+++ b/frontend/src/pages/AiProvidersPage.tsx
@@ -222,6 +222,13 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
   };
 
   useEffect(() => {
+    const starterParam = searchParams.get('starter');
+    if (starterParam && (starterParam === 'openrouter' || starterParam === 'google')) {
+      setStarterPath(starterParam as StarterPath);
+      setSearchParams({}, { replace: true });
+      return;
+    }
+
     const configureId = searchParams.get('configure');
     if (!configureId || configureHandledRef.current) {
       return;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
-import { ChevronRight } from 'lucide-react';
+import { ArrowRight, ChevronRight, Sparkles } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { Button } from '../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { useNavigate } from 'react-router-dom';
 import {
   ActiveAgentsTab,
@@ -13,7 +14,8 @@ import {
 import { getAgentRunsCountLast7Days, getAgentRunsForMetrics, getRecentAgentRuns, getDashboardActiveFlows, type AgentRunMetricsDoc, type DashboardFlowItem } from '../services/dashboardApi';
 import type { AgentRunDoc } from '../services/agentRunApi';
 import { getAgents } from '../services/agentApi';
-import type { AgentDoc } from '../types/agent.types';
+import { getProviders } from '../services/providerApi';
+import type { AgentDoc, AIProvider } from '../types/agent.types';
 
 interface DashboardMetrics {
   totalRuns: number;
@@ -140,12 +142,14 @@ function HomePage() {
   const [agentRunsLoading, setAgentRunsLoading] = useState(true);
   const [flows, setFlows] = useState<DashboardFlowItem[]>([]);
   const [flowsLoading, setFlowsLoading] = useState(true);
+  const [providers, setProviders] = useState<AIProvider[]>([]);
+  const [providersLoading, setProvidersLoading] = useState(true);
 
   useEffect(() => {
     async function fetchAllData() {
       try {
         // Fetch all data in parallel
-        const [totalRuns, runsData, agentsData, recentRuns, flowsData] = await Promise.all([
+        const [totalRuns, runsData, agentsData, recentRuns, flowsData, providersData] = await Promise.all([
           getAgentRunsCountLast7Days(),
           getAgentRunsForMetrics(),
           getAgents({
@@ -155,6 +159,7 @@ function HomePage() {
           }),
           getRecentAgentRuns(),
           getDashboardActiveFlows(10),
+          getProviders(),
         ]);
 
         // Process metrics
@@ -179,6 +184,10 @@ function HomePage() {
 
         // Set flows
         setFlows(flowsData);
+
+        // Set providers
+        const providerList = Array.isArray(providersData) ? providersData : providersData.items;
+        setProviders(providerList);
       } catch (error) {
         console.error('Error fetching dashboard data:', error);
       } finally {
@@ -186,6 +195,7 @@ function HomePage() {
         setAgentsLoading(false);
         setAgentRunsLoading(false);
         setFlowsLoading(false);
+        setProvidersLoading(false);
       }
     }
 
@@ -250,6 +260,56 @@ function HomePage() {
             />
           ))}
         </GaugeRow>
+
+        {/* Empty state card when no AI providers exist */}
+        {!providersLoading && providers.length === 0 && (
+          <Card className="border-primary/20 bg-primary/5">
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-primary">
+                  <Sparkles className="h-4 w-4" />
+                  <CardTitle className="text-base">Get started with AI</CardTitle>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="font-body text-[13px] font-medium text-steel hover:text-ink hover:bg-transparent pr-1"
+                  onClick={() => navigate('/providers')}
+                >
+                  View all providers
+                  <ChevronRight className="w-[11px] h-[11px] ml-0.5" strokeWidth={2} />
+                </Button>
+              </div>
+              <CardDescription>
+                No AI providers connected yet. Connect a provider to start creating and running agents. Pick a quick-start path or add custom provider credentials.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3 sm:flex-row">
+              <Button
+                variant="outline"
+                className="h-auto flex-1 justify-between whitespace-normal text-left p-4"
+                onClick={() => navigate('/providers?starter=openrouter')}
+              >
+                <div>
+                  <span className="block font-medium">Try OpenRouter Free</span>
+                  <span className="mt-1 block text-xs text-muted-foreground">openrouter/free · Zero-cost router for free models</span>
+                </div>
+                <ArrowRight className="ml-3 h-4 w-4 shrink-0" />
+              </Button>
+              <Button
+                variant="outline"
+                className="h-auto flex-1 justify-between whitespace-normal text-left p-4"
+                onClick={() => navigate('/providers?starter=google')}
+              >
+                <div>
+                  <span className="block font-medium">Try Gemini with Google AI Studio</span>
+                  <span className="mt-1 block text-xs text-muted-foreground">gemini-2.5-flash · Fast and intelligent model</span>
+                </div>
+                <ArrowRight className="ml-3 h-4 w-4 shrink-0" />
+              </Button>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Tabbed Interface */}
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-0">


### PR DESCRIPTION
Closes refinement gap A. Adds an empty-state card to HomePage.tsx when no AI providers exist, with quick-start paths to OpenRouter free and Google Gemini, linking to /providers.