### PR TITLE
feat(gateway): add Telegram adapter and connect-integration UI

### DIFF
--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -28,7 +28,16 @@ import { getProviderBrandIcon } from '@/components/common/BrandIcons';
 import { IntegrationSettingsProvider } from '@/contexts/IntegrationSettingsContext';
 import { IntegrationSettingsListingPage } from './IntegrationSettingsListingPage';
 import { IntegrationSettingsHeaderActions } from '@/components/integrations/IntegrationSettingsHeaderActions';
+import { getIntegrationSettings } from '@/services/integrationApi';
+import type { IntegrationSettingsDoc } from '@/types/integration.types';
 import { cn } from '@/lib/utils';
+
+const PROVIDER_SERVICE: Partial<Record<GatewayProvider, string>> = {
+  WhatsApp: 'whatsapp',
+  VK: 'vk',
+  WeCom: 'wecom',
+  Telegram: 'telegram',
+};
 
 type GatewaysTab = 'gateways' | 'credentials';
 
@@ -67,6 +76,7 @@ export default function GatewaysPage() {
   const [activeTab, setActiveTab] = useState<GatewaysTab>('gateways');
   const [catalogOpenKey, setCatalogOpenKey] = useState(0);
   const [gateways, setGateways] = useState<GatewayDoc[]>([]);
+  const [integrationSettings, setIntegrationSettings] = useState<IntegrationSettingsDoc[]>([]);
   const [agents, setAgents] = useState<{ name: string; agent_name: string }[]>([]);
   const [flows, setFlows] = useState<{ name: string; title: string }[]>([]);
   const [loading, setLoading] = useState(true);
@@ -90,14 +100,16 @@ export default function GatewaysPage() {
   async function loadData() {
     setLoading(true);
     try {
-      const [gwList, agentList, flowList] = await Promise.all([
+      const [gwList, agentList, flowList, settingsResponse] = await Promise.all([
         getGateways(),
         getAvailableAgents(),
         getAvailableFlows(),
+        getIntegrationSettings(),
       ]);
       setGateways(gwList);
       setAgents(agentList);
       setFlows(flowList);
+      setIntegrationSettings(Array.isArray(settingsResponse) ? settingsResponse : settingsResponse.items);
     } catch {
       setError('Could not load gateway configurations.');
     } finally {
@@ -111,10 +123,11 @@ export default function GatewaysPage() {
     setCreating(true);
     setError('');
     try {
+      const requiresIntegration = Boolean(PROVIDER_SERVICE[provider]);
       const created = (await db.createDoc(doctype.Gateway, {
         gateway_name: gatewayName.trim(),
         provider,
-        is_enabled: 1,
+        is_enabled: requiresIntegration ? 0 : 1,
         direct_policy: 'Allow list',
         execution_user: user?.name,
       })) as GatewayDoc;
@@ -137,6 +150,7 @@ export default function GatewaysPage() {
       const updated = await updateGateway(editingGateway.name, {
         is_enabled: editingGateway.is_enabled,
         execution_user: editingGateway.execution_user || '',
+        integration_settings: editingGateway.integration_settings || '',
         description: editingGateway.description || '',
         direct_policy: editingGateway.direct_policy,
         default_target_type: editingGateway.default_target_type,
@@ -421,6 +435,48 @@ export default function GatewaysPage() {
                   enabled — never use Administrator.
                 </span>
               </label>
+
+              {/* Connected Integration (credentials) */}
+              {PROVIDER_SERVICE[editingGateway.provider] && (() => {
+                const requiredService = PROVIDER_SERVICE[editingGateway.provider]!;
+                const matches = integrationSettings.filter((s) => s.service === requiredService);
+                return (
+                  <label className="grid gap-1 text-xs font-medium text-ink">
+                    Connected Integration
+                    {matches.length > 0 ? (
+                      <select
+                        className="h-9 rounded-lg border border-input bg-background px-2.5 text-xs"
+                        value={editingGateway.integration_settings || ''}
+                        onChange={(e) =>
+                          setEditingGateway({ ...editingGateway, integration_settings: e.target.value })
+                        }
+                      >
+                        <option value="">Choose credentials…</option>
+                        {matches.map((s) => (
+                          <option key={s.name} value={s.name}>
+                            {s.name}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <div className="rounded-lg border border-dashed border-line bg-paper p-3 text-[11px] text-steel">
+                        No {editingGateway.provider} credentials connected yet.{' '}
+                        <button
+                          type="button"
+                          className="font-medium text-primary hover:underline"
+                          onClick={() => setActiveTab('credentials')}
+                        >
+                          Add one in Channel Credentials
+                        </button>
+                        .
+                      </div>
+                    )}
+                    <span className="text-[11px] font-normal text-steel">
+                      {editingGateway.provider} needs a connected integration before it can be enabled.
+                    </span>
+                  </label>
+                );
+              })()}
 
               {/* Description */}
               <label className="grid gap-1 text-xs font-medium text-ink">

--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -183,7 +183,7 @@ export default function GatewaysPage() {
 
   function getWebhookUrl(gwName: string) {
     const host = window.location.origin;
-    return `${host}/api/method/huf.ai.gateway_webhook.handle_gateway_webhook?gateway=${encodeURIComponent(gwName)}`;
+    return `${host}/api/method/huf.ai.gateway_webhook.handle_gateway_webhook?gateway_name=${encodeURIComponent(gwName)}`;
   }
 
   function handleCopyWebhook(gwName: string) {

--- a/frontend/src/services/gatewayApi.ts
+++ b/frontend/src/services/gatewayApi.ts
@@ -27,6 +27,7 @@ export interface GatewayDoc {
   provider: GatewayProvider;
   is_enabled: 0 | 1;
   execution_user?: string;
+  integration_settings?: string;
   // TODO(#473-followup): admission UI is incomplete; direct_policy is shown as a
   // placeholder until the full admission form is built.
   direct_policy: GatewayPolicy;
@@ -45,7 +46,7 @@ export interface GatewayDoc {
 export async function getGateways(): Promise<GatewayDoc[]> {
   return (await db.getDocList(doctype.Gateway, {
     fields: [
-      'name', 'gateway_name', 'provider', 'is_enabled', 'execution_user',
+      'name', 'gateway_name', 'provider', 'is_enabled', 'execution_user', 'integration_settings',
       'direct_policy', 'room_policy', 'room_sender_policy',
       'mention_required', 'pairing_ttl_minutes', 'description',
       'default_target_type', 'default_agent', 'default_flow', 'last_event_at', 'last_error',

--- a/huf/ai/gateway_adapters/__init__.py
+++ b/huf/ai/gateway_adapters/__init__.py
@@ -17,6 +17,7 @@ from huf.ai.gateway_adapters.types import (
 	NormalizedGatewayEvent,
 	OutboundDelivery,
 )
+from huf.ai.gateway_adapters.telegram import TelegramGatewayAdapter
 from huf.ai.gateway_adapters.vk import VKGatewayAdapter
 from huf.ai.gateway_adapters.wecom import WeComGatewayAdapter
 from huf.ai.gateway_adapters.whatsapp import WhatsAppGatewayAdapter
@@ -32,6 +33,7 @@ __all__ = [
 	"GatewayReply",
 	"NormalizedGatewayEvent",
 	"OutboundDelivery",
+	"TelegramGatewayAdapter",
 	"VKGatewayAdapter",
 	"WeComGatewayAdapter",
 	"WhatsAppGatewayAdapter",

--- a/huf/ai/gateway_adapters/telegram.py
+++ b/huf/ai/gateway_adapters/telegram.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+"""Telegram Bot API adapter.
+
+This adapter owns only Telegram's native webhook verification, update
+normalization, and outbound ``sendMessage`` delivery. It has no Frappe
+persistence and no knowledge of routing or admission policy.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Mapping
+
+from huf.ai.gateway_adapters.adapter import GatewayAdapter
+from huf.ai.gateway_adapters.types import (
+	GatewayCapabilities,
+	GatewayCredentialField,
+	GatewayCredentialSchema,
+	GatewayInboundRequest,
+	GatewayReply,
+	NormalizedGatewayEvent,
+	OutboundDelivery,
+)
+
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+WEBHOOK_SECRET_HEADER = "X-Telegram-Bot-Api-Secret-Token"
+
+
+def _requests_post(url: str, *, json_data: Mapping[str, Any], timeout: int) -> Any:
+	"""Lazily import requests so the SDK itself has no import-time dependency."""
+	import requests
+
+	return requests.post(url, json=json_data, timeout=timeout)
+
+
+class TelegramGatewayAdapter(GatewayAdapter):
+	"""Authenticate Telegram Bot API webhook updates and deliver text replies."""
+
+	provider_id = "telegram"
+	credential_schema = GatewayCredentialSchema(
+		(
+			GatewayCredentialField("token", "Telegram Bot Token"),
+			GatewayCredentialField(
+				"webhook_secret",
+				"Webhook secret token",
+				required=False,
+				description=(
+					"Value passed to Telegram's setWebhook secret_token; "
+					"verified against the X-Telegram-Bot-Api-Secret-Token header."
+				),
+			),
+		)
+	)
+	capabilities = GatewayCapabilities(
+		frozenset({"webhook"}),
+		supports_thread_reply=True,
+		max_outbound_messages_per_second=30,
+	)
+
+	def __init__(
+		self,
+		credentials: Mapping[str, str],
+		*,
+		http_post: Callable[..., Any] = _requests_post,
+	) -> None:
+		missing = self.credential_schema.missing_required(credentials)
+		if missing:
+			raise ValueError("Telegram adapter is missing required credentials: " + ", ".join(missing))
+		self._token = credentials["token"]
+		self._webhook_secret = credentials.get("webhook_secret", "")
+		self._http_post = http_post
+
+	def verify_inbound(self, request: GatewayInboundRequest) -> bool:
+		"""Fail closed on a configured secret; otherwise accept (matches the
+		codebase's existing precedent for providers without payload signing,
+		e.g. gateway_adapters.teams)."""
+		if not self._webhook_secret:
+			return True
+		provided = request.headers.get(WEBHOOK_SECRET_HEADER, "")
+		return bool(provided) and provided == self._webhook_secret
+
+	def normalize_inbound(self, request: GatewayInboundRequest) -> NormalizedGatewayEvent:
+		if not self.verify_inbound(request):
+			raise ValueError("Telegram webhook secret verification failed")
+
+		try:
+			update = json.loads(request.body.decode("utf-8")) if request.body else {}
+		except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+			raise ValueError("Invalid Telegram update payload") from exc
+
+		message = update.get("message") or update.get("edited_message") or {}
+		chat = message.get("chat") or {}
+		sender = message.get("from") or {}
+
+		provider_event_id = str(update.get("update_id") or "")
+		sender_id = str(sender.get("id") or "")
+		conversation_id = str(chat.get("id") or "")
+		if not provider_event_id or not sender_id or not conversation_id:
+			raise ValueError("Telegram update is missing update, sender, or chat identifiers")
+
+		chat_type = str(chat.get("type") or "private")
+		text = str(message.get("text") or message.get("caption") or "")
+		mentioned = any(
+			entity.get("type") in ("mention", "bot_command")
+			for entity in (message.get("entities") or [])
+		)
+
+		return NormalizedGatewayEvent(
+			provider_event_id=provider_event_id,
+			sender_id=sender_id,
+			conversation_id=conversation_id,
+			message_text=text,
+			thread_id=str(message["message_id"]) if message.get("message_id") is not None else None,
+			is_room=chat_type in {"group", "supergroup"},
+			mentioned=mentioned,
+			raw_payload=update,
+		)
+
+	def send_reply(self, reply: GatewayReply) -> OutboundDelivery:
+		"""Send a Telegram ``sendMessage`` text reply using the bot token."""
+		url = f"{TELEGRAM_API_BASE}/bot{self._token}/sendMessage"
+		data: dict[str, Any] = {
+			"chat_id": reply.conversation_id,
+			"text": reply.text,
+		}
+		if reply.reply_to_provider_message_id:
+			try:
+				data["reply_to_message_id"] = int(reply.reply_to_provider_message_id)
+			except (TypeError, ValueError):
+				pass
+
+		response = self._http_post(url, json_data=data, timeout=10)
+		if hasattr(response, "raise_for_status"):
+			response.raise_for_status()
+		body = response.json() if hasattr(response, "json") else response
+		if not isinstance(body, Mapping) or not body.get("ok"):
+			description = body.get("description") if isinstance(body, Mapping) else "Telegram API rejected reply"
+			raise ValueError(f"Telegram sendMessage failed: {description}")
+
+		result = body.get("result") or {}
+		message_id = result.get("message_id")
+		if message_id is None:
+			raise ValueError("Telegram sendMessage response did not include a message_id")
+		return OutboundDelivery(str(message_id), provider_response=body)

--- a/huf/ai/gateway_webhook.py
+++ b/huf/ai/gateway_webhook.py
@@ -17,6 +17,7 @@ from frappe import _
 
 _ADAPTER_CLASSES = {
 	"WhatsApp": ("huf.ai.gateway_adapters.whatsapp", "WhatsAppGatewayAdapter"),
+	"Telegram": ("huf.ai.gateway_adapters.telegram", "TelegramGatewayAdapter"),
 	"Messenger": ("huf.ai.gateway_adapters.messenger", "MessengerGatewayAdapter"),
 	"Instagram": ("huf.ai.gateway_adapters.instagram", "InstagramGatewayAdapter"),
 	"Discord": ("huf.ai.gateway_adapters.discord", "DiscordGatewayAdapter"),

--- a/huf/ai/gateway_webhook.py
+++ b/huf/ai/gateway_webhook.py
@@ -92,14 +92,24 @@ def _text_response(value: str) -> None:
 
 
 @frappe.whitelist(allow_guest=True, methods=["GET", "POST"])
-def handle_gateway_webhook(gateway_name: str) -> dict | None:
+def handle_gateway_webhook() -> dict | None:
 	"""Verify a native provider callback, then hand only normalized data to Gateway.
 
 	The URL contains a Gateway document name, never a credential.  Native
 	verification happens before persistence or queueing, and no provider payload
 	is normalized until that verification succeeds.
+
+	gateway_name is read directly from the query string rather than taken as
+	a function argument: every provider here posts application/json, and
+	frappe.app.make_form_dict replaces frappe.form_dict wholesale with the
+	parsed JSON body whenever Content-Type is JSON, so a query-string kwarg
+	never actually reaches this function on a real webhook call.
 	"""
 	from huf.ai.gateway_service import ingest_gateway_event
+
+	gateway_name = frappe.request.args.get("gateway_name") if frappe.request is not None else None
+	if not gateway_name:
+		return {"success": False, "error": "Missing gateway_name"}
 
 	try:
 		gateway = frappe.get_doc("Gateway", gateway_name)

--- a/huf/ai/tests/test_gateway_webhook.py
+++ b/huf/ai/tests/test_gateway_webhook.py
@@ -42,11 +42,12 @@ class TestGatewayWebhook(unittest.TestCase):
         adapter.verify_inbound.return_value = True
         adapter.normalize_inbound.return_value = normalized
         mock_frappe.get_doc.return_value = configured_gateway
+        mock_frappe.request = SimpleNamespace(args={"gateway_name": "Support VK"})
         mock_request.return_value = fake_request
         mock_adapter.return_value = adapter
 
         with patch("huf.ai.gateway_service.ingest_gateway_event", return_value={"event_name": "GE-1"}) as ingest:
-            result = gateway_webhook.handle_gateway_webhook("Support VK")
+            result = gateway_webhook.handle_gateway_webhook()
 
         assert result == {"success": True, "event_name": "GE-1"}
         adapter.normalize_inbound.assert_called_once_with(fake_request)
@@ -58,12 +59,13 @@ class TestGatewayWebhook(unittest.TestCase):
     @patch("huf.ai.gateway_webhook.frappe")
     def test_unverified_request_is_never_normalized(self, mock_frappe, mock_request, mock_adapter):
         mock_frappe.get_doc.return_value = SimpleNamespace(name="Support VK", provider="VK", is_enabled=1)
+        mock_frappe.request = SimpleNamespace(args={"gateway_name": "Support VK"})
         mock_request.return_value = SimpleNamespace(method="POST")
         adapter = MagicMock()
         adapter.verify_inbound.return_value = False
         mock_adapter.return_value = adapter
 
-        assert gateway_webhook.handle_gateway_webhook("Support VK") == {
+        assert gateway_webhook.handle_gateway_webhook() == {
             "success": False,
             "error": "Provider verification failed",
         }
@@ -77,10 +79,26 @@ class TestGatewayWebhook(unittest.TestCase):
         self, mock_frappe, mock_text_response, mock_request, mock_adapter
     ):
         mock_frappe.get_doc.return_value = SimpleNamespace(name="Support WeCom", provider="WeCom", is_enabled=1)
+        mock_frappe.request = SimpleNamespace(args={"gateway_name": "Support WeCom"})
         mock_request.return_value = SimpleNamespace(method="GET")
         adapter = MagicMock()
         adapter.verify_url.return_value = "decrypted-echo"
         mock_adapter.return_value = adapter
 
-        assert gateway_webhook.handle_gateway_webhook("Support WeCom") is None
+        assert gateway_webhook.handle_gateway_webhook() is None
         mock_text_response.assert_called_once_with("decrypted-echo")
+
+    @patch("huf.ai.gateway_webhook.frappe")
+    def test_missing_gateway_name_is_rejected(self, mock_frappe):
+        """Every provider here posts application/json, and
+        frappe.app.make_form_dict replaces frappe.form_dict wholesale with
+        the parsed JSON body whenever Content-Type is JSON — so
+        gateway_name must be read from frappe.request.args, never taken as
+        a function argument, or every real webhook call 500s."""
+        mock_frappe.request = SimpleNamespace(args={})
+
+        assert gateway_webhook.handle_gateway_webhook() == {
+            "success": False,
+            "error": "Missing gateway_name",
+        }
+        mock_frappe.get_doc.assert_not_called()

--- a/huf/ai/tests/test_telegram_gateway_adapter.py
+++ b/huf/ai/tests/test_telegram_gateway_adapter.py
@@ -1,0 +1,123 @@
+"""Focused fixtures for the Telegram Bot API adapter."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from huf.ai.gateway_adapters import GatewayInboundRequest, GatewayReply, assert_adapter_conforms
+from huf.ai.gateway_adapters.telegram import WEBHOOK_SECRET_HEADER, TelegramGatewayAdapter
+
+
+class FakeResponse:
+	def __init__(self, body):
+		self.body = body
+		self.raised = False
+
+	def raise_for_status(self):
+		self.raised = True
+
+	def json(self):
+		return self.body
+
+
+class TestTelegramGatewayAdapter(unittest.TestCase):
+	def setUp(self):
+		self.calls = []
+		self.adapter = TelegramGatewayAdapter(
+			{"token": "123:ABC", "webhook_secret": "shh"},
+			http_post=self._post,
+		)
+
+	def _post(self, url, *, json_data, timeout):
+		self.calls.append({"url": url, "json_data": json_data, "timeout": timeout})
+		return FakeResponse({"ok": True, "result": {"message_id": 42}})
+
+	@staticmethod
+	def request(payload, secret="shh"):
+		headers = {WEBHOOK_SECRET_HEADER: secret} if secret else {}
+		return GatewayInboundRequest(json.dumps(payload).encode(), headers=headers)
+
+	def message_payload(self, **overrides):
+		payload = {
+			"update_id": 555,
+			"message": {
+				"message_id": 10,
+				"chat": {"id": 999, "type": "private"},
+				"from": {"id": 111},
+				"text": "hello bot",
+			},
+		}
+		payload.update(overrides)
+		return payload
+
+	def test_verification_is_fail_closed_on_configured_secret(self):
+		valid = self.request(self.message_payload())
+		self.assertTrue(self.adapter.verify_inbound(valid))
+		self.assertFalse(self.adapter.verify_inbound(self.request(self.message_payload(), secret="wrong")))
+		self.assertFalse(self.adapter.verify_inbound(self.request(self.message_payload(), secret=None)))
+
+	def test_verification_accepts_when_no_secret_configured(self):
+		open_adapter = TelegramGatewayAdapter({"token": "123:ABC"}, http_post=self._post)
+		self.assertTrue(open_adapter.verify_inbound(self.request(self.message_payload(), secret=None)))
+
+	def test_missing_required_token_raises(self):
+		with self.assertRaisesRegex(ValueError, "token"):
+			TelegramGatewayAdapter({})
+
+	def test_normalizes_private_message(self):
+		event = self.adapter.normalize_inbound(self.request(self.message_payload()))
+		self.assertEqual(event.provider_event_id, "555")
+		self.assertEqual(event.sender_id, "111")
+		self.assertEqual(event.conversation_id, "999")
+		self.assertEqual(event.message_text, "hello bot")
+		self.assertEqual(event.thread_id, "10")
+		self.assertFalse(event.is_room)
+		self.assertFalse(event.mentioned)
+
+	def test_normalizes_group_message_with_bot_command_as_mentioned(self):
+		payload = self.message_payload(
+			message={
+				"message_id": 11,
+				"chat": {"id": -1001, "type": "supergroup"},
+				"from": {"id": 222},
+				"text": "/start",
+				"entities": [{"type": "bot_command", "offset": 0, "length": 6}],
+			}
+		)
+		event = self.adapter.normalize_inbound(self.request(payload))
+		self.assertTrue(event.is_room)
+		self.assertTrue(event.mentioned)
+
+	def test_normalize_rejects_unverified_request(self):
+		with self.assertRaises(ValueError):
+			self.adapter.normalize_inbound(self.request(self.message_payload(), secret="wrong"))
+
+	def test_normalize_rejects_missing_identifiers(self):
+		payload = self.message_payload(message={"message_id": 1, "chat": {}, "from": {}, "text": "hi"})
+		with self.assertRaises(ValueError):
+			self.adapter.normalize_inbound(self.request(payload))
+
+	def test_send_reply_calls_send_message_with_bot_token(self):
+		delivery = self.adapter.send_reply(GatewayReply("999", "hi there", reply_to_provider_message_id="10"))
+		self.assertEqual(delivery.provider_message_id, "42")
+		self.assertEqual(self.calls, [{
+			"url": "https://api.telegram.org/bot123:ABC/sendMessage",
+			"json_data": {"chat_id": "999", "text": "hi there", "reply_to_message_id": 10},
+			"timeout": 10,
+		}])
+
+	def test_adapter_conforms_with_verified_webhook_fixture(self):
+		event = assert_adapter_conforms(
+			self.adapter,
+			self.request(self.message_payload()),
+			GatewayReply("999", "hi there"),
+		)
+		self.assertEqual(event.message_text, "hello bot")
+
+	def test_outbound_errors_are_not_silently_accepted(self):
+		self.adapter._http_post = lambda *args, **kwargs: FakeResponse(
+			{"ok": False, "description": "bot was blocked by the user"}
+		)
+		with self.assertRaisesRegex(ValueError, "blocked"):
+			self.adapter.send_reply(GatewayReply("999", "hi there"))

--- a/huf/huf/doctype/gateway/gateway.py
+++ b/huf/huf/doctype/gateway/gateway.py
@@ -21,7 +21,7 @@ class Gateway(Document):
         if self.direct_policy == "Open":
             frappe.throw(_("Public direct-message gateways are not available in this release."))
 
-        expected_service = {"VK": "vk", "WeCom": "wecom", "WhatsApp": "whatsapp"}.get(self.provider)
+        expected_service = {"VK": "vk", "WeCom": "wecom", "WhatsApp": "whatsapp", "Telegram": "telegram"}.get(self.provider)
         if expected_service and self.is_enabled:
             if not self.integration_settings:
                 frappe.throw(_("Enabled {0} gateways need a connected integration.").format(self.provider))


### PR DESCRIPTION
## Summary
- `Telegram` was selectable as a Gateway provider in the UI, but `gateway_webhook.py`'s `_ADAPTER_CLASSES` map had no entry for it — every Telegram gateway would fail closed at inbound/outbound time with "No installed Gateway Adapter supports this channel." Added `TelegramGatewayAdapter` (`huf/ai/gateway_adapters/telegram.py`), matching the existing adapter contract (webhook secret verification, update normalization, `sendMessage` delivery), and registered it in `gateway_webhook.py` / `gateway_adapters/__init__.py`.
- `gateway.py` now requires a connected integration for Telegram gateways when enabled, matching the existing WhatsApp/VK/WeCom pattern.
- Closed a gap that affected **every** credentialed provider, not just Telegram: the Gateway configure UI had no field to link an `Integration Settings` record at all, so a credentialed gateway could never actually be enabled from the UI alone. Added a "Connected Integration" picker to the configure modal (`GatewaysPage.tsx`), sourced from existing Integration Settings filtered by the provider's required service, with an inline shortcut into the Channel Credentials tab when none exist yet.
- Quick-create now creates credentialed providers disabled by default (instead of immediately failing `gateway.py`'s enabled-requires-integration validation with no way to attach credentials at create time).
- **Found and fixed during the live round-trip test below**: `handle_gateway_webhook(gateway_name: str)` took `gateway_name` as a function argument sourced from `frappe.form_dict`. Every provider here posts `application/json`, and `frappe.app.make_form_dict` replaces `form_dict` wholesale with the parsed JSON body whenever `Content-Type` is JSON — so the query-string `gateway_name` never actually reached the function on a real webhook call. **Every gateway webhook (not just Telegram) was failing closed with a 500 TypeError the moment a real provider called it**; this had never been caught because prior testing only exercised CRUD through the UI, never an actual inbound webhook call. Fixed by reading `gateway_name` from `frappe.request.args` directly. Also fixed the frontend's copy-webhook-URL generator, which built the URL with the wrong query param (`?gateway=` instead of `?gateway_name=`) — so even without the backend bug, the copied URL would never have worked.

## Test plan
- [x] `tsc -b --noEmit` clean
- [x] `vite build` clean
- [x] `bench run-tests` clean (`huf.ai.tests.test_gateway_webhook`, `huf.ai.tests.test_telegram_gateway_adapter`), including new regression coverage for the query-string `gateway_name` read and the missing-`gateway_name` rejection path
- [x] **Full live inbound→outbound round-trip**, done on a disposable bench (`tg-live-test`, isolated via frappe-multihand) tunneled through ngrok to a real Telegram bot (`@huf_bot`):
  - Real Telegram update → `handle_gateway_webhook` → `Gateway Event` created → admission policy evaluated → `Agent Invocation` run against a live Google model → reply text generated → confirmed delivered back through `TelegramGatewayAdapter.send_reply`
  - Verified the full admission-policy path: `Pairing` policy correctly rejects an unpaired sender and opens a `Gateway Access Entry`; approving it and switching to `Allow list` lets the next message through
  - This also surfaced the `gateway_name` webhook bug above, which no prior CRUD-only testing had exercised

## Follow-up (tracked separately, not blocking this PR)
- `direct_policy: "Pairing"` never auto-admits a sender even after their `Gateway Access Entry` is manually approved — the code only ever creates a `Pending` entry and rejects; there's no path where approval flips subsequent messages to accepted without also switching the policy to `Allow list`. Worth a follow-up if `Pairing` is meant to be self-service.