### PR TITLE
fix(agent-form): persist the disabled toggle from any tab

### DIFF
--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -1599,6 +1599,36 @@ export function AgentFormPage() {
             .map((field) => [field, agentData[field as keyof AgentUpdatePayload]]),
         ) as Partial<AgentDoc>;
 
+        const messages: string[] = [];
+
+        // The Enabled/Disabled toggle sits outside any tab's own fields and
+        // the backend only ever accepts it as part of the "general" section
+        // (huf/ai/agent_config_api.py's AGENT_SECTIONS) - so saving from any
+        // other tab must persist it via its own general-section call instead
+        // of silently dropping it, which is what happened before this fix
+        // (see Tracks/safwan-erooth.AuthDebug/FINDINGS.md, "Bug D").
+        if (disabledChanged && section !== 'general') {
+          const generalRevision = sectionRevisions.general;
+          if (!generalRevision) {
+            toast.error('This section is not ready to save. Reload the agent and try again.');
+            return;
+          }
+          const disabledResult = await updateAgentSection(
+            id,
+            'general',
+            { disabled: agentData.disabled },
+            generalRevision,
+          );
+          setSectionRevisions((current) =>
+            Object.fromEntries(
+              Object.keys(current).map((key) => [key, disabledResult.modified]),
+            ) as Partial<Record<AgentConfigSection, string>>,
+          );
+          setInitialDisabled(values.disabled);
+          form.resetField('disabled', { defaultValue: values.disabled });
+          messages.push(values.disabled ? 'Agent disabled' : 'Agent enabled');
+        }
+
         const result = await updateAgentSection(id, section, sectionPayload, expectedModified);
         const savedAgentId = result.name;
         setSectionRevisions((current) =>
@@ -1626,7 +1656,8 @@ export function AgentFormPage() {
         if (savedAgentId !== id) {
           navigate(`/agents/${encodeURIComponent(savedAgentId)}`, { replace: true });
         }
-        toast.success(`${tabConfig[section].label} saved`);
+        messages.push(`${tabConfig[section].label} saved`);
+        toast.success(messages.join(' · '));
         return;
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #547. That PR fixed the Agent editor's Enabled/Disabled toggle by adding `disabled` to the "general" tab's field list — but the section-scoped save only ever sends the *active* tab's fields, and the backend (`AGENT_SECTIONS` in `agent_config_api.py`) strictly rejects any field that doesn't belong to the section being saved. So the fix only worked when the user happened to be on the General tab when they clicked Save — toggling it while on Advanced/Behavior/etc. still silently dropped the change, same bug, narrower trigger.

- Saving now issues a small supplementary `general`-section call for just `disabled` whenever it changed and the active tab isn't General, before the normal active-tab save.
- The success toast now explicitly names the enable/disable state change ("Agent enabled · Advanced Settings saved") instead of a message that only described the active tab's save and could be misread as covering the toggle too.

## Test plan

- [x] 122/122 unit tests passing, `tsc --noEmit` clean
- [x] Live-verified against a disposable bench: reset agent to disabled, simulated toggling+saving while "on" the Advanced tab (the two sequential API calls the new code makes), confirmed the revision handoff between them doesn't trigger a conflict, and confirmed `disabled` is durable on an independent read-back afterward
- [ ] Not yet click-tested through the actual browser UI