### PR TITLE
fix(sidebar): replace EXPERIMENTAL text badge with a beaker icon

### DIFF
--- a/frontend/src/components/nav-main.tsx
+++ b/frontend/src/components/nav-main.tsx
@@ -1,4 +1,4 @@
-import { type LucideIcon } from "lucide-react"
+import { FlaskConical, type LucideIcon } from "lucide-react"
 import { NavLink, useLocation } from "react-router-dom"
 
 import {
@@ -49,8 +49,13 @@ export function NavMain({
                   {(item.badge || typeof item.count === 'number') && (
                     <div className="ml-auto flex items-center gap-1.5 group-data-[collapsible=icon]:hidden">
                       {item.badge && (
-                        <span className="font-mono text-[8.5px] uppercase tracking-wider px-1.5 py-0.5 rounded-none border border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400 font-medium">
-                          {item.badge}
+                        <span
+                          title={item.badge}
+                          aria-label={item.badge}
+                          role="img"
+                          className="flex items-center text-signal-ink dark:text-signal"
+                        >
+                          <FlaskConical className="!size-[13px]" strokeWidth={1.6} />
                         </span>
                       )}
                       {typeof item.count === 'number' && (


### PR DESCRIPTION
## Problem

The `EXPERIMENTAL` badge in the sidebar is the widest element in its nav row. "EXPERIMENTAL" is 12 characters plus padding and a 1px border — roughly **twice the width of the label it tags** (the badge outmeasures the word `Apps` about 2:1).

It appears on **6 of 16** nav items — Apps, Flows, Memory, Skills, Executions, SSH — so the filled chips stack into a vertical band down the right edge that pulls the eye harder than the nav labels do.

It was also drawn in Tailwind `amber-500` (`#F59E0B`), which is not a HUF token. HUF's signal is `--signal` (`#E8531F`), so the badge read as foreign to the rest of the UI.

## Change

A 13px `FlaskConical` icon in `--signal-ink` (`--signal` in dark), replacing the chip.

- Same meaning, no text width — the row's right side stops competing with its label.
- `title` and `aria-label` carry the word "Experimental" for hover and assistive tech.
- `role="img"` so the icon is announced rather than skipped.
- Back on the HUF palette.
- Survives translation, unlike an abbreviation.

Nested inside a `<span>`, so the sidebar's `[&>svg]:size-4` / `[&>svg]:text-steel` direct-child rules don't apply; size and colour are set explicitly.

## Scope

**Sidebar only.** `ExperimentalBadge.tsx` is a separate component used on page headers and in `AdvancedTab`, where the full word still has room — deliberately untouched, so this doesn't start abbreviating in places that don't need it.

## Verification

- `yarn typecheck` clean
- `eslint` clean on the changed file
- Options were compared at true scale before picking this one