### PR TITLE
fix: render real integration brand icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,6 +60,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-icons": "^5.7.0",
         "react-jsx-parser": "^2.4.1",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^7.9.4",
@@ -12663,6 +12664,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-icons": "^5.7.0",
     "react-jsx-parser": "^2.4.1",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^7.9.4",

--- a/frontend/src/components/dashboard/cards/ItemCard.tsx
+++ b/frontend/src/components/dashboard/cards/ItemCard.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ComponentType, ReactNode } from 'react';
 import { LucideIcon, MoreVertical } from 'lucide-react';
 import { CardHeader, CardTitle, CardDescription, CardContent, CardAction } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -25,7 +25,7 @@ interface ActionButton {
 interface ItemCardProps {
   title: string;
   description?: string;
-  icon?: LucideIcon;
+  icon?: ComponentType<{ className?: string }>;
   avatarColor?: string | null;
   status?: {
     label: string;

--- a/frontend/src/data/serviceIdentity.test.ts
+++ b/frontend/src/data/serviceIdentity.test.ts
@@ -25,6 +25,7 @@ describe('service identities', () => {
     ['github', 'GitHub'],
     ['jira', 'Jira'],
     ['google_calendar', 'Google Calendar'],
+    ['serpapi', 'SerpApi'],
   ])('uses a mapped brand identity for %s', (service, title) => {
     const identity = getServiceIdentity(service);
 

--- a/frontend/src/data/serviceIdentity.test.ts
+++ b/frontend/src/data/serviceIdentity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { Workflow } from 'lucide-react';
+import { getServiceIdentity, messagingServiceNames } from './serviceIdentity';
+
+describe('service identities', () => {
+  it('classifies the supported messaging channels', () => {
+    expect([...messagingServiceNames].sort()).toEqual([
+      'discord',
+      'microsoft_teams',
+      'slack',
+      'teams',
+      'telegram',
+      'vk',
+      'wecom',
+      'whatsapp',
+    ]);
+  });
+
+  it.each([
+    ['telegram', 'Telegram'],
+    ['slack', 'Slack'],
+    ['whatsapp', 'WhatsApp'],
+    ['discord', 'Discord'],
+    ['teams', 'Microsoft Teams'],
+    ['github', 'GitHub'],
+    ['jira', 'Jira'],
+    ['google_calendar', 'Google Calendar'],
+  ])('uses a mapped brand identity for %s', (service, title) => {
+    const identity = getServiceIdentity(service);
+
+    expect(identity.title).toBe(title);
+    expect(identity.icon).not.toBe(Workflow);
+  });
+
+  it('uses a readable title and neutral icon for custom services', () => {
+    expect(getServiceIdentity('internal_ticketing')).toEqual({
+      title: 'Internal Ticketing',
+      icon: Workflow,
+    });
+  });
+});

--- a/frontend/src/data/serviceIdentity.ts
+++ b/frontend/src/data/serviceIdentity.ts
@@ -1,20 +1,23 @@
+import type { ComponentType } from 'react';
+import { Search, Workflow } from 'lucide-react';
+import { FaMicrosoft, FaSlack } from 'react-icons/fa';
 import {
-  Bot,
-  CalendarDays,
-  Folder,
-  Github,
-  LucideIcon,
-  Mail,
-  Map,
-  MessageCircle,
-  PanelsTopLeft,
-  Search,
-  Send,
-  Slack,
-  Table2,
-  Video,
-  Workflow,
-} from 'lucide-react';
+  SiDiscord,
+  SiGithub,
+  SiGmail,
+  SiGooglecalendar,
+  SiGoogledrive,
+  SiGooglemaps,
+  SiGooglemeet,
+  SiGooglesheets,
+  SiJira,
+  SiTelegram,
+  SiVk,
+  SiWechat,
+  SiWhatsapp,
+} from 'react-icons/si';
+
+export type ServiceIcon = ComponentType<{ className?: string }>;
 
 export const messagingServiceNames = new Set([
   'telegram',
@@ -27,23 +30,23 @@ export const messagingServiceNames = new Set([
   'vk',
 ]);
 
-const serviceIdentities: Record<string, { title: string; icon: LucideIcon }> = {
-  telegram: { title: 'Telegram', icon: Send },
-  slack: { title: 'Slack', icon: Slack },
-  whatsapp: { title: 'WhatsApp', icon: MessageCircle },
-  discord: { title: 'Discord', icon: Bot },
-  microsoft_teams: { title: 'Microsoft Teams', icon: Video },
-  teams: { title: 'Microsoft Teams', icon: Video },
-  wecom: { title: 'WeCom', icon: MessageCircle },
-  vk: { title: 'VK', icon: MessageCircle },
-  github: { title: 'GitHub', icon: Github },
-  jira: { title: 'Jira', icon: PanelsTopLeft },
-  gmail: { title: 'Gmail', icon: Mail },
-  google_calendar: { title: 'Google Calendar', icon: CalendarDays },
-  google_drive: { title: 'Google Drive', icon: Folder },
-  google_sheets: { title: 'Google Sheets', icon: Table2 },
-  google_maps: { title: 'Google Maps', icon: Map },
-  google_meet: { title: 'Google Meet', icon: Video },
+const serviceIdentities: Record<string, { title: string; icon: ServiceIcon }> = {
+  telegram: { title: 'Telegram', icon: SiTelegram },
+  slack: { title: 'Slack', icon: FaSlack },
+  whatsapp: { title: 'WhatsApp', icon: SiWhatsapp },
+  discord: { title: 'Discord', icon: SiDiscord },
+  microsoft_teams: { title: 'Microsoft Teams', icon: FaMicrosoft },
+  teams: { title: 'Microsoft Teams', icon: FaMicrosoft },
+  wecom: { title: 'WeCom', icon: SiWechat },
+  vk: { title: 'VK', icon: SiVk },
+  github: { title: 'GitHub', icon: SiGithub },
+  jira: { title: 'Jira', icon: SiJira },
+  gmail: { title: 'Gmail', icon: SiGmail },
+  google_calendar: { title: 'Google Calendar', icon: SiGooglecalendar },
+  google_drive: { title: 'Google Drive', icon: SiGoogledrive },
+  google_sheets: { title: 'Google Sheets', icon: SiGooglesheets },
+  google_maps: { title: 'Google Maps', icon: SiGooglemaps },
+  google_meet: { title: 'Google Meet', icon: SiGooglemeet },
   serpapi: { title: 'SerpApi', icon: Search },
 };
 

--- a/frontend/src/data/serviceIdentity.ts
+++ b/frontend/src/data/serviceIdentity.ts
@@ -1,5 +1,6 @@
+import { createElement } from 'react';
 import type { ComponentType } from 'react';
-import { Search, Workflow } from 'lucide-react';
+import { Workflow } from 'lucide-react';
 import { FaMicrosoft, FaSlack } from 'react-icons/fa';
 import {
   SiDiscord,
@@ -18,6 +19,40 @@ import {
 } from 'react-icons/si';
 
 export type ServiceIcon = ComponentType<{ className?: string }>;
+
+// Official icon-only mark from SerpApi's media kit. It is kept inline so the
+// integration catalog never depends on a third-party image host at runtime.
+const SerpApiIcon: ServiceIcon = ({ className }) =>
+  createElement(
+    'svg',
+    {
+      className,
+      viewBox: '0 0 726.54 726.54',
+      fill: 'none',
+      'aria-hidden': true,
+    },
+    createElement('path', {
+      d: 'm 141.299,530.374 c 8.977,31.839 35.67,56.769 69.397,64.614 V 726.54 H 208.88 C 97.7879,726.54 6.95296,639.815 0.381836,530.374 Z m 69.397,-398.823 c -41.703,9.701 -72.653,45.522 -72.653,88.227 0,50.157 42.693,90.818 95.358,90.818 52.665,0 95.359,-40.661 95.359,-90.818 0,-42.705 -30.951,-78.526 -72.655,-88.227 V 0 H 517.66 C 629.366,0 720.592,87.6865 726.261,197.982 H 583.916 c -10.25,-39.63 -47.818,-69.021 -92.594,-69.021 -52.665,0 -95.358,40.66 -95.358,90.817 0,42.706 30.951,78.526 72.654,88.227 v 110.529 c -41.703,9.701 -72.654,45.522 -72.654,88.228 0,42.705 30.951,78.526 72.654,88.226 V 726.54 H 256.105 V 594.988 c 41.704,-9.701 72.655,-45.521 72.655,-88.226 0,-50.157 -42.694,-90.817 -95.359,-90.818 -44.776,0 -82.343,29.392 -92.593,69.022 H 0 V 208.88 C 0,93.5188 93.5188,0 208.88,0 h 1.816 z M 726.54,517.66 c 0,115.361 -93.519,208.88 -208.88,208.88 h -3.633 V 594.988 c 41.703,-9.701 72.654,-45.521 72.654,-88.226 0,-42.706 -30.95,-78.527 -72.654,-88.228 V 308.005 c 33.728,-7.846 60.421,-32.775 69.398,-64.614 H 726.54 Z',
+      fill: 'url(#serpapi-brand-gradient)',
+    }),
+    createElement(
+      'defs',
+      null,
+      createElement(
+        'linearGradient',
+        {
+          id: 'serpapi-brand-gradient',
+          x1: '73.5622',
+          y1: '719.275',
+          x2: '653.886',
+          y2: '63.5722',
+          gradientUnits: 'userSpaceOnUse',
+        },
+        createElement('stop', { stopColor: '#377FEA' }),
+        createElement('stop', { offset: '1', stopColor: '#8C45EF' }),
+      ),
+    ),
+  );
 
 export const messagingServiceNames = new Set([
   'telegram',
@@ -47,7 +82,7 @@ const serviceIdentities: Record<string, { title: string; icon: ServiceIcon }> = 
   google_sheets: { title: 'Google Sheets', icon: SiGooglesheets },
   google_maps: { title: 'Google Maps', icon: SiGooglemaps },
   google_meet: { title: 'Google Meet', icon: SiGooglemeet },
-  serpapi: { title: 'SerpApi', icon: Search },
+  serpapi: { title: 'SerpApi', icon: SerpApiIcon },
 };
 
 export function getServiceIdentity(serviceName: string | null | undefined) {


### PR DESCRIPTION
## Summary

Follow-up to #503's completion audit:

- replace generic integration glyphs with bundled brand icons for messaging and non-messaging services
- use the official SerpApi icon-only gradient mark from its media kit
- broaden `ItemCard`'s title icon contract so both Lucide and brand components render cleanly
- keep the neutral Workflow fallback for unknown/custom services
- add service identity coverage

## Validation

- production frontend / TypeScript build passed
- Vitest: 9 files, 85 tests passed
- `git diff --check` passed
- Linux dedicated bench build passed at `5447472`
- authenticated live catalog validation confirmed distinct SVG brand paths for Slack, Discord, Telegram, GitHub, Gmail, Google services, Jira, and SerpApi
- SerpApi rendered with its official `#377FEA` to `#8C45EF` gradient and published icon path

## Dependency impact

Adds tree-shaken `react-icons`; the production precache increased by roughly 15 KB in the initial build comparison.
