### PR TITLE
feat(chat): add chat context and cache analytics links

### DIFF
--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+import { BarChart2 } from 'lucide-react';
 import { cn } from "@/lib/utils";
 import ChatAvatar from "./ChatAvatar";
 import { getInitials } from "@/utils/getInitials";
@@ -71,6 +73,9 @@ export function ChatMessage({
     const timestamp = message.versions[0]?.id ? undefined : undefined; // We'll get timestamp from message if available
     const timeDisplay = timestamp ? formatTime(timestamp) : '';
     const userInitials = user?.full_name ? getInitials(user.full_name) : 'You';
+    const runId = message.agentRunId || (
+        message.key.startsWith('AR-') || message.key.startsWith('run-') ? message.key : undefined
+    );
 
     const showLoading = isAssistant && !message.error && (
         ((status === 'submitted' || status === 'streaming') && isEmpty) ||
@@ -113,6 +118,19 @@ export function ChatMessage({
                     )}
                     {message.injected_memories && message.injected_memories.length > 0 && (
                         <MemoryContextBadge memoryRecordNames={message.injected_memories} />
+                    )}
+                    {!isUser && runId && (
+                        <Link
+                            to={`/executions/${runId}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors ml-auto group/analytics"
+                            title="View context & cache metrics (/executions/:runId)"
+                            aria-label="View context & cache metrics"
+                        >
+                            <BarChart2 className="h-3.5 w-3.5 text-muted-foreground group-hover/analytics:text-foreground" />
+                            <span className="text-[11px] font-medium">Cache metrics</span>
+                        </Link>
                     )}
                 </div>
                 
@@ -250,6 +268,7 @@ export function ChatMessage({
                                     content={message.versions[0].content}
                                     onFeedback={onFeedback}
                                     agentMessageId={message.versions[0].id}
+                                    agentRunId={runId}
                                 />
                             </div>
                         )}

--- a/frontend/src/components/chat/MessageActions.tsx
+++ b/frontend/src/components/chat/MessageActions.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { ThumbsDown, ThumbsUp } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { BarChart2, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -17,10 +18,11 @@ import { CopyButton } from './CopyButton';
 interface MessageActionsProps {
   content: string;
   agentMessageId?: string;
+  agentRunId?: string;
   onFeedback: (feedback: 'Thumbs Up' | 'Thumbs Down', options?: { agentMessageId?: string; comments?: string }) => void;
 }
 
-export function MessageActions({ content, agentMessageId, onFeedback }: MessageActionsProps) {
+export function MessageActions({ content, agentMessageId, agentRunId, onFeedback }: MessageActionsProps) {
   const [commentDialogOpen, setCommentDialogOpen] = useState(false);
   const [commentText, setCommentText] = useState('');
 
@@ -56,6 +58,25 @@ export function MessageActions({ content, agentMessageId, onFeedback }: MessageA
         >
           <ThumbsDown className="h-4 w-4" />
         </Button>
+        {agentRunId && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            asChild
+            aria-label="View context & cache metrics"
+          >
+            <Link
+              to={`/executions/${agentRunId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="View context & cache metrics"
+            >
+              <BarChart2 className="h-4 w-4" />
+            </Link>
+          </Button>
+        )}
       </div>
 
       <AlertDialog open={commentDialogOpen} onOpenChange={setCommentDialogOpen}>

--- a/frontend/src/components/chat/chatMessageList.mappers.test.ts
+++ b/frontend/src/components/chat/chatMessageList.mappers.test.ts
@@ -219,6 +219,22 @@ describe('mergeConversationItemsIntoMessages', () => {
     expect(next[0].key).toBe('UM-1');
     expect(next.find((msg) => msg.key === 'pending-user-AR-1')).toBeUndefined();
   });
+
+  it('maps agentRunId onto assistant messages from conversation items', () => {
+    const conversationItems: ChatMessage[] = [
+      {
+        id: 'AM-1',
+        conversation: 'CONV-1',
+        content: 'assistant response',
+        isAgent: true,
+        agentRun: 'AR-100',
+      },
+    ];
+    const next = mergeConversationItemsIntoMessages([], conversationItems, false);
+    expect(next).toHaveLength(1);
+    expect(next[0].from).toBe('assistant');
+    expect(next[0].agentRunId).toBe('AR-100');
+  });
 });
 
 describe('applyPolledRunStatus', () => {

--- a/frontend/src/components/chat/chatMessageList.mappers.ts
+++ b/frontend/src/components/chat/chatMessageList.mappers.ts
@@ -122,6 +122,7 @@ export function upsertToolUpdateFromSocket(prev: MessageType[], rawEvent: ToolCa
   const newMessage: MessageType = {
     key: event.agent_run_id,
     from: 'assistant',
+    agentRunId: event.agent_run_id,
     kind: isImageGeneration ? 'Image' : undefined,
     versions: [
       {
@@ -178,13 +179,18 @@ export function upsertAgentRunStatusFromSocket(
     key: event.agent_run_id,
     from: 'assistant',
     runStatus: event.status,
+    agentRunId: event.agent_run_id,
     versions: [{ id: event.agent_run_id, content }],
   });
 
   if (event.status === 'Queued' || event.status === 'Started') {
     if (runIndex >= 0) {
       const updated = [...prev];
-      updated[runIndex] = { ...updated[runIndex], runStatus: event.status };
+      updated[runIndex] = {
+        ...updated[runIndex],
+        runStatus: event.status,
+        agentRunId: event.agent_run_id || updated[runIndex].agentRunId,
+      };
       return updated;
     }
     return [...prev, createPendingMessage()];
@@ -203,6 +209,7 @@ export function upsertAgentRunStatusFromSocket(
     updated[runIndex] = {
       ...existing,
       runStatus: 'Success',
+      agentRunId: event.agent_run_id || existing.agentRunId,
       versions: existing.versions.map((v, i) =>
         i === 0 ? { ...v, content: event.response ?? v.content } : v
       ),
@@ -226,6 +233,7 @@ export function upsertAgentRunStatusFromSocket(
           key: event.agent_run_id,
           from: 'assistant',
           runStatus: 'Failed',
+          agentRunId: event.agent_run_id,
           error: event.error,
           versions: [{ id: event.agent_run_id, content: event.error ?? '' }],
         },
@@ -235,6 +243,7 @@ export function upsertAgentRunStatusFromSocket(
     updated[targetIndex] = {
       ...updated[targetIndex],
       runStatus: 'Failed',
+      agentRunId: event.agent_run_id || updated[targetIndex].agentRunId,
       error: event.error,
     };
     return updated;
@@ -261,6 +270,7 @@ export function upsertAgentMessageFromSocket(prev: MessageType[], event: NewAgen
       generatedAudio: event.generated_audio,
       generatedVideo: event.generated_video,
       injected_memories: event.injected_memories,
+      agentRunId: event.agent_run_id || existing.agentRunId,
       runStatus: undefined,
       error: undefined,
       versions: existing.versions.map((v) =>
@@ -280,6 +290,7 @@ export function upsertAgentMessageFromSocket(prev: MessageType[], event: NewAgen
     generatedAudio: event.generated_audio,
     generatedVideo: event.generated_video,
     injected_memories: event.injected_memories,
+    agentRunId: event.agent_run_id,
     versions: [
       {
         id: event.message_id,
@@ -459,6 +470,7 @@ export function mergePendingRunsIntoMessages(
         key: run.name,
         from: 'assistant',
         runStatus: status,
+        agentRunId: run.name,
         versions: [{ id: run.name, content: '' }],
       });
       existingKeys.add(run.name);
@@ -496,7 +508,7 @@ export function mergeConversationItemsIntoMessages(
     const baseMessage: MessageType = {
       key: item.id,
       from: item.isAgent ? 'assistant' : 'user',
-      agentRunId: !item.isAgent ? item.agentRun : undefined,
+      agentRunId: item.agentRun,
       kind: item.kind,
       generatedImage: item.generatedImage,
       generatedAudio: item.generatedAudio,


### PR DESCRIPTION
Closes refinement gap F. Adds link from chat run/message UI to /executions/:runId so users can inspect cache metrics without leaving the conversation.