### PR TITLE
feat(ui): unify list and empty-state styling

### DIFF
--- a/frontend/src/components/dashboard/DataListView.tsx
+++ b/frontend/src/components/dashboard/DataListView.tsx
@@ -95,59 +95,57 @@ export function DataListView<TData, TValue>({
 					</DropdownMenu>
 				</div>
 			</div>
-			<div className="rounded-none border border-line bg-panel">
-				<Table>
-					<TableHeader>
-						{table.getHeaderGroups().map((headerGroup) => (
-							<TableRow key={headerGroup.id} className="border-line hover:bg-transparent">
-								{headerGroup.headers.map((header) => {
-									return (
-										<TableHead key={header.id} className="text-steel">
-											{header.isPlaceholder
-												? null
-												: flexRender(header.column.columnDef.header, header.getContext())}
-										</TableHead>
-									);
-								})}
-							</TableRow>
-						))}
-					</TableHeader>
-					<TableBody>
-						{loading ? (
-							<TableRow className="border-line hover:bg-transparent">
-								<TableCell colSpan={columns.length} className="h-24 text-center">
-									<div className="space-y-2">
-										{[...Array(5)].map((_, i) => (
-											<div key={i} className="h-12 bg-line rounded-none animate-pulse" />
-										))}
-									</div>
-								</TableCell>
-							</TableRow>
-						) : table.getRowModel().rows?.length ? (
-							table.getRowModel().rows.map((row) => (
-								<TableRow
-									key={row.id}
-									data-state={row.getIsSelected() && 'selected'}
-									className={`border-line transition-colors hover:bg-paper-deep ${onRowClick ? 'cursor-pointer' : ''}`}
-									onClick={() => onRowClick?.(row.original)}
-								>
-									{row.getVisibleCells().map((cell) => (
-										<TableCell key={cell.id} className="text-ink">
-											{flexRender(cell.column.columnDef.cell, cell.getContext())}
-										</TableCell>
-									))}
+			{loading || table.getRowModel().rows?.length ? (
+				<div className="rounded-none border border-line bg-panel">
+					<Table>
+						<TableHeader>
+							{table.getHeaderGroups().map((headerGroup) => (
+								<TableRow key={headerGroup.id} className="border-line hover:bg-transparent">
+									{headerGroup.headers.map((header) => {
+										return (
+											<TableHead key={header.id} className="text-steel">
+												{header.isPlaceholder
+													? null
+													: flexRender(header.column.columnDef.header, header.getContext())}
+											</TableHead>
+										);
+									})}
 								</TableRow>
-							))
-						) : (
-							<TableRow className="border-line hover:bg-transparent">
-								<TableCell colSpan={columns.length} className="h-24 text-center text-steel">
-									{emptyState || 'No results.'}
-								</TableCell>
-							</TableRow>
-						)}
-					</TableBody>
-				</Table>
-			</div>
+							))}
+						</TableHeader>
+						<TableBody>
+							{loading ? (
+								<TableRow className="border-line hover:bg-transparent">
+									<TableCell colSpan={columns.length} className="h-24 text-center">
+										<div className="space-y-2">
+											{[...Array(5)].map((_, i) => (
+												<div key={i} className="h-12 bg-line rounded-none animate-pulse" />
+											))}
+										</div>
+									</TableCell>
+								</TableRow>
+							) : (
+								table.getRowModel().rows.map((row) => (
+									<TableRow
+										key={row.id}
+										data-state={row.getIsSelected() && 'selected'}
+										className={`border-line transition-colors hover:bg-paper-deep ${onRowClick ? 'cursor-pointer' : ''}`}
+										onClick={() => onRowClick?.(row.original)}
+									>
+										{row.getVisibleCells().map((cell) => (
+											<TableCell key={cell.id} className="text-ink">
+												{flexRender(cell.column.columnDef.cell, cell.getContext())}
+											</TableCell>
+										))}
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</div>
+			) : (
+				emptyState || 'No results.'
+			)}
 		</div>
 	);
 }

--- a/frontend/src/components/dashboard/cards/ItemCard.tsx
+++ b/frontend/src/components/dashboard/cards/ItemCard.tsx
@@ -5,9 +5,24 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { BaseCard } from './BaseCard';
+import { StatusDot, type StatusDotVariant } from '@/components/dashboard/ledger/LedgerSection';
 import { cn } from '@/lib/utils';
 
 type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'success' | 'outline';
+
+function badgeVariantToStatusDot(variant?: BadgeVariant): StatusDotVariant {
+  switch (variant) {
+    case 'success':
+    case 'default':
+      return 'ok';
+    case 'destructive':
+      return 'fail';
+    case 'secondary':
+    case 'outline':
+    default:
+      return 'idle';
+  }
+}
 
 interface MetadataItem {
   label: string;
@@ -70,7 +85,7 @@ export function ItemCard({
           <CardTitle className="font-body font-semibold text-[15px] line-clamp-1 flex items-center gap-2">
             {avatarColor && (
               <span
-                className="w-3 h-3 rounded-full shrink-0 border border-border"
+                className="w-3 h-3 rounded-sm shrink-0 border border-border"
                 style={{ backgroundColor: avatarColor }}
                 aria-hidden
               />
@@ -82,10 +97,9 @@ export function ItemCard({
             <CardDescription className="text-steel text-[13px] line-clamp-2 min-h-[2.5rem]">{description}</CardDescription>
           )}
           {status && (
-            <CardAction className="top-5">
-              <Badge variant={status.variant || 'default'} className="text-xs">
-                {status.label}
-              </Badge>
+            <CardAction className="top-5 flex items-center gap-2">
+              <StatusDot variant={badgeVariantToStatusDot(status.variant)} />
+              <span className="font-body text-[13px] font-medium text-steel">{status.label}</span>
             </CardAction>
           )}
         </CardHeader>

--- a/frontend/src/components/dashboard/index.ts
+++ b/frontend/src/components/dashboard/index.ts
@@ -2,6 +2,7 @@ export { PageLayout } from './layouts/PageLayout';
 export { PageSection } from './layouts/PageSection';
 
 export { GridView } from './views/GridView';
+export { EmptyState } from './views/EmptyState';
 export { SkeletonGridView } from './views/SkeletonGridView';
 export { ActiveAgentsTab } from './views/ActiveAgentsTab';
 export { ActiveFlowsTab } from './views/ActiveFlowsTab';

--- a/frontend/src/components/dashboard/views/EmptyState.tsx
+++ b/frontend/src/components/dashboard/views/EmptyState.tsx
@@ -38,7 +38,7 @@ export function EmptyState({
         </h3>
       )}
       {description && (
-        <p className="font-body text-[13px] text-steel mt-1 max-w-sm">{description}</p>
+        <p className="font-body text-[13px] text-steel mt-1">{description}</p>
       )}
       {action && (
         <Button

--- a/frontend/src/components/dashboard/views/EmptyState.tsx
+++ b/frontend/src/components/dashboard/views/EmptyState.tsx
@@ -1,0 +1,55 @@
+import { LucideIcon, PackageOpen } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface EmptyStateProps {
+  icon?: LucideIcon;
+  title?: string;
+  description?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon = PackageOpen,
+  title = 'No items',
+  description = 'There are no items to display.',
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center text-center border border-line bg-panel p-10',
+        className,
+      )}
+    >
+      {Icon && (
+        <div className="flex h-12 w-12 items-center justify-center border border-line bg-paper-deep mb-5">
+          <Icon className="h-6 w-6 text-steel" />
+        </div>
+      )}
+      {title && (
+        <h3 className="font-display font-bold text-[18px] uppercase tracking-[.02em] text-ink">
+          {title}
+        </h3>
+      )}
+      {description && (
+        <p className="font-body text-[13px] text-steel mt-1 max-w-sm">{description}</p>
+      )}
+      {action && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-5 border-line text-ink hover:bg-paper-deep rounded-none"
+          onClick={action.onClick}
+        >
+          {action.label}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/views/GridView.tsx
+++ b/frontend/src/components/dashboard/views/GridView.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
+import { EmptyState } from './EmptyState';
 import { SkeletonGridView } from './SkeletonGridView';
 
 export interface GridViewColumns {
@@ -114,9 +115,10 @@ export function GridView<T>({
     return (
       <div className="flex items-center justify-center py-12">
         {emptyState || (
-          <div className="text-center text-muted-foreground">
-            <p>No items to display</p>
-          </div>
+          <EmptyState
+            title="No items"
+            description="There are no items to display."
+          />
         )}
       </div>
     );

--- a/frontend/src/components/dashboard/views/GridView.tsx
+++ b/frontend/src/components/dashboard/views/GridView.tsx
@@ -113,7 +113,7 @@ export function GridView<T>({
 
   if (items.length === 0) {
     return (
-      <div className="flex items-center justify-center py-12">
+      <div className="py-12">
         {emptyState || (
           <EmptyState
             title="No items"

--- a/frontend/src/components/data-table/DataRecordList.tsx
+++ b/frontend/src/components/data-table/DataRecordList.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { type ColumnDef } from '@tanstack/react-table';
 import { DataListView } from '@/components/dashboard/DataListView';
-import { ArrowUpDown } from 'lucide-react';
+import { EmptyState } from '@/components/dashboard';
+import { ArrowUpDown, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { formatTimeAgo } from '@/utils/time';
@@ -140,7 +141,13 @@ export function DataRecordList({
 			data={records}
 			loading={loading}
 			onRowClick={onRowClick}
-			emptyState={<p className="text-steel">No records found</p>}
+			emptyState={
+			<EmptyState
+				icon={FileText}
+				title="No records"
+				description="This table doesn't have any records yet."
+			/>
+		}
 		/>
 	);
 }

--- a/frontend/src/components/memory/MemoryPolicyList.tsx
+++ b/frontend/src/components/memory/MemoryPolicyList.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Plus, ShieldCheck, Layers, Sparkles, Trash2, Settings } from 'lucide-react';
+import { Plus, ShieldCheck, Layers, Sparkles, Trash2, Settings, Brain } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import { FilterBar, GridView, ItemCard } from '@/components/dashboard';
+import { FilterBar, GridView, ItemCard, EmptyState } from '@/components/dashboard';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { getMemoryPolicies, deleteMemoryPolicy } from '@/services/memoryPolicyApi';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
@@ -120,17 +120,12 @@ export function MemoryPolicyList() {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">No memory policies yet.</p>
-            <p className="text-sm text-steel max-w-md mx-auto mb-6">
-              A memory policy controls how an agent captures, retrieves, and writes
-              long-term memory. Create one to attach it to an agent's Memory settings.
-            </p>
-            <Button variant="display" size="sm" onClick={() => navigate('/memory/policies/new')}>
-              <Plus className="w-4 h-4 mr-2" />
-              New Policy
-            </Button>
-          </div>
+          <EmptyState
+            icon={Brain}
+            title="No memory policies"
+            description="Create a memory policy to control how agents capture and retrieve long-term memory."
+            action={{ label: 'New policy', onClick: () => navigate('/memory/policies/new') }}
+          />
         }
         renderItem={(policy) => (
           <ItemCard

--- a/frontend/src/pages/AgentContextArtifactsPage.tsx
+++ b/frontend/src/pages/AgentContextArtifactsPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { Loader2 } from 'lucide-react';
-import { FilterBar, PageLayout, LoadMoreButton } from '@/components/dashboard';
+import { FileText, Loader2 } from 'lucide-react';
+import { FilterBar, PageLayout, LoadMoreButton, EmptyState } from '@/components/dashboard';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getArtifacts, type AgentContextArtifactDoc, type ArtifactListParams } from '@/services/agentContextArtifactApi';
@@ -116,8 +116,14 @@ function AgentContextArtifactsPage() {
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
+        ) : artifacts.length === 0 ? (
+          <EmptyState
+            icon={FileText}
+            title="No artifacts"
+            description="No context artifacts have been stored yet."
+          />
         ) : (
-          <div className="overflow-hidden rounded-none border">
+          <div className="border border-line bg-panel">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -127,35 +133,27 @@ function AgentContextArtifactsPage() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {artifacts.length ? (
-                  artifacts.map((artifact) => (
-                    <TableRow
-                      key={artifact.name}
-                      className="cursor-pointer hover:bg-paper-deep"
-                      onClick={() => navigate(`/artifacts/${artifact.name}`)}
-                    >
-                      <TableCell className="max-w-md truncate">
-                        {artifact.summary || <span className="font-body text-steel">No summary</span>}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="secondary">{artifact.artifact_type || 'Unknown'}</Badge>
-                      </TableCell>
-                      <TableCell className="font-mono text-sm text-steel-soft">
-                        {artifact.agent_run || '—'}
-                      </TableCell>
-                      <TableCell className="text-sm">{artifact.visibility || '—'}</TableCell>
-                      <TableCell className="text-sm text-steel">
-                        {formatTimeAgo(artifact.creation ?? null)}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="font-body text-steel-soft">No artifacts found.</div>
+                {artifacts.map((artifact) => (
+                  <TableRow
+                    key={artifact.name}
+                    className="cursor-pointer hover:bg-paper-deep"
+                    onClick={() => navigate(`/artifacts/${artifact.name}`)}
+                  >
+                    <TableCell className="max-w-md truncate">
+                      {artifact.summary || <span className="font-body text-steel">No summary</span>}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{artifact.artifact_type || 'Unknown'}</Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-sm text-steel-soft">
+                      {artifact.agent_run || '—'}
+                    </TableCell>
+                    <TableCell className="text-sm">{artifact.visibility || '—'}</TableCell>
+                    <TableCell className="text-sm text-steel">
+                      {formatTimeAgo(artifact.creation ?? null)}
                     </TableCell>
                   </TableRow>
-                )}
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/frontend/src/pages/AgentPromptsPage.tsx
+++ b/frontend/src/pages/AgentPromptsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowUpDown, Loader2 } from 'lucide-react';
+import { ArrowUpDown, FileText, Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import {
   ColumnDef,
@@ -9,7 +9,7 @@ import {
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
-import { FilterBar, LoadMoreButton, PageLayout } from '@/components/dashboard';
+import { FilterBar, LoadMoreButton, PageLayout, EmptyState } from '@/components/dashboard';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Combobox } from '@/components/ui/combobox';
@@ -186,8 +186,15 @@ export function AgentPromptsPage() {
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
+        ) : prompts.length === 0 ? (
+          <EmptyState
+            icon={FileText}
+            title="No prompts"
+            description="Create a prompt template to share across agents."
+            action={{ label: 'New prompt', onClick: () => navigate('/prompts/new') }}
+          />
         ) : (
-          <div className="overflow-hidden rounded-none border">
+          <div className="border border-line bg-panel">
             <Table>
               <TableHeader>
                 {table.getHeaderGroups().map((headerGroup) => (
@@ -203,27 +210,19 @@ export function AgentPromptsPage() {
                 ))}
               </TableHeader>
               <TableBody>
-                {table.getRowModel().rows.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className="cursor-pointer hover:bg-paper-deep"
-                      onClick={() => navigate(`/prompts/${row.original.name}`)}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="font-body text-steel">No instruction prompts found.</div>
-                    </TableCell>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer hover:bg-paper-deep"
+                    onClick={() => navigate(`/prompts/${row.original.name}`)}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
                   </TableRow>
-                )}
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/frontend/src/pages/AgentSummaryPromptsPage.tsx
+++ b/frontend/src/pages/AgentSummaryPromptsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowUpDown, Loader2 } from 'lucide-react';
+import { ArrowUpDown, FileText, Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import {
   ColumnDef,
@@ -9,7 +9,7 @@ import {
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
-import { FilterBar, LoadMoreButton, PageLayout } from '@/components/dashboard';
+import { FilterBar, LoadMoreButton, PageLayout, EmptyState } from '@/components/dashboard';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Combobox } from '@/components/ui/combobox';
@@ -186,8 +186,15 @@ export function AgentSummaryPromptsPage() {
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
+        ) : prompts.length === 0 ? (
+          <EmptyState
+            icon={FileText}
+            title="No summary prompts"
+            description="Create a summary prompt template to share across agents."
+            action={{ label: 'New summary prompt', onClick: () => navigate('/summary-prompts/new') }}
+          />
         ) : (
-          <div className="overflow-hidden rounded-none border">
+          <div className="border border-line bg-panel">
             <Table>
               <TableHeader>
                 {table.getHeaderGroups().map((headerGroup) => (
@@ -203,27 +210,19 @@ export function AgentSummaryPromptsPage() {
                 ))}
               </TableHeader>
               <TableBody>
-                {table.getRowModel().rows.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className="cursor-pointer hover:bg-paper-deep"
-                      onClick={() => navigate(`/summary-prompts/${row.original.name}`)}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="font-body text-steel">No summarization prompts found.</div>
-                    </TableCell>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer hover:bg-paper-deep"
+                    onClick={() => navigate(`/summary-prompts/${row.original.name}`)}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
                   </TableRow>
-                )}
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, type ReactNode } from 'react';
-import { Calendar, Activity, Settings, Zap, Server, Lock } from 'lucide-react';
+import { Calendar, Activity, Settings, Zap, Server, Lock, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { usePermissions } from '../contexts/PermissionsContext';
 import { getAgents } from '../services/agentApi';
@@ -183,9 +183,12 @@ function AgentsPage() {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel mb-4">No agents found.</p>
-          </div>
+          <EmptyState
+            icon={Users}
+            title="No agents"
+            description="Create an agent to get started."
+            action={{ label: 'New agent', onClick: () => navigate('/agents/new') }}
+          />
         }
         renderItem={(agent) => {
           const status = getStatusLabel(agent);

--- a/frontend/src/pages/AiProvidersPage.tsx
+++ b/frontend/src/pages/AiProvidersPage.tsx
@@ -1,5 +1,4 @@
 import { ArrowRight, Check, CheckCircle2, ExternalLink, KeyRound, Loader2, Settings, Sparkles, XCircle } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import {
@@ -13,7 +12,7 @@ import {
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Checkbox } from '../components/ui/checkbox';
-import { PageLayout, FilterBar, GridView, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import {
   createModel,
@@ -407,8 +406,9 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
 
   return (
     <PageLayout
-        subtitle="Connect AI providers and external services"
-        filters={
+      title="AI Providers"
+      subtitle="Connect AI providers and external services"
+      filters={
         <FilterBar
           searchPlaceholder="Search providers..."
           searchValue={search}
@@ -416,24 +416,24 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
         />
       }
     >
-      <Card className="border-primary/20 bg-primary/5">
-        <CardHeader className="pb-3">
-          <div className="flex items-center gap-2 text-primary">
-            <Sparkles className="h-4 w-4" />
-            <CardTitle className="text-base">Get started with AI</CardTitle>
+      <div className="border border-line bg-panel p-4 space-y-3">
+        <div className="flex items-start gap-3">
+          <Sparkles className="h-4 w-4 mt-0.5 text-signal shrink-0" />
+          <div>
+            <h3 className="font-display font-bold text-[15px] uppercase text-ink">Get started with AI</h3>
+            <p className="font-body text-[13px] text-steel mt-0.5">
+              Pick a free-friendly starter path, add its key, and Huf will prepare a model for your first agent.
+            </p>
           </div>
-          <CardDescription>
-            Pick a free-friendly starter path, add its key, and Huf will prepare a model for your first agent.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-3 sm:flex-row">
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
           {completedStarter ? (
-            <div className="flex w-full flex-col gap-3 rounded-md border border-primary/20 bg-background/60 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex w-full flex-col gap-3 border border-line bg-paper p-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-start gap-2">
-                <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                <Check className="mt-0.5 h-4 w-4 shrink-0 text-good" />
                 <div>
-                  <p className="text-sm font-medium">Your {STARTER_PATHS[completedStarter].providerName} starter is ready</p>
-                  <p className="text-xs text-muted-foreground">Next, create an agent and choose {STARTER_PATHS[completedStarter].modelName}.</p>
+                  <p className="font-body text-[13px] font-medium text-ink">Your {STARTER_PATHS[completedStarter].providerName} starter is ready</p>
+                  <p className="font-body text-xs text-steel">Next, create an agent and choose {STARTER_PATHS[completedStarter].modelName}.</p>
                 </div>
               </div>
               <Button className="shrink-0" onClick={() => navigate('/agents/new')}>
@@ -441,16 +441,16 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
               </Button>
             </div>
           ) : (Object.entries(STARTER_PATHS) as [StarterPath, typeof STARTER_PATHS[StarterPath]][]).map(([path, starter]) => (
-            <Button key={path} variant="outline" className="h-auto flex-1 justify-between whitespace-normal text-left" onClick={() => setStarterPath(path)}>
+            <Button key={path} variant="outline" className="h-auto flex-1 justify-between whitespace-normal text-left border-line hover:border-ink hover:bg-paper-deep" onClick={() => setStarterPath(path)}>
               <span>
-                <span className="block font-medium">{starter.title}</span>
-                <span className="mt-1 block text-xs text-muted-foreground">{starter.modelName}</span>
+                <span className="block font-body font-medium text-[13px] text-ink">{starter.title}</span>
+                <span className="mt-1 block font-mono text-[11px] text-steel-soft">{starter.modelName}</span>
               </span>
-              <ArrowRight className="ml-3 h-4 w-4 shrink-0" />
+              <ArrowRight className="ml-3 h-4 w-4 shrink-0 text-steel" />
             </Button>
           ))}
-        </CardContent>
-      </Card>
+        </div>
+      </div>
       {error && !initialLoading && (
         <div className="text-center py-12">
           <p className="text-destructive mb-4">Failed to load providers</p>
@@ -468,51 +468,38 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
         }
         renderItem={(provider) => {
           const providerModels = models.filter(m => m.provider === provider.name);
+          const modelCount = getModelCountForProvider(provider.name);
           return (
-            <Card key={provider.name} className="h-full flex flex-col">
-              <CardHeader>
-                <div className="flex items-start justify-between">
-                  <div className="flex items-center gap-3">
-                    <ProviderBrandIcon
-                      brand={resolveProviderBrand(provider.provider_brand, provider.provider_name)}
-                      size="sm"
-                      showFallback
-                    />
-                    <div>
-                      <CardTitle className="text-base">{provider.provider_name}</CardTitle>
-                      <CardDescription className="text-xs">
-                        {getModelCountForProvider(provider.name)} models
-                      </CardDescription>
-                    </div>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="flex-1">
-                {providerModels.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {providerModels.slice(0, 3).map(model => (
-                      <Badge key={model.name} variant="secondary" className="text-xs">
-                        {model.model_name}
-                        {model.modalities ? ` · ${model.modalities}` : ''}
-                      </Badge>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-sm font-body text-steel-soft">No models configured</p>
-                )}
-              </CardContent>
-              <CardFooter>
-                <Button 
-                  variant="outline" 
-                  size="sm" 
-                  className="flex-1 gap-2"
-                  onClick={() => handleConfigure(provider)}
-                >
-                  <Settings className="w-4 h-4" />
-                  Configure
-                </Button>
-              </CardFooter>
-            </Card>
+            <ItemCard
+              key={provider.name}
+              title={provider.provider_name}
+              description={provider.is_local_llm ? 'Self-hosted endpoint' : 'Cloud API provider'}
+              icon={() => (
+                <ProviderBrandIcon
+                  brand={resolveProviderBrand(provider.provider_brand, provider.provider_name)}
+                  size="sm"
+                  showFallback
+                />
+              )}
+              status={{ label: provider.is_local_llm ? 'Local' : 'Configured', variant: 'success' }}
+              metadata={[
+                { label: 'Models', value: `${modelCount}`, icon: undefined },
+                { label: 'Brand', value: resolveProviderBrand(provider.provider_brand, provider.provider_name) || 'other', icon: undefined },
+              ]}
+              badges={providerModels.slice(0, 3).map(model => ({
+                label: model.model_name,
+                variant: 'secondary' as const,
+              }))}
+              actions={[
+                {
+                  icon: Settings,
+                  label: 'Configure',
+                  onClick: () => handleConfigure(provider),
+                  variant: 'ghost',
+                },
+              ]}
+              onClick={() => handleConfigure(provider)}
+            />
           );
         }}
         keyExtractor={(provider) => provider.name}

--- a/frontend/src/pages/AiProvidersPage.tsx
+++ b/frontend/src/pages/AiProvidersPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Check, CheckCircle2, ExternalLink, KeyRound, Loader2, Settings, Sparkles, XCircle } from 'lucide-react';
+import { ArrowRight, Check, CheckCircle2, Cloud, ExternalLink, KeyRound, Loader2, Settings, Sparkles, XCircle } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import {
@@ -12,7 +12,7 @@ import {
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Checkbox } from '../components/ui/checkbox';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import {
   createModel,
@@ -462,9 +462,12 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">No providers found.</p>
-          </div>
+          <EmptyState
+            icon={Cloud}
+            title="No providers"
+            description="Add an AI provider to connect models and start building agents."
+            action={{ label: 'Add provider', onClick: handleAddProvider }}
+          />
         }
         renderItem={(provider) => {
           const providerModels = models.filter(m => m.provider === provider.name);

--- a/frontend/src/pages/AppsPage.tsx
+++ b/frontend/src/pages/AppsPage.tsx
@@ -8,7 +8,7 @@ import {
 	TriangleAlert,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { PageLayout, GridView, BaseCard, FilterBar } from '../components/dashboard';
+import { PageLayout, GridView, BaseCard, FilterBar, EmptyState } from '../components/dashboard';
 import { ExperimentalBadge } from '../components/common/ExperimentalBadge';
 import { CardHeader, CardTitle, CardDescription, CardAction } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -401,17 +401,15 @@ function AppsPage() {
 					columns={{ sm: 1, md: 2, lg: 3 }}
 					loading={loading}
 					emptyState={
-						<div className="text-center py-12">
-							<AppWindow className="w-12 h-12 text-steel-soft mx-auto mb-4" />
-							<p className="font-body text-steel-soft mb-2">
-								{apps.length > 0 ? 'No apps match your filters' : 'No apps available yet'}
-							</p>
-							<p className="text-sm text-steel">
-								{apps.length > 0
+						<EmptyState
+							icon={AppWindow}
+							title={apps.length > 0 ? 'No apps match your filters' : 'No apps available yet'}
+							description={
+								apps.length > 0
 									? 'Try a different search or category.'
-									: 'Installed apps that depend on HUF will appear here.'}
-							</p>
-						</div>
+									: 'Installed apps that depend on HUF will appear here.'
+							}
+						/>
 					}
 					renderItem={(app) => <AppCard app={app} onToggleEnabled={handleToggleEnabled} />}
 					keyExtractor={(app) => app.app_id}

--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -11,6 +11,7 @@ import {
 	GridView,
 	ItemCard,
 	LoadMoreButton,
+	EmptyState,
 } from '../components/dashboard';
 import { DeleteTableDialog } from '../components/data-table/DeleteTableDialog';
 import { TableAgentAccessModal } from '../components/data-table/TableAgentAccessModal';
@@ -202,13 +203,12 @@ function DataPage() {
 					columns={{ sm: 1, md: 2, lg: 3 }}
 					loading={initialLoading}
 					emptyState={
-						<div className="text-center py-12">
-							<Database className="w-12 h-12 text-steel-soft mx-auto mb-4" />
-							<p className="font-body text-steel-soft mb-2">No data tables yet</p>
-							<p className="text-sm text-steel">
-								Create your first table to start managing structured data.
-							</p>
-						</div>
+						<EmptyState
+							icon={Database}
+							title="No data tables"
+							description="Create your first table to start managing structured data."
+							action={{ label: 'New table', onClick: () => navigate('/data/new') }}
+						/>
 					}
 					renderItem={() => <></>}
 					keyExtractor={() => ''}

--- a/frontend/src/pages/ExecutionProfileFormPage.tsx
+++ b/frontend/src/pages/ExecutionProfileFormPage.tsx
@@ -197,26 +197,24 @@ export function ExecutionProfileFormPage() {
     <div className="flex-1 overflow-y-auto">
       <div className="space-y-6 max-w-4xl mx-auto p-6 pb-12">
       <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-primary/10 text-primary">
-            <ShieldCheck className="h-6 w-6" />
-          </div>
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="h-8 w-8 text-steel-soft shrink-0 mt-1" strokeWidth={1.6} />
           <div>
             <InlineEditName
               value={form.watch('profile_name') || (isNew ? 'New Execution Profile' : id!)}
               onChange={(name: string) => form.setValue('profile_name', name, { shouldDirty: true })}
               placeholder="Profile Name"
-              className="text-2xl font-bold tracking-tight"
+              className="[&_h1]:font-display [&_h1]:text-[34px] [&_h1]:uppercase [&_h1]:leading-tight"
             />
-            <p className="text-sm text-muted-foreground">
-              {isNew ? 'Create a new sandboxed execution profile' : `ID: ${id}`}
+            <p className="font-mono text-[12px] text-steel mt-1">
+              {isNew ? 'Create a new sandboxed execution profile' : `ID ${id}`}
             </p>
           </div>
         </div>
 
         <div className="flex items-center gap-2">
           {!isNew && (
-            <Button variant="outline" size="sm" onClick={handleDelete} disabled={deleting || saving}>
+            <Button variant="outline" size="sm" onClick={handleDelete} disabled={deleting || saving} className="border-line hover:border-ink hover:bg-paper-deep">
               {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4 text-destructive" />}
             </Button>
           )}
@@ -229,10 +227,10 @@ export function ExecutionProfileFormPage() {
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-          <Card>
+          <Card className="border-line bg-panel">
             <CardHeader>
-              <CardTitle>General Settings</CardTitle>
-              <CardDescription>Configure security policy and sandbox behavior</CardDescription>
+              <CardTitle className="font-display font-bold text-[18px] uppercase">General Settings</CardTitle>
+              <CardDescription className="font-body text-[13px] text-steel">Configure security policy and sandbox behavior</CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
               <FormField
@@ -254,7 +252,7 @@ export function ExecutionProfileFormPage() {
                 control={form.control}
                 name="disabled"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex flex-row items-center justify-between border border-line bg-paper p-4">
                     <div className="space-y-0.5">
                       <FormLabel className="text-base">Disable Profile</FormLabel>
                       <FormDescription>Disabled profiles cannot be selected or used for code execution.</FormDescription>
@@ -337,10 +335,10 @@ export function ExecutionProfileFormPage() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="border-line bg-panel">
             <CardHeader>
-              <CardTitle>Resource Limits</CardTitle>
-              <CardDescription>Specify CPU, time, memory, and output boundaries for code runs</CardDescription>
+              <CardTitle className="font-display font-bold text-[18px] uppercase">Resource Limits</CardTitle>
+              <CardDescription className="font-body text-[13px] text-steel">Specify CPU, time, memory, and output boundaries for code runs</CardDescription>
             </CardHeader>
             <CardContent className="grid gap-6 sm:grid-cols-2">
               <FormField

--- a/frontend/src/pages/ExecutionProfilesPage.tsx
+++ b/frontend/src/pages/ExecutionProfilesPage.tsx
@@ -8,10 +8,10 @@ import {
   getSortedRowModel,
   SortingState,
   useReactTable,
+  HeaderContext,
 } from '@tanstack/react-table';
-import { FilterBar, LoadMoreButton, PageLayout } from '@/components/dashboard';
+import { FilterBar, LoadMoreButton, PageLayout, StatusDot } from '@/components/dashboard';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Combobox } from '@/components/ui/combobox';
 import {
   Table,
@@ -29,21 +29,17 @@ import {
 } from '@/services/executionProfileApi';
 import { formatTimeAgo } from '@/utils/time';
 
-function getStatusVariant(disabled?: 0 | 1): 'success' | 'secondary' {
-  return disabled === 1 ? 'secondary' : 'success';
-}
-
-function getApprovalBadgeVariant(approvalMode?: string): 'default' | 'outline' | 'destructive' {
-  switch (approvalMode) {
-    case 'Auto Approve':
-      return 'outline';
-    case 'Ask Every Time':
-      return 'default';
-    case 'Never Allow':
-      return 'destructive';
-    default:
-      return 'outline';
-  }
+function SortHeader<TData>({ column, label }: { column: HeaderContext<TData, unknown>['column']; label: string }) {
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      className="h-8 px-2 font-body text-[13px] font-medium text-steel hover:text-ink hover:bg-paper-deep"
+    >
+      {label}
+      <ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+    </Button>
+  );
 }
 
 export function ExecutionProfilesPage() {
@@ -95,25 +91,18 @@ export function ExecutionProfilesPage() {
     () => [
       {
         accessorKey: 'profile_name',
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
-            className="h-8 px-2"
-          >
-            Profile Name
-            <ArrowUpDown className="ml-2 h-4 w-4" />
-          </Button>
-        ),
+        header: ({ column }) => <SortHeader column={column} label="Profile Name" />,
         cell: ({ row }) => (
-          <div className="flex items-center gap-2 font-medium">
-            <ShieldCheck className="h-4 w-4 text-primary shrink-0" />
-            <span>{row.original.profile_name || row.original.name}</span>
-            {row.original.is_builtin === 1 && (
-              <Badge variant="outline" className="text-xs">
-                Built-in
-              </Badge>
-            )}
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-steel-soft shrink-0" strokeWidth={1.6} />
+            <div>
+              <div className="font-body text-[13px] font-semibold text-ink">
+                {row.original.profile_name || row.original.name}
+              </div>
+              {row.original.is_builtin === 1 && (
+                <span className="font-mono text-[11px] text-steel-soft">Built-in</span>
+              )}
+            </div>
           </div>
         ),
       },
@@ -121,17 +110,17 @@ export function ExecutionProfilesPage() {
         accessorKey: 'approval_mode',
         header: 'Approval Mode',
         cell: ({ row }) => (
-          <Badge variant={getApprovalBadgeVariant(row.original.approval_mode)}>
+          <span className="font-mono text-[12px] text-steel">
             {row.original.approval_mode || 'Ask Every Time'}
-          </Badge>
+          </span>
         ),
       },
       {
         accessorKey: 'filesystem_policy',
         header: 'Filesystem Policy',
         cell: ({ row }) => (
-          <div className="flex items-center gap-1.5 text-sm text-steel">
-            <HardDrive className="h-3.5 w-3.5" />
+          <div className="flex items-center gap-1.5 font-mono text-[12px] text-steel">
+            <HardDrive className="h-3.5 w-3.5" strokeWidth={1.6} />
             <span>{row.original.filesystem_policy || 'None'}</span>
           </div>
         ),
@@ -140,8 +129,8 @@ export function ExecutionProfilesPage() {
         id: 'limits',
         header: 'Resource Limits',
         cell: ({ row }) => (
-          <div className="flex items-center gap-2 text-xs text-steel">
-            <Cpu className="h-3.5 w-3.5" />
+          <div className="flex items-center gap-1.5 font-mono text-[12px] text-steel">
+            <Cpu className="h-3.5 w-3.5" strokeWidth={1.6} />
             <span>
               {row.original.max_wall_time_s ?? 30}s / {row.original.max_memory_mb ?? 256}MB
             </span>
@@ -152,25 +141,19 @@ export function ExecutionProfilesPage() {
         accessorKey: 'disabled',
         header: 'Status',
         cell: ({ row }) => (
-          <Badge variant={getStatusVariant(row.original.disabled)}>
-            {row.original.disabled === 1 ? 'Disabled' : 'Active'}
-          </Badge>
+          <div className="flex items-center gap-2">
+            <StatusDot variant={row.original.disabled === 1 ? 'idle' : 'ok'} />
+            <span className="font-body text-[13px] text-steel">
+              {row.original.disabled === 1 ? 'Disabled' : 'Active'}
+            </span>
+          </div>
         ),
       },
       {
         id: 'modified',
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
-            className="h-8 px-2"
-          >
-            Modified
-            <ArrowUpDown className="ml-2 h-4 w-4" />
-          </Button>
-        ),
+        header: ({ column }) => <SortHeader column={column} label="Modified" />,
         cell: ({ row }) => (
-          <div className="text-sm text-steel">{formatTimeAgo(row.original.modified ?? null)}</div>
+          <div className="font-mono text-[12px] text-steel">{formatTimeAgo(row.original.modified ?? null)}</div>
         ),
         sortingFn: (rowA, rowB) => {
           const timeA = rowA.original.modified ? new Date(rowA.original.modified).getTime() : 0;
@@ -199,6 +182,7 @@ export function ExecutionProfilesPage() {
 
   return (
     <PageLayout
+      title="Execution Profiles"
       subtitle="Manage sandboxed code execution environments, resource limits, and approval policies."
       filters={
         <FilterBar
@@ -224,7 +208,7 @@ export function ExecutionProfilesPage() {
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
         ) : (
-          <div className="overflow-hidden rounded-none border">
+          <div className="border border-line bg-panel">
             <Table>
               <TableHeader>
                 {table.getHeaderGroups().map((headerGroup) => (

--- a/frontend/src/pages/ExecutionProfilesPage.tsx
+++ b/frontend/src/pages/ExecutionProfilesPage.tsx
@@ -10,7 +10,7 @@ import {
   useReactTable,
   HeaderContext,
 } from '@tanstack/react-table';
-import { FilterBar, LoadMoreButton, PageLayout, StatusDot } from '@/components/dashboard';
+import { FilterBar, LoadMoreButton, PageLayout, StatusDot, EmptyState } from '@/components/dashboard';
 import { Button } from '@/components/ui/button';
 import { Combobox } from '@/components/ui/combobox';
 import {
@@ -207,6 +207,12 @@ export function ExecutionProfilesPage() {
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
+        ) : profiles.length === 0 ? (
+          <EmptyState
+            icon={ShieldCheck}
+            title="No execution profiles"
+            description="No execution profiles have been configured yet."
+          />
         ) : (
           <div className="border border-line bg-panel">
             <Table>
@@ -224,27 +230,19 @@ export function ExecutionProfilesPage() {
                 ))}
               </TableHeader>
               <TableBody>
-                {table.getRowModel().rows.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className="cursor-pointer hover:bg-paper-deep"
-                      onClick={() => navigate(`/execution-profiles/${row.original.name}`)}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="font-body text-steel">No Execution Profiles found.</div>
-                    </TableCell>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer hover:bg-paper-deep"
+                    onClick={() => navigate(`/execution-profiles/${row.original.name}`)}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
                   </TableRow>
-                )}
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/frontend/src/pages/Executions.tsx
+++ b/frontend/src/pages/Executions.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
-import { ArrowUpDown, Loader2 } from 'lucide-react';
-import { FilterBar, PageLayout, LoadMoreButton } from '@/components/dashboard';
+import { Activity, ArrowUpDown, Loader2 } from 'lucide-react';
+import { FilterBar, PageLayout, LoadMoreButton, EmptyState } from '@/components/dashboard';
 import { ExperimentalBadge } from '@/components/common/ExperimentalBadge';
 import { StatusDot, type StatusDotVariant } from '@/components/dashboard/ledger/LedgerSection';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -349,6 +349,12 @@ export default function Executions() {
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
+        ) : runs.length === 0 ? (
+          <EmptyState
+            icon={Activity}
+            title="No executions"
+            description="No agent runs have been recorded yet."
+          />
         ) : (
           <div className="border border-line bg-panel">
             <Table>
@@ -368,27 +374,19 @@ export default function Executions() {
                 ))}
               </TableHeader>
               <TableBody>
-                {table.getRowModel().rows?.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className="cursor-pointer hover:bg-paper-deep"
-                      onClick={() => navigate(`/executions/${row.original.name}`)}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="text-steel">No executions found.</div>
-                    </TableCell>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer hover:bg-paper-deep"
+                    onClick={() => navigate(`/executions/${row.original.name}`)}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
                   </TableRow>
-                )}
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/frontend/src/pages/FlowListPage.tsx
+++ b/frontend/src/pages/FlowListPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
-import { Calendar, Play, Activity, Settings } from 'lucide-react';
-import { PageLayout, FilterBar, GridView, ItemCard } from '../components/dashboard';
+import { Calendar, Play, Activity, Settings, Workflow } from 'lucide-react';
+import { PageLayout, FilterBar, GridView, ItemCard, EmptyState } from '../components/dashboard';
 import { ExperimentalBadge } from '../components/common/ExperimentalBadge';
 import { usePageData } from '../hooks/dashboard/usePageData';
 
@@ -155,6 +155,13 @@ function FlowListPage() {
         items={data}
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={loading}
+        emptyState={
+          <EmptyState
+            icon={Workflow}
+            title="No flows"
+            description="No flows have been created yet."
+          />
+        }
         renderItem={(flow) => (
           <ItemCard
             title={flow.name}

--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -3,13 +3,14 @@ import {
   Check,
   Copy,
   Link2,
+  Network,
   Plus,
   Settings,
   ShieldCheck,
   Trash2,
   X,
 } from 'lucide-react';
-import { PageLayout, GridView, ItemCard } from '@/components/dashboard';
+import { PageLayout, GridView, ItemCard, EmptyState } from '@/components/dashboard';
 import {
   getGateways,
   updateGateway,
@@ -325,16 +326,12 @@ export default function GatewaysPage() {
         loading={loading}
         columns={{ sm: 1, md: 2, lg: 3 }}
         emptyState={
-          <div className="max-w-xl py-12 text-center mx-auto">
-            <div className="mb-3 inline-flex rounded-full bg-panel p-4 text-steel border border-line">
-              <Link2 className="h-8 w-8 text-steel" />
-            </div>
-            <p className="mb-1 font-medium text-ink">No gateways configured yet</p>
-            <p className="text-xs text-steel leading-relaxed">
-              Connect WhatsApp, Facebook Messenger, Instagram Direct, Telegram, or Slack to allow customers and
-              team members to trigger AI Agents directly from messaging apps.
-            </p>
-          </div>
+          <EmptyState
+            icon={Network}
+            title="No gateways"
+            description="Connect WhatsApp, Messenger, Instagram, Telegram, or Slack to let people message your agents."
+            action={{ label: 'Add gateway', onClick: () => setShowSetup(true) }}
+          />
         }
         renderItem={(gateway) => {
           const target =

--- a/frontend/src/pages/IntegrationServicesListingPage.tsx
+++ b/frontend/src/pages/IntegrationServicesListingPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import { Calendar, KeyRound, Settings, Shield } from 'lucide-react';
+import { Calendar, KeyRound, Puzzle, Settings, Shield } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '@/components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '@/components/dashboard';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { getIntegrationServicesPaginated } from '@/services/integrationApi';
 import { integrationCategoryFilterOptions } from '@/data/integrations';
@@ -93,16 +93,12 @@ export function IntegrationServicesListingPage() {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">No integration services found.</p>
-            <button
-              type="button"
-              className="text-sm text-primary hover:underline"
-              onClick={() => navigate('/integration-services/new')}
-            >
-              Create your first service
-            </button>
-          </div>
+          <EmptyState
+            icon={Puzzle}
+            title="No integration services"
+            description="Define a service catalog to describe credentials and connection settings."
+            action={{ label: 'New service', onClick: () => navigate('/integration-services/new') }}
+          />
         }
         renderItem={(service) => {
           const identity = getServiceIdentity(service.service_name);

--- a/frontend/src/pages/IntegrationSettingsListingPage.tsx
+++ b/frontend/src/pages/IntegrationSettingsListingPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { AlertCircle, Settings, Star, Users } from 'lucide-react';
+import { AlertCircle, Link, Settings, Star, Users } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '@/components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '@/components/dashboard';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import {
   getIntegrationSettings,
@@ -148,18 +148,19 @@ export function IntegrationSettingsListingPage({
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">
-              {kind === 'channels' ? 'No channels configured yet.' : 'No integrations configured yet.'}
-            </p>
-            <button
-              type="button"
-              className="text-sm text-primary hover:underline"
-              onClick={() => setCatalogOpen(true)}
-            >
-              {kind === 'channels' ? 'Add your first channel' : 'Add your first integration'}
-            </button>
-          </div>
+          <EmptyState
+            icon={Link}
+            title={kind === 'channels' ? 'No channels' : 'No integrations'}
+            description={
+              kind === 'channels'
+                ? 'No messaging channels have been connected yet.'
+                : 'No integrations have been connected yet.'
+            }
+            action={{
+              label: kind === 'channels' ? 'Add channel' : 'Add integration',
+              onClick: () => setCatalogOpen(true),
+            }}
+          />
         }
         renderItem={(setting) => {
           const category = serviceCategoryMap.get(setting.service);

--- a/frontend/src/pages/KnowledgeSourcesPage.tsx
+++ b/frontend/src/pages/KnowledgeSourcesPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import { Calendar, Settings, Database } from 'lucide-react';
+import { Calendar, Settings, Database, BookOpen } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getKnowledgeSources } from '../services/knowledgeApi';
 import { formatTimeAgo } from '../utils/time';
@@ -113,9 +113,12 @@ function KnowledgeSourcesPage() {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">No knowledge sources found.</p>
-          </div>
+          <EmptyState
+            icon={BookOpen}
+            title="No knowledge sources"
+            description="No knowledge sources have been added yet."
+            action={{ label: 'New knowledge source', onClick: () => navigate('/knowledge/new') }}
+          />
         }
         renderItem={(source) => {
           const statusLabel = getStatusLabel(source);

--- a/frontend/src/pages/McpListingPage.tsx
+++ b/frontend/src/pages/McpListingPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import { Calendar, Settings, Tag } from 'lucide-react';
+import { Calendar, Settings, Tag, Server } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getMCPServers } from '../services/mcpApi';
 import { formatTimeAgo } from '../utils/time';
@@ -99,9 +99,11 @@ export default function McpListingPage() {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">No MCP servers found.</p>
-          </div>
+          <EmptyState
+            icon={Server}
+            title="No MCP servers"
+            description="No MCP servers have been connected yet."
+          />
         }
         renderItem={(server) => {
           const status = getMcpStatus(server);

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -18,7 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../components/ui/select';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import {
   getModels,
@@ -326,9 +326,12 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="font-body text-steel-soft mb-4">No models found.</p>
-          </div>
+          <EmptyState
+            icon={Cpu}
+            title="No models"
+            description="Add a model to use with your AI providers."
+            action={{ label: 'Add model', onClick: handleAddModel }}
+          />
         }
         renderItem={(model) => {
           const pricingSummary = formatPricingSummary(model);

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -1,7 +1,5 @@
 import { Cpu, Settings, Loader2, DollarSign } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
-import { Badge } from '../components/ui/badge';
 import {
   Dialog,
   DialogContent,
@@ -20,7 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../components/ui/select';
-import { PageLayout, FilterBar, GridView, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import {
   getModels,
@@ -307,6 +305,7 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
 
   return (
     <PageLayout
+      title="Models"
       subtitle="Manage AI models and their capabilities"
       filters={
         <FilterBar
@@ -333,51 +332,32 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         }
         renderItem={(model) => {
           const pricingSummary = formatPricingSummary(model);
+          const modalities = parseModalityBadges(model.modalities);
 
           return (
-            <Card key={model.name} className="h-full flex flex-col">
-              <CardHeader>
-                <div className="flex items-start justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-none bg-primary/10 flex items-center justify-center">
-                      <Cpu className="w-5 h-5 text-primary" />
-                    </div>
-                    <div>
-                      <CardTitle className="text-base">{model.model_name}</CardTitle>
-                      <CardDescription className="text-xs">
-                        {resolveProviderName(model.provider, providerMap)}
-                      </CardDescription>
-                    </div>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="flex-1 space-y-2">
-                <div className="flex flex-wrap gap-2">
-                  {parseModalityBadges(model.modalities).map((modality) => (
-                    <Badge key={modality} variant="secondary" className="text-xs">
-                      {modality}
-                    </Badge>
-                  ))}
-                </div>
-                {model.use_custom_pricing === 1 && (
-                  <div className="flex items-center gap-1.5 text-xs text-steel-soft">
-                    <DollarSign className="w-3 h-3" />
-                    <span>{pricingSummary || 'Custom pricing'}</span>
-                  </div>
-                )}
-              </CardContent>
-              <CardFooter>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="flex-1 gap-2"
-                  onClick={() => handleConfigure(model)}
-                >
-                  <Settings className="w-4 h-4" />
-                  Configure
-                </Button>
-              </CardFooter>
-            </Card>
+            <ItemCard
+              key={model.name}
+              title={model.model_name}
+              description={resolveProviderName(model.provider, providerMap)}
+              icon={Cpu}
+              metadata={[
+                { label: 'Provider', value: resolveProviderName(model.provider, providerMap), icon: undefined },
+                ...(pricingSummary ? [{ label: 'Pricing', value: pricingSummary, icon: DollarSign }] : []),
+              ]}
+              badges={modalities.map((modality) => ({
+                label: modality,
+                variant: 'secondary' as const,
+              }))}
+              actions={[
+                {
+                  icon: Settings,
+                  label: 'Configure',
+                  onClick: () => handleConfigure(model),
+                  variant: 'ghost',
+                },
+              ]}
+              onClick={() => handleConfigure(model)}
+            />
           );
         }}
         keyExtractor={(model) => model.name}

--- a/frontend/src/pages/SSHConnectionFormPage.tsx
+++ b/frontend/src/pages/SSHConnectionFormPage.tsx
@@ -11,8 +11,8 @@ import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Save, Trash2, Terminal, Loader2, Play, ShieldCheck, CheckCircle2, XCircle, RefreshCw } from 'lucide-react';
+import { StatusDot } from '@/components/dashboard';
+import { Save, Trash2, Terminal, Loader2, Play, ShieldCheck, RefreshCw } from 'lucide-react';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
 import {
   createSSHConnection,
@@ -260,19 +260,17 @@ export function SSHConnectionFormPage() {
   return (
     <div className="space-y-6 max-w-4xl mx-auto pb-12">
       <div className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <div className="p-2 rounded-lg bg-primary/10 text-primary">
-            <Terminal className="h-6 w-6" />
-          </div>
+        <div className="flex items-start gap-3">
+          <Terminal className="h-8 w-8 text-steel-soft shrink-0 mt-1" strokeWidth={1.6} />
           <div>
             <InlineEditName
               value={form.watch('display_name') || (isNew ? 'New SSH Connection' : id!)}
               onChange={(name: string) => form.setValue('display_name', name, { shouldDirty: true })}
               placeholder="Display Name"
-              className="text-2xl font-bold tracking-tight"
+              className="[&_h1]:font-display [&_h1]:text-[34px] [&_h1]:uppercase [&_h1]:leading-tight"
             />
-            <p className="text-sm text-muted-foreground">
-              {isNew ? 'Create a new remote SSH target connection' : `ID: ${id}`}
+            <p className="font-mono text-[12px] text-steel mt-1">
+              {isNew ? 'Create a new remote SSH target connection' : `ID ${id}`}
             </p>
           </div>
         </div>
@@ -280,11 +278,11 @@ export function SSHConnectionFormPage() {
         <div className="flex items-center gap-2">
           {!isNew && (
             <>
-              <Button variant="outline" size="sm" onClick={handleTestConnection} disabled={testing}>
-                {testing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Play className="h-4 w-4 mr-2 text-emerald-600" />}
+              <Button variant="outline" size="sm" onClick={handleTestConnection} disabled={testing} className="border-line hover:border-ink hover:bg-paper-deep">
+                {testing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Play className="h-4 w-4 mr-2 text-steel" />}
                 Test Connection
               </Button>
-              <Button variant="outline" size="sm" onClick={handleDelete} disabled={deleting || saving}>
+              <Button variant="outline" size="sm" onClick={handleDelete} disabled={deleting || saving} className="border-line hover:border-ink hover:bg-paper-deep">
                 {deleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4 text-destructive" />}
               </Button>
             </>
@@ -298,10 +296,10 @@ export function SSHConnectionFormPage() {
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-          <Card>
+          <Card className="border-line bg-panel">
             <CardHeader>
-              <CardTitle>Connection Details</CardTitle>
-              <CardDescription>Specify target hostname, port, and authentication credentials</CardDescription>
+              <CardTitle className="font-display font-bold text-[18px] uppercase">Connection Details</CardTitle>
+              <CardDescription className="font-body text-[13px] text-steel">Specify target hostname, port, and authentication credentials</CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
               <FormField
@@ -323,7 +321,7 @@ export function SSHConnectionFormPage() {
                 control={form.control}
                 name="enabled"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                  <FormItem className="flex flex-row items-center justify-between border border-line bg-paper p-4">
                     <div className="space-y-0.5">
                       <FormLabel className="text-base">Enable Connection</FormLabel>
                       <FormDescription>Disabled connections cannot be executed against by AI agents.</FormDescription>
@@ -465,50 +463,55 @@ export function SSHConnectionFormPage() {
           </Card>
 
           {!isNew && connectionDoc && (
-            <Card>
+            <Card className="border-line bg-panel">
               <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <ShieldCheck className="h-5 w-5 text-primary" />
+                <CardTitle className="flex items-center gap-2 font-display font-bold text-[18px] uppercase">
+                  <ShieldCheck className="h-5 w-5 text-steel-soft" strokeWidth={1.6} />
                   Host Key Security & Status
                 </CardTitle>
-                <CardDescription>Pinned host key verification prevents MITM attacks</CardDescription>
+                <CardDescription className="font-body text-[13px] text-steel">Pinned host key verification prevents MITM attacks</CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
-                <div className="grid gap-4 sm:grid-cols-2 rounded-lg border p-4 text-sm">
+                <div className="grid gap-4 sm:grid-cols-2 border border-line bg-paper p-4 text-sm">
                   <div>
-                    <span className="text-muted-foreground block text-xs">Host Key Fingerprint</span>
-                    <span className="font-mono font-medium text-xs break-all">
+                    <span className="font-mono text-[10px] uppercase tracking-wide text-steel-soft block">Host Key Fingerprint</span>
+                    <span className="font-mono text-[12px] text-ink break-all">
                       {connectionDoc.host_key_fingerprint || 'Not enrolled yet'}
                     </span>
                   </div>
 
                   <div>
-                    <span className="text-muted-foreground block text-xs">Host Key Type</span>
-                    <span className="font-mono font-medium text-xs">
+                    <span className="font-mono text-[10px] uppercase tracking-wide text-steel-soft block">Host Key Type</span>
+                    <span className="font-mono text-[12px] text-ink">
                       {connectionDoc.host_key_type || 'N/A'}
                     </span>
                   </div>
 
                   <div>
-                    <span className="text-muted-foreground block text-xs">Last Test Status</span>
-                    <div className="mt-1">
+                    <span className="font-mono text-[10px] uppercase tracking-wide text-steel-soft block">Last Test Status</span>
+                    <div className="mt-1 flex items-center gap-2">
                       {connectionDoc.last_test_status === 'Success' ? (
-                        <Badge variant="outline" className="text-emerald-600 border-emerald-600">
-                          <CheckCircle2 className="h-3 w-3 mr-1" /> Success
-                        </Badge>
+                        <>
+                          <StatusDot variant="ok" />
+                          <span className="font-body text-[13px] text-steel">Success</span>
+                        </>
                       ) : connectionDoc.last_test_status ? (
-                        <Badge variant="destructive">
-                          <XCircle className="h-3 w-3 mr-1" /> Failed
-                        </Badge>
+                        <>
+                          <StatusDot variant="fail" />
+                          <span className="font-body text-[13px] text-steel">Failed</span>
+                        </>
                       ) : (
-                        <span className="text-muted-foreground text-xs">Not tested</span>
+                        <>
+                          <StatusDot variant="idle" />
+                          <span className="font-body text-[13px] text-steel">Not tested</span>
+                        </>
                       )}
                     </div>
                   </div>
 
                   <div>
-                    <span className="text-muted-foreground block text-xs">Last Error</span>
-                    <span className="text-xs text-destructive break-words">
+                    <span className="font-mono text-[10px] uppercase tracking-wide text-steel-soft block">Last Error</span>
+                    <span className="font-mono text-[12px] text-destructive break-words">
                       {connectionDoc.last_error || 'None'}
                     </span>
                   </div>
@@ -521,11 +524,12 @@ export function SSHConnectionFormPage() {
                     size="sm"
                     onClick={handleEnrollHostKey}
                     disabled={enrolling}
+                    className="border-line hover:border-ink hover:bg-paper-deep"
                   >
                     {enrolling ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <RefreshCw className="h-4 w-4 mr-2" />}
                     Enroll / Update Host Key
                   </Button>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="font-body text-xs text-steel">
                     Connects to target server to automatically fetch and pin its public host key fingerprint.
                   </span>
                 </div>

--- a/frontend/src/pages/SSHConnectionsPage.tsx
+++ b/frontend/src/pages/SSHConnectionsPage.tsx
@@ -10,7 +10,7 @@ import {
   useReactTable,
   HeaderContext,
 } from '@tanstack/react-table';
-import { FilterBar, LoadMoreButton, PageLayout, StatusDot } from '@/components/dashboard';
+import { FilterBar, LoadMoreButton, PageLayout, StatusDot, EmptyState } from '@/components/dashboard';
 import { Button } from '@/components/ui/button';
 import { Combobox } from '@/components/ui/combobox';
 import {
@@ -213,6 +213,12 @@ export function SSHConnectionsPage() {
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
+        ) : connections.length === 0 ? (
+          <EmptyState
+            icon={Terminal}
+            title="No SSH connections"
+            description="No SSH connections have been configured yet."
+          />
         ) : (
           <div className="border border-line bg-panel">
             <Table>
@@ -230,27 +236,19 @@ export function SSHConnectionsPage() {
                 ))}
               </TableHeader>
               <TableBody>
-                {table.getRowModel().rows.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className="cursor-pointer hover:bg-paper-deep"
-                      onClick={() => navigate(`/ssh-connections/${row.original.name}`)}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={columns.length} className="h-24 text-center">
-                      <div className="font-body text-steel">No SSH Connections found.</div>
-                    </TableCell>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer hover:bg-paper-deep"
+                    onClick={() => navigate(`/ssh-connections/${row.original.name}`)}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
                   </TableRow>
-                )}
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/frontend/src/pages/SSHConnectionsPage.tsx
+++ b/frontend/src/pages/SSHConnectionsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowUpDown, Loader2, Terminal, Key, CheckCircle2, XCircle } from 'lucide-react';
+import { ArrowUpDown, Loader2, Terminal, Key } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import {
   ColumnDef,
@@ -8,10 +8,10 @@ import {
   getSortedRowModel,
   SortingState,
   useReactTable,
+  HeaderContext,
 } from '@tanstack/react-table';
-import { FilterBar, LoadMoreButton, PageLayout } from '@/components/dashboard';
+import { FilterBar, LoadMoreButton, PageLayout, StatusDot } from '@/components/dashboard';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Combobox } from '@/components/ui/combobox';
 import {
   Table,
@@ -29,8 +29,17 @@ import {
 } from '@/services/sshConnectionApi';
 import { formatTimeAgo } from '@/utils/time';
 
-function getStatusVariant(enabled?: 0 | 1): 'success' | 'secondary' {
-  return enabled === 1 ? 'success' : 'secondary';
+function SortHeader<TData>({ column, label }: { column: HeaderContext<TData, unknown>['column']; label: string }) {
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      className="h-8 px-2 font-body text-[13px] font-medium text-steel hover:text-ink hover:bg-paper-deep"
+    >
+      {label}
+      <ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+    </Button>
+  );
 }
 
 export function SSHConnectionsPage() {
@@ -82,29 +91,18 @@ export function SSHConnectionsPage() {
     () => [
       {
         accessorKey: 'display_name',
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
-            className="h-8 px-2"
-          >
-            Display Name
-            <ArrowUpDown className="ml-2 h-4 w-4" />
-          </Button>
-        ),
+        header: ({ column }) => <SortHeader column={column} label="Display Name" />,
         cell: ({ row }) => (
-          <div className="flex items-center gap-2 font-medium">
-            <Terminal className="h-4 w-4 text-primary shrink-0" />
-            <span>{row.original.display_name || row.original.name}</span>
-          </div>
-        ),
-      },
-      {
-        id: 'target',
-        header: 'Host Target',
-        cell: ({ row }) => (
-          <div className="font-mono text-xs text-steel">
-            {row.original.username}@{row.original.host}:{row.original.port || 22}
+          <div className="flex items-center gap-2">
+            <Terminal className="h-4 w-4 text-steel-soft shrink-0" strokeWidth={1.6} />
+            <div>
+              <div className="font-body text-[13px] font-semibold text-ink">
+                {row.original.display_name || row.original.name}
+              </div>
+              <div className="font-mono text-[11px] text-steel-soft">
+                {row.original.username}@{row.original.host}:{row.original.port || 22}
+              </div>
+            </div>
           </div>
         ),
       },
@@ -112,8 +110,8 @@ export function SSHConnectionsPage() {
         accessorKey: 'auth_method',
         header: 'Auth Method',
         cell: ({ row }) => (
-          <div className="flex items-center gap-1.5 text-xs text-steel">
-            <Key className="h-3.5 w-3.5" />
+          <div className="flex items-center gap-1.5 font-mono text-[12px] text-steel">
+            <Key className="h-3.5 w-3.5" strokeWidth={1.6} />
             <span>{row.original.auth_method || 'Password'}</span>
           </div>
         ),
@@ -124,11 +122,9 @@ export function SSHConnectionsPage() {
         cell: ({ row }) => (
           <div>
             {row.original.host_key_fingerprint ? (
-              <Badge variant="outline" className="text-xs font-mono">
-                Pinned
-              </Badge>
+              <span className="font-mono text-[11px] text-steel">Pinned</span>
             ) : (
-              <span className="text-xs text-steel-soft">Unenrolled</span>
+              <span className="font-mono text-[11px] text-steel-soft">Unenrolled</span>
             )}
           </div>
         ),
@@ -138,16 +134,11 @@ export function SSHConnectionsPage() {
         header: 'Last Test',
         cell: ({ row }) => {
           const status = row.original.last_test_status;
-          if (!status) return <span className="text-xs text-steel-soft">Never tested</span>;
-          return status === 'Success' ? (
-            <div className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
-              <CheckCircle2 className="h-3.5 w-3.5" />
-              <span>Success</span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1 text-xs text-rose-600 dark:text-rose-400">
-              <XCircle className="h-3.5 w-3.5" />
-              <span>Failed</span>
+          if (!status) return <span className="font-mono text-[11px] text-steel-soft">Never tested</span>;
+          return (
+            <div className="flex items-center gap-2">
+              <StatusDot variant={status === 'Success' ? 'ok' : 'fail'} />
+              <span className="font-body text-[13px] text-steel">{status}</span>
             </div>
           );
         },
@@ -156,25 +147,19 @@ export function SSHConnectionsPage() {
         accessorKey: 'enabled',
         header: 'Status',
         cell: ({ row }) => (
-          <Badge variant={getStatusVariant(row.original.enabled)}>
-            {row.original.enabled === 1 ? 'Enabled' : 'Disabled'}
-          </Badge>
+          <div className="flex items-center gap-2">
+            <StatusDot variant={row.original.enabled === 1 ? 'ok' : 'idle'} />
+            <span className="font-body text-[13px] text-steel">
+              {row.original.enabled === 1 ? 'Enabled' : 'Disabled'}
+            </span>
+          </div>
         ),
       },
       {
         id: 'modified',
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
-            className="h-8 px-2"
-          >
-            Modified
-            <ArrowUpDown className="ml-2 h-4 w-4" />
-          </Button>
-        ),
+        header: ({ column }) => <SortHeader column={column} label="Modified" />,
         cell: ({ row }) => (
-          <div className="text-sm text-steel">{formatTimeAgo(row.original.modified ?? null)}</div>
+          <div className="font-mono text-[12px] text-steel">{formatTimeAgo(row.original.modified ?? null)}</div>
         ),
         sortingFn: (rowA, rowB) => {
           const timeA = rowA.original.modified ? new Date(rowA.original.modified).getTime() : 0;
@@ -203,6 +188,7 @@ export function SSHConnectionsPage() {
 
   return (
     <PageLayout
+      title="SSH Connections"
       subtitle="Manage remote SSH host credentials, keys, and connection policies."
       filters={
         <FilterBar
@@ -228,7 +214,7 @@ export function SSHConnectionsPage() {
             <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
           </div>
         ) : (
-          <div className="overflow-hidden rounded-none border">
+          <div className="border border-line bg-panel">
             <Table>
               <TableHeader>
                 {table.getHeaderGroups().map((headerGroup) => (

--- a/frontend/src/pages/SkillsPage.tsx
+++ b/frontend/src/pages/SkillsPage.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../components/ui/alert-dialog';
-import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton } from '../components/dashboard';
+import { PageLayout, FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { ExperimentalBadge } from '../components/common/ExperimentalBadge';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getSkills, deleteSkill, updateSkill } from '../services/skillApi';
@@ -171,9 +171,12 @@ export function SkillsPage() {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          <div className="text-center py-12">
-            <p className="text-muted-foreground mb-4">No skills found.</p>
-          </div>
+          <EmptyState
+            icon={Sparkles}
+            title="No skills"
+            description="Create a skill to get started."
+            action={{ label: 'New skill', onClick: () => navigate('/skills/new') }}
+          />
         }
         renderItem={(skill) => (
           <ItemCard

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { UserPlus, ChevronDown } from 'lucide-react';
+import { UserPlus, ChevronDown, Users } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   getUsers,
@@ -15,7 +15,7 @@ import { getFrappeErrorMessage } from '@/lib/frappe-error';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { PageLayout, FilterBar } from '@/components/dashboard';
+import { PageLayout, FilterBar, EmptyState } from '@/components/dashboard';
 import { Switch } from '@/components/ui/switch';
 import {
   Table,
@@ -269,9 +269,14 @@ export default function UsersPage() {
       {loading ? (
         <div className="text-sm font-body text-steel-soft py-12 text-center">Loading…</div>
       ) : filteredUsers.length === 0 ? (
-        <div className="text-sm font-body text-steel-soft py-12 text-center">No users found.</div>
+        <EmptyState
+          icon={Users}
+          title="No users"
+          description="Invite a user to give them access to Huf."
+          action={{ label: 'Invite user', onClick: () => setShowInvite(true) }}
+        />
       ) : (
-        <div className="overflow-x-auto rounded-none border">
+        <div className="overflow-x-auto border border-line bg-panel">
           <Table className="w-full min-w-[32rem] table-fixed text-sm">
             <TableHeader className="bg-paper-deep/50">
               <TableRow>


### PR DESCRIPTION
- Adds a reusable `EmptyState` component using design-system v2 tokens.
- Replaces ad-hoc empty-state text across grid and table list pages.
- Makes empty states span the full list content width instead of floating as a narrow centered card.
- Wraps table lists consistently in `border-line bg-panel` panels.

Bench build passes.