### PR TITLE
feat: sectional Agent editor and focused settings navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,8 +45,6 @@ const ChatPage = lazy(() => import('./pages/ChatPageV2'));
 const ChatOnlyPage = lazy(() => import('./pages/ChatOnlyPage'));
 const Executions = lazy(() => import('./pages/Executions'));
 const AgentRunDetailPageWrapper = lazy(() => import('./pages/AgentRunDetailPageWrapper'));
-const AgentContextArtifactsPage = lazy(() => import('./pages/AgentContextArtifactsPage'));
-const AgentContextArtifactDetailPage = lazy(() => import('./pages/AgentContextArtifactDetailPage'));
 const McpDetailsPageWrapper = lazy(() => import('./pages/McpDetailsPageWrapper'));
 const McpListingPage = lazy(() => import('./pages/McpListingPage'));
 const KnowledgeSourcesPage = lazy(() => import('./pages/KnowledgeSourcesPage'));
@@ -63,6 +61,7 @@ const ConsolePage = lazy(() => import('./pages/ConsolePage'));
 const IntegrationSettingsListingPageWrapper = lazy(
   () => import('./pages/IntegrationSettingsListingPageWrapper'),
 );
+const ChannelsPageWrapper = lazy(() => import('./pages/ChannelsPageWrapper'));
 const IntegrationSettingsDetailsPageWrapper = lazy(
   () => import('./pages/IntegrationSettingsDetailsPageWrapper'),
 );
@@ -87,6 +86,7 @@ import {
 } from './services/streamChatApi';
 const UsersPage = lazy(() => import('./pages/UsersPage'));
 const RolesPage = lazy(() => import('./pages/RolesPage'));
+const MembersPage = lazy(() => import('./pages/MembersPage'));
 
 function ChatOnlyRedirectGuard() {
   const location = useLocation();
@@ -445,30 +445,7 @@ function AppShell() {
               </ProtectedRoute>
             }
           />
-          <Route
-            path="/artifacts"
-            element={
-              <ProtectedRoute>
-                <UnifiedLayout>
-                  <Suspense fallback={<PageLoader />}>
-                    <AgentContextArtifactsPage />
-                  </Suspense>
-                </UnifiedLayout>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/artifacts/:artifactId"
-            element={
-              <ProtectedRoute>
-                <UnifiedLayout>
-                  <Suspense fallback={<PageLoader />}>
-                    <AgentContextArtifactDetailPage />
-                  </Suspense>
-                </UnifiedLayout>
-              </ProtectedRoute>
-            }
-          />
+          <Route path="/artifacts/*" element={<Navigate to="/executions" replace />} />
           <Route
             path="/settings"
             element={
@@ -546,6 +523,16 @@ function AppShell() {
                     <SshPage />
                   </Suspense>
                 </UnifiedLayout>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/channels"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<PageLoader />}>
+                  <ChannelsPageWrapper />
+                </Suspense>
               </ProtectedRoute>
             }
           />
@@ -632,6 +619,16 @@ function AppShell() {
                 <Suspense fallback={<PageLoader />}>
                   <PreviewViewPage />
                 </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/members"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout>
+                  <MembersPage />
+                </UnifiedLayout>
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/agent/PromptLibraryTabs.tsx
+++ b/frontend/src/components/agent/PromptLibraryTabs.tsx
@@ -1,0 +1,29 @@
+import { NavLink } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+
+const promptSections = [
+  { label: 'Instructions', to: '/prompts' },
+  { label: 'Summarization', to: '/summary-prompts' },
+];
+
+export function PromptLibraryTabs() {
+  return (
+    <nav aria-label="Prompt sections" className="mb-5 flex border-b border-ink">
+      {promptSections.map((section) => (
+        <NavLink
+          key={section.to}
+          to={section.to}
+          end
+          className={({ isActive }) =>
+            cn(
+              'border-b-2 border-transparent px-4 pb-2 font-mono text-[11.5px] uppercase tracking-wide text-steel transition-colors hover:text-ink',
+              isActive && '-mb-px border-signal text-ink',
+            )
+          }
+        >
+          {section.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,9 +1,8 @@
 import * as React from "react"
-import { Home, LayoutDashboard, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Boxes, Terminal, Settings, Shield, LayoutGrid, Brain, Sparkles } from "lucide-react"
+import { ArrowLeft, Home, LayoutDashboard, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Terminal, Settings, Shield, LayoutGrid, Brain, Sparkles } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
-import { NavCollapsibleGroup } from "@/components/nav-collapsible"
 import { NavUser } from "@/components/nav-user"
 import { AppSidebarHeader } from "@/components/app-sidebar-header"
 import { usePermissions } from "@/contexts/PermissionsContext"
@@ -13,6 +12,9 @@ import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
   SidebarHeader,
   SidebarRail,
 } from "@/components/ui/sidebar"
@@ -50,6 +52,12 @@ const useNavItems = [
     capability: "agent.use",
     badge: "Experimental",
   },
+  {
+    title: "Chat",
+    url: "/chat",
+    icon: MessageSquare,
+    capability: "chat.use",
+  },
 ]
 
 const buildNavItems = [
@@ -60,7 +68,7 @@ const buildNavItems = [
     capability: "agent.use",
   },
   {
-    title: "Agent Prompts",
+    title: "Prompts",
     url: "/prompts",
     icon: ScrollText,
     capability: "agent.use",
@@ -115,12 +123,6 @@ const knowNavItems = [
 
 const operateNavItems = [
 	{
-		title: "Chat",
-		url: "/chat",
-		icon: MessageSquare,
-		capability: "chat.use",
-	},
-	{
 		title: "Executions",
 		url: "/executions",
 		icon: Zap,
@@ -128,101 +130,51 @@ const operateNavItems = [
 		badge: "Experimental",
 	},
 	{
-		title: "SSH",
-		url: "/ssh",
+		title: "Console",
+		url: "/console",
 		icon: Terminal,
 		capability: "agent.use",
-		badge: "Experimental",
-	},
-	{
-		title: "Artifacts",
-		url: "/artifacts",
-		icon: Boxes,
-		capability: "agent.view_all",
 	},
 ]
 
 /**
- * Settings-adjacent pages are grouped under a single collapsible sidebar
- * entry instead of each getting a top-level item, to keep the primary nav
- * short. User management lives here too — it's an admin task, not a daily
- * destination. Same capability-gating rules as allNavItems.
+ * Settings is a second-level rail, not an accordion. Opening it replaces the
+ * primary navigation so the longer administration list never pushes the main
+ * destinations off-screen.
  */
-const settingsNavItems = [
+const settingsNavGroups = [
   {
-    title: "AI Providers",
-    url: "/providers",
-    icon: Plug,
-    capability: "system.providers.manage",
+    label: "Intelligence",
+    items: [
+      { title: "AI Providers", url: "/providers", icon: Plug, capability: "system.providers.manage" },
+      { title: "Models", url: "/models", icon: Cpu, capability: "system.providers.manage" },
+    ],
   },
   {
-    title: "Models",
-    url: "/models",
-    icon: Cpu,
-    capability: "system.providers.manage",
-	},
-	{
-		title: "Agent Summary Prompts",
-		url: "/summary-prompts",
-		icon: ScrollText,
-		capability: "agent.use",
-	},
-	{
-		title: "Execution Profiles",
-		url: "/execution-profiles",
-		icon: Shield,
-		capability: "agent.use",
-	},
-	{
-		title: "SSH Connections",
-		url: "/ssh-connections",
-		icon: Terminal,
-		capability: "agent.use",
-	},
-  {
-    title: "Console",
-    url: "/console",
-    icon: Terminal,
-    capability: "agent.use",
-  },
-  // TODO(#473-followup): Gateways navigation is hidden while the feature is
-  // incomplete (no live provider adapters, no in-app connection form). Restore
-  // once the items in docs/gateway-todo.md are resolved.
-  // {
-  //   title: "Gateways",
-  //   url: "/gateways",
-  //   icon: MessageSquare,
-  //   capability: "system.integrations.manage",
-  // },
-  {
-    title: "Integrations",
-    url: "/integrations",
-    icon: Link2,
-    capability: "system.integrations.manage",
+    label: "Runtime",
+    items: [
+      { title: "Code Execution", url: "/execution-profiles", icon: Shield, capability: "agent.use" },
+      { title: "SSH Connections", url: "/ssh-connections", icon: Terminal, capability: "agent.use" },
+    ],
   },
   {
-    title: "Integration Services",
-    url: "/integration-services",
-    icon: Boxes,
-    capability: "system.integrations.manage",
+    label: "Connectivity",
+    items: [
+      { title: "Channels", url: "/channels", icon: MessageSquare, capability: "system.integrations.manage" },
+      { title: "Integrations", url: "/integrations", icon: Link2, capability: "system.integrations.manage" },
+      { title: "MCP Servers", url: "/mcp", icon: Server, capability: "system.mcp.manage" },
+    ],
   },
   {
-    title: "MCP Servers",
-    url: "/mcp",
-    icon: Server,
-    capability: "system.mcp.manage",
-  },
-  {
-    title: "Roles",
-    url: "/roles",
-    icon: Shield,
-    capability: "roles.manage",
-  },
-  {
-    title: "Users",
-    url: "/users",
-    icon: Users,
-    capability: "users.manage",
+    label: "Access",
+    items: [
+      {
+        title: "Members",
+        url: "/members",
+        icon: Users,
+        capability: ["users.manage", "roles.manage"],
+      },
+    ],
   },
 ]
 
@@ -269,18 +221,21 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	)
 	const knowledgeItems = filterItemsByCapability(knowNavItems)
 	const operateItems = filterItemsByCapability(operateNavItems)
-  const settingsItems = isLoading
-    ? []
-    : settingsNavItems.filter((item) => item.capability === null || hasCapability(item.capability))
-
-  // Settings is the only collapsible group; its open state is owned here so
-  // the active route auto-opens it on navigation.
+  const settingsGroups = settingsNavGroups
+    .map((group) => ({
+      ...group,
+      items: filterItemsByCapability(
+        group.items as Array<(typeof group.items)[number] & { capability: string | string[] | null }>,
+      ),
+    }))
+    .filter((group) => group.items.length > 0)
+  const settingsItems = settingsGroups.flatMap((group) => group.items)
   const settingsActive = isPathInItems(settingsItems)
-  const [settingsOpen, setSettingsOpen] = React.useState(settingsActive)
+  const [settingsMode, setSettingsMode] = React.useState(settingsActive)
 
   React.useEffect(() => {
     if (settingsActive) {
-      setSettingsOpen(true)
+      setSettingsMode(true)
     }
   }, [settingsActive])
 
@@ -290,22 +245,45 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <AppSidebarHeader />
       </SidebarHeader>
       <SidebarContent>
-			{dashboardItems.length > 0 && <NavMain items={dashboardItems} />}
-			{useItems.length > 0 && <NavMain items={useItems} label="Use" />}
-			{buildItems.length > 0 && <NavMain items={buildItems} label="Build" />}
-			{knowledgeItems.length > 0 && <NavMain items={knowledgeItems} label="Know" />}
-			{operateItems.length > 0 && <NavMain items={operateItems} label="Operate" />}
-			{settingsItems.length > 0 && (
-			  <NavCollapsibleGroup
-			    title="Settings"
-			    icon={Settings}
-			    items={settingsItems}
-			    open={settingsOpen}
-			    onOpenChange={setSettingsOpen}
-			  />
-			)}
+        {settingsMode ? (
+          <>
+            <SidebarMenu className="px-2">
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  tooltip="Back to main navigation"
+                  onClick={() => setSettingsMode(false)}
+                  className="font-medium"
+                >
+                  <ArrowLeft strokeWidth={1.6} />
+                  <span className="font-body text-[13.5px]">Settings</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+            {settingsGroups.map((group) => (
+              <NavMain key={group.label} items={group.items} label={group.label} />
+            ))}
+          </>
+        ) : (
+          <>
+            {dashboardItems.length > 0 && <NavMain items={dashboardItems} />}
+            {useItems.length > 0 && <NavMain items={useItems} label="Use" />}
+            {buildItems.length > 0 && <NavMain items={buildItems} label="Build" />}
+            {knowledgeItems.length > 0 && <NavMain items={knowledgeItems} label="Know" />}
+            {operateItems.length > 0 && <NavMain items={operateItems} label="Operate" />}
+          </>
+        )}
       </SidebarContent>
       <SidebarFooter className="p-0 mb-1 mt-2 border-t border-sidebar-border">
+        {!settingsMode && settingsItems.length > 0 && (
+          <SidebarMenu className="px-2 pt-2">
+            <SidebarMenuItem>
+              <SidebarMenuButton tooltip="Settings" onClick={() => setSettingsMode(true)}>
+                <Settings strokeWidth={1.6} />
+                <span className="font-body text-[13.5px]">Settings</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        )}
         <NavUser />
       </SidebarFooter>
       <SidebarRail />

--- a/frontend/src/components/integrations/IntegrationSettingsHeaderActions.tsx
+++ b/frontend/src/components/integrations/IntegrationSettingsHeaderActions.tsx
@@ -3,19 +3,23 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '../ui/button';
 import { useIntegrationSettingsContext } from '@/contexts/IntegrationSettingsContext';
 
-export function IntegrationSettingsHeaderActions() {
+export function IntegrationSettingsHeaderActions({
+  kind = 'integrations',
+}: {
+  kind?: 'channels' | 'integrations';
+}) {
   const { onAddIntegration } = useIntegrationSettingsContext();
   const navigate = useNavigate();
 
   return (
     <div className="flex items-center gap-2">
-      <Button variant="outline" size="sm" onClick={() => navigate('/integration-services')}>
+      {kind === 'integrations' && <Button variant="outline" size="sm" onClick={() => navigate('/integration-services')}>
         <Layers className="w-4 h-4 mr-2" />
         Service Catalog
-      </Button>
+      </Button>}
       <Button variant="display" onClick={onAddIntegration} size="sm">
         <Plus className="w-4 h-4 mr-2" />
-        Add Integration
+        {kind === 'channels' ? 'Add Channel' : 'Add Integration'}
       </Button>
     </div>
   );

--- a/frontend/src/components/integrations/ServiceCatalogModal.tsx
+++ b/frontend/src/components/integrations/ServiceCatalogModal.tsx
@@ -16,13 +16,19 @@ import { parseRequiredCredentials } from '@/types/integration.types';
 import type { IntegrationServiceDoc } from '@/types/integration.types';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
 import { toast } from 'sonner';
+import { getServiceIdentity, messagingServiceNames } from '@/data/serviceIdentity';
 
 interface ServiceCatalogModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  kind?: 'channels' | 'integrations';
 }
 
-export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalProps) {
+export function ServiceCatalogModal({
+  open,
+  onOpenChange,
+  kind = 'integrations',
+}: ServiceCatalogModalProps) {
   const navigate = useNavigate();
   const [services, setServices] = useState<IntegrationServiceDoc[]>([]);
   const [loading, setLoading] = useState(false);
@@ -49,15 +55,17 @@ export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalP
   const filteredServices = useMemo(() => {
     const query = search.trim().toLowerCase();
     return services.filter((service) => {
+      const isMessaging = messagingServiceNames.has(service.service_name.toLowerCase());
+      const matchesKind = kind === 'channels' ? isMessaging : !isMessaging;
       const matchesCategory = category === 'all' || service.category === category;
       const matchesSearch =
         !query ||
         service.service_name.toLowerCase().includes(query) ||
         service.description?.toLowerCase().includes(query) ||
         service.category?.toLowerCase().includes(query);
-      return matchesCategory && matchesSearch;
+      return matchesKind && matchesCategory && matchesSearch;
     });
-  }, [services, search, category]);
+  }, [services, search, category, kind]);
 
   const handleSelect = (serviceName: string) => {
     onOpenChange(false);
@@ -70,7 +78,7 @@ export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalP
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
         <DialogHeader>
-          <DialogTitle>Add Integration</DialogTitle>
+          <DialogTitle>{kind === 'channels' ? 'Add Channel' : 'Add Integration'}</DialogTitle>
           <DialogDescription>
             Choose a service to connect. Required credentials are shown for each integration.
           </DialogDescription>
@@ -108,6 +116,8 @@ export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalP
             <div className="grid gap-3 sm:grid-cols-2">
               {filteredServices.map((service) => {
                 const credSchema = parseRequiredCredentials(service.required_credentials);
+                const identity = getServiceIdentity(service.service_name);
+                const Icon = identity.icon;
                 return (
                   <Card
                     key={service.name}
@@ -116,8 +126,9 @@ export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalP
                   >
                     <CardHeader className="pb-2">
                       <div className="flex items-start justify-between gap-2">
-                        <CardTitle className="text-base capitalize">
-                          {service.service_name.replace(/_/g, ' ')}
+                        <CardTitle className="flex items-center gap-2 text-base">
+                          <Icon className="h-5 w-5 text-steel-soft" />
+                          {identity.title}
                         </CardTitle>
                         <Badge variant="outline">{service.category}</Badge>
                       </div>
@@ -151,7 +162,7 @@ export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalP
           )}
         </div>
 
-        <div className="flex items-center justify-between gap-3 pt-2 border-t">
+        {kind === 'integrations' && <div className="flex items-center justify-between gap-3 pt-2 border-t">
           <button
             type="button"
             className="text-sm text-primary hover:underline"
@@ -162,7 +173,7 @@ export function ServiceCatalogModal({ open, onOpenChange }: ServiceCatalogModalP
           >
             Create custom service
           </button>
-        </div>
+        </div>}
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/data/serviceIdentity.ts
+++ b/frontend/src/data/serviceIdentity.ts
@@ -1,0 +1,60 @@
+import {
+  Bot,
+  CalendarDays,
+  Folder,
+  Github,
+  LucideIcon,
+  Mail,
+  Map,
+  MessageCircle,
+  PanelsTopLeft,
+  Search,
+  Send,
+  Slack,
+  Table2,
+  Video,
+  Workflow,
+} from 'lucide-react';
+
+export const messagingServiceNames = new Set([
+  'telegram',
+  'slack',
+  'whatsapp',
+  'discord',
+  'microsoft_teams',
+  'teams',
+  'wecom',
+  'vk',
+]);
+
+const serviceIdentities: Record<string, { title: string; icon: LucideIcon }> = {
+  telegram: { title: 'Telegram', icon: Send },
+  slack: { title: 'Slack', icon: Slack },
+  whatsapp: { title: 'WhatsApp', icon: MessageCircle },
+  discord: { title: 'Discord', icon: Bot },
+  microsoft_teams: { title: 'Microsoft Teams', icon: Video },
+  teams: { title: 'Microsoft Teams', icon: Video },
+  wecom: { title: 'WeCom', icon: MessageCircle },
+  vk: { title: 'VK', icon: MessageCircle },
+  github: { title: 'GitHub', icon: Github },
+  jira: { title: 'Jira', icon: PanelsTopLeft },
+  gmail: { title: 'Gmail', icon: Mail },
+  google_calendar: { title: 'Google Calendar', icon: CalendarDays },
+  google_drive: { title: 'Google Drive', icon: Folder },
+  google_sheets: { title: 'Google Sheets', icon: Table2 },
+  google_maps: { title: 'Google Maps', icon: Map },
+  google_meet: { title: 'Google Meet', icon: Video },
+  serpapi: { title: 'SerpApi', icon: Search },
+};
+
+export function getServiceIdentity(serviceName: string | null | undefined) {
+  const normalized = (serviceName || '').trim().toLowerCase();
+  return serviceIdentities[normalized] ?? {
+    title: normalized
+      .split('_')
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ') || 'Integration',
+    icon: Workflow,
+  };
+}

--- a/frontend/src/layouts/UnifiedHeader.tsx
+++ b/frontend/src/layouts/UnifiedHeader.tsx
@@ -25,9 +25,9 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
     if (path.startsWith('/agents')) return 'Agent';
     if (path.startsWith('/flows')) return 'Flows';
     if (path.startsWith('/data')) return 'Data';
-    if (path.startsWith('/artifacts')) return 'Artifacts';
     if (path.startsWith('/providers')) return 'AI Providers';
-    if (path.startsWith('/integration-services')) return 'Integration Services';
+    if (path.startsWith('/integration-services')) return 'Integration Catalog';
+    if (path.startsWith('/channels')) return 'Channels';
     if (path.startsWith('/integrations')) return 'Integrations';
     if (path.startsWith('/gateways')) return 'Gateways';
     if (path.startsWith('/settings')) return 'Settings';
@@ -37,11 +37,14 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
     if (path.startsWith('/executions')) return 'Executions';
     if (path.startsWith('/knowledge')) return 'Knowledge';
     if (path.startsWith('/mcp')) return 'MCP Servers';
-    if (path.startsWith('/prompts')) return 'Agent Prompts';
-    if (path.startsWith('/summary-prompts')) return 'Agent Summary Prompts';
+    if (path.startsWith('/prompts')) return 'Prompts';
+    if (path.startsWith('/summary-prompts')) return 'Prompts';
+    if (path.startsWith('/members')) return 'Members';
     if (path.startsWith('/users')) return 'Users';
     if (path.startsWith('/roles')) return 'Roles';
     if (path.startsWith('/models')) return 'Models';
+    if (path.startsWith('/execution-profiles')) return 'Code Execution';
+    if (path.startsWith('/ssh-connections')) return 'SSH Connections';
     if (path.startsWith('/apps')) return 'Apps';
     if (path.startsWith('/memory')) return 'Memory';
     if (path.startsWith('/skills')) return 'Skills';

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -11,7 +11,7 @@ import { usePermissions } from '../contexts/PermissionsContext';
 import { AIProvider, AIModel, AgentToolFunctionRef, type ToolType } from '../types/agent.types';
 import type { AgentSkillRow } from '../types/skill.types';
 import { getSkillOptions } from '../services/skillApi';
-import { getAgent, updateAgent, createAgent, getAgentTriggers, getAgentTrigger, createAgentTrigger, updateAgentTrigger, getDocTypes, getTriggerTypes, type AgentTriggerListItem, type AgentTriggerDoc, type AgentTriggerAttachmentRow, type TriggerTypeOption, deleteAgentTrigger, runAgentTest, deleteAgent, duplicateAgent } from '../services/agentApi';
+import { getAgent, getAgentSection, updateAgent, updateAgentSection, createAgent, getAgentTriggers, getAgentTrigger, createAgentTrigger, updateAgentTrigger, getDocTypes, getTriggerTypes, type AgentConfigSection, type AgentTriggerListItem, type AgentTriggerDoc, type AgentTriggerAttachmentRow, type TriggerTypeOption, deleteAgentTrigger, runAgentTest, deleteAgent, duplicateAgent } from '../services/agentApi';
 import { getAgentPrompt } from '../services/agentPromptApi';
 import { getAgentSummaryPrompt } from '../services/agentSummaryPromptApi';
 import { getProviders, getModels } from '../services/providerApi';
@@ -191,7 +191,7 @@ export function AgentFormPage() {
   const skipBlockRef = useRef(false);
 
   // Tab configuration - single source of truth
-  const tabConfig = {
+  const tabConfig = useMemo(() => ({
     general: {
       label: 'General',
       fields: ['agent_name', 'provider', 'model', 'temperature', 'top_p', 'run_immediately', 'description', 'instructions', 'enable_prompt_caching', 'cache_control_type', 'cache_system_message', 'cache_conversation_history', 'prompt_mode', 'agent_prompt', 'prompt_version_locked', 'template_version_at_attach'],
@@ -275,7 +275,7 @@ export function AgentFormPage() {
       default: false,
       disabled: false,
     },
-  } as const;
+  } as const), []);
 
   // Extract derived values from tab config (memoized to avoid recreating on every render)
   const validTabs = Object.keys(tabConfig);
@@ -363,6 +363,9 @@ export function AgentFormPage() {
   const [initialAgentSkills, setInitialAgentSkills] = useState<AgentSkillRow[]>([]);
   const [skillOptions, setSkillOptions] = useState<{ value: string; label: string; subtitle?: string }[]>([]);
   const [agentStats, setAgentStats] = useState<{ last_run?: string | null; total_run?: number | null }>({});
+  const [sectionRevisions, setSectionRevisions] = useState<Partial<Record<AgentConfigSection, string>>>({});
+  const [loadedSections, setLoadedSections] = useState<Set<AgentConfigSection>>(new Set());
+  const [loadingSection, setLoadingSection] = useState<AgentConfigSection | null>(null);
   const [showKnowledgeModal, setShowKnowledgeModal] = useState(false);
   const [editingKnowledgeIndex, setEditingKnowledgeIndex] = useState<number | null>(null);
   const [allowChat, setAllowChat] = useState(false); // Persisted value only – updated on load/save
@@ -1137,7 +1140,24 @@ export function AgentFormPage() {
   // Load agent data when id is available (only for edit mode)
   useEffect(() => {
     if (id && !isNew) {
-      getAgent(id).then((data: AgentDoc) => {
+      getAgentSection(id, 'general').then((response) => {
+        const data = {
+          name: response.name,
+          modified: response.modified,
+          ...response.values,
+        } as AgentDoc;
+        setLoadedSections(new Set(['general']));
+        if (data.modified) {
+          setSectionRevisions({
+            general: data.modified,
+            behavior: data.modified,
+            tools: data.modified,
+            knowledge: data.modified,
+            skills: data.modified,
+            permissions: data.modified,
+            advanced: data.modified,
+          });
+        }
         // Resolved merge conflict: prefer using the utility function when available, fallback to explicit mapping if not.
         if (typeof mapAgentDocToFormValues === 'function') {
           form.reset(mapAgentDocToFormValues(data));
@@ -1345,6 +1365,109 @@ export function AgentFormPage() {
     }
   }, [id, isNew, form]);
 
+  useEffect(() => {
+    if (!id || isNew || activeTab === 'triggers') return;
+    const section = activeTab as AgentConfigSection;
+    if (loadedSections.has(section)) return;
+
+    let cancelled = false;
+    setLoadingSection(section);
+    getAgentSection(id, section)
+      .then(async (response) => {
+        if (cancelled) return;
+        const data = response.values as AgentDoc;
+        setSectionRevisions((current) => ({ ...current, [section]: response.modified }));
+
+        if (section === 'tools') {
+          const toolNames = ((data.agent_tool || []) as AgentToolRow[])
+            .map((item) => item.tool)
+            .filter(Boolean) as string[];
+          const tools = toolNames.length ? await getToolFunctionsByName(toolNames) : [];
+          if (cancelled) return;
+          setSelectedTools(tools);
+          setInitialTools(tools);
+
+          const servers = ((data.agent_mcp_server || []) as AgentMcpServerRow[]).map((item) => ({
+            name: item.name || '',
+            mcp_server: item.mcp_server,
+            server_url: item.server_url || '',
+            enabled: item.enabled === 1 || item.enabled === true ? 1 : 0,
+            tool_count: item.tool_count || 0,
+            server_name: item.server_name ?? undefined,
+            description: item.description ?? undefined,
+          }));
+          const enrichedServers = await Promise.all(
+            servers.map(async (server) => {
+              try {
+                const mcpDoc = await getMCPServer(server.mcp_server);
+                return {
+                  ...server,
+                  server_name: mcpDoc.server_name || server.server_name || server.mcp_server,
+                  description: mcpDoc.description || server.description,
+                  mcp_enabled: mcpDoc.enabled === 1 ? 1 : 0,
+                  server_url: mcpDoc.server_url || server.server_url,
+                };
+              } catch {
+                return { ...server, mcp_enabled: undefined };
+              }
+            }),
+          );
+          if (cancelled) return;
+          setMcpServers(enrichedServers);
+          setInitialMcpServers(enrichedServers);
+        } else if (section === 'knowledge') {
+          const rows = (data.agent_knowledge || []).map((item) => ({
+            name: item.name,
+            knowledge_source: item.knowledge_source,
+            mode: item.mode || 'Optional',
+            priority: item.priority ?? 0,
+            max_chunks: item.max_chunks ?? 5,
+            token_budget: item.token_budget ?? 2000,
+            description: item.description || undefined,
+          }));
+          setKnowledgeSources(rows);
+          setInitialKnowledgeSources(rows);
+        } else if (section === 'skills') {
+          const rows = (data.agent_skill || []).map((item) => ({
+            name: item.name,
+            skill: item.skill,
+            mode: item.mode || 'Optional',
+            auto_load: normalizeFlag(item.auto_load),
+            priority: item.priority ?? 0,
+            description: item.description || undefined,
+          }));
+          setAgentSkills(rows);
+          setInitialAgentSkills(rows);
+        } else {
+          const mapped = mapAgentDocToFormValues(data);
+          const fields = tabConfig[section].fields;
+          const sectionValues = Object.fromEntries(
+            fields.map((field) => [field, mapped[field as keyof AgentFormValues]]),
+          ) as Partial<AgentFormValues>;
+          form.reset(
+            { ...form.getValues(), ...sectionValues },
+            { keepDirtyValues: true },
+          );
+          if (section === 'behavior') {
+            setAllowChat(data.allow_chat === 1);
+          }
+        }
+
+        setLoadedSections((current) => new Set(current).add(section));
+      })
+      .catch((error) => {
+        console.error(`Error loading ${section} section:`, error);
+        toast.error(`Failed to load ${tabConfig[section].label}`);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingSection(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, form, id, isNew, loadedSections, tabConfig]);
+
   const onSubmit = useCallback(async (values: AgentFormValues) => {
     setSaving(true);
     try {
@@ -1439,6 +1562,60 @@ export function AgentFormPage() {
           description: skill.description || '',
         })),
       } as AgentUpdatePayload;
+
+      if (!isNew && id && activeTab !== 'triggers') {
+        const section = activeTab as AgentConfigSection;
+        const expectedModified = sectionRevisions[section];
+        if (!expectedModified) {
+          toast.error('This section is not ready to save. Reload the agent and try again.');
+          return;
+        }
+
+        const sectionFields: Record<AgentConfigSection, readonly string[]> = {
+          general: tabConfig.general.fields,
+          behavior: tabConfig.behavior.fields,
+          tools: ['agent_tool', 'agent_mcp_server'],
+          knowledge: ['agent_knowledge'],
+          skills: ['agent_skill'],
+          permissions: tabConfig.permissions.fields,
+          advanced: tabConfig.advanced.fields,
+        };
+        const sectionPayload = Object.fromEntries(
+          sectionFields[section]
+            .filter((field) => field in agentData)
+            .map((field) => [field, agentData[field as keyof AgentUpdatePayload]]),
+        ) as Partial<AgentDoc>;
+
+        const result = await updateAgentSection(id, section, sectionPayload, expectedModified);
+        const savedAgentId = result.name;
+        setSectionRevisions((current) =>
+          Object.fromEntries(
+            Object.keys(current).map((key) => [key, result.modified]),
+          ) as Partial<Record<AgentConfigSection, string>>,
+        );
+        sectionFields[section].forEach((field) => {
+          const fieldName = field as keyof AgentFormValues;
+          form.resetField(fieldName, { defaultValue: values[fieldName] });
+        });
+        if (section === 'tools') {
+          setInitialTools([...selectedTools]);
+          setInitialMcpServers([...mcpServers]);
+        } else if (section === 'knowledge') {
+          setInitialKnowledgeSources([...knowledgeSources]);
+        } else if (section === 'skills') {
+          setInitialAgentSkills([...agentSkills]);
+        } else if (section === 'general') {
+          setInitialDisabled(values.disabled);
+        } else if (section === 'behavior') {
+          setAllowChat(values.allow_chat);
+        }
+        writeToolDetailsSetting(savedAgentId, !!values.show_tool_execution_details);
+        if (savedAgentId !== id) {
+          navigate(`/agents/${encodeURIComponent(savedAgentId)}`, { replace: true });
+        }
+        toast.success(`${tabConfig[section].label} saved`);
+        return;
+      }
 
       if (isNew) {
         // Create new agent
@@ -1698,7 +1875,7 @@ export function AgentFormPage() {
     } finally {
       setSaving(false);
     }
-  }, [form, id, isNew, mcpServers, navigate, selectedTools, knowledgeSources, agentSkills]);
+  }, [activeTab, agentSkills, form, id, isNew, knowledgeSources, mcpServers, navigate, sectionRevisions, selectedTools, tabConfig]);
 
   // Memoize the form submit handler to avoid recreating it on every render
   const handleFormSubmit = useMemo(
@@ -2197,6 +2374,12 @@ export function AgentFormPage() {
                   </TabsTrigger>
                 ))}
               </TabsList>
+
+              {loadingSection === activeTab && (
+                <div className="py-8 text-center text-sm text-steel-soft">
+                  Loading {tabConfig[activeTab as keyof typeof tabConfig].label.toLowerCase()}…
+                </div>
+              )}
 
               <TabsContent value="general" className="space-y-4">
                 <GeneralTab

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -1366,7 +1366,8 @@ export function AgentFormPage() {
   }, [id, isNew, form]);
 
   useEffect(() => {
-    if (!id || isNew || activeTab === 'triggers') return;
+    // General is the bootstrap request above; only secondary sections are lazy-loaded here.
+    if (!id || isNew || activeTab === 'general' || activeTab === 'triggers') return;
     const section = activeTab as AgentConfigSection;
     if (loadedSections.has(section)) return;
 

--- a/frontend/src/pages/AgentPromptFormPageWrapper.tsx
+++ b/frontend/src/pages/AgentPromptFormPageWrapper.tsx
@@ -27,7 +27,7 @@ function AgentPromptFormPageWrapper() {
     }
   }, [id, isNew]);
 
-  const breadcrumbs = [{ label: 'Agent Prompts', href: '/prompts' }, { label: promptTitle }];
+  const breadcrumbs = [{ label: 'Prompts', href: '/prompts' }, { label: promptTitle }];
 
   return (
     <UnifiedLayout breadcrumbs={breadcrumbs}>

--- a/frontend/src/pages/AgentPromptsPage.tsx
+++ b/frontend/src/pages/AgentPromptsPage.tsx
@@ -28,6 +28,7 @@ import {
   type GetAgentPromptsParams,
 } from '@/services/agentPromptApi';
 import { formatTimeAgo } from '@/utils/time';
+import { PromptLibraryTabs } from '@/components/agent/PromptLibraryTabs';
 
 function getStatusVariant(enabled: 0 | 1): 'success' | 'secondary' {
   return enabled === 1 ? 'success' : 'secondary';
@@ -179,6 +180,7 @@ export function AgentPromptsPage() {
         />
       }
     >
+      <PromptLibraryTabs />
       <div className="w-full">
         {initialLoading ? (
           <div className="flex items-center justify-center py-12">
@@ -218,7 +220,7 @@ export function AgentPromptsPage() {
                 ) : (
                   <TableRow>
                     <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="font-body text-steel">No Agent Prompts found.</div>
+                      <div className="font-body text-steel">No instruction prompts found.</div>
                     </TableCell>
                   </TableRow>
                 )}

--- a/frontend/src/pages/AgentRunDetailPage.tsx
+++ b/frontend/src/pages/AgentRunDetailPage.tsx
@@ -13,7 +13,6 @@ import { doctype } from '@/data/doctypes';
 import { handleFrappeError } from '@/lib/frappe-error';
 import { calculateDuration, formatTimeAgo } from '@/utils/time';
 import { getAgentRunStatusVariant } from '@/utils/status';
-import { getArtifacts, type AgentContextArtifactDoc } from '@/services/agentContextArtifactApi';
 import { getRunContextMetrics } from '@/services/runContextMetricsApi';
 import type { RunContextMetricsResponse } from '@/types/runContextMetrics.types';
 import { ContextBar } from '@/components/ui/context-bar';
@@ -54,54 +53,6 @@ async function fetchAgentRunDetail(name: string): Promise<AgentRunDetail | null>
     handleFrappeError(error, `Error fetching agent run ${name}`);
     return null;
   }
-}
-
-function RunArtifactsPanel({ runId }: { runId: string }) {
-  const [artifacts, setArtifacts] = useState<AgentContextArtifactDoc[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      const result = await getArtifacts({ agent_run: runId, limit: 20 });
-      if (!cancelled) {
-        setArtifacts(result.data);
-        setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [runId]);
-
-  if (loading || artifacts.length === 0) return null;
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Artifacts</CardTitle>
-        <CardDescription>Context artifacts recorded for this run.</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {artifacts.map((artifact) => (
-          <Link
-            key={artifact.name}
-            to={`/artifacts/${artifact.name}`}
-            className="flex items-center justify-between rounded-none border p-3 text-sm hover:bg-paper-deep"
-          >
-            <div className="min-w-0">
-              <div className="truncate font-medium">{artifact.summary || artifact.name}</div>
-              <div className="text-xs text-steel-soft">{artifact.visibility}</div>
-            </div>
-            <Badge variant="secondary" className="shrink-0">
-              {artifact.artifact_type || 'Unknown'}
-            </Badge>
-          </Link>
-        ))}
-      </CardContent>
-    </Card>
-  );
 }
 
 export { AgentRunDetailPage };
@@ -571,8 +522,6 @@ function AgentRunDetailPage() {
           </Card>
         </div>
 
-        <RunArtifactsPanel runId={run.name} />
-
         {/* Agent Orchestration Table */}
         {childRuns.length > 0 && (
           <Card>
@@ -638,5 +587,3 @@ function AgentRunDetailPage() {
     </div>
   );
 }
-
-

--- a/frontend/src/pages/AgentSummaryPromptFormPageWrapper.tsx
+++ b/frontend/src/pages/AgentSummaryPromptFormPageWrapper.tsx
@@ -29,7 +29,7 @@ function AgentSummaryPromptFormPageWrapper() {
   }, [id, isNew]);
 
   const breadcrumbs = [
-    { label: 'Agent Summary Prompts', href: '/summary-prompts' },
+    { label: 'Prompts', href: '/summary-prompts' },
     { label: promptTitle },
   ];
 

--- a/frontend/src/pages/AgentSummaryPromptsPage.tsx
+++ b/frontend/src/pages/AgentSummaryPromptsPage.tsx
@@ -28,6 +28,7 @@ import {
   type GetAgentSummaryPromptsParams,
 } from '@/services/agentSummaryPromptApi';
 import { formatTimeAgo } from '@/utils/time';
+import { PromptLibraryTabs } from '@/components/agent/PromptLibraryTabs';
 
 function getStatusVariant(enabled: 0 | 1): 'success' | 'secondary' {
   return enabled === 1 ? 'success' : 'secondary';
@@ -179,6 +180,7 @@ export function AgentSummaryPromptsPage() {
         />
       }
     >
+      <PromptLibraryTabs />
       <div className="w-full">
         {initialLoading ? (
           <div className="flex items-center justify-center py-12">
@@ -218,7 +220,7 @@ export function AgentSummaryPromptsPage() {
                 ) : (
                   <TableRow>
                     <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="font-body text-steel">No Agent Summary Prompts found.</div>
+                      <div className="font-body text-steel">No summarization prompts found.</div>
                     </TableCell>
                   </TableRow>
                 )}

--- a/frontend/src/pages/ChannelsPageWrapper.tsx
+++ b/frontend/src/pages/ChannelsPageWrapper.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import { UnifiedLayout } from '@/layouts/UnifiedLayout';
+import { IntegrationSettingsProvider } from '@/contexts/IntegrationSettingsContext';
+import { IntegrationSettingsListingPage } from './IntegrationSettingsListingPage';
+import { IntegrationSettingsHeaderActions } from '@/components/integrations/IntegrationSettingsHeaderActions';
+
+export default function ChannelsPageWrapper() {
+  const [catalogOpenKey, setCatalogOpenKey] = useState(0);
+
+  return (
+    <IntegrationSettingsProvider onAddIntegration={() => setCatalogOpenKey((value) => value + 1)}>
+      <UnifiedLayout headerActions={<IntegrationSettingsHeaderActions kind="channels" />}>
+        <IntegrationSettingsListingPage kind="channels" catalogOpenKey={catalogOpenKey} />
+      </UnifiedLayout>
+    </IntegrationSettingsProvider>
+  );
+}

--- a/frontend/src/pages/ExecutionProfileFormPageWrapper.tsx
+++ b/frontend/src/pages/ExecutionProfileFormPageWrapper.tsx
@@ -26,7 +26,7 @@ export function ExecutionProfileFormPageWrapper() {
   }, [id, isNew]);
 
   const breadcrumbs = [
-    { label: 'Execution Profiles', href: '/execution-profiles' },
+    { label: 'Code Execution', href: '/execution-profiles' },
     { label: profileTitle },
   ];
 

--- a/frontend/src/pages/IntegrationServiceFormPageWrapper.tsx
+++ b/frontend/src/pages/IntegrationServiceFormPageWrapper.tsx
@@ -24,7 +24,7 @@ export function IntegrationServiceFormPageWrapper() {
   }, [serviceId, isNew]);
 
   const breadcrumbs = [
-    { label: 'Integration Services', href: '/integration-services' },
+    { label: 'Integration Catalog', href: '/integration-services' },
     { label: title },
   ];
 

--- a/frontend/src/pages/IntegrationServicesListingPage.tsx
+++ b/frontend/src/pages/IntegrationServicesListingPage.tsx
@@ -9,6 +9,7 @@ import { integrationCategoryFilterOptions } from '@/data/integrations';
 import { parseRequiredCredentials } from '@/types/integration.types';
 import type { IntegrationServiceDoc } from '@/types/integration.types';
 import { formatTimeAgo } from '@/utils/time';
+import { getServiceIdentity } from '@/data/serviceIdentity';
 
 export function IntegrationServicesListingPage() {
   const navigate = useNavigate();
@@ -104,6 +105,7 @@ export function IntegrationServicesListingPage() {
           </div>
         }
         renderItem={(service) => {
+          const identity = getServiceIdentity(service.service_name);
           const credentialCount = parseRequiredCredentials(service.required_credentials).length;
           const metadata = [
             { label: 'Category', value: service.category },
@@ -122,7 +124,8 @@ export function IntegrationServicesListingPage() {
 
           return (
             <ItemCard
-              title={service.service_name.replace(/_/g, ' ')}
+              title={identity.title}
+              icon={identity.icon}
               description={service.description || 'No description'}
               status={{
                 label: service.is_builtin ? 'built-in' : 'custom',

--- a/frontend/src/pages/IntegrationSettingsListingPage.tsx
+++ b/frontend/src/pages/IntegrationSettingsListingPage.tsx
@@ -119,7 +119,7 @@ export function IntegrationSettingsListingPage({
       }
       filters={
         <FilterBar
-          searchPlaceholder="Search integrations..."
+          searchPlaceholder={kind === 'channels' ? 'Search channels...' : 'Search integrations...'}
           searchValue={search}
           onSearchChange={setSearch}
           filters={[

--- a/frontend/src/pages/IntegrationSettingsListingPage.tsx
+++ b/frontend/src/pages/IntegrationSettingsListingPage.tsx
@@ -11,13 +11,16 @@ import {
 import { ServiceCatalogModal } from '@/components/integrations/ServiceCatalogModal';
 import type { IntegrationSettingsDoc, IntegrationServiceDoc } from '@/types/integration.types';
 import { formatTimeAgo } from '@/utils/time';
+import { getServiceIdentity, messagingServiceNames } from '@/data/serviceIdentity';
 
 interface IntegrationSettingsListingPageProps {
   catalogOpenKey?: number;
+  kind?: 'channels' | 'integrations';
 }
 
 export function IntegrationSettingsListingPage({
   catalogOpenKey,
+  kind = 'integrations',
 }: IntegrationSettingsListingPageProps) {
   const navigate = useNavigate();
   const [catalogOpen, setCatalogOpen] = useState(false);
@@ -91,11 +94,13 @@ export function IntegrationSettingsListingPage({
   });
 
   const settings = useMemo(() => {
-    if (categoryFilter === 'all') return allSettings;
-    return allSettings.filter(
-      (item) => serviceCategoryMap.get(item.service) === categoryFilter,
-    );
-  }, [allSettings, categoryFilter, serviceCategoryMap]);
+    const byKind = allSettings.filter((item) => {
+      const isMessaging = messagingServiceNames.has(item.service.toLowerCase());
+      return kind === 'channels' ? isMessaging : !isMessaging;
+    });
+    if (categoryFilter === 'all') return byKind;
+    return byKind.filter((item) => serviceCategoryMap.get(item.service) === categoryFilter);
+  }, [allSettings, categoryFilter, kind, serviceCategoryMap]);
 
   useEffect(() => {
     if (error) {
@@ -107,7 +112,11 @@ export function IntegrationSettingsListingPage({
 
   return (
     <PageLayout
-      subtitle="Connect external services like Slack, Telegram, GitHub, and Google Workspace"
+      subtitle={
+        kind === 'channels'
+          ? 'Connect the messaging apps where people talk to your agents'
+          : 'Connect calendars, project tools, developer services, and business systems'
+      }
       filters={
         <FilterBar
           searchPlaceholder="Search integrations..."
@@ -125,7 +134,7 @@ export function IntegrationSettingsListingPage({
         />
       }
     >
-      <ServiceCatalogModal open={catalogOpen} onOpenChange={setCatalogOpen} />
+      <ServiceCatalogModal open={catalogOpen} onOpenChange={setCatalogOpen} kind={kind} />
 
       {error && !initialLoading && (
         <div className="text-center py-12">
@@ -140,18 +149,21 @@ export function IntegrationSettingsListingPage({
         loading={initialLoading}
         emptyState={
           <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">No integrations configured yet.</p>
+            <p className="font-body text-steel-soft mb-4">
+              {kind === 'channels' ? 'No channels configured yet.' : 'No integrations configured yet.'}
+            </p>
             <button
               type="button"
               className="text-sm text-primary hover:underline"
               onClick={() => setCatalogOpen(true)}
             >
-              Add your first integration
+              {kind === 'channels' ? 'Add your first channel' : 'Add your first integration'}
             </button>
           </div>
         }
         renderItem={(setting) => {
           const category = serviceCategoryMap.get(setting.service);
+          const identity = getServiceIdentity(setting.service);
           const metadata = [
             ...(category ? [{ label: 'Category', value: category }] : []),
             ...(setting.is_default ? [{ label: 'Default', value: 'Yes', icon: Star }] : []),
@@ -166,7 +178,8 @@ export function IntegrationSettingsListingPage({
           return (
             <ItemCard
               title={setting.name}
-              description={`${setting.service.replace(/_/g, ' ')} integration`}
+              description={`${identity.title} ${kind === 'channels' ? 'channel' : 'integration'}`}
+              icon={identity.icon}
               status={{
                 label: setting.is_active ? 'active' : 'inactive',
                 variant: setting.is_active ? 'default' : 'secondary',

--- a/frontend/src/pages/MembersPage.tsx
+++ b/frontend/src/pages/MembersPage.tsx
@@ -1,0 +1,37 @@
+import { useSearchParams } from 'react-router-dom';
+import UsersPage from './UsersPage';
+import RolesPage from './RolesPage';
+
+const views = [
+  { value: 'people', label: 'People' },
+  { value: 'roles', label: 'Roles & access' },
+] as const;
+
+export default function MembersPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = searchParams.get('view') === 'roles' ? 'roles' : 'people';
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <nav aria-label="Member administration" className="mx-6 mt-5 flex shrink-0 border-b border-ink">
+        {views.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() => setSearchParams(item.value === 'people' ? {} : { view: item.value })}
+            className={`border-b-2 px-4 pb-2 font-mono text-[11.5px] uppercase tracking-wide transition-colors ${
+              view === item.value
+                ? '-mb-px border-signal text-ink'
+                : 'border-transparent text-steel hover:text-ink'
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </nav>
+      <div className="min-h-0 flex-1">
+        {view === 'roles' ? <RolesPage /> : <UsersPage />}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/agentApi.ts
+++ b/frontend/src/services/agentApi.ts
@@ -7,6 +7,56 @@ import { handleFrappeError } from '@/lib/frappe-error';
 import { getBrandLabel } from '@/utils/providerBrands';
 import { fetchPaginatedCount } from './utilsApi';
 
+export type AgentConfigSection =
+  | 'general'
+  | 'behavior'
+  | 'tools'
+  | 'knowledge'
+  | 'skills'
+  | 'permissions'
+  | 'advanced';
+
+export interface AgentSectionResponse {
+  name: string;
+  section: AgentConfigSection;
+  modified: string;
+  values: Partial<AgentDoc>;
+}
+
+export async function getAgentSection(
+  name: string,
+  section: AgentConfigSection,
+): Promise<AgentSectionResponse> {
+  try {
+    const result = await call.get('huf.ai.agent_config_api.get_agent_section', {
+      agent_name: name,
+      section,
+    });
+    return result.message as AgentSectionResponse;
+  } catch (error) {
+    handleFrappeError(error, `Error fetching ${section} settings for agent ${name}`);
+  }
+}
+
+export async function updateAgentSection(
+  name: string,
+  section: AgentConfigSection,
+  values: Partial<AgentDoc>,
+  expectedModified: string,
+): Promise<AgentSectionResponse> {
+  try {
+    const result = await call.post('huf.ai.agent_config_api.update_agent_section', {
+      agent_name: name,
+      section,
+      values: JSON.stringify(values),
+      expected_modified: expectedModified,
+    });
+    return result.message as AgentSectionResponse;
+  } catch (error) {
+    handleFrappeError(error, `Error updating ${section} settings for agent ${name}`);
+  }
+}
+
 /**
  * Trigger type from API
  */

--- a/huf/ai/agent_config_api.py
+++ b/huf/ai/agent_config_api.py
@@ -1,0 +1,191 @@
+"""Section-oriented Agent configuration API.
+
+The Agent DocType remains the canonical runtime aggregate. These endpoints
+only change the editor transport boundary: callers load and save one cohesive
+section at a time instead of round-tripping every field and child table.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+import frappe
+from frappe import _
+from frappe.utils import get_datetime
+
+
+AGENT_SECTIONS: dict[str, tuple[str, ...]] = {
+	"general": (
+		"agent_name",
+		"provider",
+		"model",
+		"temperature",
+		"top_p",
+		"disabled",
+		"run_immediately",
+		"description",
+		"instructions",
+		"prompt_mode",
+		"agent_prompt",
+		"prompt_version_locked",
+		"template_version_at_attach",
+		"copied_from_prompt",
+		"enable_prompt_caching",
+		"cache_control_type",
+		"cache_system_message",
+		"cache_conversation_history",
+		"is_system",
+		"last_run",
+		"total_run",
+	),
+	"behavior": (
+		"allow_chat",
+		"persist_conversation",
+		"persist_user_history",
+		"enable_multi_run",
+		"default_plan",
+	),
+	"tools": ("agent_tool", "agent_mcp_server"),
+	"knowledge": ("agent_knowledge",),
+	"skills": ("agent_skill",),
+	"permissions": ("allow_guest", "allowed_users", "allowed_roles"),
+	"advanced": (
+		"context_strategy",
+		"summary_model",
+		"summary_ratio",
+		"summary_prompt_mode",
+		"summary_prompt_template",
+		"summary_prompt_version_locked",
+		"summary_template_version_at_attach",
+		"summary_prompt",
+		"copied_from_summary_prompt",
+		"history_limit",
+		"max_knowledge_tokens",
+		"max_turns",
+		"max_context_chars",
+		"enable_conversation_data",
+		"inject_conversation_data",
+		"conversation_data_api_permission",
+		"autonaming_of_conversation_title",
+		"enable_memory",
+		"memory_policy",
+		"enable_memory_search_tool",
+		"enable_memory_write_tool",
+		"agent_color",
+		"show_tool_execution_details",
+		"image_generation_model",
+		"tts_model",
+		"tts_voice",
+		"stt_model",
+		"allow_file_upload",
+		"enable_ocr",
+		"max_upload_size_mb",
+		"allow_code_execution",
+		"execution_profile",
+		"execution_shared_dir_limit_mb",
+		"allow_ssh",
+		"ssh_connections",
+	),
+}
+
+READ_ONLY_FIELDS = {
+	"is_system",
+	"last_run",
+	"total_run",
+	"copied_from_prompt",
+	"copied_from_summary_prompt",
+}
+
+
+def _get_section_fields(section: str) -> tuple[str, ...]:
+	try:
+		return AGENT_SECTIONS[section]
+	except KeyError:
+		frappe.throw(
+			_("Unknown Agent configuration section: {0}").format(section),
+			frappe.ValidationError,
+		)
+
+
+def _serialize_value(value):
+	if isinstance(value, list):
+		return [row.as_dict(no_nulls=False) if hasattr(row, "as_dict") else row for row in value]
+	return value
+
+
+def _parse_values(values) -> dict:
+	if isinstance(values, str):
+		values = json.loads(values)
+	if not isinstance(values, Mapping):
+		frappe.throw(_("Section values must be a JSON object."), frappe.ValidationError)
+	return dict(values)
+
+
+def _assert_revision(agent_doc, expected_modified: str) -> None:
+	if not expected_modified:
+		frappe.throw(_("The Agent revision is required. Reload this section and try again."), frappe.ValidationError)
+	if get_datetime(agent_doc.modified) != get_datetime(expected_modified):
+		raise frappe.TimestampMismatchError(
+			_("This Agent changed after the section was loaded. Reload the section before saving.")
+		)
+
+
+def _section_response(agent_doc, section: str) -> dict:
+	return {
+		"name": agent_doc.name,
+		"section": section,
+		"modified": str(agent_doc.modified),
+		"values": {
+			field: _serialize_value(agent_doc.get(field))
+			for field in _get_section_fields(section)
+		},
+	}
+
+
+@frappe.whitelist()
+def get_agent_section(agent_name: str, section: str) -> dict:
+	"""Return one editor section and the revision it was read from."""
+	agent_doc = frappe.get_doc("Agent", agent_name)
+	agent_doc.check_permission("read")
+	return _section_response(agent_doc, section)
+
+
+@frappe.whitelist(methods=["POST"])
+def update_agent_section(
+	agent_name: str,
+	section: str,
+	values,
+	expected_modified: str,
+) -> dict:
+	"""Revision-check and replace the editable values in one Agent section."""
+	fields = set(_get_section_fields(section))
+	editable_fields = fields - READ_ONLY_FIELDS
+	parsed_values = _parse_values(values)
+	unknown_fields = set(parsed_values) - editable_fields
+	if unknown_fields:
+		frappe.throw(
+			_("Fields do not belong to section {0}: {1}").format(
+				section, ", ".join(sorted(unknown_fields))
+			),
+			frappe.ValidationError,
+		)
+
+	agent_doc = frappe.get_doc("Agent", agent_name)
+	agent_doc.check_permission("write")
+	_assert_revision(agent_doc, expected_modified)
+
+	new_agent_name = parsed_values.pop("agent_name", None)
+	if new_agent_name is not None:
+		new_agent_name = str(new_agent_name).strip()
+		if not new_agent_name:
+			frappe.throw(_("Agent name is required."), frappe.ValidationError)
+		if new_agent_name != agent_doc.name:
+			frappe.rename_doc("Agent", agent_doc.name, new_agent_name)
+			agent_doc = frappe.get_doc("Agent", new_agent_name)
+
+	for field, value in parsed_values.items():
+		agent_doc.set(field, value)
+
+	agent_doc.save()
+	return _section_response(agent_doc, section)

--- a/huf/ai/tests/test_agent_config_api.py
+++ b/huf/ai/tests/test_agent_config_api.py
@@ -1,0 +1,88 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from huf.ai.agent_config_api import get_agent_section, update_agent_section
+
+
+class TestAgentConfigAPI(IntegrationTestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+		model = frappe.get_all("AI Model", fields=["name", "provider"], limit=1)
+		if not model:
+			self.skipTest("no AI Model records on this site")
+		self.agent = frappe.get_doc(
+			{
+				"doctype": "Agent",
+				"agent_name": f"section-api-{frappe.generate_hash(length=8)}",
+				"provider": model[0].provider,
+				"model": model[0].name,
+				"instructions": "Keep this instruction",
+				"allow_chat": 0,
+				"persist_conversation": 1,
+			}
+		).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		if getattr(self, "agent", None) and frappe.db.exists("Agent", self.agent.name):
+			frappe.delete_doc("Agent", self.agent.name, ignore_permissions=True, force=True)
+
+	def test_section_read_is_narrow(self):
+		result = get_agent_section(self.agent.name, "general")
+
+		self.assertEqual(result["name"], self.agent.name)
+		self.assertIn("instructions", result["values"])
+		self.assertNotIn("agent_tool", result["values"])
+		self.assertNotIn("agent_knowledge", result["values"])
+
+	def test_section_update_preserves_other_sections(self):
+		before = get_agent_section(self.agent.name, "behavior")
+		result = update_agent_section(
+			self.agent.name,
+			"behavior",
+			{"allow_chat": 1, "persist_conversation": 1},
+			before["modified"],
+		)
+
+		self.assertEqual(result["values"]["allow_chat"], 1)
+		self.assertEqual(
+			frappe.db.get_value("Agent", self.agent.name, "instructions"),
+			"Keep this instruction",
+		)
+
+	def test_stale_revision_is_rejected(self):
+		before = get_agent_section(self.agent.name, "behavior")
+		frappe.db.set_value("Agent", self.agent.name, "description", "changed elsewhere")
+
+		with self.assertRaises(frappe.TimestampMismatchError):
+			update_agent_section(
+				self.agent.name,
+				"behavior",
+				{"persist_conversation": 1},
+				before["modified"],
+			)
+
+	def test_cross_section_field_is_rejected(self):
+		before = get_agent_section(self.agent.name, "behavior")
+
+		with self.assertRaises(frappe.ValidationError):
+			update_agent_section(
+				self.agent.name,
+				"behavior",
+				{"instructions": "not a behavior field"},
+				before["modified"],
+			)
+
+	def test_general_section_can_rename_agent(self):
+		before = get_agent_section(self.agent.name, "general")
+		new_name = f"{self.agent.name}-renamed"
+
+		result = update_agent_section(
+			self.agent.name,
+			"general",
+			{"agent_name": new_name},
+			before["modified"],
+		)
+
+		self.agent = frappe.get_doc("Agent", new_name)
+		self.assertEqual(result["name"], new_name)
+		self.assertEqual(self.agent.agent_name, new_name)


### PR DESCRIPTION
## Summary

- keep `Agent` as the canonical runtime aggregate while adding lazy, section-oriented read/save APIs
- protect section saves with parent `modified` revision checks and strict field allowlists
- turn Settings into a focused second-level sidebar with Intelligence, Runtime, Connectivity, and Access groups
- consolidate Agent and Summary prompts under Prompts with Instructions and Summarization sections
- split messaging Channels from non-messaging Integrations, combine Users/Roles under Members, and use service-specific identities
- hide incomplete Context Artifact navigation and redirect its routes to Executions

## Architecture

This intentionally does not create `Agent Settings`, `Agent Knowledge Settings`, or similar DocTypes. Runtime code still receives one consistent Agent aggregate. The editor loads General first, lazy-loads secondary sections, and saves only the active section with optimistic concurrency.

## Validation

- production frontend build / TypeScript project build: passed
- Vitest: 8 files, 74 tests passed
- new backend integration suite: 5 tests passed on a fresh dedicated bench
- Python syntax compilation: passed
- `git diff --check`: passed
- authenticated live pass on dedicated `16_agentnav` bench:
  - Settings drill-in and Back
  - Prompts Instructions/Summarization
  - Channels and Members
  - Artifact redirect
  - lazy Agent section load and section-only Behavior save

## Notes

The browser pass found and fixed two follow-ups before opening this PR: a stale General loading label caused by competing bootstrap/lazy requests, and Channels retaining the Integrations search placeholder.
