### PR TITLE
Hide shortcut-key hint badges until hover/focus

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -294,11 +294,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               <SidebarMenuButton
                 tooltip="Keyboard shortcuts"
                 onClick={() => setShortcutsHelpOpen(true)}
-                className="group-data-[collapsible=icon]:justify-center"
+                className="group/shortcut-hint group-data-[collapsible=icon]:justify-center"
               >
                 <Keyboard strokeWidth={1.6} />
                 <span className="font-body text-[13.5px] flex-1">Keyboard shortcuts</span>
-                <ShortcutKey size="sm">?</ShortcutKey>
+                <ShortcutKey size="sm" hoverOnly="shortcut-hint">?</ShortcutKey>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/frontend/src/components/ui/shortcut-key.tsx
+++ b/frontend/src/components/ui/shortcut-key.tsx
@@ -6,18 +6,35 @@ interface ShortcutKeyProps {
     keys?: string[]
     size?: "sm" | "md"
     className?: string
+    /**
+     * Hide the badge until an ancestor is hovered/focused. Use for shortcut
+     * hints attached to an actionable element (a button, a menu item) — not
+     * for standalone informational text. `true` matches a plain `group`
+     * ancestor; `"shortcut-hint"` matches a named `group/shortcut-hint`
+     * ancestor (needed when that ancestor already uses plain `group` for
+     * something else, e.g. sidebar collapse state).
+     */
+    hoverOnly?: boolean | "shortcut-hint"
 }
 
-export function ShortcutKey({ children, keys, size = "md", className }: ShortcutKeyProps) {
+export function ShortcutKey({ children, keys, size = "md", className, hoverOnly }: ShortcutKeyProps) {
     const badgeClasses = cn(
         "flex items-center gap-2 font-sans border border-zinc-300 rounded px-1",
         size === "sm" && "text-[10px] px-1 leading-4",
         className
     )
 
+    const wrapperClasses = cn(
+        "inline-flex items-center gap-1",
+        hoverOnly === true &&
+            "opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100",
+        hoverOnly === "shortcut-hint" &&
+            "opacity-0 transition-opacity duration-150 group-hover/shortcut-hint:opacity-100 group-focus-within/shortcut-hint:opacity-100"
+    )
+
     if (keys) {
         return (
-            <span className="inline-flex items-center gap-1">
+            <span className={wrapperClasses}>
                 {keys.map((key, index) => (
                     <kbd key={`${key}-${index}`} className={badgeClasses}>
                         {key}
@@ -27,5 +44,5 @@ export function ShortcutKey({ children, keys, size = "md", className }: Shortcut
         )
     }
 
-    return <kbd className={badgeClasses}>{children}</kbd>
+    return <kbd className={cn(badgeClasses, wrapperClasses)}>{children}</kbd>
 }


### PR DESCRIPTION
## Summary
- Follow-up to #510: the `ShortcutKey` hint badge was always visible next to its label, which is noisier than the intended Linear-style pattern.
- `ShortcutKey` now accepts `hoverOnly` (plain `group` ancestor) or `hoverOnly="shortcut-hint"` (named `group/shortcut-hint` ancestor, needed where the parent already uses plain `group` for something else — the sidebar uses it for collapse state).
- Applied to the sidebar's "Keyboard shortcuts" `?` badge, the one real instance of this pattern in the app today.

## Test plan
- [x] `yarn typecheck` — passes
- [x] `yarn test` — 108/108 passing
- [x] `yarn lint` — no new issues (pre-existing errors/warnings only, all in unrelated files)
- [x] Manual visual verification via an isolated Vite preview harness (not committed): badge is invisible by default and fades in on hover for both the plain-group and named-group cases; screenshots below