### PR TITLE
feat(execution): seed default execution profiles in install.py

### DIFF
--- a/huf/huf/doctype/execution_profile/test_execution_profile.py
+++ b/huf/huf/doctype/execution_profile/test_execution_profile.py
@@ -15,7 +15,7 @@ import unittest
 import frappe
 
 from huf.ai.tools.code_execution import _make_broker_handler
-from huf.install import create_huf_roles
+from huf.install import create_default_execution_profiles, create_huf_roles
 
 
 class TestExecutionProfile(unittest.TestCase):
@@ -199,6 +199,20 @@ class TestExecutionProfile(unittest.TestCase):
 		self.assertTrue(ok, payload)
 		self.assertEqual(payload.get("name"), todo.name)
 
+	def test_default_execution_profiles_creation(self):
+		create_default_execution_profiles()
+		expected = {
+			"Restricted": "Ask Every Time",
+			"Trusted": "Auto Approve",
+			"Blocked": "Never Allow",
+		}
+		for name, approval_mode in expected.items():
+			self.assertTrue(frappe.db.exists("Execution Profile", name))
+			doc = frappe.get_doc("Execution Profile", name)
+			self.assertEqual(doc.approval_mode, approval_mode)
+			self.assertEqual(doc.is_builtin, 1)
+
 
 if __name__ == "__main__":
 	unittest.main()
+

--- a/huf/install.py
+++ b/huf/install.py
@@ -75,6 +75,7 @@ def after_install():
     create_flow_tools()
     create_memory_tools()
     create_default_memory_policies()
+    create_default_execution_profiles()
     register_integration_services()
     sync_tool_types()
     sync_default_tool_categories()
@@ -128,6 +129,7 @@ def after_migrate():
 		create_flow_tools()
 		create_memory_tools()
 		create_default_memory_policies()
+		create_default_execution_profiles()
 		register_integration_services()
 		sync_tool_types()
 		sync_default_tool_categories()
@@ -1191,3 +1193,53 @@ def create_default_memory_policies():
 			)
 
 	frappe.db.commit()
+
+
+def create_default_execution_profiles():
+	"""Create default Execution Profile presets shipped with Huf."""
+	profiles = [
+		{
+			"profile_name": "Restricted",
+			"approval_mode": "Ask Every Time",
+			"is_builtin": 1,
+			"filesystem_policy": "Scratch Only",
+			"max_wall_time_s": 30,
+			"max_cpu_seconds": 30,
+			"max_memory_mb": 256,
+			"max_output_bytes": 1048576,
+		},
+		{
+			"profile_name": "Trusted",
+			"approval_mode": "Auto Approve",
+			"is_builtin": 1,
+			"filesystem_policy": "Scratch Only",
+			"max_wall_time_s": 60,
+			"max_cpu_seconds": 60,
+			"max_memory_mb": 512,
+			"max_output_bytes": 2097152,
+		},
+		{
+			"profile_name": "Blocked",
+			"approval_mode": "Never Allow",
+			"is_builtin": 1,
+			"filesystem_policy": "None",
+			"max_wall_time_s": 5,
+			"max_cpu_seconds": 5,
+			"max_memory_mb": 128,
+			"max_output_bytes": 65536,
+		},
+	]
+	for profile in profiles:
+		if frappe.db.exists("Execution Profile", profile["profile_name"]):
+			continue
+		try:
+			doc = frappe.new_doc("Execution Profile")
+			doc.update(profile)
+			doc.insert(ignore_permissions=True)
+		except Exception as e:
+			logger.warning(
+				f"Failed to create default execution profile {profile['profile_name']}: {e!s}"
+			)
+
+	frappe.db.commit()
+


### PR DESCRIPTION
Closes refinement gap B. Adds 2-3 built-in profiles in huf/install.py (Restricted, Trusted, Blocked) and wires into after_install/after_migrate.