### PR TITLE
chore(models): remove stale gemini-2.5 models, prefer lite defaults, add Google capabilities to Hub Orchestrator

### DIFF
--- a/huf/ai/app_seeding/hub_orchestrator.py
+++ b/huf/ai/app_seeding/hub_orchestrator.py
@@ -28,8 +28,10 @@ SEED_FILE = "hub-orchestrator.json"
 # Ordered chat-model preferences; the first one present in AI Model for the
 # chosen provider wins. Falls back to the provider's first non-specialized model.
 PREFERRED_MODELS = [
-    "gpt-4o-mini",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
     "gemini-3.5-flash",
+    "gpt-4o-mini",
     "claude-haiku-4.5",
     "claude-sonnet-4.5",
     "openai/gpt-4o-mini",
@@ -41,6 +43,8 @@ PREFERRED_MODELS = [
 DEPRECATED_MODELS = {
     "gemini-2.5-flash",
     "google/gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    "google/gemini-2.5-flash-lite-preview-06-17",
 }
 
 # Model names matching these are not chat models; never auto-select them.

--- a/huf/huf/agents/hub-orchestrator.json
+++ b/huf/huf/agents/hub-orchestrator.json
@@ -23,5 +23,9 @@
   "inject_conversation_data": 1,
   "conversation_data_api_permission": "Read",
   "allow_guest": 0,
-  "agent_color": "#0EA5E9"
+  "agent_color": "#0EA5E9",
+  "allow_file_upload": 1,
+  "image_generation_model": "nano-banana-pro",
+  "tts_model": "gemini-3.1-flash-lite",
+  "audio_transcription_model": "gemini-3.1-flash-lite"
 }

--- a/huf/install.py
+++ b/huf/install.py
@@ -257,6 +257,8 @@ def create_demo_ai_models():
     deprecated_models = (
         "gemini-2.5-flash",
         "google/gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "google/gemini-2.5-flash-lite-preview-06-17",
     )
 
     for model_name in deprecated_models:
@@ -286,7 +288,6 @@ def create_demo_ai_models():
         {"doctype": "AI Model", "model_name": "gemini-3.1-flash-lite", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemini-3-flash-preview", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemini-2.5-pro", "provider": "Google"},
-        {"doctype": "AI Model", "model_name": "gemini-2.5-flash-lite", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemma-3-27b-it", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "gemma-3-9b-it", "provider": "Google"},
         {"doctype": "AI Model", "model_name": "nano-banana-pro", "provider": "Google"},


### PR DESCRIPTION
## Summary

- **Stale model cleanup**: `gemini-2.5-flash-lite` and `google/gemini-2.5-flash-lite-preview-06-17` moved to the deprecated list in `install.py` and `hub_orchestrator.py` — they are no longer available from Google and cause run failures
- **Duplicate removed**: duplicate `gemini-3.1-flash-lite` entry that crept in during cleanup
- **Model preferences**: `PREFERRED_MODELS` in `hub_orchestrator.py` now picks `gemini-3.5-flash-lite` → `gemini-3.1-flash-lite` → `gemini-3.5-flash` for new installs, aligning with the workspace preference to use fast lite models by default
- **Hub Orchestrator defaults (task 4)**: new install of Hub Orchestrator now ships with:
  - `allow_file_upload: 1` — file attachment and vision enabled by default
  - `image_generation_model: nano-banana-pro` — Google-native image generation
  - `tts_model: gemini-3.1-flash-lite` — Google TTS via Gemini
  - `audio_transcription_model: gemini-3.1-flash-lite` — Google audio transcription via Gemini

## Test plan

- [ ] Fresh `bench migrate` on a clean site — verify deprecated models are removed and not re-added
- [ ] Hub Orchestrator agent on a fresh install has `allow_file_upload = 1` and the correct modality models
- [ ] Existing Hub Orchestrator agents are not broken (seed only runs on fresh insert)
- [ ] `PREFERRED_MODELS` order selects `gemini-3.5-flash-lite` when Google provider has a key