### PR TITLE
Add Linear-style keyboard shortcuts, hints, and Enter/Shift+Enter polish

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, LayoutDashboard, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Terminal, Settings, Shield, LayoutGrid, Brain, Sparkles } from "lucide-react"
+import { ArrowLeft, Home, LayoutDashboard, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Terminal, Settings, Shield, LayoutGrid, Brain, Sparkles, Keyboard } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -8,6 +8,8 @@ import { AppSidebarHeader } from "@/components/app-sidebar-header"
 import { usePermissions } from "@/contexts/PermissionsContext"
 import { fetchDocCountQuiet } from "@/services/utilsApi"
 import { doctype } from "@/data/doctypes"
+import { ShortcutKey } from "@/components/ui/shortcut-key"
+import { useShortcutsHelp } from "@/components/shortcuts/ShortcutsHelpContext"
 import {
   Sidebar,
   SidebarContent,
@@ -183,6 +185,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const location = useLocation()
   const { hasCapability, isLoading } = usePermissions()
   const [agentCount, setAgentCount] = React.useState<number | undefined>(undefined)
+  const { setOpen: setShortcutsHelpOpen } = useShortcutsHelp()
 
   React.useEffect(() => {
     let cancelled = false
@@ -281,6 +284,21 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               <SidebarMenuButton tooltip="Settings" onClick={() => setSettingsMode(true)}>
                 <Settings strokeWidth={1.6} />
                 <span className="font-body text-[13.5px]">Settings</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        )}
+        {!settingsMode && (
+          <SidebarMenu className="px-2">
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                tooltip="Keyboard shortcuts"
+                onClick={() => setShortcutsHelpOpen(true)}
+                className="group-data-[collapsible=icon]:justify-center"
+              >
+                <Keyboard strokeWidth={1.6} />
+                <span className="font-body text-[13.5px] flex-1">Keyboard shortcuts</span>
+                <ShortcutKey size="sm">?</ShortcutKey>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/frontend/src/components/shortcuts/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/components/shortcuts/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { ShortcutKey } from '@/components/ui/shortcut-key';
+import { SHORTCUTS, formatBinding, type ShortcutScope } from '@/lib/shortcuts/registry';
+import { usePlatform } from '@/lib/shortcuts/platform';
+
+const SCOPE_ORDER: ShortcutScope[] = ['Global', 'Chat', 'Sidebar'];
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcutsDialogProps) {
+  const platform = usePlatform();
+
+  const groups = SCOPE_ORDER.map((scope) => ({
+    scope,
+    shortcuts: SHORTCUTS.filter((s) => s.scope === scope),
+  })).filter((group) => group.shortcuts.length > 0);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>Speed up common actions across the app.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-5">
+          {groups.map((group) => (
+            <div key={group.scope} className="flex flex-col gap-2">
+              <h3 className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+                {group.scope}
+              </h3>
+              <div className="flex flex-col gap-2">
+                {group.shortcuts.map((shortcut) => (
+                  <div key={shortcut.id} className="flex items-center justify-between gap-4">
+                    <span className="text-sm text-zinc-700">{shortcut.description}</span>
+                    <ShortcutKey keys={formatBinding(shortcut.binding, platform)} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/shortcuts/ShortcutsHelpContext.tsx
+++ b/frontend/src/components/shortcuts/ShortcutsHelpContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+import { useKeyboardShortcut } from '@/lib/shortcuts/useKeyboardShortcut';
+import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog';
+
+interface ShortcutsHelpContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const ShortcutsHelpContext = createContext<ShortcutsHelpContextValue | null>(null);
+
+/**
+ * Owns the "?" keyboard shortcuts help dialog: binds the "?" key globally
+ * and exposes `useShortcutsHelp()` so any visible affordance (sidebar
+ * footer, help menu, etc.) can open the same dialog.
+ */
+export function ShortcutsHelpProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  useKeyboardShortcut({ key: '?' }, () => setOpen(true));
+
+  const value = useMemo(() => ({ open, setOpen }), [open]);
+
+  return (
+    <ShortcutsHelpContext.Provider value={value}>
+      {children}
+      <KeyboardShortcutsDialog open={open} onOpenChange={setOpen} />
+    </ShortcutsHelpContext.Provider>
+  );
+}
+
+export function useShortcutsHelp(): ShortcutsHelpContextValue {
+  const ctx = useContext(ShortcutsHelpContext);
+  if (!ctx) {
+    throw new Error('useShortcutsHelp must be used within a ShortcutsHelpProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/components/ui/shortcut-key.tsx
+++ b/frontend/src/components/ui/shortcut-key.tsx
@@ -1,7 +1,31 @@
-export function ShortcutKey({ children }: { children: React.ReactNode }) {
-    return (
-        <kbd className="flex items-center gap-2 font-sans border border-zinc-300 rounded px-1">
-            {children}
-        </kbd>
+import { cn } from "@/lib/utils"
+
+interface ShortcutKeyProps {
+    children?: React.ReactNode
+    /** Render one badge per key label (e.g. ["⌘", "K"]) instead of `children`. */
+    keys?: string[]
+    size?: "sm" | "md"
+    className?: string
+}
+
+export function ShortcutKey({ children, keys, size = "md", className }: ShortcutKeyProps) {
+    const badgeClasses = cn(
+        "flex items-center gap-2 font-sans border border-zinc-300 rounded px-1",
+        size === "sm" && "text-[10px] px-1 leading-4",
+        className
     )
+
+    if (keys) {
+        return (
+            <span className="inline-flex items-center gap-1">
+                {keys.map((key, index) => (
+                    <kbd key={`${key}-${index}`} className={badgeClasses}>
+                        {key}
+                    </kbd>
+                ))}
+            </span>
+        )
+    }
+
+    return <kbd className={badgeClasses}>{children}</kbd>
 }

--- a/frontend/src/layouts/UnifiedLayout.tsx
+++ b/frontend/src/layouts/UnifiedLayout.tsx
@@ -8,6 +8,7 @@ import {
   SidebarTrigger,
 } from '../components/ui/sidebar';
 import { Separator } from '../components/ui/separator';
+import { ShortcutsHelpProvider } from '../components/shortcuts/ShortcutsHelpContext';
 
 export interface BreadcrumbItem {
   label: string;
@@ -27,22 +28,24 @@ export function UnifiedLayout({ children, hideHeader, headerActions, breadcrumbs
   const defaultOpen = location.pathname !== '/';
 
   return (
-    <SidebarProvider defaultOpen={defaultOpen}>
-      <AppSidebar />
-      <SidebarInset className="h-svh max-h-svh overflow-hidden">
-        {!hideHeader && (
-          <header className="flex h-[60px] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-[60px] border-b border-line bg-panel">
-            <div className="flex items-center gap-2 px-4 w-full">
-              <SidebarTrigger className="-ml-1 text-steel hover:text-ink" />
-              <Separator orientation="vertical" className="mr-2 h-4 bg-line" />
-              <UnifiedHeader actions={headerActions} breadcrumbs={breadcrumbs} />
-            </div>
-          </header>
-        )}
-        <main className="flex-1 overflow-hidden flex flex-col min-h-0">
-          {children || <Outlet />}
-        </main>
-      </SidebarInset>
-    </SidebarProvider>
+    <ShortcutsHelpProvider>
+      <SidebarProvider defaultOpen={defaultOpen}>
+        <AppSidebar />
+        <SidebarInset className="h-svh max-h-svh overflow-hidden">
+          {!hideHeader && (
+            <header className="flex h-[60px] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-[60px] border-b border-line bg-panel">
+              <div className="flex items-center gap-2 px-4 w-full">
+                <SidebarTrigger className="-ml-1 text-steel hover:text-ink" />
+                <Separator orientation="vertical" className="mr-2 h-4 bg-line" />
+                <UnifiedHeader actions={headerActions} breadcrumbs={breadcrumbs} />
+              </div>
+            </header>
+          )}
+          <main className="flex-1 overflow-hidden flex flex-col min-h-0">
+            {children || <Outlet />}
+          </main>
+        </SidebarInset>
+      </SidebarProvider>
+    </ShortcutsHelpProvider>
   );
 }

--- a/frontend/src/lib/shortcuts/matching.test.ts
+++ b/frontend/src/lib/shortcuts/matching.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { isEditableTarget, matchesBinding, shouldHandleShortcut } from './matching';
+
+function event(overrides: Partial<{
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}> = {}) {
+  return {
+    key: overrides.key ?? 'b',
+    metaKey: overrides.metaKey ?? false,
+    ctrlKey: overrides.ctrlKey ?? false,
+    shiftKey: overrides.shiftKey ?? false,
+    altKey: overrides.altKey ?? false,
+  };
+}
+
+describe('matchesBinding', () => {
+  it('matches Cmd+B on mac via metaKey', () => {
+    expect(matchesBinding(event({ key: 'b', metaKey: true }), { key: 'b', mod: true }, 'mac')).toBe(
+      true
+    );
+  });
+
+  it('matches Ctrl+B on windows/linux via ctrlKey', () => {
+    expect(
+      matchesBinding(event({ key: 'b', ctrlKey: true }), { key: 'b', mod: true }, 'windows')
+    ).toBe(true);
+  });
+
+  it('does not match when the wrong platform modifier is pressed', () => {
+    expect(matchesBinding(event({ key: 'b', ctrlKey: true }), { key: 'b', mod: true }, 'mac')).toBe(
+      false
+    );
+  });
+
+  it('does not match when the required modifier is missing', () => {
+    expect(matchesBinding(event({ key: 'b' }), { key: 'b', mod: true }, 'mac')).toBe(false);
+  });
+
+  it('is case-insensitive on the key', () => {
+    expect(matchesBinding(event({ key: 'B' }), { key: 'b' }, 'mac')).toBe(true);
+  });
+
+  it('ignores shift/alt when the binding does not specify them', () => {
+    expect(matchesBinding(event({ key: '?', shiftKey: true }), { key: '?' }, 'mac')).toBe(true);
+  });
+
+  it('requires shift to match when the binding specifies it', () => {
+    expect(
+      matchesBinding(event({ key: 'Enter', shiftKey: true }), { key: 'Enter', shift: true }, 'mac')
+    ).toBe(true);
+    expect(
+      matchesBinding(event({ key: 'Enter', shiftKey: false }), { key: 'Enter', shift: true }, 'mac')
+    ).toBe(false);
+  });
+});
+
+describe('isEditableTarget', () => {
+  it('treats input, textarea and select as editable', () => {
+    expect(isEditableTarget({ tagName: 'INPUT' })).toBe(true);
+    expect(isEditableTarget({ tagName: 'TEXTAREA' })).toBe(true);
+    expect(isEditableTarget({ tagName: 'SELECT' })).toBe(true);
+  });
+
+  it('treats contenteditable elements as editable regardless of tag', () => {
+    expect(isEditableTarget({ tagName: 'DIV', isContentEditable: true })).toBe(true);
+  });
+
+  it('treats other elements as non-editable', () => {
+    expect(isEditableTarget({ tagName: 'DIV' })).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('shouldHandleShortcut', () => {
+  it('allows shortcuts when focus is not in an editable element', () => {
+    expect(
+      shouldHandleShortcut({ target: { tagName: 'DIV' }, key: 'k' })
+    ).toBe(true);
+  });
+
+  it('suppresses shortcuts while typing in an input', () => {
+    expect(
+      shouldHandleShortcut({ target: { tagName: 'INPUT' }, key: 'k' })
+    ).toBe(false);
+  });
+
+  it('allows a key in alwaysAllowKeys while typing (e.g. Escape)', () => {
+    expect(
+      shouldHandleShortcut({
+        target: { tagName: 'TEXTAREA' },
+        key: 'Escape',
+        alwaysAllowKeys: ['Escape'],
+      })
+    ).toBe(true);
+  });
+
+  it('respects a custom alwaysAllowKeys list', () => {
+    expect(
+      shouldHandleShortcut({
+        target: { tagName: 'INPUT' },
+        key: 'Enter',
+        alwaysAllowKeys: ['Enter'],
+      })
+    ).toBe(true);
+  });
+
+  it('allows any key in editable elements when allowInEditable is set', () => {
+    expect(
+      shouldHandleShortcut({ target: { tagName: 'INPUT' }, key: 'k', allowInEditable: true })
+    ).toBe(true);
+  });
+});

--- a/frontend/src/lib/shortcuts/matching.ts
+++ b/frontend/src/lib/shortcuts/matching.ts
@@ -1,0 +1,74 @@
+import type { Platform } from './platform';
+
+/**
+ * A key combination to match against a keydown event.
+ * Modifier fields are optional: omit one to ignore it entirely (useful for
+ * symbol keys like "?" where the shift state is already encoded in the
+ * character), or set it explicitly (true/false) to require an exact match.
+ */
+export interface ShortcutBinding {
+  key: string;
+  /** Cmd on Mac, Ctrl on Windows/Linux. */
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+}
+
+export interface MatchableEvent {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+export function matchesBinding(
+  event: MatchableEvent,
+  binding: ShortcutBinding,
+  platform: Platform
+): boolean {
+  if (event.key.toLowerCase() !== binding.key.toLowerCase()) return false;
+
+  if (binding.mod !== undefined) {
+    const modPressed = platform === 'mac' ? event.metaKey : event.ctrlKey;
+    if (modPressed !== binding.mod) return false;
+  }
+
+  if (binding.shift !== undefined && event.shiftKey !== binding.shift) return false;
+  if (binding.alt !== undefined && event.altKey !== binding.alt) return false;
+
+  return true;
+}
+
+export interface FocusTarget {
+  tagName?: string;
+  isContentEditable?: boolean;
+}
+
+const EDITABLE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+export function isEditableTarget(target: FocusTarget | null | undefined): boolean {
+  if (!target) return false;
+  if (target.isContentEditable) return true;
+  return !!target.tagName && EDITABLE_TAGS.has(target.tagName.toUpperCase());
+}
+
+export interface ShouldHandleOptions {
+  target: FocusTarget | null | undefined;
+  key: string;
+  /** Allow the shortcut to fire even while focus is in an editable element. */
+  allowInEditable?: boolean;
+  /** Keys that are always allowed regardless of focus (e.g. Escape). */
+  alwaysAllowKeys?: string[];
+}
+
+/**
+ * Decides whether a global shortcut should fire given where focus currently
+ * is. Typing in an input/textarea/contenteditable suppresses shortcuts
+ * unless explicitly allowed.
+ */
+export function shouldHandleShortcut(opts: ShouldHandleOptions): boolean {
+  if (!isEditableTarget(opts.target)) return true;
+  if (opts.allowInEditable) return true;
+  return !!opts.alwaysAllowKeys?.some((k) => k.toLowerCase() === opts.key.toLowerCase());
+}

--- a/frontend/src/lib/shortcuts/platform.test.ts
+++ b/frontend/src/lib/shortcuts/platform.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { detectPlatform, getModifierKey } from './platform';
+
+describe('detectPlatform', () => {
+  it('detects mac from userAgentData.platform', () => {
+    expect(detectPlatform({ userAgentData: { platform: 'macOS' } })).toBe('mac');
+  });
+
+  it('detects mac from navigator.platform when userAgentData is unavailable', () => {
+    expect(detectPlatform({ platform: 'MacIntel' })).toBe('mac');
+  });
+
+  it('falls back to userAgent when platform is unavailable', () => {
+    expect(
+      detectPlatform({ userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' })
+    ).toBe('mac');
+  });
+
+  it('detects linux', () => {
+    expect(detectPlatform({ platform: 'Linux x86_64' })).toBe('linux');
+  });
+
+  it('defaults to windows for windows hints and unknown input', () => {
+    expect(detectPlatform({ platform: 'Win32' })).toBe('windows');
+    expect(detectPlatform({})).toBe('windows');
+  });
+
+  it('prefers userAgentData over the legacy platform fallback', () => {
+    expect(detectPlatform({ userAgentData: { platform: 'Linux' }, platform: 'MacIntel' })).toBe(
+      'linux'
+    );
+  });
+});
+
+describe('getModifierKey', () => {
+  it('returns Cmd/Option symbols on mac', () => {
+    expect(getModifierKey('mac')).toEqual({
+      platform: 'mac',
+      mod: '⌘',
+      modLabel: 'Cmd',
+      alt: '⌥',
+      altLabel: 'Option',
+    });
+  });
+
+  it('returns Ctrl/Alt labels on windows and linux', () => {
+    expect(getModifierKey('windows')).toMatchObject({ mod: 'Ctrl', alt: 'Alt' });
+    expect(getModifierKey('linux')).toMatchObject({ mod: 'Ctrl', alt: 'Alt' });
+  });
+});

--- a/frontend/src/lib/shortcuts/platform.ts
+++ b/frontend/src/lib/shortcuts/platform.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+export type Platform = 'mac' | 'windows' | 'linux';
+
+interface NavigatorLike {
+  platform?: string;
+  userAgent?: string;
+  userAgentData?: { platform?: string };
+}
+
+/**
+ * Resolves the OS family from the platform hints available on `navigator`.
+ * `userAgentData.platform` is the modern source but isn't universally
+ * supported (notably Safari/Firefox), so `platform`/`userAgent` are always
+ * checked as a fallback.
+ */
+export function detectPlatform(nav?: NavigatorLike): Platform {
+  const n = nav ?? (typeof navigator !== 'undefined' ? (navigator as NavigatorLike) : undefined);
+  if (!n) return 'windows';
+
+  const hint = n.userAgentData?.platform || n.platform || n.userAgent || '';
+
+  if (/mac|iphone|ipad|ipod/i.test(hint)) return 'mac';
+  if (/linux/i.test(hint)) return 'linux';
+  return 'windows';
+}
+
+export interface ModifierLabels {
+  platform: Platform;
+  /** Primary modifier: ⌘ on Mac, Ctrl on Windows/Linux. */
+  mod: string;
+  modLabel: string;
+  /** Secondary modifier: ⌥ (Option) on Mac, Alt on Windows/Linux. */
+  alt: string;
+  altLabel: string;
+}
+
+export function getModifierKey(platform: Platform = detectPlatform()): ModifierLabels {
+  if (platform === 'mac') {
+    return { platform, mod: '⌘', modLabel: 'Cmd', alt: '⌥', altLabel: 'Option' };
+  }
+  return { platform, mod: 'Ctrl', modLabel: 'Ctrl', alt: 'Alt', altLabel: 'Alt' };
+}
+
+/** Detects the current platform, re-resolving after mount for SSR safety. */
+export function usePlatform(): Platform {
+  const [platform, setPlatform] = useState<Platform>(() => detectPlatform());
+
+  useEffect(() => {
+    setPlatform(detectPlatform());
+  }, []);
+
+  return platform;
+}

--- a/frontend/src/lib/shortcuts/registry.ts
+++ b/frontend/src/lib/shortcuts/registry.ts
@@ -1,0 +1,77 @@
+import type { ShortcutBinding } from './matching';
+import { getModifierKey, type Platform } from './platform';
+
+export type ShortcutScope = 'Global' | 'Chat' | 'Sidebar';
+
+export interface ShortcutDescriptor {
+  id: string;
+  binding: ShortcutBinding;
+  description: string;
+  scope: ShortcutScope;
+}
+
+/**
+ * Central, typed list of every real keyboard shortcut in the app. This
+ * drives the "?" help dialog. A handful are bound elsewhere (sidebar
+ * toggle in `components/ui/sidebar.tsx`, save in `useSaveShortcut`, submit
+ * in `ChatInput`) — they're listed here purely for discoverability, not
+ * re-bound, to avoid double listeners.
+ */
+export const SHORTCUTS: ShortcutDescriptor[] = [
+  {
+    id: 'shortcuts-help',
+    binding: { key: '?' },
+    description: 'Show keyboard shortcuts',
+    scope: 'Global',
+  },
+  {
+    id: 'sidebar-toggle',
+    binding: { key: 'b', mod: true },
+    description: 'Toggle sidebar',
+    scope: 'Global',
+  },
+  {
+    id: 'save',
+    binding: { key: 's', mod: true },
+    description: 'Save',
+    scope: 'Global',
+  },
+  {
+    id: 'close-dialog',
+    binding: { key: 'Escape' },
+    description: 'Close dialog or popover',
+    scope: 'Global',
+  },
+  {
+    id: 'chat-send',
+    binding: { key: 'Enter' },
+    description: 'Send message',
+    scope: 'Chat',
+  },
+  {
+    id: 'chat-newline',
+    binding: { key: 'Enter', shift: true },
+    description: 'Insert new line',
+    scope: 'Chat',
+  },
+];
+
+/** Renders a binding as the ordered list of key labels for a given platform. */
+export function formatBinding(binding: ShortcutBinding, platform: Platform): string[] {
+  const mod = getModifierKey(platform);
+  const labels: string[] = [];
+
+  if (binding.mod) labels.push(mod.mod);
+  if (binding.alt) labels.push(mod.alt);
+  if (binding.shift) labels.push('Shift');
+
+  labels.push(formatKeyLabel(binding.key));
+
+  return labels;
+}
+
+function formatKeyLabel(key: string): string {
+  if (key === ' ') return 'Space';
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}

--- a/frontend/src/lib/shortcuts/useKeyboardShortcut.ts
+++ b/frontend/src/lib/shortcuts/useKeyboardShortcut.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from 'react';
+import { detectPlatform } from './platform';
+import { matchesBinding, shouldHandleShortcut, type ShortcutBinding } from './matching';
+
+const DEFAULT_ALWAYS_ALLOW = ['Escape'];
+
+export interface UseKeyboardShortcutOptions {
+  enabled?: boolean;
+  /** Fire even when focus is in an input/textarea/contenteditable. */
+  allowInEditable?: boolean;
+  /** Keys allowed regardless of focus. Defaults to ["Escape"]. */
+  alwaysAllowKeys?: string[];
+  /** Scope the listener to a container instead of the whole window. */
+  target?: React.RefObject<HTMLElement>;
+}
+
+/**
+ * Binds a single keyboard shortcut. Ignores keydowns while focus is in an
+ * editable element unless `allowInEditable` or `alwaysAllowKeys` say
+ * otherwise, and cleans up on unmount.
+ */
+export function useKeyboardShortcut(
+  binding: ShortcutBinding,
+  handler: (event: KeyboardEvent) => void,
+  opts: UseKeyboardShortcutOptions = {}
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  const {
+    enabled = true,
+    allowInEditable = false,
+    alwaysAllowKeys = DEFAULT_ALWAYS_ALLOW,
+    target,
+  } = opts;
+
+  const bindingKey = binding.key;
+  const bindingMod = binding.mod;
+  const bindingShift = binding.shift;
+  const bindingAlt = binding.alt;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const el: Window | HTMLElement = target?.current ?? window;
+
+    const listener = (event: Event) => {
+      const keyboardEvent = event as KeyboardEvent;
+      const platform = detectPlatform();
+      const currentBinding: ShortcutBinding = {
+        key: bindingKey,
+        mod: bindingMod,
+        shift: bindingShift,
+        alt: bindingAlt,
+      };
+
+      if (!matchesBinding(keyboardEvent, currentBinding, platform)) return;
+      if (
+        !shouldHandleShortcut({
+          target: keyboardEvent.target as HTMLElement | null,
+          key: keyboardEvent.key,
+          allowInEditable,
+          alwaysAllowKeys,
+        })
+      ) {
+        return;
+      }
+
+      keyboardEvent.preventDefault();
+      handlerRef.current(keyboardEvent);
+    };
+
+    el.addEventListener('keydown', listener);
+    return () => el.removeEventListener('keydown', listener);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bindingKey, bindingMod, bindingShift, bindingAlt, enabled, allowInEditable, target]);
+}


### PR DESCRIPTION
## Summary
- Typed keyboard-shortcut registry + `useKeyboardShortcut` hook with per-platform (Mac/Windows/Linux) modifier detection, safe against browser/OS shortcut conflicts (input-focus suppression, Escape always allowed).
- `?`-triggered "Keyboard shortcuts" help dialog listing all bound shortcuts by scope (Global, Chat, Sidebar), rendered from the central registry.
- Small `ShortcutKey` badge component wired onto the sidebar's new "Keyboard shortcuts" menu item and the help dialog rows, matching the tiny-hint pattern used by Linear/10x UX products.
- Verified (no change needed) that the chat composer already does Enter=send / Shift+Enter=newline, and that Escape already closes Radix dialogs/popovers and Cmd/Ctrl+B already toggles the sidebar — these are now documented in the shortcut registry for discoverability instead of being re-bound/duplicated.
- Deliberately did not add a fake Cmd/Ctrl+K (no command palette exists yet) or an ambiguous single-letter "create" shortcut, to avoid shipping non-functional bindings.

## Test plan
- [x] `yarn typecheck` — passes
- [x] `yarn lint` — no new issues (pre-existing warnings only, none in new files beyond an existing repo-wide pattern)
- [x] `yarn test` — 108/108 passing, including new `platform.test.ts` and `matching.test.ts` covering per-platform modifier resolution and input-focus suppression
- [x] Manual visual verification via an isolated Vite preview harness (not committed): help dialog renders correctly, groups shortcuts by scope, shows platform-correct badges (⌘/S), and Escape closes it