### PR TITLE
fix: retire stale Gemini 2.5 Flash and sanitize provider errors

### DIFF
--- a/frontend/src/pages/AiProvidersPage.tsx
+++ b/frontend/src/pages/AiProvidersPage.tsx
@@ -66,9 +66,9 @@ const STARTER_PATHS: Record<StarterPath, {
   google: {
     providerName: 'Google',
     providerBrand: 'google',
-    modelName: 'gemini-2.5-flash',
+    modelName: 'gemini-3.5-flash',
     title: 'Try Gemini with Google AI Studio',
-    description: 'Use Gemini 2.5 Flash with the Google Gemini API free tier to explore Huf.',
+    description: 'Use Gemini 3.5 Flash with the Google Gemini API free tier to explore Huf.',
     caution: 'Free-tier limits apply. Google states that free-tier content may be used to improve its products; avoid sensitive production data.',
     signupUrl: 'https://aistudio.google.com/app/apikey',
     signupLabel: 'Get a Google AI Studio key',

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -303,7 +303,7 @@ function HomePage() {
               >
                 <div>
                   <span className="block font-medium">Try Gemini with Google AI Studio</span>
-                  <span className="mt-1 block text-xs text-muted-foreground">gemini-2.5-flash · Fast and intelligent model</span>
+                  <span className="mt-1 block text-xs text-muted-foreground">gemini-3.5-flash · Fast and intelligent model</span>
                 </div>
                 <ArrowRight className="ml-3 h-4 w-4 shrink-0" />
               </Button>

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -1880,9 +1880,10 @@ def _execute_agent_run(
         # model prefix, empty response). Surface it as a failed run — never
         # as assistant message content.
         error_msg = str(e)
+        log_error_msg = getattr(e, "log_message", error_msg)
         run_doc.db_set("status", "Failed", update_modified=True)
         run_doc.db_set("error_message", error_msg)
-        frappe.log_error(f"Provider unavailable for agent '{agent_name}': {error_msg}", "Huf Provider")
+        frappe.log_error(f"Provider unavailable for agent '{agent_name}': {log_error_msg}", "Huf Provider")
         _emit_run_lifecycle_event(run_doc, conversation, "failed", {"error": error_msg})
 
         # Handle Sub-Agent Failure Lifecycle Hook
@@ -3037,7 +3038,8 @@ async def run_agent_stream(
                 # Expected operational failure (connection refused, model not
                 # pulled, bad model prefix) — message is self-explanatory, no
                 # traceback needed. The run is still marked Failed below.
-                frappe.log_error(f"Provider unavailable for agent '{agent_name}': {error_msg}", "Huf Provider")
+                log_error_msg = getattr(e, "log_message", error_msg)
+                frappe.log_error(f"Provider unavailable for agent '{agent_name}': {log_error_msg}", "Huf Provider")
             else:
                 frappe.log_error(f"Agent Stream Error: {frappe.get_traceback()}", "Huf Streaming")
             if "ContextWindowExceededError" in error_msg:

--- a/huf/ai/app_seeding/hub_orchestrator.py
+++ b/huf/ai/app_seeding/hub_orchestrator.py
@@ -29,14 +29,19 @@ SEED_FILE = "hub-orchestrator.json"
 # chosen provider wins. Falls back to the provider's first non-specialized model.
 PREFERRED_MODELS = [
     "gpt-4o-mini",
-    "gemini-2.5-flash",
+    "gemini-3.5-flash",
     "claude-haiku-4.5",
     "claude-sonnet-4.5",
     "openai/gpt-4o-mini",
-    "google/gemini-2.5-flash",
+    "google/gemini-3.5-flash",
     "sonar",
     "command-a-03-2025",
 ]
+
+DEPRECATED_MODELS = {
+    "gemini-2.5-flash",
+    "google/gemini-2.5-flash",
+}
 
 # Model names matching these are not chat models; never auto-select them.
 _NON_CHAT_MARKERS = ("embedding", "whisper", "dall-e", "gpt-image", "tts", "image", "alternate")
@@ -228,7 +233,12 @@ def provision_hub_orchestrator(provider_doc=None) -> bool:
         return False
 
     agent = frappe.get_doc("Agent", HUB_AGENT_NAME)
-    if agent.provider and agent.model and _provider_has_key(agent.provider):
+    if (
+        agent.provider
+        and agent.model
+        and _provider_has_key(agent.provider)
+        and agent.model not in DEPRECATED_MODELS
+    ):
         return False
 
     if provider_doc is not None and provider_doc.get_password("api_key"):

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -58,6 +58,57 @@ class ProviderUnavailableError(Exception):
     """Raised when the LLM provider cannot serve this request (conn refused, model missing,
     bad model prefix, auth). Distinct from content-level errors."""
 
+    def __init__(self, public_message: str, *, log_message: str | None = None):
+        super().__init__(public_message)
+        self.public_message = public_message
+        self.log_message = log_message or public_message
+
+
+def _sanitize_provider_error_message(raw_message: str, normalized_model: str | None = None) -> str:
+    """Return a user-safe provider error message with no LiteLLM/provider internals."""
+    text = (raw_message or "").lower()
+
+    if "api key not configured" in text or "password not found" in text or "invalid api key" in text:
+        return "This provider is not configured correctly yet. Add or update its API key and try again."
+
+    if any(marker in text for marker in (
+        "no longer available",
+        "model not found",
+        "notfounderror",
+        "unsupported model",
+    )):
+        return "The selected model is no longer available from this provider. Choose a different model and try again."
+
+    if "ratelimit" in text or "rate limit" in text or "too many requests" in text:
+        return "This provider is rate-limiting requests right now. Please wait a moment and try again."
+
+    if "contextwindowexceedederror" in text or "context window" in text or "maximum context length" in text:
+        return "This conversation is too large for the selected model. Start a new conversation or reduce the context and try again."
+
+    if any(marker in text for marker in (
+        "internalservererror",
+        "server error",
+        "service unavailable",
+        "temporarily unavailable",
+        "connection refused",
+        "failed to connect",
+        "connection error",
+        "connection reset",
+        "broken pipe",
+        "unexpected eof",
+    )):
+        return "The AI provider is temporarily unavailable. Please try again in a moment."
+
+    model_hint = f" for {normalized_model}" if normalized_model else ""
+    return f"The AI provider could not complete this request{model_hint}. Please try again or choose a different model."
+
+
+def _raise_provider_unavailable(raw_message: str, normalized_model: str | None = None):
+    raise ProviderUnavailableError(
+        _sanitize_provider_error_message(raw_message, normalized_model),
+        log_message=raw_message,
+    )
+
 
 # High-performance in-memory cache for provider capabilities
 # Stores capability flags to avoid Redis hits on every request
@@ -752,12 +803,12 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                     pass
 
             except InternalServerError as e:
-                msg = (
+                raw_msg = (
                     f"OpenAI API server error with model '{normalized_model}'. "
                     f"This may be temporary. Details: {str(e)}"
                 )
-                frappe.log_error(message=msg, title="LiteLLM Provider")
-                raise ProviderUnavailableError(msg)
+                frappe.log_error(message=raw_msg, title="LiteLLM Provider")
+                _raise_provider_unavailable(raw_msg, normalized_model)
 
             except RateLimitError as e:
                 title = f"LiteLLM RateLimit: {normalized_model}"[:140]
@@ -775,20 +826,20 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                 raise e
 
             except APIError as e:
-                msg = f"API error for model '{normalized_model}': {str(e)}"
-                frappe.log_error(message=msg, title="LiteLLM Provider")
-                raise ProviderUnavailableError(msg)
+                raw_msg = f"API error for model '{normalized_model}': {str(e)}"
+                frappe.log_error(message=raw_msg, title="LiteLLM Provider")
+                _raise_provider_unavailable(raw_msg, normalized_model)
 
             except Exception as e:
-                msg = f"LiteLLM error for model '{normalized_model}': {str(e)}"
+                raw_msg = f"LiteLLM error for model '{normalized_model}': {str(e)}"
                 frappe.log_error(
-                    message=f"{msg}\n\n{frappe.get_traceback()}",
+                    message=f"{raw_msg}\n\n{frappe.get_traceback()}",
                     title="LiteLLM Provider"
                 )
                 if "ContextWindowExceededError" in str(e) or "RateLimitError" in str(e):
                     raise e
 
-                raise ProviderUnavailableError(msg)
+                _raise_provider_unavailable(raw_msg, normalized_model)
 
             # Empty-response guard: reasoning models (e.g. gpt-oss) on the 'ollama/'
             # endpoint can return empty content with no tool calls. Retry the completion
@@ -804,11 +855,12 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                     )
                     response = await _litellm_completion_with_retry(**completion_kwargs)
                 else:
-                    raise ProviderUnavailableError(
+                    raw_msg = (
                         f"Model '{normalized_model}' returned an empty response. "
                         "Known issue with reasoning models (e.g. gpt-oss) on the 'ollama/' "
                         "endpoint — use the 'ollama_chat/' prefix or check the model."
                     )
+                    raise ProviderUnavailableError(raw_msg, log_message=raw_msg)
 
             # Extract response
             choice = response.choices[0].message
@@ -999,7 +1051,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
         if "ContextWindowExceededError" in str(e) or "RateLimitError" in str(e):
             raise e
 
-        raise ProviderUnavailableError(msg)
+        _raise_provider_unavailable(msg)
 
 
 async def get_simple_completion(model: str, messages: list, provider: str) -> str:
@@ -1594,23 +1646,28 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                     break
 
             except InternalServerError as e:
-                yield {"type": "error", "error": f"OpenAI API server error: {str(e)}"}
+                raw_msg = f"OpenAI API server error: {str(e)}"
+                yield {"type": "error", "error": _sanitize_provider_error_message(raw_msg)}
                 return
             except RateLimitError as e:
-                yield {"type": "error", "error": f"RateLimitError: {str(e)}"}
+                raw_msg = f"RateLimitError: {str(e)}"
+                yield {"type": "error", "error": _sanitize_provider_error_message(raw_msg)}
                 return
             except ContextWindowExceededError as e:
-                yield {"type": "error", "error": f"ContextWindowExceededError: {str(e)}"}
+                raw_msg = f"ContextWindowExceededError: {str(e)}"
+                yield {"type": "error", "error": _sanitize_provider_error_message(raw_msg)}
                 return
             except APIError as e:
-                yield {"type": "error", "error": f"API error: {str(e)}"}
+                raw_msg = f"API error: {str(e)}"
+                yield {"type": "error", "error": _sanitize_provider_error_message(raw_msg)}
                 return
             except Exception as e:
                 frappe.log_error(
                     message=f"LiteLLM streaming round error: {str(e)}\n\n{frappe.get_traceback()}",
                     title="LiteLLM Streaming"
                 )
-                yield {"type": "error", "error": f"LiteLLM error: {str(e)}"}
+                raw_msg = f"LiteLLM error: {str(e)}"
+                yield {"type": "error", "error": _sanitize_provider_error_message(raw_msg)}
                 return
 
         # Max rounds reached

--- a/huf/ai/tests/test_provider_error_contract.py
+++ b/huf/ai/tests/test_provider_error_contract.py
@@ -26,6 +26,7 @@ from frappe.tests.utils import FrappeTestCase
 from huf.ai.providers import litellm as litellm_module
 from huf.ai.providers.litellm import (
     ProviderUnavailableError,
+    _sanitize_provider_error_message,
     _is_transient_litellm_error,
     _normalize_model_name,
     _resolve_api_base,
@@ -188,3 +189,25 @@ class TestTransientRetryKeywords(FrappeTestCase):
     def test_non_transient_errors_unchanged(self):
         self.assertFalse(_is_transient_litellm_error(Exception("invalid api key")))
         self.assertFalse(_is_transient_litellm_error(Exception("model not found")))
+
+
+class TestProviderErrorSanitization(FrappeTestCase):
+    def test_unavailable_model_message_hides_litellm_details(self):
+        message = _sanitize_provider_error_message(
+            "LiteLLM error: litellm.NotFoundError: Vertex_ai_betaException - model models/gemini-2.5-flash is no longer available",
+            "gemini-2.5-flash",
+        )
+        self.assertEqual(
+            message,
+            "The selected model is no longer available from this provider. Choose a different model and try again.",
+        )
+
+    def test_generic_provider_message_hides_litellm_branding(self):
+        message = _sanitize_provider_error_message(
+            "LiteLLM Provider Error: provider exploded in some internal way",
+            "gemini-3.5-flash",
+        )
+        self.assertEqual(
+            message,
+            "The AI provider could not complete this request for gemini-3.5-flash. Please try again or choose a different model.",
+        )

--- a/huf/install.py
+++ b/huf/install.py
@@ -119,6 +119,7 @@ def after_migrate():
 	Syncs all discovered tools from all installed apps.
 	"""
 	create_huf_roles()
+	create_demo_ai_models()
 	setup_desktop_icon_as_workspace("huf")
 	try:
 		create_image_generation_tool()
@@ -215,6 +216,15 @@ def create_demo_ai_providers():
             doc.insert(ignore_permissions=True)
 
 def create_demo_ai_models():
+    deprecated_models = (
+        "gemini-2.5-flash",
+        "google/gemini-2.5-flash",
+    )
+
+    for model_name in deprecated_models:
+        if frappe.db.exists("AI Model", model_name):
+            frappe.delete_doc("AI Model", model_name, ignore_permissions=True, force=True)
+
     models = [
         # {"doctype": "AI Model", "model_name": "deepseek/deepseek-chat-v3-0324", "provider": "DeepSeek"},
         # {"doctype": "AI Model", "model_name": "deepseek/deepseek-v3", "provider": "DeepSeek"},
@@ -238,7 +248,6 @@ def create_demo_ai_models():
         {"doctype": "AI Model", "model_name": "gemini-3.1-flash-lite", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemini-3-flash-preview", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemini-2.5-pro", "provider": "Google"},
-        {"doctype": "AI Model", "model_name": "gemini-2.5-flash", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemini-2.5-flash-lite", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemma-3-27b-it", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemma-3-9b-it", "provider": "Google"},
@@ -256,7 +265,6 @@ def create_demo_ai_models():
         {"doctype": "AI Model", "model_name": "openai/gpt-5-mini", "provider": "OpenRouter"},
         {"doctype": "AI Model", "model_name": "openai/gpt-5-nano", "provider": "OpenRouter"},
         {"doctype": "AI Model", "model_name": "openai/gpt-4o-mini", "provider": "OpenRouter"},
-        {"doctype": "AI Model", "model_name": "google/gemini-2.5-flash", "provider": "OpenRouter"},
         {"doctype": "AI Model", "model_name": "google/gemini-2.5-flash-lite-preview-06-17", "provider": "OpenRouter"},
         {"doctype": "AI Model", "model_name": "google/gemma-3-27b-it", "provider": "OpenRouter"},
         {"doctype": "AI Model", "model_name": "deepseek/deepseek-v4-pro", "provider": "OpenRouter"},
@@ -1245,4 +1253,3 @@ def create_default_execution_profiles():
 			)
 
 	frappe.db.commit()
-


### PR DESCRIPTION
## Summary
- stop serving deprecated `gemini-2.5-flash` defaults and seeded model rows
- repoint upgraded Hub Orchestrator installs to `gemini-3.5-flash` on migrate
- sanitize provider/LiteLLM failures so user-visible chat errors stay plain-language while logs keep the raw detail

## Validation
- `python3 -m compileall` on changed backend files
- `bench build` on `16_agentnav`
- `bench --site huf-agentnav.localhost migrate`
- `bench --site huf-agentnav.localhost clear-cache`
- verified upgraded site only returns `gemini-3.5-flash` from the targeted Google/OpenRouter stale-model check
- verified `Hub Orchestrator` re-provisioned to `Google / gemini-3.5-flash`
- verified sanitized unavailable-model message in bench console
- verified real Google provider path on `gemini-3.5-flash` returned `hello` in bench console

## Notes
- the focused `run-tests --module huf.ai.tests.test_provider_error_contract` attempt hit an existing Frappe test-import issue in this bench (`frappe.logger` missing during unrelated module discovery), so runtime verification was completed directly in the live bench context instead