### PR TITLE
fix(pwa): stop navigation appearing stuck after a new deploy

### DIFF
--- a/frontend/src/pwa/registerSW.ts
+++ b/frontend/src/pwa/registerSW.ts
@@ -4,4 +4,18 @@ if ('serviceWorker' in navigator) {
       console.error('Failed to register Huf service worker', error);
     });
   });
+
+  // Paired with workbox's skipWaiting/clientsClaim (see vite.config.ts): when
+  // a new service worker takes control of this page, the JS/CSS the page
+  // already loaded is from the OLD bundle and won't update on its own.
+  // Reload once so the app picks up the new bundle automatically instead of
+  // requiring the user to manually refresh (often twice) to see a new
+  // deploy. `refreshing` guards against a reload loop if the controller
+  // changes more than once in a session.
+  let refreshing = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
+  });
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -48,6 +48,16 @@ export default defineConfig({
         // /huf/workbox-<hash>.js file cannot be routed and 404s.
         inlineWorkboxRuntime: true,
         navigateFallback: null,
+        // Without these, a new deploy installs as a "waiting" service worker
+        // that never takes over the already-open tab — the page keeps running
+        // the OLD JS bundle (stale routes/components) until every tab is
+        // closed and reopened. skipWaiting + clientsClaim make a new worker
+        // activate and take control immediately; paired with the
+        // controllerchange listener in src/pwa/registerSW.ts, the app
+        // reloads itself once to pick up the new bundle instead of requiring
+        // the user to manually refresh (often twice).
+        skipWaiting: true,
+        clientsClaim: true,
         globPatterns: ['**/*.{js,css,ico,png,svg,woff,woff2,ttf}'],
         modifyURLPrefix: {
           '': '/assets/huf/frontend/',


### PR DESCRIPTION
## Summary

Reported symptom: clicking a sidebar item updates the URL bar, but the page
content doesn't change until a manual refresh (sometimes needing a second
refresh).

`NavLink`/react-router client-side navigation is implemented correctly
(`components/nav-main.tsx`) — that's not the bug. The bug is the service
worker lifecycle: Workbox's `generateSW` defaults to `skipWaiting: false`
and `clientsClaim: false`, so a new deploy's service worker installs but
stays "waiting" — the already-open tab keeps running the **previous**
deploy's JS bundle indefinitely, until every tab is closed and reopened.
Any route or component that only exists in the new bundle silently fails
to render correctly under the stale one, even though the URL update
(happening inside that same stale, still-running app) works fine. This is
a well-documented Workbox gotcha, not a routing bug.

## Fix

- `vite.config.ts`: `skipWaiting: true` + `clientsClaim: true` on the
  workbox config — a new service worker now activates and takes control of
  open tabs immediately.
- `src/pwa/registerSW.ts`: listen for `controllerchange` and reload once
  when a new worker takes control, so the app self-heals to the fresh
  bundle instead of relying on the user to know to (repeatedly) refresh.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `yarn build` clean; confirmed both `skipWaiting()` and
      `clients.claim()` are present in the compiled `sw.js`
- [x] Confirmed the served `sw.js` (via the site's `assets/huf` symlink on
      the `memory-policy-test` bench) matches the freshly built one