### PR TITLE
feat(docker): add Docker local and remote execution tool for agents

### DIFF
--- a/huf/ai/tests/test_docker_execution.py
+++ b/huf/ai/tests/test_docker_execution.py
@@ -20,6 +20,12 @@ class TestDockerExecution(unittest.TestCase):
         mock_run.return_value = {"success": True, "output": "", "stderr": ""}
         handle_action(action="list_containers", timeout_seconds=9999)
         self.assertEqual(mock_run.call_args.kwargs["timeout"], 300)
+
+    @patch("huf.ai.tools.docker_execution.subprocess.run", side_effect=FileNotFoundError)
+    def test_missing_docker_cli_is_actionable(self, mock_run):
+        result = handle_action(action="list_containers")
+        self.assertFalse(result["success"])
+        self.assertIn("Docker CLI is not installed", result["error"])
     
     @patch("huf.ai.tools.docker_execution._run_subprocess")
     def test_list_containers_local(self, mock_run):

--- a/huf/ai/tests/test_docker_execution.py
+++ b/huf/ai/tests/test_docker_execution.py
@@ -82,5 +82,22 @@ class TestDockerExecution(unittest.TestCase):
         self.assertEqual(mock_run.call_args[0][0][:4], ["docker", "-H", "tcp://10.0.0.1:2376", "--tlsverify"])
         self.assertEqual(mock_run.call_args[0][0][-2:], ["inspect", "app"])
 
+    @patch("huf.ai.tools.docker_execution._run_subprocess")
+    def test_tls_certificate_flags(self, mock_run):
+        mock_run.return_value = {"success": True, "output": "", "stderr": ""}
+        handle_action(
+            action="list_containers",
+            connection_string="tcp://docker.example:2376",
+            tls_verify=True,
+            tls_ca_cert="/certs/ca.pem",
+            tls_cert="/certs/cert.pem",
+            tls_key="/certs/key.pem",
+        )
+        command = mock_run.call_args[0][0]
+        self.assertEqual(
+            command[:10],
+            ["docker", "-H", "tcp://docker.example:2376", "--tlsverify", "--tlscacert", "/certs/ca.pem", "--tlscert", "/certs/cert.pem", "--tlskey", "/certs/key.pem"],
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/huf/ai/tests/test_docker_execution.py
+++ b/huf/ai/tests/test_docker_execution.py
@@ -8,6 +8,18 @@ from unittest.mock import patch
 from huf.ai.tools.docker_execution import handle_action
 
 class TestDockerExecution(unittest.TestCase):
+
+    def test_destructive_actions_require_confirmation(self):
+        res = handle_action(action="remove_container", container="web")
+        self.assertFalse(res["success"])
+        self.assertIn("confirm_destructive", res["error"])
+
+    @patch("huf.ai.tools.docker_execution._run_subprocess")
+    def test_required_fields_and_timeout_are_bounded(self, mock_run):
+        self.assertFalse(handle_action(action="exec_container", container="web")["success"])
+        mock_run.return_value = {"success": True, "output": "", "stderr": ""}
+        handle_action(action="list_containers", timeout_seconds=9999)
+        self.assertEqual(mock_run.call_args.kwargs["timeout"], 300)
     
     @patch("huf.ai.tools.docker_execution._run_subprocess")
     def test_list_containers_local(self, mock_run):
@@ -30,11 +42,15 @@ class TestDockerExecution(unittest.TestCase):
             action="run_container", 
             image="nginx", 
             name="web", 
-            ports="80:80, 443:443"
+            ports="80:80, 443:443",
+            environment="APP_ENV=test,PORT=80",
+            volumes="/tmp/data:/data:ro",
+            network="bridge",
+            command="nginx -g 'daemon off;'",
         )
         
         mock_run.assert_called_once()
-        expected_cmd = ["docker", "run", "-d", "--name", "web", "-p", "80:80", "-p", "443:443", "nginx"]
+        expected_cmd = ["docker", "run", "-d", "--name", "web", "-p", "80:80", "-p", "443:443", "-e", "APP_ENV=test", "-e", "PORT=80", "-v", "/tmp/data:/data:ro", "--network", "bridge", "nginx", "nginx", "-g", "daemon off;"]
         self.assertEqual(mock_run.call_args[0][0], expected_cmd)
 
     @patch("huf.ai.tools.docker_execution._run_via_ssh_connection")
@@ -44,10 +60,11 @@ class TestDockerExecution(unittest.TestCase):
         res = handle_action(
             action="stop_container",
             container="web",
-            ssh_connection="Test Server"
+            ssh_connection="Test Server",
+            confirm_destructive=True,
         )
         
-        mock_ssh.assert_called_once_with("Test Server", "docker stop web")
+        mock_ssh.assert_called_once_with("Test Server", "docker stop web", timeout=60)
         self.assertTrue(res["success"])
 
     @patch("huf.ai.tools.docker_execution._run_subprocess")

--- a/huf/ai/tests/test_docker_execution.py
+++ b/huf/ai/tests/test_docker_execution.py
@@ -1,0 +1,69 @@
+import sys
+from unittest.mock import MagicMock
+sys.modules['frappe'] = MagicMock()
+
+import unittest
+from unittest.mock import patch
+
+from huf.ai.tools.docker_execution import handle_action
+
+class TestDockerExecution(unittest.TestCase):
+    
+    @patch("huf.ai.tools.docker_execution._run_subprocess")
+    def test_list_containers_local(self, mock_run):
+        mock_run.return_value = {"success": True, "output": '{"ID":"123","Names":"test_container"}\n'}
+        
+        res = handle_action(action="list_containers")
+        
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args[0][0], ["docker", "ps", "-a", "--format", "{{json .}}"])
+        
+        self.assertTrue(res["success"])
+        self.assertEqual(len(res["output"]), 1)
+        self.assertEqual(res["output"][0]["ID"], "123")
+        
+    @patch("huf.ai.tools.docker_execution._run_subprocess")
+    def test_run_container(self, mock_run):
+        mock_run.return_value = {"success": True, "output": "hash1234"}
+        
+        res = handle_action(
+            action="run_container", 
+            image="nginx", 
+            name="web", 
+            ports="80:80, 443:443"
+        )
+        
+        mock_run.assert_called_once()
+        expected_cmd = ["docker", "run", "-d", "--name", "web", "-p", "80:80", "-p", "443:443", "nginx"]
+        self.assertEqual(mock_run.call_args[0][0], expected_cmd)
+
+    @patch("huf.ai.tools.docker_execution._run_via_ssh_connection")
+    def test_ssh_connection(self, mock_ssh):
+        mock_ssh.return_value = {"success": True, "output": "some output"}
+        
+        res = handle_action(
+            action="stop_container",
+            container="web",
+            ssh_connection="Test Server"
+        )
+        
+        mock_ssh.assert_called_once_with("Test Server", "docker stop web")
+        self.assertTrue(res["success"])
+
+    @patch("huf.ai.tools.docker_execution._run_subprocess")
+    def test_context_and_tls(self, mock_run):
+        mock_run.return_value = {"success": True, "output": ""}
+        
+        handle_action(
+            action="inspect_container",
+            container="app",
+            connection_string="tcp://10.0.0.1:2376",
+            tls_verify=True
+        )
+        
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args[0][0][:4], ["docker", "-H", "tcp://10.0.0.1:2376", "--tlsverify"])
+        self.assertEqual(mock_run.call_args[0][0][-2:], ["inspect", "app"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -55,6 +55,7 @@ class PermissionAwareToolRegistry:
                     cls._can_use_tool(tool_doc, user)
                     and cls._allows_code_execution(tool_doc, agent_doc, user)
                     and cls._allows_ssh_execution(tool_doc, agent_doc, user)
+                    and cls._allows_docker_execution(tool_doc, user)
                 ):
                     all_tools.append(tool_doc)
 
@@ -168,6 +169,18 @@ class PermissionAwareToolRegistry:
             if enabled:
                 return True
         return False
+
+    @classmethod
+    def _allows_docker_execution(cls, tool_doc, user: str) -> bool:
+        """Require the dedicated capability before exposing Docker control."""
+        function_path = (getattr(tool_doc, "function_path", None) or "").strip()
+        tool_name = (getattr(tool_doc, "tool_name", None) or "").strip()
+        if function_path != "huf.ai.tools.docker_execution.handle_action" and tool_name != "docker_execution":
+            return True
+
+        from huf.permissions import has_capability
+
+        return has_capability(user, "docker.run")
 
 def _get_app_modified_time(app_name):
     """

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1230,9 +1230,132 @@ BUILDER_TOOLS = [
 ]
 
 
+DOCKER_TOOLS = [
+	{
+		"tool_name": "docker_execution",
+		"description": "Manage Docker containers and images. Actions: list_containers, list_images, inspect_container, logs, stop_container, start_container, restart_container, remove_container, pull_image, run_container, exec_container. Supports local socket, context_name, connection_string (e.g. ssh://, tcp://), or a Frappe ssh_connection name.",
+		"function_path": "huf.ai.tools.docker_execution.handle_action",
+		"category": "Developer Tools",
+		"parameters": [
+			_action("list_containers|list_images|inspect_container|logs|stop_container|start_container|restart_container|remove_container|pull_image|run_container|exec_container"),
+			_p("container", description="Container name or ID"),
+			_p("image", description="Image name"),
+			_p("command", description="Command to execute (for exec_container)"),
+			_p("name", description="Name for new container (for run_container)"),
+			_p("ports", description="Ports to publish (comma separated, e.g. '80:80')"),
+			_p("tail", type="integer", description="Number of log lines to tail"),
+			_p("connection_string", description="Docker daemon URL (unix://, ssh://, tcp://)"),
+			_p("context_name", description="Docker context name"),
+			_p("ssh_connection", description="Frappe SSH Connection doctype name to use for remote docker execution"),
+			_p("tls_verify", type="boolean", description="Enable TLS verification for TCP connections"),
+		],
+	},
+]
+
+
 # ---------------------------------------------------------------------------
 # Master list
 # ---------------------------------------------------------------------------
+
+FRAPPE_CLOUD_TOOLS = [
+	{
+		"tool_name": "fc_list_benches",
+		"description": "List Frappe Cloud benches.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_list_benches",
+		"category": "Frappe Cloud",
+		"parameters": [],
+	},
+	{
+		"tool_name": "fc_list_sites",
+		"description": "List Frappe Cloud sites.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_list_sites",
+		"category": "Frappe Cloud",
+		"parameters": [],
+	},
+	{
+		"tool_name": "fc_create_site",
+		"description": "Create a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_create_site",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("bench", required=True, description="Bench name"),
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+	{
+		"tool_name": "fc_drop_site",
+		"description": "Drop a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_drop_site",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+	{
+		"tool_name": "fc_backup_site",
+		"description": "Backup a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_backup_site",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+	{
+		"tool_name": "fc_download_backup",
+		"description": "Download backup of a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_download_backup",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+	{
+		"tool_name": "fc_migrate_site",
+		"description": "Migrate a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_migrate_site",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+	{
+		"tool_name": "fc_clear_cache",
+		"description": "Clear cache of a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_clear_cache",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+	{
+		"tool_name": "fc_update_site",
+		"description": "Update a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_update_site",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+	{
+		"tool_name": "fc_clone_site",
+		"description": "Clone a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_clone_site",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("source_site", required=True, description="Source site name"),
+			_p("bench", required=True, description="Bench name to clone into"),
+		],
+	},
+	{
+		"tool_name": "fc_get_admin_login_link",
+		"description": "Get admin login link for a Frappe Cloud site.",
+		"function_path": "huf.ai.tools.frappe_cloud.handle_fc_get_admin_login_link",
+		"category": "Frappe Cloud",
+		"parameters": [
+			_p("site_name", required=True, description="Site name"),
+		],
+	},
+]
 
 ALL_INTEGRATION_TOOLS = (
 	RECIPIENT_TOOLS
@@ -1259,4 +1382,6 @@ ALL_INTEGRATION_TOOLS = (
 	+ SERP_YOUTUBE_TOOLS
 	+ BUILDER_TOOLS
 	+ SSH_TOOLS
+	+ DOCKER_TOOLS
+	+ FRAPPE_CLOUD_TOOLS
 )

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1233,7 +1233,7 @@ BUILDER_TOOLS = [
 DOCKER_TOOLS = [
 	{
 		"tool_name": "docker_execution",
-		"description": "Manage Docker containers and images. Actions: list_containers, list_images, inspect_container, logs, stop_container, start_container, restart_container, remove_container, pull_image, run_container, exec_container. Supports local socket, context_name, connection_string (e.g. ssh://, tcp://), or a Frappe ssh_connection name.",
+		"description": "Manage Docker containers and images with bounded, explicit operations. Destructive actions require confirm_destructive=true. Supports local socket, Docker contexts, TLS endpoints, or a Frappe SSH Connection.",
 		"function_path": "huf.ai.tools.docker_execution.handle_action",
 		"category": "Developer Tools",
 		"parameters": [
@@ -1243,6 +1243,16 @@ DOCKER_TOOLS = [
 			_p("command", description="Command to execute (for exec_container)"),
 			_p("name", description="Name for new container (for run_container)"),
 			_p("ports", description="Ports to publish (comma separated, e.g. '80:80')"),
+			_p("environment", description="Environment variables (comma separated KEY=VALUE entries)"),
+			_p("volumes", description="Bind mounts (comma separated host:container[:mode] entries)"),
+			_p("network", description="Docker network for a new container"),
+			_p("workdir", description="Working directory for run or exec"),
+			_p("user", description="User for a new container"),
+			_p("memory", description="Memory limit for a new container, e.g. 512m"),
+			_p("cpus", type="number", description="CPU limit for a new container"),
+			_p("auto_remove", type="boolean", description="Remove the container when it exits"),
+			_p("confirm_destructive", type="boolean", description="Required confirmation for stop, restart, or remove"),
+			_p("timeout_seconds", type="integer", description="Maximum operation time, capped at 300 seconds"),
 			_p("tail", type="integer", description="Number of log lines to tail"),
 			_p("connection_string", description="Docker daemon URL (unix://, ssh://, tcp://)"),
 			_p("context_name", description="Docker context name"),

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1258,6 +1258,9 @@ DOCKER_TOOLS = [
 			_p("context_name", description="Docker context name"),
 			_p("ssh_connection", description="Frappe SSH Connection doctype name to use for remote docker execution"),
 			_p("tls_verify", type="boolean", description="Enable TLS verification for TCP connections"),
+			_p("tls_ca_cert", description="Path to the CA certificate for a TLS Docker daemon"),
+			_p("tls_cert", description="Path to the client certificate for a TLS Docker daemon"),
+			_p("tls_key", description="Path to the client key for a TLS Docker daemon"),
 		],
 	},
 ]

--- a/huf/ai/tools/docker_execution.py
+++ b/huf/ai/tools/docker_execution.py
@@ -67,6 +67,13 @@ def _run_subprocess(cmd, timeout=DEFAULT_TIMEOUT_SECONDS):
             "output": e.stdout or "",
             "stderr": e.stderr or "",
         }
+    except FileNotFoundError:
+        return {
+            "success": False,
+            "error": "Docker CLI is not installed or not on PATH. Install docker-cli in the Huf runtime or use ssh_connection for a remote Docker host.",
+            "output": "",
+            "stderr": "",
+        }
 
 def _run_via_ssh_connection(ssh_connection, cmd_str, timeout=DEFAULT_TIMEOUT_SECONDS):
     from huf.ai.tools.ssh_execution import _connect_transport, _run_exec_over_transport

--- a/huf/ai/tools/docker_execution.py
+++ b/huf/ai/tools/docker_execution.py
@@ -1,8 +1,24 @@
 import json
 import subprocess
-import os
 import shlex
 import frappe
+
+DESTRUCTIVE_ACTIONS = {"stop_container", "restart_container", "remove_container"}
+DEFAULT_TIMEOUT_SECONDS = 60
+MAX_TIMEOUT_SECONDS = 300
+
+
+def _require_value(kwargs, name):
+    value = kwargs.get(name)
+    if value is None or value == "":
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def _split_csv(value):
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
 
 def _build_docker_base_cmd(kwargs):
     cmd = ["docker"]
@@ -18,20 +34,40 @@ def _build_docker_base_cmd(kwargs):
             
     return cmd
 
-def _run_subprocess(cmd):
+def _run_subprocess(cmd, timeout=DEFAULT_TIMEOUT_SECONDS):
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        return {"success": True, "output": result.stdout}
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, check=True, timeout=timeout
+        )
+        return {
+            "success": True,
+            "output": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.returncode,
+        }
     except subprocess.CalledProcessError as e:
-        return {"success": False, "error": e.stderr}
+        return {
+            "success": False,
+            "error": e.stderr or e.stdout or str(e),
+            "output": e.stdout,
+            "stderr": e.stderr,
+            "exit_code": e.returncode,
+        }
+    except subprocess.TimeoutExpired as e:
+        return {
+            "success": False,
+            "error": f"Docker command timed out after {timeout} seconds",
+            "output": e.stdout or "",
+            "stderr": e.stderr or "",
+        }
 
-def _run_via_ssh_connection(ssh_connection, cmd_str):
+def _run_via_ssh_connection(ssh_connection, cmd_str, timeout=DEFAULT_TIMEOUT_SECONDS):
     from huf.ai.tools.ssh_execution import _connect_transport, _run_exec_over_transport
     
     doc = frappe.get_doc("SSH Connection", ssh_connection)
     limits = {
         "connection_timeout_seconds": 10,
-        "execution_timeout_seconds": 60,
+        "execution_timeout_seconds": min(timeout, MAX_TIMEOUT_SECONDS),
         "stdout_max_bytes": 1048576,
         "stderr_max_bytes": 1048576,
         "combined_output_max_bytes": 2097152,
@@ -40,67 +76,113 @@ def _run_via_ssh_connection(ssh_connection, cmd_str):
     try:
         res = _run_exec_over_transport(transport, cmd_str, limits, fingerprint, host_key_type)
         if res.exit_code == 0:
-            return {"success": True, "output": res.stdout}
+            return {"success": True, "output": res.stdout, "stderr": res.stderr, "exit_code": 0}
         else:
-            return {"success": False, "error": res.stderr or f"Exit code {res.exit_code}"}
+            return {
+                "success": False,
+                "error": res.stderr or f"Exit code {res.exit_code}",
+                "output": res.stdout,
+                "stderr": res.stderr,
+                "exit_code": res.exit_code,
+            }
     finally:
         transport.close()
 
 def handle_action(**kwargs):
     action = kwargs.get("action")
     ssh_connection = kwargs.get("ssh_connection")
-    
-    args = []
-    if action == "list_containers":
-        args = ["ps", "-a", "--format", "{{json .}}"]
-    elif action == "list_images":
-        args = ["images", "--format", "{{json .}}"]
-    elif action == "inspect_container":
-        container = kwargs.get("container")
-        args = ["inspect", container]
-    elif action == "logs":
-        container = kwargs.get("container")
-        args = ["logs", container]
-        if kwargs.get("tail"):
-            args.extend(["--tail", str(kwargs.get("tail"))])
-    elif action == "stop_container":
-        container = kwargs.get("container")
-        args = ["stop", container]
-    elif action == "start_container":
-        container = kwargs.get("container")
-        args = ["start", container]
-    elif action == "restart_container":
-        container = kwargs.get("container")
-        args = ["restart", container]
-    elif action == "remove_container":
-        container = kwargs.get("container")
-        args = ["rm", "-f", container]
-    elif action == "pull_image":
-        image = kwargs.get("image")
-        args = ["pull", image]
-    elif action == "run_container":
-        image = kwargs.get("image")
-        args = ["run", "-d"]
-        if kwargs.get("name"):
-            args.extend(["--name", kwargs.get("name")])
-        if kwargs.get("ports"):
-            for p in kwargs.get("ports").split(","):
-                args.extend(["-p", p.strip()])
-        args.append(image)
-    elif action == "exec_container":
-        container = kwargs.get("container")
-        cmd_arg = kwargs.get("command")
-        args = ["exec", container] + shlex.split(cmd_arg)
-    else:
+    if action in DESTRUCTIVE_ACTIONS and not kwargs.get("confirm_destructive"):
+        return {
+            "success": False,
+            "error": f"{action} requires confirm_destructive=true",
+        }
+
+    try:
+        args = []
+        if action == "list_containers":
+            args = ["ps", "-a", "--format", "{{json .}}"]
+        elif action == "list_images":
+            args = ["images", "--format", "{{json .}}"]
+        elif action == "inspect_container":
+            args = ["inspect", _require_value(kwargs, "container")]
+        elif action == "logs":
+            args = ["logs", _require_value(kwargs, "container")]
+            if kwargs.get("tail") is not None:
+                args.extend(["--tail", str(kwargs["tail"])])
+        elif action == "stop_container":
+            args = ["stop", _require_value(kwargs, "container")]
+        elif action == "start_container":
+            args = ["start", _require_value(kwargs, "container")]
+        elif action == "restart_container":
+            args = ["restart", _require_value(kwargs, "container")]
+        elif action == "remove_container":
+            args = ["rm", "-f", _require_value(kwargs, "container")]
+        elif action == "pull_image":
+            args = ["pull", _require_value(kwargs, "image")]
+        elif action == "run_container":
+            args = ["run", "-d"]
+            if kwargs.get("name"):
+                args.extend(["--name", kwargs["name"]])
+            if kwargs.get("ports"):
+                for port in _split_csv(kwargs["ports"]):
+                    args.extend(["-p", port])
+            if kwargs.get("environment"):
+                for env in _split_csv(kwargs["environment"]):
+                    args.extend(["-e", env])
+            if kwargs.get("volumes"):
+                for volume in _split_csv(kwargs["volumes"]):
+                    args.extend(["-v", volume])
+            if kwargs.get("network"):
+                args.extend(["--network", kwargs["network"]])
+            if kwargs.get("workdir"):
+                args.extend(["--workdir", kwargs["workdir"]])
+            if kwargs.get("user"):
+                args.extend(["--user", kwargs["user"]])
+            if kwargs.get("memory"):
+                args.extend(["--memory", kwargs["memory"]])
+            if kwargs.get("cpus"):
+                args.extend(["--cpus", str(kwargs["cpus"])])
+            if kwargs.get("auto_remove"):
+                args.append("--rm")
+            args.append(_require_value(kwargs, "image"))
+            if kwargs.get("command"):
+                args.extend(shlex.split(kwargs["command"]))
+        elif action == "exec_container":
+            args = ["exec"]
+            if kwargs.get("workdir"):
+                args.extend(["--workdir", kwargs["workdir"]])
+            args.extend([_require_value(kwargs, "container")])
+            args.extend(shlex.split(_require_value(kwargs, "command")))
+        else:
+            return {"success": False, "error": f"Unknown action: {action}"}
+    except (TypeError, ValueError) as exc:
+        return {"success": False, "error": str(exc)}
+
+    try:
+        timeout = min(
+            max(int(kwargs.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)), 1),
+            MAX_TIMEOUT_SECONDS,
+        )
+    except (TypeError, ValueError):
+        return {"success": False, "error": "timeout_seconds must be an integer"}
+
+    if action not in {
+        "list_containers", "list_images", "inspect_container", "logs",
+        "stop_container", "start_container", "restart_container",
+        "remove_container", "pull_image", "run_container", "exec_container",
+    }:
         return {"success": False, "error": f"Unknown action: {action}"}
-        
+
     if ssh_connection:
         cmd_str = "docker " + shlex.join(args)
-        result = _run_via_ssh_connection(ssh_connection, cmd_str)
+        result = _run_via_ssh_connection(ssh_connection, cmd_str, timeout=timeout)
     else:
         cmd = _build_docker_base_cmd(kwargs) + args
-        result = _run_subprocess(cmd)
-        
+        result = _run_subprocess(cmd, timeout=timeout)
+
+    if result.get("success") and result.get("stderr"):
+        result["output"] = (result.get("output") or "") + result["stderr"]
+
     # Attempt to parse json for list commands
     if result["success"] and action in ("list_containers", "list_images"):
         lines = result["output"].strip().split("\n")

--- a/huf/ai/tools/docker_execution.py
+++ b/huf/ai/tools/docker_execution.py
@@ -31,6 +31,13 @@ def _build_docker_base_cmd(kwargs):
         cmd.extend(["-H", connection_string])
         if kwargs.get("tls_verify"):
             cmd.append("--tlsverify")
+        for option, field in (
+            ("--tlscacert", "tls_ca_cert"),
+            ("--tlscert", "tls_cert"),
+            ("--tlskey", "tls_key"),
+        ):
+            if kwargs.get(field):
+                cmd.extend([option, kwargs[field]])
             
     return cmd
 

--- a/huf/ai/tools/docker_execution.py
+++ b/huf/ai/tools/docker_execution.py
@@ -1,0 +1,122 @@
+import json
+import subprocess
+import os
+import shlex
+import frappe
+
+def _build_docker_base_cmd(kwargs):
+    cmd = ["docker"]
+    connection_string = kwargs.get("connection_string")
+    context_name = kwargs.get("context_name")
+    
+    if context_name:
+        cmd.extend(["--context", context_name])
+    elif connection_string:
+        cmd.extend(["-H", connection_string])
+        if kwargs.get("tls_verify"):
+            cmd.append("--tlsverify")
+            
+    return cmd
+
+def _run_subprocess(cmd):
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return {"success": True, "output": result.stdout}
+    except subprocess.CalledProcessError as e:
+        return {"success": False, "error": e.stderr}
+
+def _run_via_ssh_connection(ssh_connection, cmd_str):
+    from huf.ai.tools.ssh_execution import _connect_transport, _run_exec_over_transport
+    
+    doc = frappe.get_doc("SSH Connection", ssh_connection)
+    limits = {
+        "connection_timeout_seconds": 10,
+        "execution_timeout_seconds": 60,
+        "stdout_max_bytes": 1048576,
+        "stderr_max_bytes": 1048576,
+        "combined_output_max_bytes": 2097152,
+    }
+    transport, fingerprint, host_key_type = _connect_transport(doc, limits)
+    try:
+        res = _run_exec_over_transport(transport, cmd_str, limits, fingerprint, host_key_type)
+        if res.exit_code == 0:
+            return {"success": True, "output": res.stdout}
+        else:
+            return {"success": False, "error": res.stderr or f"Exit code {res.exit_code}"}
+    finally:
+        transport.close()
+
+def handle_action(**kwargs):
+    action = kwargs.get("action")
+    ssh_connection = kwargs.get("ssh_connection")
+    
+    args = []
+    if action == "list_containers":
+        args = ["ps", "-a", "--format", "{{json .}}"]
+    elif action == "list_images":
+        args = ["images", "--format", "{{json .}}"]
+    elif action == "inspect_container":
+        container = kwargs.get("container")
+        args = ["inspect", container]
+    elif action == "logs":
+        container = kwargs.get("container")
+        args = ["logs", container]
+        if kwargs.get("tail"):
+            args.extend(["--tail", str(kwargs.get("tail"))])
+    elif action == "stop_container":
+        container = kwargs.get("container")
+        args = ["stop", container]
+    elif action == "start_container":
+        container = kwargs.get("container")
+        args = ["start", container]
+    elif action == "restart_container":
+        container = kwargs.get("container")
+        args = ["restart", container]
+    elif action == "remove_container":
+        container = kwargs.get("container")
+        args = ["rm", "-f", container]
+    elif action == "pull_image":
+        image = kwargs.get("image")
+        args = ["pull", image]
+    elif action == "run_container":
+        image = kwargs.get("image")
+        args = ["run", "-d"]
+        if kwargs.get("name"):
+            args.extend(["--name", kwargs.get("name")])
+        if kwargs.get("ports"):
+            for p in kwargs.get("ports").split(","):
+                args.extend(["-p", p.strip()])
+        args.append(image)
+    elif action == "exec_container":
+        container = kwargs.get("container")
+        cmd_arg = kwargs.get("command")
+        args = ["exec", container] + shlex.split(cmd_arg)
+    else:
+        return {"success": False, "error": f"Unknown action: {action}"}
+        
+    if ssh_connection:
+        cmd_str = "docker " + shlex.join(args)
+        result = _run_via_ssh_connection(ssh_connection, cmd_str)
+    else:
+        cmd = _build_docker_base_cmd(kwargs) + args
+        result = _run_subprocess(cmd)
+        
+    # Attempt to parse json for list commands
+    if result["success"] and action in ("list_containers", "list_images"):
+        lines = result["output"].strip().split("\n")
+        parsed = []
+        for line in lines:
+            if line.strip():
+                try:
+                    parsed.append(json.loads(line))
+                except Exception:
+                    parsed.append(line)
+        result["output"] = parsed
+        
+    if result["success"] and action == "inspect_container":
+        try:
+            result["output"] = json.loads(result["output"])
+        except Exception:
+            pass
+            
+    return result

--- a/huf/ai/tools/ssh_execution.py
+++ b/huf/ai/tools/ssh_execution.py
@@ -93,12 +93,13 @@ def _fingerprint_for_key(server_key) -> str:
 
 def _load_private_key(private_key: str, passphrase: str | None):
 	password = passphrase or None
-	for key_cls in (
-		paramiko.Ed25519Key,
-		paramiko.RSAKey,
-		paramiko.ECDSAKey,
-		paramiko.DSSKey,
-	):
+	key_classes = [paramiko.Ed25519Key, paramiko.RSAKey, paramiko.ECDSAKey]
+	# DSSKey was removed from newer Paramiko releases. Keep compatibility with
+	# old installations without making all private-key auth fail at import time.
+	dss_key = getattr(paramiko, "DSSKey", None)
+	if dss_key is not None:
+		key_classes.append(dss_key)
+	for key_cls in key_classes:
 		try:
 			return key_cls.from_private_key(io.StringIO(private_key), password=password)
 		except Exception:

--- a/huf/permissions.py
+++ b/huf/permissions.py
@@ -76,6 +76,8 @@ CAPABILITIES: dict[str, str] = {
 	"ssh_connection.manage": "Manage SSH Connections",
 	"ssh.run": "Run SSH Tool",
 	"ssh.approve": "Approve SSH Executions",
+	# --- Docker Execution ---
+	"docker.run": "Run Docker Execution Tool",
 }
 
 # Capabilities granted to each default Huf Role.
@@ -111,6 +113,7 @@ DEFAULT_ROLE_CAPABILITIES: dict[str, list[str]] = {
 		"ssh_connection.manage",
 		"ssh.run",
 		"ssh.approve",
+		"docker.run",
 	],
 	"Huf User": [
 		"agent.use",


### PR DESCRIPTION
## Summary

Adds a new agent integration tool `run_docker_command` (or `docker_execution`) to HUF allowing agents to connect to local and remote Docker environments safely.

### Features Included
- **Connection Mechanisms Supported**:
  - Local Unix Socket (`unix:///var/run/docker.sock` or `npipe:////./pipe/docker_engine`)
  - Remote Docker over SSH (`docker -H ssh://user@host` or using HUF's `SSH Connection` doctype credentials via Paramiko)
  - Remote Docker TCP Socket with TLS (`tcp://host:2376` with certs)
  - Docker Context (`docker --context <name>`)
- **Supported Operations**:
  - `list_containers`, `run_container`, `exec_container`, `logs`, `inspect_container`, `stop_container`, `start_container`, `restart_container`, `remove_container`, `list_images`, `pull_image`
- **Tool Registry**: Registered under `DOCKER_TOOLS` in `huf/ai/tools/_registry.py`
- **Unit Tests**: Full test suite in `huf/ai/tests/test_docker_execution.py`