### PR TITLE
fix(ui): stop InlineEditName spreading pencil/badges away from the title

### DIFF
--- a/frontend/src/components/common/InlineEditName.tsx
+++ b/frontend/src/components/common/InlineEditName.tsx
@@ -66,14 +66,9 @@ export function InlineEditName({
     </Button>
   );
 
-  const wrapperClassName = cn(
-    'flex items-center gap-2 w-full max-w-md min-w-0',
-    className
-  );
-
   if (isEditing) {
     return (
-      <div className={wrapperClassName}>
+      <div className={cn('flex items-center gap-2 w-full max-w-md min-w-0', className)}>
         <Input
           value={value}
           onChange={(event) => onChange(event.target.value)}
@@ -88,8 +83,8 @@ export function InlineEditName({
   }
 
   return (
-    <div className={wrapperClassName}>
-      <h1 className="text-2xl font-bold flex-1 min-w-0 truncate">
+    <div className={cn('inline-flex items-center gap-2 max-w-md min-w-0', className)}>
+      <h1 className="text-2xl font-bold min-w-0 max-w-full truncate">
         {value || placeholder}
       </h1>
       {editButton}


### PR DESCRIPTION
## Summary

Found while reviewing the new Memory Policy detail page: the "Operational"
title had its edit pencil and "Enabled" badge sitting far to the right,
disconnected from the title text.

Root cause: `InlineEditName`'s display-mode wrapper was
`flex items-center gap-2 w-full max-w-md min-w-0` with the `<h1>` set to
`flex-1` — that stretches to a fixed 448px box regardless of title length,
and `flex-1` pushes the pencil button to the far edge of that box rather
than right after the text. Any sibling badge in the same flex row inherits
the same dead gap.

Fix: display-mode wrapper is now `inline-flex` (hugs content), `<h1>` drops
`flex-1`, keeping `max-w-md truncate` as a cap for genuinely long titles.
Edit-mode (the `<Input>`) is untouched — it still wants the full-width
click target while typing.

This component is shared by 9 headers: Agent, Knowledge Source, MCP,
Integration Service, Execution Profile, SSH Connection, both Prompt pages,
and Memory Policy — so this fixes the spacing everywhere, not just Memory
Policy.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `yarn build` clean
- [x] Live-verified on the `memory-policy-test` bench: Memory Policy detail
      header — pencil/badge now sit tight next to "Operational"
- [x] Spot-checked Agent detail header (different consumer of the same
      component) — same fix applies cleanly, no regression