### PR TITLE
fix: data table CSV import, sidebar/hub UX, skills page consistency

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,9 +130,11 @@ function AppShell() {
             path="/"
             element={
               <ProtectedRoute>
-                <Suspense fallback={<PageLoader />}>
-                  <HubSimplePage />
-                </Suspense>
+                <UnifiedLayout hideHeader>
+                  <Suspense fallback={<PageLoader />}>
+                    <HubSimplePage />
+                  </Suspense>
+                </UnifiedLayout>
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/HomeHeaderActions.tsx
+++ b/frontend/src/components/HomeHeaderActions.tsx
@@ -5,7 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { ChevronLeft, Plus, Bot, Workflow } from 'lucide-react';
+import { Plus, Bot, Workflow } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 export function HomeHeaderActions() {
@@ -21,10 +21,6 @@ export function HomeHeaderActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <Button variant="ghost" size="sm" onClick={() => navigate('/')} className="gap-1.5 text-slate-600">
-        <ChevronLeft className="w-4 h-4" />
-        Hub
-      </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="display" size="sm">

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -296,8 +296,16 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 className="group/shortcut-hint group-data-[collapsible=icon]:justify-center"
               >
                 <Keyboard strokeWidth={1.6} />
-                <span className="font-body text-[13.5px] flex-1">Keyboard shortcuts</span>
-                <ShortcutKey size="sm" hoverOnly="shortcut-hint">?</ShortcutKey>
+                <span className="font-body text-[13.5px] flex-1 group-data-[collapsible=icon]:hidden">
+                  Keyboard shortcuts
+                </span>
+                <ShortcutKey
+                  size="sm"
+                  hoverOnly="shortcut-hint"
+                  className="group-data-[collapsible=icon]:hidden"
+                >
+                  ?
+                </ShortcutKey>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/frontend/src/components/data-table/FieldConfigPanel.tsx
+++ b/frontend/src/components/data-table/FieldConfigPanel.tsx
@@ -264,15 +264,18 @@ export function FieldConfigPanel({
 				</div>
 			)}
 
-			<div className="pt-4 border-t border-line mt-4">
+			<div className="pt-4 border-t border-line mt-4 flex items-center justify-between gap-2">
+				<p className="text-[10px] text-steel">
+					Changes save with the table.
+				</p>
 				<Button
-					variant="destructive"
+					variant="ghost"
 					size="sm"
-					className="w-full rounded-none"
+					className="text-destructive hover:text-destructive hover:bg-destructive/10"
 					onClick={onDelete}
 				>
-					<Trash2 className="w-3.5 h-3.5 mr-2" />
-					Delete Field
+					<Trash2 className="w-3.5 h-3.5 mr-1.5" />
+					Delete field
 				</Button>
 			</div>
 		</div>

--- a/frontend/src/components/nav-user.tsx
+++ b/frontend/src/components/nav-user.tsx
@@ -62,7 +62,7 @@ export function NavUser() {
                   </span>
                 )}
               </div>
-              <div className="grid flex-1 text-left leading-tight">
+              <div className="grid flex-1 text-left leading-tight group-data-[collapsible=icon]:hidden">
                 <span className="truncate font-body text-[13px] font-semibold text-ink">
                   {displayName}
                 </span>
@@ -72,7 +72,7 @@ export function NavUser() {
                   </span>
                 )}
               </div>
-              <ChevronsUpDown className="ml-auto size-4 text-steel-soft" />
+              <ChevronsUpDown className="ml-auto size-4 text-steel-soft group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -431,7 +431,11 @@ export const SidebarGroup = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col px-2 py-0.5", className)}
+      className={cn(
+        "relative flex w-full min-w-0 flex-col px-2 py-0.5",
+        "group-data-[collapsible=icon]:mt-1.5 group-data-[collapsible=icon]:pt-1.5 group-data-[collapsible=icon]:first:mt-0 group-data-[collapsible=icon]:first:pt-0.5 group-data-[collapsible=icon]:first:border-t-0 group-data-[collapsible=icon]:border-t group-data-[collapsible=icon]:border-sidebar-border",
+        className
+      )}
       {...props}
     />
   )
@@ -450,7 +454,7 @@ export const SidebarGroupLabel = React.forwardRef<
       data-sidebar="group-label"
       className={cn(
         "flex h-6 shrink-0 items-center rounded-none px-2 font-mono text-[10px] uppercase tracking-widest text-steel-soft outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:pointer-events-none",
         className
       )}
       {...props}

--- a/frontend/src/pages/ExecutionProfileFormPage.tsx
+++ b/frontend/src/pages/ExecutionProfileFormPage.tsx
@@ -194,7 +194,8 @@ export function ExecutionProfileFormPage() {
   }
 
   return (
-    <div className="space-y-6 max-w-4xl mx-auto pb-12">
+    <div className="flex-1 overflow-y-auto">
+      <div className="space-y-6 max-w-4xl mx-auto p-6 pb-12">
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <div className="p-2 rounded-lg bg-primary/10 text-primary">
@@ -405,6 +406,7 @@ export function ExecutionProfileFormPage() {
           </Card>
         </form>
       </Form>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/HubSimplePage.tsx
+++ b/frontend/src/pages/HubSimplePage.tsx
@@ -1,14 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'motion/react';
-import {
-  Plus, MessageSquare, Bot, Workflow,
-  Database, BookOpen, Cpu, LayoutDashboard, Settings, Send,
-  PanelLeftClose, PanelLeftOpen,
-} from 'lucide-react';
-import { useUser } from '@/contexts/UserContext';
+import { Plus, Send } from 'lucide-react';
 import { usePermissions } from '@/contexts/PermissionsContext';
-import { IconRail, IconRailButton } from '@/components/IconRail';
+import { IconRailButton } from '@/components/IconRail';
 import { HubConversationView } from '@/components/hub/HubConversationView';
 import { AutoGrowTextarea } from '@/components/hub/AutoGrowTextarea';
 import { HubRecentChats } from '@/components/hub/HubRecentChats';
@@ -46,37 +41,14 @@ const STARTER_PROMPTS: Record<string, StarterPrompt[]> = {
   ],
 };
 
-const NAV_ITEMS = [
-  { icon: MessageSquare, label: 'Home', path: '/' },
-  { icon: Bot, label: 'Agents', path: '/agents' },
-  { icon: Workflow, label: 'Flows', path: '/flows' },
-  { icon: Database, label: 'Executions', path: '/executions' },
-  { icon: BookOpen, label: 'Knowledge', path: '/knowledge' },
-  { icon: Cpu, label: 'AI Providers', path: '/models' },
-];
-
-const RAIL_VISIBLE_KEY = 'hub:rail-visible';
-
-function readRailVisible(): boolean {
-  try {
-    return localStorage.getItem(RAIL_VISIBLE_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
-
 export default function HubSimplePage() {
   const navigate = useNavigate();
-  const { user } = useUser();
   const { hufRole } = usePermissions();
 
   const role =
     hufRole === 'Huf Admin' ? 'admin'
     : hufRole === 'Huf Manager' || hufRole === 'Huf User' ? 'builder'
     : 'viewer';
-
-  const initials = (user?.full_name || user?.name || 'U')
-    .split(' ').map((n: string) => n[0]).join('').toUpperCase().slice(0, 2);
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState('');
@@ -89,19 +61,6 @@ export default function HubSimplePage() {
   const [readiness, setReadiness] = useState<HubReadiness | null>(null);
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
   const [isStreaming, setIsStreaming] = useState(false);
-  const [railVisible, setRailVisible] = useState<boolean>(readRailVisible);
-
-  const toggleRail = () => {
-    setRailVisible(prev => {
-      const next = !prev;
-      try {
-        localStorage.setItem(RAIL_VISIBLE_KEY, String(next));
-      } catch {
-        void 0;
-      }
-      return next;
-    });
-  };
 
   // Detect slash commands
   useEffect(() => {
@@ -245,75 +204,15 @@ export default function HubSimplePage() {
     setConversationId(id);
   };
 
-  const handleSwitchToAdvanced = () => {
-    navigate('/dashboard');
-  };
-
   return (
-    <div className="h-screen flex bg-paper overflow-hidden">
-      {/* Collapsed rail — same 48px look as the dashboard's collapsed sidebar */}
-      <motion.div
-        initial={false}
-        animate={{ width: railVisible ? 48 : 0 }}
-        transition={{ duration: 0.2, ease: 'easeInOut' }}
-        className="flex flex-shrink-0 overflow-hidden"
-      >
-        <IconRail
-          header={
-            /* Matches AppSidebarHeader's collapsed mark (signal square) */
-            <div className="flex items-center gap-2 px-2 py-3">
-              <span className="inline-block w-2 h-2 bg-signal flex-shrink-0" />
-            </div>
-          }
-          actions={
-            <>
-              <IconRailButton icon={Plus} label="New chat" onClick={handleNewChat} />
-              <HubRecentChats onSelect={handleLoadConversation} />
-            </>
-          }
-          items={NAV_ITEMS.map((item, i) => ({
-            key: item.label,
-            icon: item.icon,
-            label: item.label,
-            active: i === 0,
-            onClick: () => navigate(item.path),
-          }))}
-          footer={
-            <>
-              <IconRailButton
-                icon={LayoutDashboard}
-                label="Switch to Advanced Hub"
-                onClick={handleSwitchToAdvanced}
-              />
-              <IconRailButton
-                icon={Settings}
-                label="Settings"
-                onClick={() => navigate('/models')}
-              />
-            </>
-          }
-        />
-      </motion.div>
-
-      {/* Rail hide/show toggle — stays visible when the rail is hidden */}
-      <button
-        onClick={toggleRail}
-        title={railVisible ? 'Hide sidebar' : 'Show sidebar'}
-        aria-label={railVisible ? 'Hide sidebar' : 'Show sidebar'}
-        className={`fixed top-3 z-50 flex size-7 items-center justify-center rounded-sm border border-line bg-panel text-steel shadow-sm hover:border-steel-soft hover:text-ink transition-all duration-200 ${
-          railVisible ? 'left-[60px]' : 'left-3'
-        }`}
-      >
-        {railVisible ? <PanelLeftClose className="w-4 h-4" /> : <PanelLeftOpen className="w-4 h-4" />}
-      </button>
-
-      {/* Main Content */}
+    <div className="h-full flex bg-paper overflow-hidden">
+      {/* Main Content — sidebar, header and user avatar are provided by
+          UnifiedLayout/AppSidebar so the Hub matches the rest of the app. */}
       <main className="flex-1 flex flex-col h-full relative overflow-hidden">
-        {/* User avatar top-right */}
-        <div className="absolute top-3 right-4 z-10">
-          <div className="w-7 h-7 rounded-full bg-ink flex items-center justify-center text-paper text-xs font-medium">
-            {initials}
-          </div>
+        {/* Chat toolbar — new chat / resume a recent conversation */}
+        <div className="absolute top-3 left-4 z-10 flex items-center gap-1">
+          <IconRailButton icon={Plus} label="New chat" onClick={handleNewChat} />
+          <HubRecentChats onSelect={handleLoadConversation} />
         </div>
 
         <AnimatePresence mode="wait">
@@ -331,7 +230,7 @@ export default function HubSimplePage() {
                 {/* Greeting */}
                 <div className="mb-8">
                   <h1 className="font-display font-bold text-2xl uppercase tracking-wide text-ink text-center">
-                    What can I do for you.
+                    What can huf do for you today?
                   </h1>
                 </div>
 

--- a/frontend/src/pages/SkillFormPage.tsx
+++ b/frontend/src/pages/SkillFormPage.tsx
@@ -443,9 +443,9 @@ export function SkillFormPage() {
         <Form {...form}>
           <form onSubmit={handleFormSubmit} className="space-y-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <TabsList className="flex h-auto w-full justify-start overflow-x-auto overflow-y-hidden p-1">
+              <TabsList layout="scroll" className="w-full">
                 {Object.entries(tabConfig).map(([tabKey, config]) => (
-                  <TabsTrigger key={tabKey} value={tabKey} className="flex-1 shrink-0">
+                  <TabsTrigger key={tabKey} value={tabKey} className="shrink-0 px-3 sm:min-w-[110px]">
                     {config.label}
                   </TabsTrigger>
                 ))}

--- a/frontend/src/pages/SkillsPage.tsx
+++ b/frontend/src/pages/SkillsPage.tsx
@@ -1,11 +1,21 @@
-import { useEffect } from 'react';
-import { Sparkles, Settings } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Sparkles, Settings, Trash2, Ban, CheckCircle2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../components/ui/alert-dialog';
 import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
 import { ExperimentalBadge } from '../components/common/ExperimentalBadge';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
-import { getSkills } from '../services/skillApi';
+import { getSkills, deleteSkill, updateSkill } from '../services/skillApi';
 import { formatTimeAgo } from '../utils/time';
 import type { SkillDoc } from '../types/skill.types';
 
@@ -42,6 +52,8 @@ function getStatusVariant(status: string): 'default' | 'secondary' | 'destructiv
 
 export function SkillsPage() {
   const navigate = useNavigate();
+  const [deleteSkillTarget, setDeleteSkillTarget] = useState<SkillDoc | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const {
     items: skills,
@@ -88,6 +100,36 @@ export function SkillsPage() {
       });
     }
   }, [error]);
+
+  const handleToggleStatus = async (skill: SkillDoc) => {
+    const nextStatus = skill.status === 'Disabled' ? 'Active' : 'Disabled';
+    try {
+      await updateSkill(skill.name, { status: nextStatus });
+      toast.success(nextStatus === 'Disabled' ? 'Skill disabled' : 'Skill enabled');
+      window.location.reload();
+    } catch (err) {
+      toast.error('Failed to update skill', {
+        description: err instanceof Error ? err.message : 'An error occurred.',
+      });
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteSkillTarget) return;
+    setDeleting(true);
+    try {
+      await deleteSkill(deleteSkillTarget.name);
+      toast.success('Skill deleted');
+      setDeleteSkillTarget(null);
+      window.location.reload();
+    } catch (err) {
+      toast.error('Failed to delete skill', {
+        description: err instanceof Error ? err.message : 'An error occurred.',
+      });
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   return (
     <PageLayout
@@ -154,6 +196,20 @@ export function SkillsPage() {
                 onClick: () => navigate(`/skills/${skill.name}`),
               },
             ]}
+            menuIcon={Settings}
+            menuActions={[
+              {
+                icon: skill.status === 'Disabled' ? CheckCircle2 : Ban,
+                label: skill.status === 'Disabled' ? 'Enable' : 'Disable',
+                onClick: () => handleToggleStatus(skill),
+              },
+              {
+                icon: Trash2,
+                label: 'Delete Skill',
+                variant: 'destructive',
+                onClick: () => setDeleteSkillTarget(skill),
+              },
+            ]}
             onClick={() => navigate(`/skills/${skill.name}`)}
           />
         )}
@@ -170,6 +226,25 @@ export function SkillsPage() {
           {total !== undefined ? `Showing all ${total} skills` : 'No more skills to load'}
         </div>
       )}
+      <AlertDialog open={!!deleteSkillTarget} onOpenChange={(open) => !open && setDeleteSkillTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete skill "{deleteSkillTarget?.title || deleteSkillTarget?.skill_name || deleteSkillTarget?.name}"?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes the skill. Skills attached to an agent cannot be deleted —
+              remove them from any agent first.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteConfirm} disabled={deleting}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageLayout>
   );
 }

--- a/frontend/src/services/dataTableApi.ts
+++ b/frontend/src/services/dataTableApi.ts
@@ -265,7 +265,7 @@ export async function getBulkImportTemplateUrl(
 	exportRecords = false
 ): Promise<BulkImportTemplate> {
 	try {
-		const result = await call.get(
+		const result = await call.post(
 			'huf.huf.doctype.huf_data_table.api.get_bulk_import_template_url',
 			{ table_id: tableId, export_records: exportRecords }
 		);

--- a/huf/huf/doctype/skill/skill.py
+++ b/huf/huf/doctype/skill/skill.py
@@ -10,3 +10,22 @@ class Skill(Document):
 	def validate(self):
 		if self.source_type == "App Provided" and not self.provider_app:
 			frappe.throw(_("Provider App is required for App Provided skills."))
+
+	def on_trash(self):
+		attached_agents = frappe.get_all(
+			"Agent Skill",
+			filters={"skill": self.name},
+			pluck="parent",
+		)
+		if attached_agents:
+			frappe.throw(
+				_("Cannot delete skill {0}: attached to {1} agent(s): {2}").format(
+					frappe.bold(self.name),
+					len(attached_agents),
+					", ".join(attached_agents[:5]),
+				)
+			)
+
+		# Skill Import Log is a historical audit trail, not a real dependency —
+		# safe to unlink so it never blocks deleting the skill it logged.
+		frappe.db.delete("Skill Import Log", {"skill": self.name})


### PR DESCRIPTION
## Summary

Fixes 12 UX/bug issues reported against `develop`:

1. **Data Table CSV template download** — the backend endpoint created a `File` doc as a side effect but was called via GET; Frappe rolls back DB writes at the end of GET requests, so the file never actually persisted and the returned URL 403'd. Switched the frontend call to POST.
2. **Data table field editor** — de-emphasized the "Delete field" button (was full-width destructive, looked like the primary action) and added a note that changes save with the table.
3. **Execution Profile `/execution-profiles/new`** — the form wasn't scrollable (no `overflow-y-auto` container), so `Resource Limits` and everything below was unreachable. Added a scroll wrapper.
4. **Collapsed sidebar user avatar** — text/chevron siblings weren't hidden in icon-only mode, squeezing the avatar. Hidden via `group-data-[collapsible=icon]:hidden`.
5. **Collapsed sidebar settings items not clickable** — `SidebarGroupLabel`'s collapsed state used `opacity-0` with a negative margin that overlapped neighboring icons without `pointer-events-none`, silently swallowing clicks on Back/Models/SSH Connections/MCP Servers/Dashboard. Added `pointer-events-none`.
6. **Keyboard shortcut hint** — now collapses to icon-only instead of showing the full label + "?" badge when the sidebar is collapsed.
7. **Icon rail separation** — added a top border between nav groups when collapsed so sections are visually distinct.
8. **Header "< Hub" link** — removed from the Dashboard header (not a real breadcrumb relationship).
9. **Hub page sidebar** — replaced the separate `IconRail` + hardcoded top-right avatar with the shared `AppSidebar`/`UnifiedLayout`, so Hub and Dashboard are visually and behaviorally consistent (user avatar bottom-left, same nav, same settings).
10. **Skills page tabs** — fixed broken tab layout by using the same `TabsList layout="scroll"` pattern as Agents/Knowledge instead of hand-rolled conflicting classes.
11. **Skill delete/disable** — added Delete/Disable quick actions to the Skills list (matching the Data Table page's `menuActions` pattern), and added an `on_trash` hook on `Skill` that blocks deletion only when actually attached to an Agent (via `Agent Skill`), while safely unlinking historical `Skill Import Log` rows instead of letting them block deletion.
12. **Hub greeting copy** — "What can I do for you." → "What can huf do for you today?"

## Verification

All 12 items were manually verified in a live, isolated bench (fresh site, fresh `bench install-app` + build) via browser automation:
- CSV template download confirmed working end-to-end (network request now POST, returned file actually fetchable with real CSV content).
- Field editor Delete de-emphasis and save-with-table note visually confirmed.
- Execution profile form scroll confirmed (Resource Limits section now reachable).
- Collapsed sidebar: avatar layout, Back/Models/SSH Connections/Dashboard click-through, keyboard-shortcut icon-only, and group separators all confirmed via DOM inspection + interaction.
- Header no longer shows "< Hub" on `/dashboard`.
- Hub page now renders through the shared sidebar (verified nav items, settings toggle, and user avatar match the Dashboard).
- Skills tabs render like Agents/Knowledge tabs.
- Skill delete/disable verified end-to-end via UI (create → disable/delete) and via `bench console` (confirmed deletion is blocked when attached to an Agent via `Agent Skill`, and that a `Skill Import Log` row is auto-cleaned and does not block deletion).
- Hub greeting copy confirmed.

## Test plan

- [x] Fresh `bench install-app huf` + `bench build --app huf` on a clean site
- [x] Manual verification of all 12 items via browser automation (see above)
- [x] `tsc -b` typecheck passes with no errors
- [x] Backend `on_trash` hook verified via `bench console` for both the allowed (log-only) and blocked (agent-attached) cases