### PR TITLE
fix(auth): stop 403s from silently killing/confusing valid sessions

### DIFF
--- a/frontend/src/components/settings/AgentSettingsTab.tsx
+++ b/frontend/src/components/settings/AgentSettingsTab.tsx
@@ -14,6 +14,8 @@ import {
 import { getAgentSettings, updateAgentSettings, type AgentSettingsDoc } from '@/services/agentSettingsApi';
 import { getProviders, getModels } from '@/services/providerApi';
 import type { AIProvider, AIModel } from '@/types/agent.types';
+import { settleAll } from '@/lib/settleAll';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
 
 export { AgentSettingsTab };
 export default AgentSettingsTab;
@@ -29,8 +31,16 @@ function AgentSettingsTab() {
   useEffect(() => {
     (async () => {
       setLoading(true);
-      const [providersRes, settings] = await Promise.all([getProviders(), getAgentSettings()]);
-      setProviders(Array.isArray(providersRes) ? providersRes : providersRes.items);
+      const errorLabels = ['providers', 'agent settings'];
+      const [providersRes, settings] = await settleAll(
+        [getProviders(), getAgentSettings()],
+        (index, error) => {
+          toast.error(`Failed to load ${errorLabels[index]}: ${getFrappeErrorMessage(error)}`);
+        },
+      );
+      if (providersRes) {
+        setProviders(Array.isArray(providersRes) ? providersRes : providersRes.items);
+      }
       setDefaultProvider(settings?.default_provider || undefined);
       setDefaultModel(settings?.default_model || undefined);
       setLoading(false);

--- a/frontend/src/components/settings/VoiceSettingsTab.tsx
+++ b/frontend/src/components/settings/VoiceSettingsTab.tsx
@@ -25,6 +25,8 @@ import {
 import { getProviders } from '@/services/providerApi';
 import type { AIProvider } from '@/types/agent.types';
 import type { ElevenlabsSettingsDoc, HttpProviderSettingsDoc } from '@/types/integration.types';
+import { settleAll } from '@/lib/settleAll';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
 
 export { VoiceSettingsTab };
 export default VoiceSettingsTab;
@@ -292,13 +294,16 @@ function VoiceSettingsTab() {
   useEffect(() => {
     (async () => {
       setLoading(true);
-      const [providersRes, openaiRes, groqRes, elevenlabsRes] = await Promise.all([
-        getProviders(),
-        getOpenAISettings(),
-        getGroqSettings(),
-        getElevenlabsSettings(),
-      ]);
-      setProviders(Array.isArray(providersRes) ? providersRes : providersRes.items);
+      const errorLabels = ['providers', 'OpenAI settings', 'Groq settings', 'ElevenLabs settings'];
+      const [providersRes, openaiRes, groqRes, elevenlabsRes] = await settleAll(
+        [getProviders(), getOpenAISettings(), getGroqSettings(), getElevenlabsSettings()],
+        (index, error) => {
+          toast.error(`Failed to load ${errorLabels[index]}: ${getFrappeErrorMessage(error)}`);
+        },
+      );
+      if (providersRes) {
+        setProviders(Array.isArray(providersRes) ? providersRes : providersRes.items);
+      }
       if (openaiRes) setOpenai(openaiRes);
       if (groqRes) setGroq(groqRes);
       if (elevenlabsRes) setElevenlabs(elevenlabsRes);

--- a/frontend/src/components/tools/toolCreationForm.utils.ts
+++ b/frontend/src/components/tools/toolCreationForm.utils.ts
@@ -655,13 +655,22 @@ export async function loadDocTypeFieldCatalog(doctypeName: string): Promise<DocT
   const childMetaEntries = await Promise.all(
     childTableFields.map(async (tableDf) => {
       const childDoctype = tableDf.options || '';
-      const childMeta = (await getDocTypeMeta(childDoctype)) as DocTypeMeta;
-      return [tableDf.fieldname || '', childMeta] as const;
+      try {
+        const childMeta = (await getDocTypeMeta(childDoctype)) as DocTypeMeta;
+        return [tableDf.fieldname || '', childMeta] as const;
+      } catch (error) {
+        // One child table's meta being denied/unavailable must not break
+        // building the tool schema for every other field on this doctype.
+        console.error(`Error loading child table meta for ${childDoctype}:`, error);
+        return null;
+      }
     })
   );
 
   const childTableMetas: Record<string, DocTypeMeta> = {};
-  childMetaEntries.forEach(([tableFieldname, meta]) => {
+  childMetaEntries.forEach((entry) => {
+    if (!entry) return;
+    const [tableFieldname, meta] = entry;
     childTableMetas[tableFieldname] = meta;
   });
 

--- a/frontend/src/contexts/UserContext.tsx
+++ b/frontend/src/contexts/UserContext.tsx
@@ -1,6 +1,10 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { toast } from 'sonner';
 import { auth, db } from '@/lib/frappe-sdk';
 import { doctype } from '@/data/doctypes';
+import { onSessionInvalidated } from '@/lib/sessionInvalidation';
+
+const SESSION_ENDED_FLAG = 'huf:session-ended';
 
 interface User {
   name: string;
@@ -99,6 +103,24 @@ export function UserProvider({ children }: UserProviderProps) {
     window.location.href = `${LOGIN_URL}${redirectTo}#login`;
   };
 
+  /**
+   * A dead session surfaces as a "not whitelisted" PermissionError on
+   * whichever API call notices it first (see lib/sessionInvalidation.ts) -
+   * anywhere in the app, not just the login-check call this context owns.
+   * Redirect immediately with a clear reason instead of leaving the
+   * triggering page to show a confusing one-off "permission denied" toast
+   * and leaving every other stale/unretried call to fail the same way.
+   */
+  const handleSessionInvalidated = () => {
+    try {
+      sessionStorage.setItem(SESSION_ENDED_FLAG, '1');
+    } catch {
+      // sessionStorage unavailable - the flag is only a nice-to-have message
+    }
+    setUser(null);
+    redirectToLogin();
+  };
+
   const checkAuth = async () => {
     try {
       setIsLoading(true);
@@ -121,6 +143,14 @@ export function UserProvider({ children }: UserProviderProps) {
       if (loggedUserId) {
         const userDetails = await fetchUserDetails(loggedUserId);
         setUser(userDetails);
+        try {
+          if (sessionStorage.getItem(SESSION_ENDED_FLAG) === '1') {
+            sessionStorage.removeItem(SESSION_ENDED_FLAG);
+            toast.info('You were signed out because your session ended. Please retry your last action.');
+          }
+        } catch {
+          // sessionStorage unavailable - nothing to clean up
+        }
       } else {
         setUser(null);
         redirectToLogin();
@@ -151,6 +181,10 @@ export function UserProvider({ children }: UserProviderProps) {
 
   useEffect(() => {
     checkAuth();
+  }, []);
+
+  useEffect(() => {
+    onSessionInvalidated(handleSessionInvalidated);
   }, []);
 
   const value: UserContextType = {

--- a/frontend/src/lib/csrfRetryInterceptor.test.ts
+++ b/frontend/src/lib/csrfRetryInterceptor.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AxiosError, AxiosInstance } from 'axios';
+
+import { createCsrfRetryHandler } from './csrfRetryInterceptor';
+
+// This test suite runs under vitest's default 'node' environment (no jsdom),
+// so stub the minimal `window` surface the interceptor touches.
+beforeEach(() => {
+  (globalThis as unknown as { window: { csrf_token?: string } }).window = {};
+});
+
+function makeCsrfError(overrides: Partial<AxiosError> = {}): AxiosError<{ exc_type?: string }> {
+  return {
+    isAxiosError: true,
+    name: 'AxiosError',
+    message: 'Invalid Request',
+    toJSON: () => ({}),
+    config: { headers: { set: vi.fn() } } as never,
+    response: {
+      status: 400,
+      data: { exc_type: 'CSRFTokenError' },
+      statusText: 'Bad Request',
+      headers: {},
+      config: {} as never,
+    },
+    ...overrides,
+  } as AxiosError<{ exc_type?: string }>;
+}
+
+describe('createCsrfRetryHandler', () => {
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: { csrf_token?: string } }).window;
+  });
+
+  it('fetches a fresh token and retries the original request once on a CSRFTokenError', async () => {
+    const retriedResponse = { data: { message: 'saved' } };
+    const axiosInstance = {
+      get: vi.fn().mockResolvedValue({ data: { message: 'fresh-token' } }),
+      request: vi.fn().mockResolvedValue(retriedResponse),
+    } as unknown as AxiosInstance;
+
+    const handler = createCsrfRetryHandler(axiosInstance);
+    const error = makeCsrfError();
+
+    const result = await handler(error);
+
+    expect(axiosInstance.get).toHaveBeenCalledWith('/api/method/huf.ai.session_api.get_csrf_token');
+    expect(error.config!.headers.set).toHaveBeenCalledWith('X-Frappe-CSRF-Token', 'fresh-token');
+    expect(
+      (globalThis as unknown as { window: { csrf_token?: string } }).window.csrf_token,
+    ).toBe('fresh-token');
+    expect(axiosInstance.request).toHaveBeenCalledWith(error.config);
+    expect(result).toBe(retriedResponse);
+  });
+
+  it('does not retry a second time for the same request (prevents infinite loops)', async () => {
+    const axiosInstance = {
+      get: vi.fn().mockResolvedValue({ data: { message: 'fresh-token' } }),
+      request: vi.fn().mockResolvedValue({}),
+    } as unknown as AxiosInstance;
+
+    const handler = createCsrfRetryHandler(axiosInstance);
+    const error = makeCsrfError();
+    (error.config as { _csrfRetried?: boolean })._csrfRetried = true;
+
+    await expect(handler(error)).rejects.toBe(error);
+    expect(axiosInstance.get).not.toHaveBeenCalled();
+    expect(axiosInstance.request).not.toHaveBeenCalled();
+  });
+
+  it('rejects with the original error when the token refresh itself fails (real logout case)', async () => {
+    const axiosInstance = {
+      get: vi.fn().mockRejectedValue(new Error('not authenticated')),
+      request: vi.fn(),
+    } as unknown as AxiosInstance;
+
+    const handler = createCsrfRetryHandler(axiosInstance);
+    const error = makeCsrfError();
+
+    await expect(handler(error)).rejects.toBe(error);
+    expect(axiosInstance.request).not.toHaveBeenCalled();
+  });
+
+  it('passes through non-CSRF errors unchanged', async () => {
+    const axiosInstance = {
+      get: vi.fn(),
+      request: vi.fn(),
+    } as unknown as AxiosInstance;
+
+    const handler = createCsrfRetryHandler(axiosInstance);
+    const error = makeCsrfError({
+      response: {
+        status: 403,
+        data: { exc_type: 'PermissionError' },
+        statusText: 'Forbidden',
+        headers: {},
+        config: {} as never,
+      },
+    });
+
+    await expect(handler(error)).rejects.toBe(error);
+    expect(axiosInstance.get).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/csrfRetryInterceptor.ts
+++ b/frontend/src/lib/csrfRetryInterceptor.ts
@@ -1,0 +1,39 @@
+import type { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+
+interface RetriableRequestConfig extends InternalAxiosRequestConfig {
+  _csrfRetried?: boolean;
+}
+
+/**
+ * `window.csrf_token` is only ever set once, from the server-rendered boot
+ * HTML (huf/www/huf.py). Frappe can regenerate the session's real CSRF
+ * token independently (e.g. after a worker restart or cache clear), which
+ * makes every write in an already-open tab fail with a 400 CSRFTokenError
+ * even though the session cookie itself is still valid. Refresh the token
+ * once and retry instead of surfacing that as a broken/logged-out session.
+ */
+export function createCsrfRetryHandler(axiosInstance: AxiosInstance) {
+  return async (error: AxiosError<{ exc_type?: string }>) => {
+    const config = error.config as RetriableRequestConfig | undefined;
+    const isCsrfError =
+      error.response?.status === 400 && error.response?.data?.exc_type === 'CSRFTokenError';
+
+    if (isCsrfError && config && !config._csrfRetried) {
+      config._csrfRetried = true;
+      try {
+        const { data } = await axiosInstance.get('/api/method/huf.ai.session_api.get_csrf_token');
+        const freshToken = data?.message;
+        if (freshToken) {
+          (window as unknown as { csrf_token?: string }).csrf_token = freshToken;
+          config.headers.set('X-Frappe-CSRF-Token', freshToken);
+          return axiosInstance.request(config);
+        }
+      } catch {
+        // Fall through to the original error - if the token endpoint itself
+        // fails, the session is genuinely gone and normal auth handling applies.
+      }
+    }
+
+    return Promise.reject(error);
+  };
+}

--- a/frontend/src/lib/frappe-sdk.ts
+++ b/frontend/src/lib/frappe-sdk.ts
@@ -1,5 +1,6 @@
 import { FrappeApp } from 'frappe-js-sdk';
 import { createCsrfRetryHandler } from './csrfRetryInterceptor';
+import { isSessionInvalidatedError, notifySessionInvalidated } from './sessionInvalidation';
 
 // Initialize Frappe App instance
 const frappeUrl = import.meta.env.VITE_FRAPPE_URL || window.location.origin;
@@ -12,3 +13,21 @@ export const call = frappe.call();
 export const file = frappe.file();
 
 frappe.axios.interceptors.response.use((response) => response, createCsrfRetryHandler(frappe.axios));
+
+/**
+ * A session that's genuinely gone (see sessionInvalidation.ts) surfaces
+ * identically to a one-off feature-permission denial - "Function X is not
+ * whitelisted" - on whichever API call happens to notice it first. Route
+ * that straight to a clean, immediate sign-out instead of letting each page
+ * show its own confusing "permission denied" toast for what is actually a
+ * dead session.
+ */
+frappe.axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (isSessionInvalidatedError(error)) {
+      notifySessionInvalidated();
+    }
+    return Promise.reject(error);
+  },
+);

--- a/frontend/src/lib/frappe-sdk.ts
+++ b/frontend/src/lib/frappe-sdk.ts
@@ -1,4 +1,5 @@
 import { FrappeApp } from 'frappe-js-sdk';
+import { createCsrfRetryHandler } from './csrfRetryInterceptor';
 
 // Initialize Frappe App instance
 const frappeUrl = import.meta.env.VITE_FRAPPE_URL || window.location.origin;
@@ -9,3 +10,5 @@ export const auth = frappe.auth();
 export const db = frappe.db();
 export const call = frappe.call();
 export const file = frappe.file();
+
+frappe.axios.interceptors.response.use((response) => response, createCsrfRetryHandler(frappe.axios));

--- a/frontend/src/lib/sessionInvalidation.test.ts
+++ b/frontend/src/lib/sessionInvalidation.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AxiosError } from 'axios';
+
+import { isSessionInvalidatedError } from './sessionInvalidation';
+
+function makeError(status: number, exception?: string): AxiosError<{ exception?: string }> {
+  return {
+    isAxiosError: true,
+    name: 'AxiosError',
+    message: 'error',
+    toJSON: () => ({}),
+    config: {} as never,
+    response: {
+      status,
+      data: { exception },
+      statusText: '',
+      headers: {},
+      config: {} as never,
+    },
+  } as AxiosError<{ exception?: string }>;
+}
+
+describe('isSessionInvalidatedError', () => {
+  it('matches the exact "is not whitelisted" 403 signature', () => {
+    const error = makeError(403, 'frappe.exceptions.PermissionError: Function foo.bar is not whitelisted.');
+    expect(isSessionInvalidatedError(error)).toBe(true);
+  });
+
+  it('does not match a real capability-denial 403 with a different message', () => {
+    const error = makeError(403, 'frappe.exceptions.PermissionError: Insufficient Permission for Agent');
+    expect(isSessionInvalidatedError(error)).toBe(false);
+  });
+
+  it('does not match a non-403 status', () => {
+    const error = makeError(400, 'Function foo.bar is not whitelisted.');
+    expect(isSessionInvalidatedError(error)).toBe(false);
+  });
+
+  it('does not match a 403 with no exception field', () => {
+    const error = makeError(403, undefined);
+    expect(isSessionInvalidatedError(error)).toBe(false);
+  });
+});
+
+describe('notifySessionInvalidated', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('calls the registered handler', async () => {
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+    mod.notifySessionInvalidated();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('only calls the handler once even if notified multiple times (debounced per page life)', async () => {
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+    mod.notifySessionInvalidated();
+    mod.notifySessionInvalidated();
+    mod.notifySessionInvalidated();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/sessionInvalidation.ts
+++ b/frontend/src/lib/sessionInvalidation.ts
@@ -1,0 +1,41 @@
+import type { AxiosError } from 'axios';
+
+/**
+ * Frappe's is_whitelisted() throws this exact text whenever
+ * `method not in whitelisted OR (is_guest AND method not in guest_methods)` -
+ * both branches produce the identical "Function X is not whitelisted"
+ * message. For any endpoint this build actually calls, "not registered" is
+ * not a real possibility (it would fail on every request, not
+ * intermittently) - so in practice this signature means the session
+ * resolved to Guest for this specific request. Unlike a normal capability
+ * denial (a different message, e.g. "Insufficient Permission for X" or a
+ * huf.permissions "not permitted" string), this means the session itself is
+ * gone, not that one feature is unavailable - see
+ * Tracks/safwan-erooth.AuthDebug/FINDINGS.md ("Bug C") in the workspace repo.
+ */
+const NOT_WHITELISTED_PATTERN = /is not whitelisted/i;
+
+export function isSessionInvalidatedError(error: AxiosError<{ exception?: string }>): boolean {
+  if (error.response?.status !== 403) return false;
+  const exception = error.response?.data?.exception;
+  return typeof exception === 'string' && NOT_WHITELISTED_PATTERN.test(exception);
+}
+
+let handler: (() => void) | null = null;
+let notified = false;
+
+/** Called once by UserContext on mount to receive session-death notifications. */
+export function onSessionInvalidated(fn: () => void): void {
+  handler = fn;
+}
+
+/**
+ * Notify the registered handler at most once per page life - a burst of
+ * concurrent requests can all hit this signature together, and we only want
+ * one clean redirect, not N of them racing.
+ */
+export function notifySessionInvalidated(): void {
+  if (notified) return;
+  notified = true;
+  handler?.();
+}

--- a/frontend/src/lib/settleAll.test.ts
+++ b/frontend/src/lib/settleAll.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { settleAll } from './settleAll';
+
+describe('settleAll', () => {
+  it('resolves every slot when all promises succeed', async () => {
+    const result = await settleAll([Promise.resolve(1), Promise.resolve('two')]);
+    expect(result).toEqual([1, 'two']);
+  });
+
+  it('does not let one rejected promise take down the others', async () => {
+    const result = await settleAll([
+      Promise.resolve('ok'),
+      Promise.reject(new Error('denied')),
+      Promise.resolve('also ok'),
+    ]);
+    expect(result).toEqual(['ok', undefined, 'also ok']);
+  });
+
+  it('calls onError with the index and reason for each rejected slot', async () => {
+    const onError = vi.fn();
+    const boom = new Error('boom');
+    await settleAll([Promise.resolve('ok'), Promise.reject(boom)], onError);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(1, boom);
+  });
+
+  it('does not call onError for fulfilled slots', async () => {
+    const onError = vi.fn();
+    await settleAll([Promise.resolve('ok')], onError);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/settleAll.ts
+++ b/frontend/src/lib/settleAll.ts
@@ -1,0 +1,20 @@
+/**
+ * Run independent promises together without one denial/failure taking the
+ * rest down with it (the failure mode of a plain `Promise.all` when one
+ * branch is a 403-denied API call). Each slot resolves to its value on
+ * success or `undefined` on failure; `onError` is called per failed slot so
+ * callers can toast or log without losing the others.
+ */
+export async function settleAll<T extends readonly unknown[]>(
+  promises: readonly [...{ [K in keyof T]: Promise<T[K]> }],
+  onError?: (index: number, error: unknown) => void,
+): Promise<{ [K in keyof T]: T[K] | undefined }> {
+  const results = await Promise.allSettled(promises);
+  return results.map((result, index) => {
+    if (result.status === 'fulfilled') {
+      return result.value;
+    }
+    onError?.(index, result.reason);
+    return undefined;
+  }) as { [K in keyof T]: T[K] | undefined };
+}

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -194,7 +194,7 @@ export function AgentFormPage() {
   const tabConfig = useMemo(() => ({
     general: {
       label: 'General',
-      fields: ['agent_name', 'provider', 'model', 'temperature', 'top_p', 'run_immediately', 'description', 'instructions', 'enable_prompt_caching', 'cache_control_type', 'cache_system_message', 'cache_conversation_history', 'prompt_mode', 'agent_prompt', 'prompt_version_locked', 'template_version_at_attach'],
+      fields: ['agent_name', 'provider', 'model', 'temperature', 'top_p', 'disabled', 'run_immediately', 'description', 'instructions', 'enable_prompt_caching', 'cache_control_type', 'cache_system_message', 'cache_conversation_history', 'prompt_mode', 'agent_prompt', 'prompt_version_locked', 'template_version_at_attach'],
       default: true,
       disabled: false,
     },

--- a/frontend/src/pages/ChatOnlyPage.tsx
+++ b/frontend/src/pages/ChatOnlyPage.tsx
@@ -104,9 +104,16 @@ export default function ChatOnlyPage() {
     async function loadResumeChats() {
       const entries = await Promise.all(
         agents.map(async (agent) => {
-          const response = await getConversationsByAgent(agent.name, { limit: 1 });
-          const latestId = response.data[0]?.id;
-          return latestId ? ([agent.name, latestId] as const) : null;
+          try {
+            const response = await getConversationsByAgent(agent.name, { limit: 1 });
+            const latestId = response.data[0]?.id;
+            return latestId ? ([agent.name, latestId] as const) : null;
+          } catch (error) {
+            // One agent's history being inaccessible must not hide the
+            // "continue last chat" action for every other agent.
+            console.error(`Error loading resume chat for agent ${agent.name}:`, error);
+            return null;
+          }
         })
       );
 

--- a/frontend/src/pages/ConsolePage.tsx
+++ b/frontend/src/pages/ConsolePage.tsx
@@ -17,6 +17,8 @@ import { getAgents } from '@/services/agentApi';
 import { getProviders, getModels } from '@/services/providerApi';
 import { runAgentSync } from '@/services/consoleApi';
 import type { AgentDoc, AIProvider, AIModel } from '@/types/agent.types';
+import { settleAll } from '@/lib/settleAll';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
 
 export { ConsolePage };
 export default ConsolePage;
@@ -38,9 +40,15 @@ function ConsolePage() {
   useEffect(() => {
     (async () => {
       setLoading(true);
-      const [agentsRes, providersRes] = await Promise.all([getAgents(), getProviders()]);
-      setAgents(Array.isArray(agentsRes) ? agentsRes : agentsRes.items);
-      setProviders(Array.isArray(providersRes) ? providersRes : providersRes.items);
+      const errorLabels = ['agents', 'providers'];
+      const [agentsRes, providersRes] = await settleAll(
+        [getAgents(), getProviders()],
+        (index, error) => {
+          toast.error(`Failed to load ${errorLabels[index]}: ${getFrappeErrorMessage(error)}`);
+        },
+      );
+      if (agentsRes) setAgents(Array.isArray(agentsRes) ? agentsRes : agentsRes.items);
+      if (providersRes) setProviders(Array.isArray(providersRes) ? providersRes : providersRes.items);
       setLoading(false);
     })();
   }, []);

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -16,6 +16,7 @@ import type { AgentRunDoc } from '../services/agentRunApi';
 import { getAgents } from '../services/agentApi';
 import { getProviders } from '../services/providerApi';
 import type { AgentDoc, AIProvider } from '../types/agent.types';
+import { settleAll } from '../lib/settleAll';
 
 interface DashboardMetrics {
   totalRuns: number;
@@ -148,46 +149,55 @@ function HomePage() {
   useEffect(() => {
     async function fetchAllData() {
       try {
-        // Fetch all data in parallel
-        const [totalRuns, runsData, agentsData, recentRuns, flowsData, providersData] = await Promise.all([
-          getAgentRunsCountLast7Days(),
-          getAgentRunsForMetrics(),
-          getAgents({
-            status: 'active',
-            limit: 10,
-            page: 1,
-          }),
-          getRecentAgentRuns(),
-          getDashboardActiveFlows(10),
-          getProviders(),
-        ]);
+        // Fetch all data in parallel - one denied widget must not blank the
+        // rest of the dashboard, so each slot is isolated via settleAll.
+        const widgetLabels = ['run count', 'run metrics', 'agents', 'recent runs', 'flows', 'providers'];
+        const [totalRuns, runsData, agentsData, recentRuns, flowsData, providersData] = await settleAll(
+          [
+            getAgentRunsCountLast7Days(),
+            getAgentRunsForMetrics(),
+            getAgents({
+              status: 'active',
+              limit: 10,
+              page: 1,
+            }),
+            getRecentAgentRuns(),
+            getDashboardActiveFlows(10),
+            getProviders(),
+          ],
+          (index, error) => {
+            console.error(`Error fetching dashboard ${widgetLabels[index]}:`, error);
+          },
+        );
 
         // Process metrics
-        const successRate = calculateSuccessRate(runsData);
-        const avgRuntime = calculateAvgRuntime(runsData);
-        const totalCost = calculateTotalCost(runsData);
-
-        setMetrics({
-          totalRuns,
-          successRate,
-          avgRuntime,
-          totalCost,
-        });
+        if (runsData) {
+          setMetrics({
+            totalRuns: totalRuns ?? 0,
+            successRate: calculateSuccessRate(runsData),
+            avgRuntime: calculateAvgRuntime(runsData),
+            totalCost: calculateTotalCost(runsData),
+          });
+        }
 
         // Process agents
-        const agentList = Array.isArray(agentsData) ? agentsData : agentsData.items;
-        const activeAgents = agentList.filter((agent) => agent.disabled === 0);
-        setAgents(activeAgents.slice(0, 10));
+        if (agentsData) {
+          const agentList = Array.isArray(agentsData) ? agentsData : agentsData.items;
+          const activeAgents = agentList.filter((agent) => agent.disabled === 0);
+          setAgents(activeAgents.slice(0, 10));
+        }
 
         // Set agent runs
-        setAgentRuns(recentRuns);
+        if (recentRuns) setAgentRuns(recentRuns);
 
         // Set flows
-        setFlows(flowsData);
+        if (flowsData) setFlows(flowsData);
 
         // Set providers
-        const providerList = Array.isArray(providersData) ? providersData : providersData.items;
-        setProviders(providerList);
+        if (providersData) {
+          const providerList = Array.isArray(providersData) ? providersData : providersData.items;
+          setProviders(providerList);
+        }
       } catch (error) {
         console.error('Error fetching dashboard data:', error);
       } finally {

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -10,6 +10,8 @@ import {
   type HufUser,
   type HufRole,
 } from '@/services/permissionsApi';
+import { settleAll } from '@/lib/settleAll';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
@@ -187,9 +189,12 @@ export default function UsersPage() {
   const load = async () => {
     setLoading(true);
     try {
-      const [u, r] = await Promise.all([getUsers(), getHufRoles()]);
-      setUsers(u);
-      setRoles(r);
+      const errorLabels = ['users', 'roles'];
+      const [u, r] = await settleAll([getUsers(), getHufRoles()], (index, error) => {
+        toast.error(`Failed to load ${errorLabels[index]}: ${getFrappeErrorMessage(error)}`);
+      });
+      if (u) setUsers(u);
+      if (r) setRoles(r);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/services/chatApi.ts
+++ b/frontend/src/services/chatApi.ts
@@ -204,14 +204,21 @@ export async function getAgentsWithConversationCounts(): Promise<AgentWithCount[
         model?: string;
         allow_chat?: number;
       }>).map(async (agent) => {
-        const count = await fetchDocCount(doctype['Agent Conversation'], [
-          ['agent', '=', agent.name],
-          ['channel', '=', 'Chat'],
-        ]);
+        let count = 0;
+        try {
+          count = (await fetchDocCount(doctype['Agent Conversation'], [
+            ['agent', '=', agent.name],
+            ['channel', '=', 'Chat'],
+          ])) || 0;
+        } catch (error) {
+          // One agent's conversation count being denied/unavailable must not
+          // drop every other agent from the "By Agent" listing.
+          console.error(`Error fetching conversation count for agent ${agent.name}:`, error);
+        }
         return {
           name: agent.name,
           agent_name: agent.agent_name || agent.name,
-          conversationCount: count || 0,
+          conversationCount: count,
           last_updated: agent.modified,
           agent_color: agent.agent_color || null,
           provider: agent.provider,

--- a/frontend/src/services/dashboardApi.ts
+++ b/frontend/src/services/dashboardApi.ts
@@ -117,18 +117,31 @@ export async function getDashboardActiveFlows(limit = 10): Promise<DashboardFlow
 
     return Promise.all(
       active.map(async (flow) => {
-        const [runCount, recentRuns] = await Promise.all([
-          fetchDocCount(doctype['Flow Run'], [['flow_id', '=', flow.flow_id]]),
-          listFlowRuns(flow.flow_id, undefined, 1),
-        ]);
+        try {
+          const [runCount, recentRuns] = await Promise.all([
+            fetchDocCount(doctype['Flow Run'], [['flow_id', '=', flow.flow_id]]),
+            listFlowRuns(flow.flow_id, undefined, 1),
+          ]);
 
-        return {
-          id: flow.flow_id,
-          name: flow.flow_name,
-          status: mapBackendStatusToFrontend(flow.status),
-          runCount: runCount ?? 0,
-          lastRunAt: recentRuns[0]?.started_at ?? null,
-        };
+          return {
+            id: flow.flow_id,
+            name: flow.flow_name,
+            status: mapBackendStatusToFrontend(flow.status),
+            runCount: runCount ?? 0,
+            lastRunAt: recentRuns[0]?.started_at ?? null,
+          };
+        } catch (error) {
+          // One flow's run stats being denied/unavailable must not blank the
+          // whole active-flows widget - show it with unknown stats instead.
+          console.error(`Error fetching run stats for flow ${flow.flow_id}:`, error);
+          return {
+            id: flow.flow_id,
+            name: flow.flow_name,
+            status: mapBackendStatusToFrontend(flow.status),
+            runCount: 0,
+            lastRunAt: null,
+          };
+        }
       })
     );
   } catch (error) {

--- a/huf/ai/session_api.py
+++ b/huf/ai/session_api.py
@@ -1,0 +1,20 @@
+"""
+huf/ai/session_api.py
+
+Whitelisted endpoint to refresh a stale CSRF token without a full page reload.
+
+The frontend caches ``window.csrf_token`` from the initial page render
+(huf/www/huf.py). Frappe regenerates the session's real CSRF token
+independently of that render (frappe.sessions.generate_csrf_token), so a
+long-open tab can end up sending a stale token on writes and get a 400
+CSRFTokenError even though its session cookie is still perfectly valid. This
+endpoint lets the frontend fetch the current token for its own (already
+authenticated) session and retry instead of forcing a hard refresh.
+"""
+
+import frappe
+
+
+@frappe.whitelist()
+def get_csrf_token():
+	return frappe.sessions.get_csrf_token()


### PR DESCRIPTION
## Summary

Investigation into the recurring "user gets logged out on nearly every action/refresh" complaint found this wasn't one bug — several independent issues share the same underlying pattern: a failed API call being treated as (or producing the same confusing symptom as) a dead session, when the session itself was never actually invalid.

**Fixed:**
- **Stale CSRF token.** `window.csrf_token` is only ever set once from server-rendered boot HTML and never refreshed. If the session's real token rotates server-side (worker restart, cache clear), every write in an already-open tab fails with a 400 `CSRFTokenError` until a hard refresh — session cookie stays valid the whole time. Added a new whitelisted `huf.ai.session_api.get_csrf_token` endpoint plus a response interceptor (`csrfRetryInterceptor.ts`) that transparently fetches a fresh token and retries once.
- **Unisolated `Promise.all` fan-outs.** ~8 page loaders (`AgentSettingsTab`, `VoiceSettingsTab`, `ConsolePage`, `UsersPage`, `HomePage`, `ChatOnlyPage`, `dashboardApi`, `chatApi`, `toolCreationForm.utils`) fetched independent resources with plain `Promise.all`, so one denied/failed sub-request blanked the whole page instead of just that feature. Added a shared `settleAll` helper and applied it (or per-item try/catch) at each real gap — checked ~24 candidate sites individually rather than blind-sweeping; most were already safe.
- **Agent "disabled" toggle silently unsavable.** The sectional Agent editor (`get_agent_section`/`update_agent_section`) builds its save payload from `tabConfig[activeTab].fields`, and `general`'s field list never included `disabled` even though the backend's `AGENT_SECTIONS["general"]` already expects it. Toggling Enabled/Disabled showed the Save button but every save silently excluded the field — no error, agent stayed disabled, switching tabs hid the Save button with no trace anything was lost. Fixed by adding `'disabled'` to the field list; audited every other field across all 7 sections against the backend map, no other gaps found.

**Mitigated, root cause still open:**
- **Session silently becomes `Guest` mid-use.** `is_whitelisted()` throws an identical "Function X is not whitelisted" error whether a method is genuinely unregistered or the session has become Guest — for any endpoint this build calls, it's always the latter (confirmed: even `frappe.auth.get_logged_user`, which is always registered, hit this). Four candidate triggers were investigated (Werkzeug dev-reloader race, `simultaneous_sessions` enforcement, `clear_cache`/`migrate` wiping Redis sessions, other explicit `clear_sessions()` call sites) — all four ruled out with direct evidence. The actual trigger remains unknown. Added a defensive fix regardless: a global interceptor recognizes this exact signature (distinct from a real capability-denial message) and immediately redirects to login with a clear explanation ("You were signed out because your session ended") instead of letting it cascade as confusing, unrelated per-feature errors across the app until the user happens to refresh.

## Test plan

- [x] 122/122 unit tests passing (`yarn vitest run`), including 14 new tests for the interceptors and `settleAll`
- [x] `tsc --noEmit` clean
- [x] Live-verified via direct API calls against a disposable bench: CSRF rotation → retry → success round trip; restricted-role 403 on `AgentSettingsTab`'s dependencies; `disabled` field save → durable on independent read-back
- [ ] **Not yet tested through an actual browser/UI click-through** — all verification above was via curl/unit tests. Given the interceptor changes sit in front of every API call and can trigger a redirect, a manual pass is worth doing before this is trusted in a real session, particularly around the new session-invalidation redirect (false positives there would be worse than the current behavior).
- [ ] The Guest-session root cause is still open — this PR does not prevent it, only makes its symptom clear and recoverable instead of confusing.