### PR TITLE
fix(hub): anchor slash-command menu to the input box

### DIFF
--- a/frontend/src/components/hub/HubConversationView.tsx
+++ b/frontend/src/components/hub/HubConversationView.tsx
@@ -176,8 +176,7 @@ export function HubConversationView({
 
       {/* Input */}
       <div className="px-4 py-4 border-t border-line bg-panel">
-        <div className="max-w-2xl mx-auto relative">
-          <SlashCommandMenu isVisible={showSlashMenu} query={slashQuery} onSelect={onSlashSelect} />
+        <div className="max-w-2xl mx-auto">
           <div className={`relative bg-panel border transition-all rounded-sm ${
             showSlashMenu ? 'border-signal' : 'border-line shadow-sm hover:border-steel-soft focus-within:border-signal'
           }`}>
@@ -196,6 +195,7 @@ export function HubConversationView({
                 <Send className="w-4 h-4" />
               </button>
             </div>
+            <SlashCommandMenu isVisible={showSlashMenu} query={slashQuery} onSelect={onSlashSelect} placement="above" />
           </div>
         </div>
       </div>

--- a/frontend/src/components/hub/SlashCommandMenu.tsx
+++ b/frontend/src/components/hub/SlashCommandMenu.tsx
@@ -23,9 +23,11 @@ interface SlashCommandMenuProps {
   isVisible: boolean;
   query: string;
   onSelect: (command: string) => void;
+  /** Which side of the input to open on. 'below' suits a centred composer, 'above' a bottom-docked one. */
+  placement?: 'below' | 'above';
 }
 
-export function SlashCommandMenu({ isVisible, query, onSelect }: SlashCommandMenuProps) {
+export function SlashCommandMenu({ isVisible, query, onSelect, placement = 'below' }: SlashCommandMenuProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
@@ -55,11 +57,13 @@ export function SlashCommandMenu({ isVisible, query, onSelect }: SlashCommandMen
   return (
     <AnimatePresence>
       <motion.div
-        initial={{ opacity: 0, y: -4 }}
+        initial={{ opacity: 0, y: placement === 'below' ? -4 : 4 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.1 }}
-        className="absolute left-0 right-0 top-full mt-1 bg-panel rounded border border-line shadow-xl overflow-hidden z-50"
+        className={`absolute left-0 right-0 bg-panel rounded border border-line shadow-xl overflow-hidden z-50 ${
+          placement === 'below' ? 'top-full mt-1' : 'bottom-full mb-1'
+        }`}
         style={{ maxHeight: 320 }}
       >
         <div className="overflow-y-auto py-1" style={{ maxHeight: 280 }}>

--- a/frontend/src/pages/HubSimplePage.tsx
+++ b/frontend/src/pages/HubSimplePage.tsx
@@ -336,8 +336,7 @@ export default function HubSimplePage() {
                 </div>
 
                 {/* Input composer */}
-                <div className="w-full max-w-2xl relative">
-                  <SlashCommandMenu isVisible={showSlashMenu} query={slashQuery} onSelect={handleSlashSelect} />
+                <div className="w-full max-w-2xl">
                   <div className={`relative bg-panel border transition-all duration-200 ${
                     isInputFocused ? 'rounded-xl border-signal' : 'rounded-xl border-line hover:border-steel-soft'
                   }`}>
@@ -358,13 +357,14 @@ export default function HubSimplePage() {
                     >
                       <Send className="w-3.5 h-3.5" />
                     </button>
+                    <SlashCommandMenu isVisible={showSlashMenu} query={slashQuery} onSelect={handleSlashSelect} />
                   </div>
 
                   {/* Starter prompts */}
                   <motion.div
                     animate={{ opacity: showSlashMenu ? 0 : 1 }}
                     transition={{ duration: 0.15 }}
-                    className="mt-5 grid grid-cols-2 gap-2"
+                    className={`mt-5 grid grid-cols-2 gap-2 ${showSlashMenu ? 'pointer-events-none' : ''}`}
                   >
                     {(STARTER_PROMPTS[role] || STARTER_PROMPTS.admin).map((prompt, i) => (
                       <motion.button


### PR DESCRIPTION
## Problem

Typing `/` in the Hub composer opened the suggestion list ~112px below the input, floating in dead space instead of hanging off the field.

## Root cause

`SlashCommandMenu` positions itself `absolute … top-full mt-1`, so it hangs off the bottom of its nearest *positioned ancestor*. In `HubSimplePage` that ancestor was the outer composer wrapper (`div.w-full.max-w-2xl.relative`), which contains the input **and** the starter-prompt grid. When the menu opens the grid animates to `opacity: 0` but still occupies layout, so `top-full` measured from the bottom of *input + invisible grid*.

`HubConversationView` had the mirror-image problem: its composer is docked to the bottom of the viewport, so `top-full` put the menu below the fold.

## Fix

- `SlashCommandMenu` gains a `placement?: 'below' | 'above'` prop (`top-full` vs `bottom-full`), default `below`.
- Both call sites move the menu *inside* the input box element (already `relative`), so it anchors to the field rather than the whole composer.
- `HubConversationView` passes `placement="above"`.
- The faded-out starter prompts get `pointer-events-none` while the menu is open — they were still clickable through it.

## Verification

Measured geometry in-browser, rendering the real `HubSimplePage` / `HubConversationView`:

| | before | after |
|---|---|---|
| Home composer: gap input→menu | 112px | 1px |
| Conversation composer | menu below `y=863` in an `879px` viewport (off-screen) | menu spans `484–804`, flush above the input |

`yarn typecheck` passes. Also built and deployed to a local bench for manual checking.