### PR TITLE
fix(permissions): gate agent/mcp/data-table UI on capabilities, fix missing role permissions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -249,7 +249,7 @@ function AppShell() {
           <Route
             path="/data/new"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute requiredCapability="data.tables.manage">
                 <DataTableBuilderWrapper />
               </ProtectedRoute>
             }
@@ -275,7 +275,7 @@ function AppShell() {
           <Route
             path="/data/:tableId/edit"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute requiredCapability="data.tables.manage">
                 <DataTableBuilderWrapper />
               </ProtectedRoute>
             }

--- a/frontend/src/components/AgentsHeaderActions.tsx
+++ b/frontend/src/components/AgentsHeaderActions.tsx
@@ -1,13 +1,19 @@
 import { Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from './ui/button';
+import { usePermissions } from '../contexts/PermissionsContext';
 
 export function AgentsHeaderActions() {
   const navigate = useNavigate();
+  const { hasCapability } = usePermissions();
 
   const handleNewAgent = () => {
     navigate('/agents/new');
   };
+
+  if (!hasCapability('agent.create')) {
+    return null;
+  }
 
   return (
     <Button variant="display" onClick={handleNewAgent} size="sm">

--- a/frontend/src/components/DataHeaderActions.tsx
+++ b/frontend/src/components/DataHeaderActions.tsx
@@ -1,9 +1,15 @@
 import { Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from './ui/button';
+import { usePermissions } from '../contexts/PermissionsContext';
 
 export function DataHeaderActions() {
 	const navigate = useNavigate();
+	const { hasCapability } = usePermissions();
+
+	if (!hasCapability('data.tables.manage')) {
+		return null;
+	}
 
 	return (
 		<Button variant="display" onClick={() => navigate('/data/new')} size="sm">

--- a/frontend/src/components/McpHeaderActions.tsx
+++ b/frontend/src/components/McpHeaderActions.tsx
@@ -1,13 +1,19 @@
 import { Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from './ui/button';
+import { usePermissions } from '../contexts/PermissionsContext';
 
 export function McpHeaderActions() {
   const navigate = useNavigate();
+  const { hasCapability } = usePermissions();
 
   const handleNewMcp = () => {
     navigate('/mcp/new');
   };
+
+  if (!hasCapability('system.mcp.manage')) {
+    return null;
+  }
 
   return (
     <Button variant="display" onClick={handleNewMcp} size="sm">

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,21 +1,60 @@
 import { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AlertCircle, Home } from 'lucide-react';
 import { useUser } from '@/contexts/UserContext';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { AuthenticatingPage } from './AuthenticatingPage';
+import { Button } from './ui/button';
 
 interface ProtectedRouteProps {
   children: ReactNode;
+  /**
+   * Capability required to view this route (see huf/permissions.py
+   * CAPABILITIES). Only pass this for routes that are exclusively a
+   * creation/management action distinct from viewing (e.g. "/data/new") —
+   * a route shared between viewing and editing (e.g. "/agents/:id") must
+   * gate edit/save affordances inside the page instead, since a viewer
+   * without edit rights should still be able to open the page.
+   */
+  requiredCapability?: string;
 }
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
+export function ProtectedRoute({ children, requiredCapability }: ProtectedRouteProps) {
   const { isLoading, isAuthenticated } = useUser();
+  const { isLoading: permissionsLoading, hasCapability } = usePermissions();
+  const navigate = useNavigate();
 
-  if (isLoading) {
+  if (isLoading || (requiredCapability && permissionsLoading)) {
     return <AuthenticatingPage />;
   }
 
   if (!isAuthenticated) {
     // The redirect will be handled by UserContext
     return null;
+  }
+
+  if (requiredCapability && !hasCapability(requiredCapability)) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center space-y-6 max-w-md">
+          <div className="flex justify-center">
+            <div className="w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center">
+              <AlertCircle className="w-8 h-8 text-destructive" />
+            </div>
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold mb-2">No permission</h2>
+            <p className="text-steel">
+              You don't have permission to access this page. Contact a Huf Admin or Manager for access.
+            </p>
+          </div>
+          <Button onClick={() => navigate('/')}>
+            <Home className="w-4 h-4 mr-2" />
+            Back to Dashboard
+          </Button>
+        </div>
+      </div>
+    );
   }
 
   return <>{children}</>;

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -164,12 +164,17 @@ export function AgentFormPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const isNew = id === 'new';
-  const { hufRole } = usePermissions();
+  const { hufRole, hasCapability } = usePermissions();
   // Backend maps Administrator / System Manager to the "Huf Admin" Huf role.
   const isAdmin = hufRole === 'Huf Admin';
   const [isSystemAgent, setIsSystemAgent] = useState(false);
   // System agents are locked: protected fields are read-only for non-admins.
   const systemLocked = isSystemAgent && !isAdmin;
+  // Mirrors the backend's Agent.has_permission() capability checks (agent.py) —
+  // without this, the UI would offer Save/Duplicate/Delete to users the server
+  // will reject, so they only find out after submitting.
+  const canManageAgent = hasCapability(isNew ? 'agent.create' : 'agent.edit');
+  const permissionLocked = !canManageAgent;
   const [pendingSelectedPrompt, setPendingSelectedPrompt] = useState<string | null>(null);
   const [pendingSelectedPromptField, setPendingSelectedPromptField] = useState<string | null>(null);
   const [pendingScrollToPromptField, setPendingScrollToPromptField] = useState(false);
@@ -492,7 +497,7 @@ export function AgentFormPage() {
     });
   }, [agentSkills, initialAgentSkills, isNew]);
 
-  const showSaveButton = isNew || isDirty || toolsChanged || disabledChanged || mcpServersChanged || knowledgeChanged || skillsChanged;
+  const showSaveButton = canManageAgent && (isNew || isDirty || toolsChanged || disabledChanged || mcpServersChanged || knowledgeChanged || skillsChanged);
 
   // Deliberately excludes `isNew` (unlike showSaveButton) - a blank new-agent form
   // has nothing to lose, so it shouldn't block navigation until the user actually changes something.
@@ -556,26 +561,49 @@ export function AgentFormPage() {
     }
   }, [showTriggerModal, docTypes.length, loadingDocTypes]);
 
-  // Load providers, models, and tool types on mount
+  // Load providers, models, and tool types on mount.
+  // Each lookup is independent (a Huf User, for instance, can't list Users/Roles)
+  // so a denied/failed one must not blank fields that loaded fine — hence
+  // allSettled with a per-field fallback instead of Promise.all + one catch.
   useEffect(() => {
-    Promise.all([
+    const labels = ['providers', 'models', 'tool types', 'skill options', 'users', 'roles'];
+    Promise.allSettled([
       getProviders(),
       getModels(),
       getToolTypes(),
       getSkillOptions(),
       db.getDocList('User', { fields: ['name'], limit: 1000, orderBy: { field: 'name', order: 'asc' } }),
       db.getDocList('Role', { fields: ['name'], limit: 1000, orderBy: { field: 'name', order: 'asc' } }),
-    ]).then(([providersData, modelsData, toolTypesData, skillOptionsData, usersData, rolesData]) => {
-      setProviders(providersData as AIProvider[]);
-      const modelsArray: AIModel[] = Array.isArray(modelsData) ? modelsData : (modelsData as { items: AIModel[] }).items;
-      setAllModels(modelsArray);
-      setToolTypes(toolTypesData);
-      setSkillOptions((skillOptionsData || []) as { value: string; label: string; subtitle?: string }[]);
-      setUsers(usersData as Array<{ name: string }>);
-      setRoles((rolesData as Array<{ name: string }>).filter((role) => role.name !== 'Guest'));
-    }).catch((error) => {
-      console.error('Error loading providers/models/types:', error);
-      toast.error('Failed to load providers and models');
+    ]).then(([providersResult, modelsResult, toolTypesResult, skillOptionsResult, usersResult, rolesResult]) => {
+      const results = [providersResult, modelsResult, toolTypesResult, skillOptionsResult, usersResult, rolesResult];
+      results.forEach((result, i) => {
+        if (result.status === 'rejected') {
+          console.error(`Error loading ${labels[i]}:`, result.reason);
+          toast.error(`Failed to load ${labels[i]}`);
+        }
+      });
+
+      if (providersResult.status === 'fulfilled') {
+        setProviders(providersResult.value as AIProvider[]);
+      }
+      if (modelsResult.status === 'fulfilled') {
+        const modelsArray: AIModel[] = Array.isArray(modelsResult.value)
+          ? modelsResult.value
+          : (modelsResult.value as { items: AIModel[] }).items;
+        setAllModels(modelsArray);
+      }
+      if (toolTypesResult.status === 'fulfilled') {
+        setToolTypes(toolTypesResult.value);
+      }
+      if (skillOptionsResult.status === 'fulfilled') {
+        setSkillOptions((skillOptionsResult.value || []) as { value: string; label: string; subtitle?: string }[]);
+      }
+      if (usersResult.status === 'fulfilled') {
+        setUsers(usersResult.value as Array<{ name: string }>);
+      }
+      if (rolesResult.status === 'fulfilled') {
+        setRoles((rolesResult.value as Array<{ name: string }>).filter((role) => role.name !== 'Guest'));
+      }
     });
   }, []);
 
@@ -2001,6 +2029,17 @@ export function AgentFormPage() {
             </AlertDescription>
           </Alert>
         )}
+        {permissionLocked && (
+          <Alert>
+            <Lock className="h-4 w-4" />
+            <AlertTitle>Read-only</AlertTitle>
+            <AlertDescription>
+              {isNew
+                ? "You don't have permission to create agents. Contact a Huf Admin or Manager for access."
+                : "You don't have permission to edit this agent. You can use it, but changes won't be saved."}
+            </AlertDescription>
+          </Alert>
+        )}
         <AgentHeader
           form={form}
           watchDisabled={watchDisabled}
@@ -2009,7 +2048,7 @@ export function AgentFormPage() {
           activeTriggerCount={activeTriggerCount}
           isNew={isNew}
           isSystem={isSystemAgent}
-          locked={systemLocked}
+          locked={systemLocked || permissionLocked}
           showSaveButton={showSaveButton}
           saving={saving}
           runningTest={runningTest}

--- a/frontend/src/pages/McpDetailsPage.tsx
+++ b/frontend/src/pages/McpDetailsPage.tsx
@@ -15,6 +15,8 @@ import {
   AlertDialogTitle,
 } from '../components/ui/alert-dialog';
 import { toast } from 'sonner';
+import { Lock } from 'lucide-react';
+import { Alert, AlertTitle, AlertDescription } from '../components/ui/alert';
 import {
   getMCPServer,
   createMCPServer,
@@ -34,6 +36,7 @@ import { mcpFormSchema, type MCPFormValues, type MCPTool } from '../components/m
 import { createFormSubmitHandler, type TabFieldMapping } from '../utils/formValidation';
 import { useSaveShortcut } from '../hooks/useSaveShortcut';
 import { linkMcpServerToAgent } from '../services/agentApi';
+import { usePermissions } from '../contexts/PermissionsContext';
 
 export function McpDetailsPage() {
   const { mcpId } = useParams<{ mcpId: string }>();
@@ -41,6 +44,11 @@ export function McpDetailsPage() {
   const [searchParams] = useSearchParams();
   const fromAgent = searchParams.get('agent');
   const isNew = mcpId === 'new';
+  const { hasCapability } = usePermissions();
+  // Mirrors the backend capability requirement for MCP Server mutations
+  // (system.mcp.manage) - without this the save button and delete action
+  // were offered to any logged-in user regardless of capability.
+  const canManageMcp = hasCapability('system.mcp.manage');
 
   // Tab configuration - single source of truth
   const tabConfig = {
@@ -409,7 +417,7 @@ export function McpDetailsPage() {
   );
 
   // Show save button for new servers or when form is dirty
-  const showSaveButton = isNew || isDirty;
+  const showSaveButton = canManageMcp && (isNew || isDirty);
 
   useSaveShortcut({
     onSave: handleFormSubmit,
@@ -628,6 +636,17 @@ export function McpDetailsPage() {
   return (
     <div className="h-full overflow-auto">
       <div className="p-6 space-y-6 max-w-6xl mx-auto">
+        {!canManageMcp && (
+          <Alert>
+            <Lock className="h-4 w-4" />
+            <AlertTitle>Read-only</AlertTitle>
+            <AlertDescription>
+              {isNew
+                ? "You don't have permission to create MCP servers. Contact a Huf Admin for access."
+                : "You don't have permission to edit this MCP server. Changes won't be saved."}
+            </AlertDescription>
+          </Alert>
+        )}
         <MCPHeader
           form={form}
           watchEnabled={watchEnabled}
@@ -641,7 +660,7 @@ export function McpDetailsPage() {
           onCancel={fromAgent ? handleCancel : undefined}
           onSync={handleSyncTools}
           onTestConnection={handleTestConnection}
-          onDelete={!isNew && !fromAgent ? () => setDeleteDialogOpen(true) : undefined}
+          onDelete={!isNew && !fromAgent && canManageMcp ? () => setDeleteDialogOpen(true) : undefined}
         />
 
         <Form {...form}>
@@ -664,7 +683,7 @@ export function McpDetailsPage() {
                   form={form}
                   serverName={mcpId || ''}
                   isNew={isNew}
-                  onSaveAndConnect={isNew ? handleSaveAndConnect : undefined}
+                  onSaveAndConnect={isNew && canManageMcp ? handleSaveAndConnect : undefined}
                 />
               </TabsContent>
 

--- a/huf/huf/doctype/agent_prompt/agent_prompt.json
+++ b/huf/huf/doctype/agent_prompt/agent_prompt.json
@@ -203,6 +203,22 @@
    "role": "Huf Manager",
    "select": 1,
    "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Huf User",
+   "select": 1,
+   "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Huf Viewer",
+   "select": 1,
+   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/huf/huf/doctype/agent_summary_prompt/agent_summary_prompt.json
+++ b/huf/huf/doctype/agent_summary_prompt/agent_summary_prompt.json
@@ -183,6 +183,22 @@
    "role": "Huf Manager",
    "select": 1,
    "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Huf User",
+   "select": 1,
+   "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Huf Viewer",
+   "select": 1,
+   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/huf/huf/doctype/huf_data_table/huf_data_table.json
+++ b/huf/huf/doctype/huf_data_table/huf_data_table.json
@@ -115,6 +115,30 @@
 			"role": "System Manager",
 			"share": 1,
 			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"print": 1,
+			"read": 1,
+			"role": "Huf Manager",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"email": 1,
+			"print": 1,
+			"read": 1,
+			"role": "Huf User",
+			"share": 1
+		},
+		{
+			"email": 1,
+			"print": 1,
+			"read": 1,
+			"role": "Huf Viewer",
+			"share": 1
 		}
 	],
 	"row_format": "Dynamic",


### PR DESCRIPTION
## Summary

Consolidation merges tightened backend capability checks (`agent.create`/`edit`/`delete`, `system.mcp.manage`, `data.tables.manage`) without updating the frontend to match, so non-admin users saw actions they could not actually use and only found out after submitting. Found and fixed while verifying a separate regression report live on a fresh `develop`-branch bench.

**UI capability gating**
- `AgentsHeaderActions`, `McpHeaderActions`, `DataHeaderActions`: hide New Agent / New MCP Server / Create Table without the matching capability
- `AgentFormPage`, `McpDetailsPage`: gate Save/Duplicate/Delete on `agent.create`/`edit` / `system.mcp.manage`, including a second independent "Save & Connect" action inside the MCP Connection tab that bypassed the header-level check entirely. Both now show a clear read-only permission alert instead of a silent post-submit failure.
- `ProtectedRoute`: new optional `requiredCapability` prop (backward compatible), applied to `/data/new` and `/data/:tableId/edit` — routes genuinely distinct from viewing, unlike `/agents/:id` or `/mcp/:mcpId` which share view and edit and must stay gated in-page instead.

**Backend permission fixes** (found while reproducing the above live)
- `Huf Data Table`, `Agent Prompt`, `Agent Summary Prompt` DocTypes only listed System Manager (and sometimes Huf Manager) in their permissions — Huf User/Viewer had no role permission at all, so pages any regular user should be able to view (the Tables list, prompt template pickers in the agent form) 403'd outright, independent of the create-gating issue above. Added read access for Huf User/Viewer, and full CRUD for Huf Manager on Huf Data Table to match its `data.tables.manage` capability.

**Hydration resilience**
- `AgentFormPage`: providers/models/toolTypes/skillOptions/users/roles now load via `Promise.allSettled` instead of `Promise.all`, so one denied lookup (e.g. Roles, which Huf User cannot list) surfaces its own specific toast instead of blanking fields that loaded fine.

## Test plan
Verified live on a fresh `develop`-branch bench with real restricted test accounts (Huf User, Huf Manager), each change confirmed independently against the database/API rather than trusting the UI alone:
- [x] Agent/MCP/Data Table create buttons correctly hidden for a Huf User
- [x] `/data/new` and `/data/:tableId/edit` route-block with a clear permission page for a Huf User
- [x] Huf Data Table list, Agent Prompt/Summary Prompt pickers now load for a Huf User instead of throwing Insufficient Permission
- [x] Agent form loads Provider/Model/tools/skills/users correctly for a Huf User even though the Roles lookup is (correctly) denied
- [x] MCP server New/Save/Connect/Delete correctly disabled for a Huf User

**Checked and intentionally not changed:**
- SSH Connection permissions look stale in the DocType JSON (Huf Manager shows `write:0`) but `SSHConnection.has_permission()` already grants access based on the `ssh_connection.manage` capability — verified a Huf Manager can actually create one; the static list is cosmetic only.
- Agent save sending its full payload on every edit: tested directly via a minimal-payload PUT against an agent with 12 existing tool rows — Frappe merges partial updates correctly and does not wipe child tables, so this is not a reproducible bug worth a refactor.
- Dashboard/rename-on-save all-or-nothing patterns reviewed, no failing case reproduced with current data.