### PR TITLE
fix(ui): prevent SidebarGroupLabel from overlapping last item in collapsed sidebar

### DIFF
--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -454,7 +454,7 @@ export const SidebarGroupLabel = React.forwardRef<
       data-sidebar="group-label"
       className={cn(
         "flex h-6 shrink-0 items-center rounded-none px-2 font-mono text-[10px] uppercase tracking-widest text-steel-soft outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:pointer-events-none",
+        "group-data-[collapsible=icon]:hidden",
         className
       )}
       {...props}


### PR DESCRIPTION
### Cause
In `SidebarGroupLabel`, `group-data-[collapsible=icon]:-mt-8` applied a negative top margin of -32px when the sidebar was collapsed to icon rail mode. This pulled each group's invisible label element 32px upward, causing it to overlay directly on top of the last navigation item of the preceding `SidebarGroup` (e.g., Dashboard, Chat, Flows, Skills, Models, SSH Connections, MCP Servers).

### Fix
Replaced `group-data-[collapsible=icon]:-mt-8 ...` with `group-data-[collapsible=icon]:hidden` so that group labels are removed from DOM layout calculations when collapsed, preventing element overlap while maintaining the `border-t` group divider.