### PR TITLE
fix(data-table): allow title/label for Tab Break (sub-tab) fields

### DIFF
--- a/frontend/src/components/data-table/DataRecordForm.tsx
+++ b/frontend/src/components/data-table/DataRecordForm.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/sheet';
 import { Separator } from '@/components/ui/separator';
 import { createTableRecord, updateTableRecord } from '@/services/dataTableApi';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import type { DataTableFieldDef } from '@/types/dataTable.types';
 import { buildFormLayout, FieldInput, initFormData } from './DataRecordFormLayout';
 
@@ -73,7 +74,7 @@ export function DataRecordForm({
 	};
 
 	const dataFields = fields.filter(
-		(field) => field.fieldtype !== 'Section Break' && field.fieldtype !== 'Column Break'
+		(field) => !LAYOUT_FIELD_TYPES.includes(field.fieldtype)
 	);
 	const sections = buildFormLayout(fields);
 

--- a/frontend/src/components/data-table/DataRecordFormLayout.tsx
+++ b/frontend/src/components/data-table/DataRecordFormLayout.tsx
@@ -13,6 +13,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { LinkFieldInput } from './LinkFieldInput';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import type { DataTableFieldDef } from '@/types/dataTable.types';
 
 export interface LayoutSection {
@@ -49,7 +50,7 @@ export function initFormData(
 ): Record<string, unknown> {
 	const data: Record<string, unknown> = {};
 	for (const field of fields) {
-		if (field.fieldtype === 'Section Break' || field.fieldtype === 'Column Break') continue;
+		if (LAYOUT_FIELD_TYPES.includes(field.fieldtype)) continue;
 		if (record) {
 			data[field.fieldname] = record[field.fieldname] ?? field.default ?? '';
 		} else {

--- a/frontend/src/components/data-table/DataRecordList.tsx
+++ b/frontend/src/components/data-table/DataRecordList.tsx
@@ -5,6 +5,7 @@ import { ArrowUpDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { formatTimeAgo } from '@/utils/time';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import type { DataTableFieldDef } from '@/types/dataTable.types';
 
 interface DataRecordListProps {
@@ -59,14 +60,11 @@ export function DataRecordList({
 	
 	const listFields = useMemo(() => {
 		const visible = fields.filter(
-			(f) =>
-				f.in_list_view === 1 &&
-				f.fieldtype !== 'Section Break' &&
-				f.fieldtype !== 'Column Break'
+			(f) => f.in_list_view === 1 && !LAYOUT_FIELD_TYPES.includes(f.fieldtype)
 		);
 		if (visible.length > 0) return visible;
 		return fields
-			.filter((f) => f.fieldtype !== 'Section Break' && f.fieldtype !== 'Column Break')
+			.filter((f) => !LAYOUT_FIELD_TYPES.includes(f.fieldtype))
 			.slice(0, 4);
 	}, [fields]);
 

--- a/frontend/src/components/data-table/FieldCard.tsx
+++ b/frontend/src/components/data-table/FieldCard.tsx
@@ -2,6 +2,7 @@ import { GripVertical, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import type { DataTableFieldDef } from '@/types/dataTable.types';
 
 interface FieldCardProps {
@@ -25,7 +26,7 @@ export function FieldCard({
 	onDragOver,
 	onDrop,
 }: FieldCardProps) {
-	const isLayout = field.fieldtype === 'Section Break' || field.fieldtype === 'Column Break';
+	const isLayout = LAYOUT_FIELD_TYPES.includes(field.fieldtype);
 
 	if (isLayout) {
 		return (
@@ -44,7 +45,14 @@ export function FieldCard({
 			>
 				<GripVertical className="w-4 h-4 text-steel cursor-grab shrink-0" />
 				<div className="flex items-center gap-2 flex-1 min-w-0">
-					{field.fieldtype === 'Section Break' ? (
+					{field.fieldtype === 'Tab Break' ? (
+						<>
+							<span className="text-xs text-steel">▭</span>
+							<span className="text-sm text-steel">
+								{field.label || 'Tab Break'}
+							</span>
+						</>
+					) : field.fieldtype === 'Section Break' ? (
 						<>
 							<span className="text-xs text-steel">---</span>
 							<span className="text-sm text-steel">

--- a/frontend/src/components/data-table/TableSettingsPanel.tsx
+++ b/frontend/src/components/data-table/TableSettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { TABLE_ICONS, TABLE_ICON_MAP } from '@/data/tableIcons';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import { getTableGroups } from '@/services/dataTableApi';
 import type { DataTableFieldDef } from '@/types/dataTable.types';
 
@@ -47,7 +48,7 @@ export function TableSettingsPanel({
 	onTableGroupChange,
 }: TableSettingsPanelProps) {
 	const dataFields = fields.filter(
-		(f) => f.fieldtype !== 'Section Break' && f.fieldtype !== 'Column Break'
+		(f) => !LAYOUT_FIELD_TYPES.includes(f.fieldtype)
 	);
 
 	const [existingGroups, setExistingGroups] = useState<string[]>([]);

--- a/frontend/src/data/fieldTypes.ts
+++ b/frontend/src/data/fieldTypes.ts
@@ -89,6 +89,12 @@ export const FIELD_TYPE_GROUPS: FieldTypeGroup[] = [
 		label: 'Layout',
 		types: [
 			{
+				type: 'Tab Break',
+				label: 'Tab',
+				icon: 'Folder',
+				description: 'Group fields into a tab',
+			},
+			{
 				type: 'Section Break',
 				label: 'Section',
 				icon: 'Minus',
@@ -163,8 +169,9 @@ export const FIELD_PROPERTIES: Record<string, string[]> = {
 	// Frappe does not permit `in_list_view` on Attach/Attach Image fields.
 	Attach: ['label', 'reqd', 'read_only', 'description'],
 	'Attach Image': ['label', 'reqd', 'read_only', 'description'],
+	'Tab Break': ['label'],
 	'Section Break': ['label'],
 	'Column Break': [],
 };
 
-export const LAYOUT_FIELD_TYPES: DataTableFieldType[] = ['Section Break', 'Column Break'];
+export const LAYOUT_FIELD_TYPES: DataTableFieldType[] = ['Tab Break', 'Section Break', 'Column Break'];

--- a/frontend/src/pages/DataRecordViewPage.tsx
+++ b/frontend/src/pages/DataRecordViewPage.tsx
@@ -16,6 +16,7 @@ import {
 	createTableRecord,
 } from '@/services/dataTableApi';
 import type { DataTableSchema, DataTableFieldDef } from '@/types/dataTable.types';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import { buildFormLayout, FieldInput, initFormData } from '@/components/data-table/DataRecordFormLayout';
 import { useSaveShortcut } from '@/hooks/useSaveShortcut';
 
@@ -201,7 +202,7 @@ export function DataRecordViewPage({ schema, onHeaderActionsChange }: DataRecord
 	}
 
 	const dataFields: DataTableFieldDef[] = schema.fields.filter(
-		(field) => field.fieldtype !== 'Section Break' && field.fieldtype !== 'Column Break'
+		(field) => !LAYOUT_FIELD_TYPES.includes(field.fieldtype)
 	);
 	const sections = buildFormLayout(schema.fields);
 	const tabGroups = sections.reduce<{ label?: string; sections: typeof sections }[]>((groups, section) => {

--- a/frontend/src/pages/DataTableBuilderPage.tsx
+++ b/frontend/src/pages/DataTableBuilderPage.tsx
@@ -8,6 +8,7 @@ import { TableBuilderCanvas } from '@/components/data-table/TableBuilderCanvas';
 import { FieldConfigPanel } from '@/components/data-table/FieldConfigPanel';
 import { TableSettingsPanel } from '@/components/data-table/TableSettingsPanel';
 import { createDataTable, updateDataTable, getTableSchema } from '@/services/dataTableApi';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import type { DataTableFieldDef, DataTableFieldType, DataTableSchema } from '@/types/dataTable.types';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
@@ -192,7 +193,7 @@ export function DataTableBuilderPage() {
 
 	const handleAddField = useCallback(
 		(type: DataTableFieldType) => {
-			const isLayout = type === 'Section Break' || type === 'Column Break';
+			const isLayout = LAYOUT_FIELD_TYPES.includes(type);
 			// Frappe does not permit `in_list_view` on Attach/Attach Image fields.
 			const supportsListView = type !== 'Attach' && type !== 'Attach Image';
 			const baseName = isLayout
@@ -207,9 +208,9 @@ export function DataTableBuilderPage() {
 			const newField: DataTableFieldDef = {
 				fieldname,
 				fieldtype: type,
-				label: isLayout ? '' : '',
+				label: '',
 				...(isLayout || !supportsListView ? {} : { in_list_view: state.fields.filter(
-					(f) => f.fieldtype !== 'Section Break' && f.fieldtype !== 'Column Break'
+					(f) => !LAYOUT_FIELD_TYPES.includes(f.fieldtype)
 				).length < 4 ? 1 : 0 as 0 | 1 }),
 			};
 
@@ -225,7 +226,7 @@ export function DataTableBuilderPage() {
 		}
 
 		const dataFields = state.fields.filter(
-			(f) => f.fieldtype !== 'Section Break' && f.fieldtype !== 'Column Break'
+			(f) => !LAYOUT_FIELD_TYPES.includes(f.fieldtype)
 		);
 		if (dataFields.length === 0) {
 			toast.error('Add at least one data field');

--- a/frontend/src/pages/DataTableViewPage.tsx
+++ b/frontend/src/pages/DataTableViewPage.tsx
@@ -14,6 +14,7 @@ import {
 	getTableRecords,
 	deleteDataTable,
 } from '@/services/dataTableApi';
+import { LAYOUT_FIELD_TYPES } from '@/data/fieldTypes';
 import type { DataTableFieldDef, DataTableSchema } from '@/types/dataTable.types';
 
 export interface DataTableViewPageProps {
@@ -172,8 +173,7 @@ export function DataTableViewPage({ onHeaderActionsChange }: DataTableViewPagePr
 	}
 
 	const dataFields = schema.fields.filter(
-		(f: DataTableFieldDef) =>
-			f.fieldtype !== 'Section Break' && f.fieldtype !== 'Column Break'
+		(f: DataTableFieldDef) => !LAYOUT_FIELD_TYPES.includes(f.fieldtype)
 	);
 	const recordCount = records.length;
 


### PR DESCRIPTION
## Problem
In the HUF Data Table builder (`/huf/data/new`), users could select **Tab Break** (sub-tab) as a layout field type, but the right-side config panel did not render a Label input. Because `Tab Break` was not registered in `LAYOUT_FIELD_TYPES`, the builder treated it as a data field: it required a label, counted it toward the data-field minimum, and would fail when saving a table that contained an unlabeled Tab Break.

## Root cause
- `FIELD_PROPERTIES` had no entry for `Tab Break`, so the sidebar had no controls.
- Several builder/record/list/view components hard-coded `Section Break` / `Column Break` as the only layout fields, excluding `Tab Break`.

## Fix
- Add `Tab Break` to `FIELD_TYPE_GROUPS`, `FIELD_PROPERTIES`, and `LAYOUT_FIELD_TYPES` in `frontend/src/data/fieldTypes.ts`.
- Replace hard-coded layout checks with `LAYOUT_FIELD_TYPES.includes(...)` across the builder canvas, record forms, record list, settings panel, and view pages.
- Render Tab Break cards with a tab indicator in `FieldCard`.

## Verification
Verified on a disposable Frappe bench that a Tab Break field can be added, given the label "Primary Tab", and the table can be created successfully.

## Files changed
- `frontend/src/data/fieldTypes.ts`
- `frontend/src/pages/DataTableBuilderPage.tsx`
- `frontend/src/components/data-table/FieldCard.tsx`
- `frontend/src/components/data-table/DataRecordForm.tsx`
- `frontend/src/components/data-table/DataRecordFormLayout.tsx`
- `frontend/src/components/data-table/DataRecordList.tsx`
- `frontend/src/components/data-table/TableSettingsPanel.tsx`
- `frontend/src/pages/DataRecordViewPage.tsx`
- `frontend/src/pages/DataTableViewPage.tsx`