### PR TITLE
Add clean flow webhook receiver

### DIFF
--- a/huf/ai/flow_api.py
+++ b/huf/ai/flow_api.py
@@ -8,6 +8,8 @@ Provides REST-style APIs for:
 - Agent tools (run_flow, get_flow_run, resume_flow_run, approve/reject)
 """
 
+from __future__ import annotations
+
 import hmac
 import json
 
@@ -352,20 +354,120 @@ def _webhook_key_is_valid(defn: dict, webhook_key: str | None) -> bool:
 	return hmac.compare_digest(str(webhook_key or ""), str(expected_auth))
 
 
-@frappe.whitelist(allow_guest=True)
-def flow_webhook(flow_id: str, webhook_key: str | None = None) -> dict:
-	"""
-	Webhook trigger endpoint for flows.
+def _webhook_entry_auth(defn: dict) -> str | None:
+	entry_id = defn.get("entry")
+	for node in defn.get("nodes", []):
+		if node.get("id") == entry_id and node.get("type") == "trigger.webhook":
+			return node.get("config", {}).get("auth")
+	return None
 
-	Validates webhook auth and starts a flow run.
 
-	Args:
-	    flow_id: Flow ID to trigger
-	    webhook_key: Authentication key
+def _request_headers() -> dict:
+	request = getattr(frappe, "request", None)
+	if not request:
+		return {}
+	return getattr(request, "headers", {}) or {}
 
-	Returns:
-	    dict with flow_run_id and status
-	"""
+
+def _header_value(*names: str) -> str | None:
+	headers = _request_headers()
+	for name in names:
+		value = headers.get(name)
+		if value:
+			return value
+	return None
+
+
+def _bearer_token(value: str | None) -> str | None:
+	if not value:
+		return None
+	parts = value.split(None, 1)
+	if len(parts) == 2 and parts[0].lower() == "bearer":
+		return parts[1].strip() or None
+	return None
+
+
+def _parse_webhook_payload() -> dict:
+	payload = {}
+	if not getattr(frappe, "request", None):
+		return payload
+
+	try:
+		raw = frappe.request.get_data(as_text=True)
+		if raw:
+			payload = frappe.parse_json(raw)
+	except (json.JSONDecodeError, TypeError):
+		frappe.log_error(frappe.get_traceback(), "Flow Webhook Payload Parse Error")
+		payload = {}
+
+	if not payload:
+		if frappe.request.form:
+			payload = dict(frappe.request.form)
+		else:
+			exclude = {"cmd", "flow_id", "webhook_key", "key", "secret", "token"}
+			payload = {k: v for k, v in frappe.local.form_dict.items() if k not in exclude}
+
+	return payload if isinstance(payload, dict) else {"payload": payload}
+
+
+def _extract_webhook_key(payload: dict | None = None, explicit_key: str | None = None) -> str | None:
+	if explicit_key:
+		return explicit_key
+
+	request = getattr(frappe, "request", None)
+	if request and getattr(request, "args", None):
+		for key in ("webhook_key", "key", "secret", "token"):
+			if request.args.get(key):
+				return request.args.get(key)
+
+	headers_key = _header_value(
+		"X-Webhook-Secret",
+		"X-Huf-Webhook-Key",
+		"X-Webhook-Key",
+		"X-Hub-Signature",
+	)
+	if headers_key:
+		return headers_key
+
+	bearer = _bearer_token(_header_value("Authorization"))
+	if bearer:
+		return bearer
+
+	if request and getattr(request, "form", None):
+		for key in ("webhook_key", "key", "secret", "token"):
+			if request.form.get(key):
+				return request.form.get(key)
+
+	if payload:
+		for key in ("webhook_key", "key", "secret", "token"):
+			if payload.get(key):
+				return payload.get(key)
+
+	return None
+
+
+def _extract_flow_id(payload: dict | None = None, explicit_flow_id: str | None = None) -> str | None:
+	if explicit_flow_id:
+		return explicit_flow_id
+
+	request = getattr(frappe, "request", None)
+	if request and getattr(request, "args", None) and request.args.get("flow_id"):
+		return request.args.get("flow_id")
+
+	header_flow_id = _header_value("X-Huf-Flow-Id", "X-Flow-Id")
+	if header_flow_id:
+		return header_flow_id
+
+	if request and getattr(request, "form", None) and request.form.get("flow_id"):
+		return request.form.get("flow_id")
+
+	if payload and payload.get("flow_id"):
+		return payload.get("flow_id")
+
+	return None
+
+
+def _load_active_flow_definition(flow_id: str) -> tuple[object, dict]:
 	if not frappe.db.exists("Flow Definition", flow_id):
 		frappe.throw(_("Flow '{0}' not found").format(flow_id), frappe.DoesNotExistError)
 
@@ -374,36 +476,45 @@ def flow_webhook(flow_id: str, webhook_key: str | None = None) -> dict:
 		frappe.throw(_("Flow '{0}' is not active").format(flow_id))
 
 	defn = json.loads(defn_doc.definition_json) if isinstance(defn_doc.definition_json, str) else defn_doc.definition_json
+	return defn_doc, defn
 
-	# Frappe's make_form_dict drops query string arguments if the request has a JSON body.
-	# We must manually extract webhook_key from request.args if it's missing.
-	if webhook_key is None and getattr(frappe, "request", None) and frappe.request.args:
-		webhook_key = frappe.request.args.get("webhook_key")
 
-	# Validate webhook auth — mandatory, fail closed.
+def _resolve_flow_by_webhook_key(webhook_key: str | None) -> str:
+	if not webhook_key:
+		frappe.throw(_("Webhook key is required"), frappe.AuthenticationError)
+
+	matches = []
+	for row in frappe.get_all(
+		"Flow Definition",
+		filters={"status": "Active"},
+		fields=["name", "definition_json"],
+	):
+		name = row.get("name") if isinstance(row, dict) else row.name
+		definition_json = row.get("definition_json") if isinstance(row, dict) else row.definition_json
+		defn = json.loads(definition_json) if isinstance(definition_json, str) else definition_json
+		expected_auth = _webhook_entry_auth(defn or {})
+		if expected_auth and hmac.compare_digest(str(webhook_key), str(expected_auth)):
+			matches.append(name)
+
+	if not matches:
+		frappe.throw(_("Invalid webhook key"), frappe.AuthenticationError)
+	if len(matches) > 1:
+		frappe.throw(_("Webhook key matches multiple active flows; provide flow_id"))
+	return matches[0]
+
+
+def _run_flow_webhook(flow_id: str, webhook_key: str | None, payload: dict | None = None) -> dict:
+	defn_doc, defn = _load_active_flow_definition(flow_id)
+
+	# Validate webhook auth - mandatory, fail closed.
 	if not _webhook_key_is_valid(defn, webhook_key):
 		frappe.throw(_("Invalid webhook key"), frappe.AuthenticationError)
 
 	# Switch execution identity to the flow owner so the run does not execute as Guest
 	frappe.set_user(defn_doc.owner or "Administrator")
 
-	# Get payload from request
-	payload = {}
-	if frappe.request:
-		try:
-			raw = frappe.request.get_data(as_text=True)
-			if raw:
-				payload = frappe.parse_json(raw)
-		except (json.JSONDecodeError, TypeError):
-			frappe.log_error(frappe.get_traceback(), "Flow Webhook Payload Parse Error")
-			payload = {}
-
-		if not payload:
-			if frappe.request.form:
-				payload = dict(frappe.request.form)
-			else:
-				exclude = {'cmd', 'flow_id', 'webhook_key'}
-				payload = {k: v for k, v in frappe.local.form_dict.items() if k not in exclude}
+	if payload is None:
+		payload = _parse_webhook_payload()
 
 	from huf.ai.flow_engine import create_flow_run, run_flow as engine_run_flow
 
@@ -424,6 +535,47 @@ def flow_webhook(flow_id: str, webhook_key: str | None = None) -> dict:
 		"flow_run_id": flow_run.name,
 		"status": flow_run.status,
 	}
+
+
+@frappe.whitelist(allow_guest=True)
+def flow_webhook(flow_id: str, webhook_key: str | None = None) -> dict:
+	"""
+	Webhook trigger endpoint for flows.
+
+	Validates webhook auth and starts a flow run.
+
+	Args:
+	    flow_id: Flow ID to trigger
+	    webhook_key: Authentication key
+
+	Returns:
+	    dict with flow_run_id and status
+	"""
+	# Frappe's make_form_dict drops query string arguments if the request has a JSON body.
+	# We must manually extract webhook_key from request.args if it's missing.
+	if webhook_key is None and getattr(frappe, "request", None) and frappe.request.args:
+		webhook_key = frappe.request.args.get("webhook_key")
+
+	return _run_flow_webhook(flow_id, webhook_key)
+
+
+@frappe.whitelist(allow_guest=True)
+def flow_webhook_clean(flow_id: str | None = None, webhook_key: str | None = None) -> dict:
+	"""
+	Clean URL webhook receiver for providers that reject query parameters.
+
+	Key resolution is intentionally versatile while still failing closed:
+	- Frappe Cloud/Press: X-Webhook-Secret header.
+	- Huf/native callers: X-Huf-Webhook-Key or X-Huf-Flow-Id headers.
+	- Generic providers: Authorization: Bearer <key>, form fields, JSON body, or legacy args.
+
+	If flow_id is omitted, Huf resolves it by finding exactly one active
+	trigger.webhook flow whose configured auth matches the resolved key.
+	"""
+	payload = _parse_webhook_payload()
+	resolved_key = _extract_webhook_key(payload, webhook_key)
+	resolved_flow_id = _extract_flow_id(payload, flow_id) or _resolve_flow_by_webhook_key(resolved_key)
+	return _run_flow_webhook(resolved_flow_id, resolved_key, payload)
 
 
 @frappe.whitelist()

--- a/huf/ai/tests/test_phase1_security.py
+++ b/huf/ai/tests/test_phase1_security.py
@@ -287,3 +287,64 @@ class TestWebhookEndpointSecurity(FrappeTestCase):
                         flow_webhook("flow-1", webhook_key="wrong-key")
         finally:
             frappe.request = None
+
+    def test_clean_flow_webhook_accepts_frappe_cloud_secret_header(self):
+        from huf.ai.flow_api import flow_webhook_clean
+
+        definition_json = (
+            '{"entry":"start","nodes":[{"id":"start","type":"trigger.webhook",'
+            '"config":{"auth":"correct-key"}}]}'
+        )
+        defn_doc = SimpleNamespace(status="Active", definition_json=definition_json, owner="flow-owner")
+        flow_run = SimpleNamespace(name="FLOW-RUN-1", status="Queued")
+        mock_request = frappe._dict(
+            args={},
+            form={},
+            headers={"X-Webhook-Secret": "correct-key"},
+            get_data=lambda **kw: b'{"event":"Site Status Update","site":"demo.frappe.cloud"}',
+        )
+        frappe.request = mock_request
+        try:
+            with patch("frappe.get_all", return_value=[{"name": "flow-1", "definition_json": definition_json}]):
+                with patch("frappe.db.exists", return_value=True):
+                    with patch("frappe.get_doc", return_value=defn_doc):
+                        with patch("frappe.set_user") as mock_set_user:
+                            with patch("huf.ai.flow_engine.create_flow_run", return_value=flow_run) as mock_create_run:
+                                with patch("frappe.enqueue") as mock_enqueue:
+                                    result = flow_webhook_clean()
+
+            self.assertEqual(result["flow_run_id"], "FLOW-RUN-1")
+            mock_set_user.assert_called_once_with("flow-owner")
+            mock_create_run.assert_called_once()
+            self.assertEqual(mock_create_run.call_args.kwargs["flow_id"], "flow-1")
+            self.assertEqual(mock_create_run.call_args.kwargs["payload"]["event"], "Site Status Update")
+            mock_enqueue.assert_called_once()
+        finally:
+            frappe.request = None
+
+    def test_clean_flow_webhook_rejects_ambiguous_key_without_flow_id(self):
+        from huf.ai.flow_api import flow_webhook_clean
+
+        definition_json = (
+            '{"entry":"start","nodes":[{"id":"start","type":"trigger.webhook",'
+            '"config":{"auth":"shared-key"}}]}'
+        )
+        mock_request = frappe._dict(
+            args={},
+            form={},
+            headers={"X-Webhook-Secret": "shared-key"},
+            get_data=lambda **kw: b"{}",
+        )
+        frappe.request = mock_request
+        try:
+            with patch(
+                "frappe.get_all",
+                return_value=[
+                    {"name": "flow-1", "definition_json": definition_json},
+                    {"name": "flow-2", "definition_json": definition_json},
+                ],
+            ):
+                with self.assertRaises(Exception):
+                    flow_webhook_clean()
+        finally:
+            frappe.request = None


### PR DESCRIPTION
## Summary
- add huf.ai.flow_api.flow_webhook_clean for providers that reject query-string webhook URLs
- resolve webhook auth from Frappe Cloud X-Webhook-Secret header, Huf headers, bearer token, form/JSON fields, or legacy query args
- allow key-only flow resolution when exactly one active trigger.webhook flow matches; fail closed on no match or ambiguity
- keep the existing query-string flow_webhook endpoint working

## Validation
- python3 -m py_compile huf/ai/flow_api.py huf/ai/tests/test_phase1_security.py
- git diff --check
- focused pytest is blocked on host because this checkout is outside a Frappe bench: frappe.tests is unavailable