### PR TITLE
fix(install): add missing docker.run capability + seed AI providers before demo models

### DIFF
--- a/huf/huf/doctype/huf_role_permission/huf_role_permission.json
+++ b/huf/huf/doctype/huf_role_permission/huf_role_permission.json
@@ -14,7 +14,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Capability",
-   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.integrations.manage\nsystem.settings.manage\ndata.tables.manage\ndata.records.create\ndata.records.view_own\ndata.records.view_all\ndata.records.edit_own\ndata.records.edit_all\nusers.invite\nusers.manage\nroles.manage\nexecution_profile.manage\nnetwork_access_policy.manage\nexecution.approve\ncode_execution.run\nssh_connection.manage\nssh.run\nssh.approve",
+   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.integrations.manage\nsystem.settings.manage\ndata.tables.manage\ndata.records.create\ndata.records.view_own\ndata.records.view_all\ndata.records.edit_own\ndata.records.edit_all\nusers.invite\nusers.manage\nroles.manage\nexecution_profile.manage\nnetwork_access_policy.manage\nexecution.approve\ncode_execution.run\nssh_connection.manage\nssh.run\nssh.approve\ndocker.run",
    "reqd": 1
   },
   {

--- a/huf/install.py
+++ b/huf/install.py
@@ -119,6 +119,7 @@ def after_migrate():
 	Syncs all discovered tools from all installed apps.
 	"""
 	create_huf_roles()
+	create_demo_ai_providers()
 	create_demo_ai_models()
 	setup_desktop_icon_as_workspace("huf")
 	try:


### PR DESCRIPTION
## Summary
- `huf_role_permission.json`'s `capability` Select was missing `docker.run`, even though `DEFAULT_ROLE_CAPABILITIES` (huf/permissions.py) grants it to Huf Admin/Manager — broke `create_huf_roles()` in `after_install` with `ValidationError: Capability cannot be "docker.run"`.
- `after_migrate()` called `create_demo_ai_models()` without seeding `AI Provider` fixtures first, so a fresh install could hit `LinkValidationError: Could not find Provider: Huggingface`. Now calls `create_demo_ai_providers()` first, same as `after_install()`.

## Test plan
- [x] Fresh `bench new-site` + `bench install-app huf` + `bench migrate` in a live bench, confirmed both hooks complete with no errors.
- [x] Confirmed all 4 Huf Roles created, `Huggingface` AI Provider exists, demo AI Model linked to it created successfully.