### PR TITLE
revert(nav): restore createBrowserRouter — BrowserRouter broke useBlocker

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react';
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'motion/react';
 import { UserProvider } from './contexts/UserContext';
 import { PermissionsProvider, usePermissions } from './contexts/PermissionsContext';
@@ -76,7 +76,7 @@ const GatewaysPage = lazy(() => import('./pages/GatewaysPage'));
 const AgentSettingsPage = lazy(() => import('./pages/AgentSettingsPage'));
 
 import { useEffect } from 'react';
-import { AppErrorBoundary, clearChunkReloadFlag } from './components/RouteErrorBoundary';
+import { RouteErrorBoundary, clearChunkReloadFlag } from './components/RouteErrorBoundary';
 import { SocketProvider } from './contexts/SocketContext';
 import {
   checkStreamingAvailable,
@@ -674,6 +674,11 @@ function AppShell() {
   );
 }
 
+const router = createBrowserRouter(
+  [{ path: '*', element: <AppShell />, errorElement: <RouteErrorBoundary /> }],
+  { basename: '/huf' },
+);
+
 function App() {
   useEffect(() => {
     // Streaming (SSE) is the explicit direct-execution mode: it is only used
@@ -686,21 +691,7 @@ function App() {
     });
   }, []);
 
-  // Deliberately <BrowserRouter>, not createBrowserRouter/<RouterProvider>.
-  // All routing here is a descendant <Routes> inside AppShell — there are no
-  // loaders or actions, so the data router adds nothing. It also broke
-  // navigation: RouterProvider kept its own copy of router state, and after
-  // the first commit that copy stopped tracking the router. Clicking a nav
-  // link updated history and router.state (URL changed) while the rendered
-  // tree stayed pinned to the location it mounted with, so the page only
-  // changed on a manual refresh. BrowserRouter has no such intermediate copy.
-  return (
-    <AppErrorBoundary>
-      <BrowserRouter basename="/huf">
-        <AppShell />
-      </BrowserRouter>
-    </AppErrorBoundary>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/frontend/src/components/RouteErrorBoundary.tsx
+++ b/frontend/src/components/RouteErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, useEffect, type ReactNode } from 'react';
+import { useEffect } from 'react';
+import { useRouteError } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 
 const RELOAD_FLAG = 'huf:chunk-reload';
@@ -10,12 +11,14 @@ function isChunkLoadError(error: unknown): boolean {
 }
 
 /**
- * Dynamic-import failures mean the browser holds a stale bundle (a new build
- * replaced the hashed chunks) — the only fix is a reload, so do it once
- * automatically and show a calm message instead of a raw error screen. The
- * flag is cleared on healthy load (AppShell) so future redeploys reload again.
+ * Route errorElement. Dynamic-import failures mean the browser holds a stale
+ * bundle (a new build replaced the hashed chunks) — the only fix is a reload,
+ * so do it once automatically and show a calm message instead of the raw
+ * "Unexpected Application Error" screen. The flag is cleared on healthy load
+ * (AppShell) so future real redeploys reload again.
  */
-function ErrorScreen({ error }: { error: unknown }) {
+export function RouteErrorBoundary() {
+	const error = useRouteError();
 	const chunkError = isChunkLoadError(error);
 	const alreadyRetried =
 		typeof sessionStorage !== 'undefined' && sessionStorage.getItem(RELOAD_FLAG) === '1';
@@ -57,25 +60,6 @@ function ErrorScreen({ error }: { error: unknown }) {
 			</Button>
 		</div>
 	);
-}
-
-/**
- * Top-level error boundary. This is a plain React boundary rather than a
- * route `errorElement` because the app renders through <BrowserRouter> — see
- * App.tsx for why the data router (createBrowserRouter/RouterProvider) is not
- * used here.
- */
-export class AppErrorBoundary extends Component<{ children: ReactNode }, { error: unknown }> {
-	state: { error: unknown } = { error: null };
-
-	static getDerivedStateFromError(error: unknown) {
-		return { error };
-	}
-
-	render() {
-		if (this.state.error) return <ErrorScreen error={this.state.error} />;
-		return this.props.children;
-	}
 }
 
 /** Clear the reload guard once the app has loaded healthy. Call from AppShell. */


### PR DESCRIPTION
## Problem

PR #541 switched from `createBrowserRouter`/`RouterProvider` to `<BrowserRouter>` to fix a sidebar navigation regression. That regression was already fixed by af1ac236 (pinning `react-router-dom` back to `7.9.4` after the `^8.3.0` override introduced by e2da0ee1 caused RouterProvider's `pendingState` to freeze).

The `<BrowserRouter>` change was therefore unnecessary — and it broke `useBlocker` in three pages:
- `AgentFormPage`
- `KnowledgeSourceFormPage`
- `DataTableBuilderPage`

(`useBlocker` only works with data routers — it requires `DataRouterContext`.)

## Fix

Restores `App.tsx` and `RouteErrorBoundary.tsx` to their pre-#541 state. The PWA service worker hardening from #541 (`skipWaiting`, `clientsClaim`, `controllerchange` reload) is **kept** — those changes are in `registerSW.ts` and `vite.config.ts` and are unaffected by this revert.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/App.tsx` | Reverts to `createBrowserRouter` + `RouterProvider` |
| `frontend/src/components/RouteErrorBoundary.tsx` | Reverts to `useRouteError`-based route error element |