### PR TITLE
refactor(ui): condense sidebar density, mute experimental badges, and update navigation icons

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, LayoutDashboard, Bot, Workflow, Database, Plug, MessageSquare, Zap, Server, ScrollText, Users, BookOpen, Cpu, Link2, Terminal, Settings, Shield, LayoutGrid, Brain, Sparkles, Keyboard } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Plug, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, Layers, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -37,7 +37,7 @@ const dashboardNavItems = [
   {
     title: "Dashboard",
     url: "/dashboard",
-    icon: LayoutDashboard,
+    icon: ChartColumnIncreasing,
     capability: null,
   },
 ]
@@ -66,13 +66,13 @@ const buildNavItems = [
   {
     title: "Agents",
     url: "/agents",
-    icon: Bot,
+    icon: SquareAsterisk,
     capability: "agent.use",
   },
   {
     title: "Prompts",
     url: "/prompts",
-    icon: ScrollText,
+    icon: FileText,
     capability: "agent.use",
   },
   {
@@ -149,20 +149,20 @@ const settingsNavGroups = [
     label: "Intelligence",
     items: [
       { title: "AI Providers", url: "/providers", icon: Plug, capability: "system.providers.manage" },
-      { title: "Models", url: "/models", icon: Cpu, capability: "system.providers.manage" },
+      { title: "Models", url: "/models", icon: Layers, capability: "system.providers.manage" },
     ],
   },
   {
     label: "Runtime",
     items: [
-      { title: "Code Execution", url: "/execution-profiles", icon: Shield, capability: "agent.use" },
-      { title: "SSH Connections", url: "/ssh-connections", icon: Terminal, capability: "agent.use" },
+      { title: "Code Execution", url: "/execution-profiles", icon: SquareChevronRight, capability: "agent.use" },
+      { title: "SSH Connections", url: "/ssh-connections", icon: ChevronsLeftRightEllipsis, capability: "agent.use" },
     ],
   },
   {
     label: "Connectivity",
     items: [
-      { title: "Gateways", url: "/gateways", icon: MessageSquare, capability: "system.integrations.manage" },
+      { title: "Gateways", url: "/gateways", icon: GlobeLock, capability: "system.integrations.manage" },
       { title: "Channels", url: "/channels", icon: MessageSquare, capability: "system.integrations.manage" },
       { title: "Integrations", url: "/integrations", icon: Link2, capability: "system.integrations.manage" },
       { title: "MCP Servers", url: "/mcp", icon: Server, capability: "system.mcp.manage" },

--- a/frontend/src/components/common/ExperimentalBadge.tsx
+++ b/frontend/src/components/common/ExperimentalBadge.tsx
@@ -12,12 +12,12 @@ export function ExperimentalBadge({ className, size = 'md' }: ExperimentalBadgeP
       title="Experimental feature"
       aria-label="Experimental feature"
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-none border border-amber-500/40 bg-amber-500/10 font-mono uppercase tracking-wider text-amber-600 dark:text-amber-400 select-none font-medium',
-        size === 'sm' ? 'px-1.5 py-0.5 text-[9px]' : 'px-2 py-0.5 text-[10.5px]',
+        'inline-flex items-center gap-1.5 rounded-none border border-line bg-panel/60 font-mono uppercase tracking-wider text-steel-soft dark:text-steel select-none font-medium',
+        size === 'sm' ? 'px-1.5 py-0.5 text-[9px]' : 'px-2 py-0.5 text-[10px]',
         className
       )}
     >
-      <FlaskConical className={cn(size === 'sm' ? 'size-2.5' : 'size-3.5', 'shrink-0')} strokeWidth={1.8} />
+      <FlaskConical className={cn(size === 'sm' ? 'size-2.5' : 'size-3', 'shrink-0 opacity-70')} strokeWidth={1.5} />
       <span>Experimental</span>
     </span>
   );

--- a/frontend/src/components/nav-main.tsx
+++ b/frontend/src/components/nav-main.tsx
@@ -53,9 +53,9 @@ export function NavMain({
                           title={item.badge}
                           aria-label={item.badge}
                           role="img"
-                          className="flex items-center text-signal-ink dark:text-signal"
+                          className="flex items-center text-steel-soft dark:text-steel opacity-70 hover:opacity-100 transition-opacity"
                         >
-                          <FlaskConical className="!size-[13px]" strokeWidth={1.6} />
+                          <FlaskConical className="!size-[12.5px]" strokeWidth={1.5} />
                         </span>
                       )}
                       {typeof item.count === 'number' && (

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -414,7 +414,7 @@ export const SidebarContent = React.forwardRef<
       ref={ref}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-0.5 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className
       )}
       {...props}
@@ -431,7 +431,7 @@ export const SidebarGroup = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col px-2 py-0.5", className)}
       {...props}
     />
   )
@@ -449,7 +449,7 @@ export const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-none px-2 font-mono text-[10px] uppercase tracking-widest text-steel-soft outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-6 shrink-0 items-center rounded-none px-2 font-mono text-[10px] uppercase tracking-widest text-steel-soft outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -501,7 +501,7 @@ export const SidebarMenu = React.forwardRef<
   <ul
     ref={ref}
     data-sidebar="menu"
-    className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+    className={cn("flex w-full min-w-0 flex-col gap-0.5", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
### Summary of Changes
1. **Sidebar Spacing & Density (`sidebar.tsx`):**
   - Condensed vertical content gaps (`gap-2` → `gap-0.5`) in `SidebarContent`.
   - Tightened `SidebarGroup` padding (`p-2` → `px-2 py-0.5`).
   - Reduced `SidebarGroupLabel` height (`h-8` → `h-6`).
   - Reduced `SidebarMenu` item spacing (`gap-1` → `gap-0.5`).

2. **Muted Experimental Badges (`ExperimentalBadge.tsx` & `nav-main.tsx`):**
   - **Main Badge:** Muted amber border & background (`border-amber-500/40 bg-amber-500/10`) to subtle panel styling (`border-line bg-panel/60 text-steel-soft dark:text-steel`).
   - **Sidebar Nav Beaker:** Softened beaker indicator to muted steel (`text-steel-soft dark:text-steel opacity-70`).

3. **Navigation Icon Updates (`app-sidebar.tsx`):**
   - **Dashboard:** `LayoutDashboard` → `ChartColumnIncreasing`
   - **Agents:** `Bot` → `SquareAsterisk`
   - **Prompts:** `ScrollText` → `FileText`
   - **Models:** `Cpu` → `Layers`
   - **Code Execution:** `Shield` → `SquareChevronRight`
   - **SSH Connections:** `Terminal` → `ChevronsLeftRightEllipsis`
   - **Gateways:** `MessageSquare` → `GlobeLock`