### PR TITLE
fix(reasoning+chat): restore reasoning panel and prevent chat input disappearance

### DIFF
--- a/frontend/src/components/ai-elements/reasoning.tsx
+++ b/frontend/src/components/ai-elements/reasoning.tsx
@@ -77,10 +77,16 @@ export const Reasoning = memo(
       }
     }, [isStreaming, startTime, setDuration]);
 
-    // Auto-open when streaming starts, auto-close when streaming ends (once only)
+    // Auto-open when streaming starts (once only)
     useEffect(() => {
-      if (defaultOpen && !isStreaming && isOpen && !hasAutoClosed) {
-        // Add a small delay before closing to allow user to see the content
+      if (isStreaming && !isOpen && !hasAutoClosed) {
+        setIsOpen(true);
+      }
+    }, [isStreaming, isOpen, setIsOpen, hasAutoClosed]);
+
+    // Auto-close when streaming ends (once only, after a short delay)
+    useEffect(() => {
+      if (!isStreaming && isOpen && !hasAutoClosed) {
         const timer = setTimeout(() => {
           setIsOpen(false);
           setHasAutoClosed(true);
@@ -88,7 +94,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer);
       }
-    }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosed]);
+    }, [isStreaming, isOpen, setIsOpen, hasAutoClosed]);
 
     const handleOpenChange = (newOpen: boolean) => {
       setIsOpen(newOpen);

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -18,6 +18,7 @@ import { getFileTypeInfo } from "@/utils/fileTypeUtils";
 import { getFrappeErrorMessage } from "@/lib/frappe-error";
 import type { MessageType } from './types';
 import { cacheReasoning } from './chatMessageList.mappers';
+import { cacheAgentNameForChat } from './useChatAgentIdentity';
 
 export type LoadingType = 'default' | 'transcribing';
 
@@ -422,6 +423,7 @@ export function ChatInput({
                 onStatusChange('ready');
                 if (conversationId && onConversationCreated) {
                     newlyCreatedConversationIdRef.current = conversationId;
+                    cacheAgentNameForChat(conversationId, agentName);
                     onConversationCreated(conversationId, agentName);
                     setTimeout(() => { isCreatingConversationRef.current = false; }, 500);
                 } else {
@@ -542,6 +544,7 @@ export function ChatInput({
             onStatusChange('ready');
             if (conversationId && onConversationCreated) {
                 newlyCreatedConversationIdRef.current = conversationId;
+                cacheAgentNameForChat(conversationId, agentName);
                 onConversationCreated(conversationId, agentName);
                 setTimeout(() => { isCreatingConversationRef.current = false; }, 500);
             } else {
@@ -700,6 +703,7 @@ export function ChatInput({
             onStatusChange('ready');
             if (res?.conversation_id && onConversationCreated) {
                 newlyCreatedConversationIdRef.current = res.conversation_id;
+                cacheAgentNameForChat(res.conversation_id, agentName);
                 onConversationCreated(res.conversation_id, agentName);
             }
             return transcript;

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -17,6 +17,7 @@ import { ChatAttachmentCard } from "@/components/chat/ChatAttachmentCard";
 import { getFileTypeInfo } from "@/utils/fileTypeUtils";
 import { getFrappeErrorMessage } from "@/lib/frappe-error";
 import type { MessageType } from './types';
+import { cacheReasoning } from './chatMessageList.mappers';
 
 export type LoadingType = 'default' | 'transcribing';
 
@@ -242,6 +243,9 @@ export function ChatInput({
                 prev.map((msg) => {
                     if (msg.key !== tempId) return msg;
                     const existingContent = content ?? msg.versions[0]?.content ?? '';
+                    // Cache reasoning so it survives a ChatMessageList remount
+                    // (e.g. new-conversation navigation that resets prev=[]).
+                    if (msg.reasoning) cacheReasoning(realId, msg.reasoning);
                     return {
                         ...msg,
                         key: realId,

--- a/frontend/src/components/chat/chatMessageList.mappers.ts
+++ b/frontend/src/components/chat/chatMessageList.mappers.ts
@@ -4,6 +4,20 @@ import type { ToolUIPart } from 'ai';
 import { mapToolStatusToState } from './utils';
 import type { MessageType } from './types';
 
+// Reasoning text is streamed client-side only and is NOT persisted on the server.
+// When ChatMessageList remounts (e.g. after new-conversation navigation), prev=[],
+// so the normal key-based lookup loses the reasoning. This cache bridges the gap:
+// ChatInput writes here when streaming ends; the mapper reads it as a fallback.
+const _reasoningCache = new Map<string, string>();
+export function cacheReasoning(messageId: string, reasoning: string): void {
+  _reasoningCache.set(messageId, reasoning);
+}
+function consumeReasoningCache(messageId: string): string | undefined {
+  const r = _reasoningCache.get(messageId);
+  if (r !== undefined) _reasoningCache.delete(messageId);
+  return r;
+}
+
 /** Normalize socket event - backend may send `status`/`result` instead of `tool_status`/`tool_result` */
 function normalizeToolCallEvent(raw: Record<string, unknown>): ToolCallEvent {
   const tool_status =
@@ -521,7 +535,7 @@ export function mergeConversationItemsIntoMessages(
       // server-side), so it must be carried over from the prior local
       // message the same way tools are, or it vanishes the moment the
       // conversation is re-synced from the server after the run completes.
-      reasoning: tempMessage?.reasoning,
+      reasoning: tempMessage?.reasoning ?? consumeReasoningCache(item.id),
       reasoningStreaming: tempMessage?.reasoningStreaming,
       versions: [
         {

--- a/frontend/src/components/chat/useChatAgentIdentity.ts
+++ b/frontend/src/components/chat/useChatAgentIdentity.ts
@@ -3,6 +3,19 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { getConversation } from '@/services/chatApi';
 import { getAgent } from '@/services/agentApi';
 
+// Pre-populate the agent name for a new chatId so ChatInput never flashes
+// invisible while `getConversation` is in-flight after a new-conversation
+// navigation (ChatInput returns null when agentName is empty).
+const _agentNameCache = new Map<string, string>();
+export function cacheAgentNameForChat(chatId: string, agentName: string): void {
+  _agentNameCache.set(chatId, agentName);
+}
+function consumeAgentNameCache(chatId: string): string {
+  const name = _agentNameCache.get(chatId);
+  if (name !== undefined) _agentNameCache.delete(chatId);
+  return name ?? '';
+}
+
 /** localStorage key for cross-tab sync of the tool-execution-details toggle */
 function toolDetailsKey(agent: string): string {
   return `huf:agent:${agent}:show_tool_execution_details`;
@@ -18,7 +31,9 @@ export function writeToolDetailsSetting(agent: string, enabled: boolean): void {
 }
 
 export function useChatAgentIdentity(chatId: string | null, searchParams: URLSearchParams) {
-  const [agentName, setAgentName] = useState<string>('');
+  const [agentName, setAgentName] = useState<string>(() =>
+    chatId ? consumeAgentNameCache(chatId) : (searchParams.get('agent') ?? '')
+  );
   const [agentColor, setAgentColor] = useState<string | null>(null);
   const [showToolExecutionDetails, setShowToolExecutionDetails] = useState<boolean>(true);
   const [allowFileUpload, setAllowFileUpload] = useState<boolean>(false);


### PR DESCRIPTION
## Summary

Fixes three independent bugs all triggered by new-conversation navigation.

### Bug 1 — reasoning panel never auto-opens (\`reasoning.tsx\`)

The existing effect was gated on \`defaultOpen &&\` (ChatMessage.tsx always passes \`defaultOpen={false}\`), so the panel never opened automatically when streaming started.

**Fix:** Split into two separate effects — one opens the panel when \`isStreaming\` becomes \`true\`, one closes it ~1 s after streaming ends — with no \`defaultOpen\` gate.

### Bug 2 — reasoning lost on new-conversation navigation (\`chatMessageList.mappers.ts\` + \`ChatInput.tsx\`)

When a new conversation is created, \`ChatMessageList\` remounts with \`prev=[]\` (keyed on \`chatId\`). \`mergeConversationItemsIntoMessages\` can't match the temp message, so \`message.reasoning\` becomes \`undefined\` and the \`<Reasoning>\` component unmounts entirely — taking "Thought for X seconds" with it.

**Fix:** Added a module-level \`_reasoningCache\` Map keyed by real message ID. \`ChatInput.syncAssistantMessageId\` writes reasoning into the cache just before navigation; the mapper reads and clears it as a fallback when the temp message can't be found.

### Bug 3 — chat input disappears after new-conversation navigation (\`useChatAgentIdentity.ts\` + \`ChatInput.tsx\`)

\`useChatAgentIdentity\` initialized \`agentName\` to \`''\` on every mount. When \`ChatMessageList\` remounts on new-chatId navigation, the async \`getConversation\` call left \`agentName\` empty long enough for \`ChatInput\`'s \`if (!agentName) return null\` guard to fire — making the input disappear until the fetch resolved (or permanently on error).

**Fix:** Added a module-level \`_agentNameCache\` Map. \`ChatInput\` writes the known \`agentName\` into the cache (keyed by \`conversationId\`) at all three \`onConversationCreated\` call sites before navigation. \`useChatAgentIdentity\` reads and consumes this cached value as its initial state, so \`agentName\` is never empty on mount.

## Files changed

- \`frontend/src/components/ai-elements/reasoning.tsx\`
- \`frontend/src/components/chat/chatMessageList.mappers.ts\`
- \`frontend/src/components/chat/ChatInput.tsx\`
- \`frontend/src/components/chat/useChatAgentIdentity.ts\`

## Test plan

- [x] Send a message to an agent configured with a reasoning-capable model
- [x] Confirm "Thought for X seconds" trigger remains on the settled message
- [x] Start a brand-new conversation — confirm reasoning survives the chatId remount
- [x] Confirm chat input remains visible immediately after new-conversation navigation (no disappear/reload needed)
- [x] \`yarn tsc --noEmit\` passes with no errors