### PR TITLE
fix(memory): enforce policy TTL and make "Relevant Only" actually filter

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -267,8 +267,12 @@ class AgentManager:
         return None
 
 
-    def create_agent(self) -> Agent:
-        """Create main agent """
+    def create_agent(self, memory_query: str = None, conversation_id: str = None) -> Agent:
+        """Create main agent
+
+        memory_query/conversation_id are the current turn's user text and
+        conversation, used to narrow "Relevant Only" memory injection.
+        """
 
         if not self.agent_doc.model:
             frappe.throw(_("Agent model is not configured"))
@@ -358,7 +362,9 @@ class AgentManager:
                     policy = frappe.get_doc("Memory Policy", self.agent_doc.memory_policy)
                     from huf.ai.memory_tools import get_injected_memory_text
 
-                    injected_memory = get_injected_memory_text(self.agent_doc.name, policy)
+                    injected_memory = get_injected_memory_text(
+                        self.agent_doc.name, policy, conversation_id=conversation_id, query=memory_query
+                    )
                     if injected_memory:
                         instructions += f"\n\n{injected_memory}\n"
                 except Exception as e:
@@ -1323,7 +1329,7 @@ def _execute_agent_run(
             manager.agent_doc.agent_prompt = resolved_prompt_template
             manager.agent_doc.prompt_version_locked = 0
 
-        agent = manager.create_agent()
+        agent = manager.create_agent(memory_query=prompt, conversation_id=conversation_id)
 
         # Build knowledge context for mandatory sources
         knowledge_context = None
@@ -2483,7 +2489,7 @@ async def run_agent_stream(
                 "prompt_version_locked": 0
             })
 
-        agent = manager.create_agent()
+        agent = manager.create_agent(memory_query=prompt, conversation_id=conversation.name)
 
         resolved_prompt_cache = _resolve_prompt_cache_options(channel_id, prompt_cache_options)
 

--- a/huf/ai/memory_tools.py
+++ b/huf/ai/memory_tools.py
@@ -151,6 +151,7 @@ def save_memory_record(
 		frappe.throw(_("Knowledge promotion blocked"))
 
 	# Apply Memory Policy rules if Agent has a policy
+	record_ttl_days = 0
 	if policy:
 		# Record type validation
 		if policy.allowed_record_types:
@@ -170,6 +171,10 @@ def save_memory_record(
 				promote_to_knowledge = True
 				if not knowledge_source:
 					knowledge_source = policy.knowledge_source
+
+		# TTL: propagate policy expiry onto the record (record controller converts this to effective_until)
+		if policy.ttl_days:
+			record_ttl_days = int(policy.ttl_days)
 
 	tag_text = ", ".join(tags) if isinstance(tags, list) else (tags or "")
 	doc = frappe.get_doc(
@@ -193,6 +198,7 @@ def save_memory_record(
 			"raw_context_excerpt": raw_context_excerpt,
 			"promote_to_knowledge": 1 if promote_to_knowledge else 0,
 			"knowledge_source": knowledge_source,
+			"ttl_days": record_ttl_days,
 		}
 	)
 	# P0-5: Use ignore_permissions=True — the _can_write_memory check above is the sole authority.
@@ -212,13 +218,15 @@ def save_memory_record(
 	}
 
 
-def get_injected_memory_text(agent_name, policy, conversation_id=None):
+def get_injected_memory_text(agent_name, policy, conversation_id=None, query=None):
 	"""Fetch memories to inject into system prompt based on policy.
 
 	P1-8: Wrap injected content in a data-not-instructions envelope to
 	      prevent prompt-injection attacks from user-authored memory content.
 	P2-1: Respect policy.enabled — disabled policies do nothing.
 	P2-3: Tool Only mode means agent can call search tool but nothing auto-injects.
+	"Relevant Only" narrows results to the current turn's text (substring match);
+	"Always" ignores query and injects every active record for the scope.
 	"""
 	if not policy:
 		return None
@@ -241,8 +249,10 @@ def get_injected_memory_text(agent_name, policy, conversation_id=None):
 
 	# Use search to get active memories the agent is allowed to read
 	# P1-8: Pass conversation_id so Conversation-scoped memories are included
+	# "Relevant Only" narrows by the current turn's text; "Always" injects everything active.
+	relevance_query = query if policy.inject_mode == "Relevant Only" else None
 	res = search_memory_records(
-		query=None,
+		query=relevance_query,
 		status="Active",
 		limit=limit * 2,  # Fetch more in case we hit token limits
 		conversation_id=conversation_id,

--- a/huf/ai/tests/test_memory_tools.py
+++ b/huf/ai/tests/test_memory_tools.py
@@ -300,5 +300,48 @@ class TestMemoryToolAutoWiring(unittest.TestCase):
         self.assertNotIn("save_memory_record", created_names)
 
 
+@unittest.skipIf(_HAS_REAL_FRAPPE, _SKIP_REASON)
+class TestInjectModeRelevance(unittest.TestCase):
+    """inject_mode must decide whether the current turn's text filters retrieval.
+
+    Regression guard: "Relevant Only" and "Always" previously hit an identical
+    code path (query was hardcoded to None), so the two modes behaved the same.
+    """
+
+    def _make_policy(self, inject_mode):
+        return MagicMock(
+            enabled=True,
+            inject_mode=inject_mode,
+            max_records=5,
+            token_budget=1000,
+        )
+
+    @patch.object(memory_tools, "search_memory_records")
+    def test_relevant_only_passes_query_through(self, mock_search):
+        mock_search.return_value = {"success": True, "results": []}
+        memory_tools.get_injected_memory_text(
+            "agent-1", self._make_policy("Relevant Only"), query="renewal date"
+        )
+        self.assertEqual(mock_search.call_args.kwargs["query"], "renewal date")
+
+    @patch.object(memory_tools, "search_memory_records")
+    def test_always_ignores_query(self, mock_search):
+        mock_search.return_value = {"success": True, "results": []}
+        memory_tools.get_injected_memory_text(
+            "agent-1", self._make_policy("Always"), query="renewal date"
+        )
+        self.assertIsNone(mock_search.call_args.kwargs["query"])
+
+    @patch.object(memory_tools, "search_memory_records")
+    def test_never_and_tool_only_do_not_retrieve(self, mock_search):
+        for mode in ("Never", "Tool Only"):
+            mock_search.reset_mock()
+            result = memory_tools.get_injected_memory_text(
+                "agent-1", self._make_policy(mode), query="renewal date"
+            )
+            self.assertIsNone(result)
+            mock_search.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Two `Memory Policy` fields were configurable in the doctype but had no effect at runtime — this fixes both.

- **TTL Days**: `Memory Policy.ttl_days` was never read. `Memory Record` already has its own `ttl_days` → `effective_until` conversion (and the `expire_stale_memory_records` scheduler already acts on it) — the only missing link was copying the policy value onto the record at creation time in `save_memory_record`. Fixed.
- **Inject Mode "Relevant Only"**: `get_injected_memory_text()` called `search_memory_records(query=None)` unconditionally, so `Relevant Only` and `Always` were behaviorally identical — every active record injected every turn regardless of mode. `create_agent()` now threads the current turn's user text (`memory_query`) and `conversation_id` through to the injection call, both already in scope at both call sites. Relevance is substring matching (same as the existing retrieval layer) — semantic/embedding relevance is a follow-up, not blocking this fix.
- Bonus: `conversation_id` was never passed to `get_injected_memory_text` at all, so Conversation-scoped memories were silently never injected. Also fixed by the same threading.

`Never` and `Tool Only` behavior is unchanged (no retrieval). `Always` behavior is unchanged (ignores query). Both new `create_agent()` params default to `None`, so no other caller is affected.

## Test plan
- [x] Added `TestInjectModeRelevance` (3 cases: Relevant Only passes query, Always ignores query, Never/Tool Only skip retrieval entirely) — all pass.
- [x] Confirmed the 2 pre-existing `TestMemoryToolAutoWiring` failures reproduce identically on unmodified `develop` (not caused by this change).
- [x] Live-verified on a running bench via `bench console`: policy `ttl_days=3` → record `ttl_days=3` + `effective_until` set; `Relevant Only` returns a hit for matching turn text and none for unrelated text; `Always` still ignores the query and injects regardless. Test data cleaned up after.