### PR TITLE
feat(ui): add subtle experimental badges to new features

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ const KnowledgeSourceFormPageWrapper = lazy(() => import('./pages/KnowledgeSourc
 const MemoryPage = lazy(() => import('./pages/MemoryPage'));
 const SkillsPage = lazy(() => import('./pages/SkillsPage'));
 const SkillFormPageWrapper = lazy(() => import('./pages/SkillFormPageWrapper'));
+const SshPage = lazy(() => import('./pages/SshPage'));
 const PreviewViewPage = lazy(() => import('./pages/PreviewViewPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
 const DataRecordViewWrapper = lazy(() => import('./pages/DataRecordViewWrapper'));
@@ -483,6 +484,18 @@ function AppShell() {
                 <Suspense fallback={<PageLoader />}>
                   <SkillFormPageWrapper />
                 </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/ssh"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout>
+                  <Suspense fallback={<PageLoader />}>
+                    <SshPage />
+                  </Suspense>
+                </UnifiedLayout>
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/agent/AdvancedTab.tsx
+++ b/frontend/src/components/agent/AdvancedTab.tsx
@@ -15,6 +15,7 @@ import { Plus } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import type { AgentPromptOption } from './PromptTemplateSection';
 import { FormSettingsSection } from './FormSettingsSection';
+import { ExperimentalBadge } from '@/components/common/ExperimentalBadge';
 import {
 	MODEL_MODALITY_IMAGE,
 	MODEL_MODALITY_TTS,
@@ -897,7 +898,12 @@ This includes whether each tool call is completed and its corresponding result.`
 			</FormSettingsSection>
 
 			<FormSettingsSection
-				title="SSH Execution"
+				title={
+					<div className="flex items-center gap-2.5">
+						<span>SSH Execution</span>
+						<ExperimentalBadge size="sm" />
+					</div>
+				}
 				description="Allow this agent to run one-shot SSH commands against explicitly allowlisted SSH Connection records. Interactive PTY sessions are deferred."
 			>
 				<div className="grid gap-6 sm:grid-cols-2">

--- a/frontend/src/components/agent/FormSettingsSection.tsx
+++ b/frontend/src/components/agent/FormSettingsSection.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 
 interface FormSettingsSectionProps {
-	title: string;
+	title: React.ReactNode;
 	description: string;
 	children: React.ReactNode;
 	className?: string;

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -48,6 +48,7 @@ const useNavItems = [
     url: "/apps",
     icon: LayoutGrid,
     capability: "agent.use",
+    badge: "Experimental",
   },
 ]
 
@@ -69,6 +70,7 @@ const buildNavItems = [
     url: "/flows",
     icon: Workflow,
     capability: "flows.use",
+    badge: "Experimental",
   },
 ]
 
@@ -100,12 +102,14 @@ const knowNavItems = [
     url: "/memory",
     icon: Brain,
     capability: "agent.use",
+    badge: "Experimental",
   },
   {
     title: "Skills",
     url: "/skills",
     icon: Sparkles,
     capability: "agent.use",
+    badge: "Experimental",
   },
 ]
 
@@ -121,6 +125,14 @@ const operateNavItems = [
 		url: "/executions",
 		icon: Zap,
 		capability: "agent.use",
+		badge: "Experimental",
+	},
+	{
+		title: "SSH",
+		url: "/ssh",
+		icon: Terminal,
+		capability: "agent.use",
+		badge: "Experimental",
 	},
 	{
 		title: "Artifacts",

--- a/frontend/src/components/common/ExperimentalBadge.tsx
+++ b/frontend/src/components/common/ExperimentalBadge.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/lib/utils';
+
+interface ExperimentalBadgeProps {
+  className?: string;
+  size?: 'sm' | 'md';
+}
+
+export function ExperimentalBadge({ className, size = 'md' }: ExperimentalBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-none border border-amber-500/40 bg-amber-500/10 font-mono uppercase tracking-wider text-amber-600 dark:text-amber-400 select-none font-medium',
+        size === 'sm' ? 'px-1.5 py-0.5 text-[9px]' : 'px-2 py-0.5 text-[10.5px]',
+        className
+      )}
+    >
+      Experimental
+    </span>
+  );
+}
+
+export default ExperimentalBadge;

--- a/frontend/src/components/dashboard/layouts/PageLayout.tsx
+++ b/frontend/src/components/dashboard/layouts/PageLayout.tsx
@@ -2,7 +2,8 @@ import { ReactNode, RefObject } from 'react';
 import { cn } from '@/lib/utils';
 
 interface PageLayoutProps {
-  title?: string;
+  title?: ReactNode;
+  badge?: ReactNode;
   subtitle?: string;
   filters?: ReactNode;
   toolbar?: ReactNode;
@@ -13,6 +14,7 @@ interface PageLayoutProps {
 
 export function PageLayout({
   title,
+  badge,
   subtitle,
   filters,
   toolbar,
@@ -27,9 +29,12 @@ export function PageLayout({
           <div className="flex items-end justify-between gap-4">
             <div className="space-y-1">
               {title && (
-                <h1 className="font-display font-bold text-[36px] uppercase text-ink leading-tight">
-                  {title}
-                </h1>
+                <div className="flex items-center gap-3">
+                  <h1 className="font-display font-bold text-[36px] uppercase text-ink leading-tight">
+                    {title}
+                  </h1>
+                  {badge}
+                </div>
               )}
               {subtitle && (
                 <p className="font-body text-steel text-[14.5px]">{subtitle}</p>

--- a/frontend/src/components/nav-main.tsx
+++ b/frontend/src/components/nav-main.tsx
@@ -19,6 +19,7 @@ export function NavMain({
     url: string
     icon?: LucideIcon
     count?: number
+    badge?: string
   }[]
   label?: string
 }) {
@@ -45,10 +46,19 @@ export function NavMain({
                 <NavLink to={item.url} onClick={handleNavClick} className="flex w-full items-center gap-2">
                   {item.icon && <item.icon strokeWidth={1.6} />}
                   <span className="font-body text-[13.5px]">{item.title}</span>
-                  {typeof item.count === 'number' && (
-                    <span className="ml-auto font-mono text-[10.5px] text-steel-soft group-data-[collapsible=icon]:hidden">
-                      {item.count}
-                    </span>
+                  {(item.badge || typeof item.count === 'number') && (
+                    <div className="ml-auto flex items-center gap-1.5 group-data-[collapsible=icon]:hidden">
+                      {item.badge && (
+                        <span className="font-mono text-[8.5px] uppercase tracking-wider px-1.5 py-0.5 rounded-none border border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400 font-medium">
+                          {item.badge}
+                        </span>
+                      )}
+                      {typeof item.count === 'number' && (
+                        <span className="font-mono text-[10.5px] text-steel-soft">
+                          {item.count}
+                        </span>
+                      )}
+                    </div>
                   )}
                 </NavLink>
               </SidebarMenuButton>

--- a/frontend/src/layouts/UnifiedHeader.tsx
+++ b/frontend/src/layouts/UnifiedHeader.tsx
@@ -42,6 +42,10 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
     if (path.startsWith('/users')) return 'Users';
     if (path.startsWith('/roles')) return 'Roles';
     if (path.startsWith('/models')) return 'Models';
+    if (path.startsWith('/apps')) return 'Apps';
+    if (path.startsWith('/memory')) return 'Memory';
+    if (path.startsWith('/skills')) return 'Skills';
+    if (path.startsWith('/ssh')) return 'SSH Execution';
     return 'HufAI';
   };
 

--- a/frontend/src/pages/AppsPage.tsx
+++ b/frontend/src/pages/AppsPage.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { PageLayout, GridView, BaseCard, FilterBar } from '../components/dashboard';
+import { ExperimentalBadge } from '../components/common/ExperimentalBadge';
 import { CardHeader, CardTitle, CardDescription, CardAction } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -345,6 +346,7 @@ function AppsPage() {
 	return (
 		<PageLayout
 			title="Apps"
+			badge={<ExperimentalBadge />}
 			subtitle="Launch applications built on HUF"
 			toolbar={
 				<Button

--- a/frontend/src/pages/Executions.tsx
+++ b/frontend/src/pages/Executions.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowUpDown, Loader2 } from 'lucide-react';
 import { FilterBar, PageLayout, LoadMoreButton } from '@/components/dashboard';
+import { ExperimentalBadge } from '@/components/common/ExperimentalBadge';
 import { StatusDot, type StatusDotVariant } from '@/components/dashboard/ledger/LedgerSection';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
@@ -298,6 +299,7 @@ export default function Executions() {
   return (
     <PageLayout
       title="Executions"
+      badge={<ExperimentalBadge />}
       subtitle="Inspect agent runs and their results."
       filters={
         <FilterBar

--- a/frontend/src/pages/FlowListPage.tsx
+++ b/frontend/src/pages/FlowListPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { Calendar, Play, Activity, Settings } from 'lucide-react';
 import { PageLayout, FilterBar, GridView, ItemCard } from '../components/dashboard';
+import { ExperimentalBadge } from '../components/common/ExperimentalBadge';
 import { usePageData } from '../hooks/dashboard/usePageData';
 
 import { FlowMetadata } from '../types/flow.types';
@@ -126,6 +127,7 @@ function FlowListPage() {
   return (
     <PageLayout
       title="Flows"
+      badge={<ExperimentalBadge />}
       subtitle="Design and orchestrate agent workflows."
       filters={
         <FilterBar

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -1,15 +1,15 @@
+import { PageLayout } from "@/components/dashboard";
+import { ExperimentalBadge } from "@/components/common/ExperimentalBadge";
 import { MemoryList } from "@/components/memory/MemoryList";
 
 export default function MemoryPage() {
   return (
-    <div className="p-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold tracking-tight">Memory</h1>
-        <p className="text-muted-foreground mt-2">
-          Facts, preferences, and context your AI agents have learned from conversations.
-        </p>
-      </div>
+    <PageLayout
+      title="Memory"
+      badge={<ExperimentalBadge />}
+      subtitle="Facts, preferences, and context your AI agents have learned from conversations."
+    >
       <MemoryList />
-    </div>
+    </PageLayout>
   );
 }

--- a/frontend/src/pages/SkillsPage.tsx
+++ b/frontend/src/pages/SkillsPage.tsx
@@ -3,6 +3,7 @@ import { Sparkles, Settings } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
+import { ExperimentalBadge } from '../components/common/ExperimentalBadge';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getSkills } from '../services/skillApi';
 import { formatTimeAgo } from '../utils/time';
@@ -90,6 +91,8 @@ export function SkillsPage() {
 
   return (
     <PageLayout
+      title="Skills"
+      badge={<ExperimentalBadge />}
       subtitle="Manage reusable skill bundles for your agents"
       filters={
         <FilterBar

--- a/frontend/src/pages/SshPage.tsx
+++ b/frontend/src/pages/SshPage.tsx
@@ -1,0 +1,61 @@
+import { PageLayout } from '@/components/dashboard';
+import { ExperimentalBadge } from '@/components/common/ExperimentalBadge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ExternalLink, Terminal, Shield, Cpu } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+export function SshPage() {
+  const navigate = useNavigate();
+
+  return (
+    <PageLayout
+      title="SSH Execution"
+      badge={<ExperimentalBadge />}
+      subtitle="Allow agents to run one-shot remote SSH commands against allowlisted target servers."
+    >
+      <div className="max-w-4xl space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Terminal className="w-5 h-5" />
+              SSH Remote Execution
+            </CardTitle>
+            <CardDescription>
+              Execute single remote commands on managed hosts via host-key verification and Redis-backed state locks.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-steel">
+            <div className="rounded-none border border-line bg-paper-deep p-4 space-y-2">
+              <h3 className="font-semibold text-ink flex items-center gap-2">
+                <Shield className="w-4 h-4 text-steel" />
+                Connection Allowlisting & Credentials
+              </h3>
+              <p>
+                SSH credentials, host-key verification, and connection profiles are configured in Frappe Desk using the <strong>SSH Connection</strong> DocType.
+              </p>
+            </div>
+
+            <div className="rounded-none border border-line bg-paper-deep p-4 space-y-2">
+              <h3 className="font-semibold text-ink flex items-center gap-2">
+                <Cpu className="w-4 h-4 text-steel" />
+                Agent Configuration
+              </h3>
+              <p>
+                Enable SSH execution for specific agents under their <strong>Advanced Settings</strong> tab. Select allowlisted connections and execution profiles.
+              </p>
+              <div className="pt-2">
+                <Button variant="outline" size="sm" onClick={() => navigate('/agents')} className="gap-2">
+                  Configure Agents
+                  <ExternalLink className="w-3.5 h-3.5" />
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </PageLayout>
+  );
+}
+
+export default SshPage;


### PR DESCRIPTION
Closes refinement gap E. Adds subtle Experimental chips/badges to Skills, Flows, Executions, SSH, Memory, Apps in app-sidebar.tsx and on their page headers.