### PR TITLE
fix(gateways): default execution_user on quick-create, surface real error

### DIFF
--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/services/gatewayApi';
 import { db } from '@/lib/frappe-sdk';
 import { doctype } from '@/data/doctypes';
+import { useUser } from '@/contexts/UserContext';
 import { Button } from '@/components/ui/button';
 import { getProviderBrandIcon } from '@/components/common/BrandIcons';
 import { IntegrationSettingsProvider } from '@/contexts/IntegrationSettingsContext';
@@ -62,6 +63,7 @@ const uiProviders: GatewayProvider[] = [
 ];
 
 export default function GatewaysPage() {
+  const { user } = useUser();
   const [activeTab, setActiveTab] = useState<GatewaysTab>('gateways');
   const [catalogOpenKey, setCatalogOpenKey] = useState(0);
   const [gateways, setGateways] = useState<GatewayDoc[]>([]);
@@ -114,14 +116,15 @@ export default function GatewaysPage() {
         provider,
         is_enabled: 1,
         direct_policy: 'Allow list',
+        execution_user: user?.name,
       })) as GatewayDoc;
       setGateways((current) => [created, ...current]);
       setGatewayName('');
       setShowSetup(false);
       // Open configuration modal immediately for the new gateway
       setEditingGateway(created);
-    } catch {
-      setError('Could not create the gateway. Please ensure the name is unique.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not create the gateway. Please ensure the name is unique.');
     } finally {
       setCreating(false);
     }
@@ -133,6 +136,7 @@ export default function GatewaysPage() {
     try {
       const updated = await updateGateway(editingGateway.name, {
         is_enabled: editingGateway.is_enabled,
+        execution_user: editingGateway.execution_user || '',
         description: editingGateway.description || '',
         direct_policy: editingGateway.direct_policy,
         default_target_type: editingGateway.default_target_type,
@@ -143,8 +147,8 @@ export default function GatewaysPage() {
         prev.map((gw) => (gw.name === updated.name ? { ...gw, ...updated } : gw))
       );
       setEditingGateway(null);
-    } catch {
-      setError('Failed to save gateway configuration.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save gateway configuration.');
     } finally {
       setSaving(false);
     }
@@ -400,6 +404,23 @@ export default function GatewaysPage() {
                   <div className="w-9 h-5 bg-line peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-emerald-500"></div>
                 </label>
               </div>
+
+              {/* Run as user */}
+              <label className="grid gap-1 text-xs font-medium text-ink">
+                Run as user
+                <input
+                  className="h-9 rounded-lg border border-input bg-background px-3 text-xs"
+                  value={editingGateway.execution_user || ''}
+                  onChange={(e) =>
+                    setEditingGateway({ ...editingGateway, execution_user: e.target.value })
+                  }
+                  placeholder="e.g. gateway-service@yourcompany.com"
+                />
+                <span className="text-[11px] font-normal text-steel">
+                  Least-privileged user this gateway runs Agents/Flows as. Required while
+                  enabled — never use Administrator.
+                </span>
+              </label>
 
               {/* Description */}
               <label className="grid gap-1 text-xs font-medium text-ink">

--- a/frontend/src/services/gatewayApi.ts
+++ b/frontend/src/services/gatewayApi.ts
@@ -26,6 +26,7 @@ export interface GatewayDoc {
   gateway_name: string;
   provider: GatewayProvider;
   is_enabled: 0 | 1;
+  execution_user?: string;
   // TODO(#473-followup): admission UI is incomplete; direct_policy is shown as a
   // placeholder until the full admission form is built.
   direct_policy: GatewayPolicy;
@@ -44,7 +45,7 @@ export interface GatewayDoc {
 export async function getGateways(): Promise<GatewayDoc[]> {
   return (await db.getDocList(doctype.Gateway, {
     fields: [
-      'name', 'gateway_name', 'provider', 'is_enabled',
+      'name', 'gateway_name', 'provider', 'is_enabled', 'execution_user',
       'direct_policy', 'room_policy', 'room_sender_policy',
       'mention_required', 'pairing_ttl_minutes', 'description',
       'default_target_type', 'default_agent', 'default_flow', 'last_event_at', 'last_error',


### PR DESCRIPTION
## Summary
- `handleCreateGateway()` in GatewaysPage.tsx created gateways with `is_enabled: 1` but never set `execution_user`, which `Gateway.validate()` (huf/huf/doctype/gateway/gateway.py) always rejects for enabled gateways — every quick-create silently failed.
- Default `execution_user` to the current session user (via `useUser()`) so quick-create succeeds immediately; the field is still editable in the Configure Gateway modal so it can be swapped for a dedicated least-privileged service user.
- Replaced the hardcoded "Could not create the gateway. Please ensure the name is unique." error with the actual backend message, so future validation errors aren't misattributed.

Confirmed pre-existing on develop HEAD (not introduced by #522).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 108/108 passing
- [ ] Manual smoke test in a running bench (no local bench mount available for this worktree in this session)