### PR TITLE
fix(auth): confirm dead session before signing out on 403 'not whitelisted'

### DIFF
--- a/frontend/src/lib/frappe-sdk.ts
+++ b/frontend/src/lib/frappe-sdk.ts
@@ -1,6 +1,6 @@
 import { FrappeApp } from 'frappe-js-sdk';
 import { createCsrfRetryHandler } from './csrfRetryInterceptor';
-import { isSessionInvalidatedError, notifySessionInvalidated } from './sessionInvalidation';
+import { createSessionInvalidationHandler } from './sessionInvalidation';
 
 // Initialize Frappe App instance
 const frappeUrl = import.meta.env.VITE_FRAPPE_URL || window.location.origin;
@@ -17,17 +17,12 @@ frappe.axios.interceptors.response.use((response) => response, createCsrfRetryHa
 /**
  * A session that's genuinely gone (see sessionInvalidation.ts) surfaces
  * identically to a one-off feature-permission denial - "Function X is not
- * whitelisted" - on whichever API call happens to notice it first. Route
- * that straight to a clean, immediate sign-out instead of letting each page
- * show its own confusing "permission denied" toast for what is actually a
- * dead session.
+ * whitelisted" - on whichever API call happens to notice it first. We confirm
+ * the session is actually dead with a lightweight token request before
+ * triggering a logout, so transient blips (cold worker, cache clear, cookie
+ * race) don't sign the user out of an otherwise valid session.
  */
 frappe.axios.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (isSessionInvalidatedError(error)) {
-      notifySessionInvalidated();
-    }
-    return Promise.reject(error);
-  },
+  createSessionInvalidationHandler(frappe.axios),
 );

--- a/frontend/src/lib/sessionInvalidation.test.ts
+++ b/frontend/src/lib/sessionInvalidation.test.ts
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AxiosError } from 'axios';
 
-import { isSessionInvalidatedError } from './sessionInvalidation';
-
 function makeError(status: number, exception?: string): AxiosError<{ exception?: string }> {
   return {
     isAxiosError: true,
@@ -21,24 +19,32 @@ function makeError(status: number, exception?: string): AxiosError<{ exception?:
 }
 
 describe('isSessionInvalidatedError', () => {
-  it('matches the exact "is not whitelisted" 403 signature', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('matches the exact "is not whitelisted" 403 signature', async () => {
+    const mod = await import('./sessionInvalidation');
     const error = makeError(403, 'frappe.exceptions.PermissionError: Function foo.bar is not whitelisted.');
-    expect(isSessionInvalidatedError(error)).toBe(true);
+    expect(mod.isSessionInvalidatedError(error)).toBe(true);
   });
 
-  it('does not match a real capability-denial 403 with a different message', () => {
+  it('does not match a real capability-denial 403 with a different message', async () => {
+    const mod = await import('./sessionInvalidation');
     const error = makeError(403, 'frappe.exceptions.PermissionError: Insufficient Permission for Agent');
-    expect(isSessionInvalidatedError(error)).toBe(false);
+    expect(mod.isSessionInvalidatedError(error)).toBe(false);
   });
 
-  it('does not match a non-403 status', () => {
+  it('does not match a non-403 status', async () => {
+    const mod = await import('./sessionInvalidation');
     const error = makeError(400, 'Function foo.bar is not whitelisted.');
-    expect(isSessionInvalidatedError(error)).toBe(false);
+    expect(mod.isSessionInvalidatedError(error)).toBe(false);
   });
 
-  it('does not match a 403 with no exception field', () => {
+  it('does not match a 403 with no exception field', async () => {
+    const mod = await import('./sessionInvalidation');
     const error = makeError(403, undefined);
-    expect(isSessionInvalidatedError(error)).toBe(false);
+    expect(mod.isSessionInvalidatedError(error)).toBe(false);
   });
 });
 
@@ -63,5 +69,79 @@ describe('notifySessionInvalidated', () => {
     mod.notifySessionInvalidated();
     mod.notifySessionInvalidated();
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createSessionInvalidationHandler', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('does not notify logout when the confirmation call succeeds (transient 403)', async () => {
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+
+    const axiosInstance = {
+      get: vi.fn().mockResolvedValue({ data: { message: 'fresh-token' } }),
+    } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
+
+    const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
+    const error = makeError(403, 'frappe.exceptions.PermissionError: Function foo.bar is not whitelisted.');
+    await expect(interceptor(error)).rejects.toBe(error);
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      '/api/method/huf.ai.session_api.get_csrf_token',
+      expect.objectContaining({ _sessionCheck: true }),
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('notifies logout when both the original and confirmation call fail', async () => {
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+
+    const axiosInstance = {
+      get: vi.fn().mockRejectedValue(new Error('session dead')),
+    } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
+
+    const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
+    const error = makeError(403, 'frappe.exceptions.PermissionError: Function foo.bar is not whitelisted.');
+    await expect(interceptor(error)).rejects.toBe(error);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-session 403 errors', async () => {
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+
+    const axiosInstance = { get: vi.fn() } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
+    const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
+
+    const error = makeError(403, 'frappe.exceptions.PermissionError: Insufficient Permission for Agent');
+    await expect(interceptor(error)).rejects.toBe(error);
+
+    expect(axiosInstance.get).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not run confirmation for the confirmation request itself', async () => {
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+
+    const axiosInstance = { get: vi.fn() } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
+    const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
+
+    const error = makeError(403, 'frappe.exceptions.PermissionError: Function foo.bar is not whitelisted.');
+    (error.config as { _sessionCheck?: boolean }) = { _sessionCheck: true };
+
+    await expect(interceptor(error)).rejects.toBe(error);
+
+    expect(axiosInstance.get).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/sessionInvalidation.ts
+++ b/frontend/src/lib/sessionInvalidation.ts
@@ -1,4 +1,4 @@
-import type { AxiosError } from 'axios';
+import type { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 
 /**
  * Frappe's is_whitelisted() throws this exact text whenever
@@ -6,12 +6,11 @@ import type { AxiosError } from 'axios';
  * both branches produce the identical "Function X is not whitelisted"
  * message. For any endpoint this build actually calls, "not registered" is
  * not a real possibility (it would fail on every request, not
- * intermittently) - so in practice this signature means the session
- * resolved to Guest for this specific request. Unlike a normal capability
- * denial (a different message, e.g. "Insufficient Permission for X" or a
+ * intermittently) - so in practice this signature means the session resolved
+ * to Guest for this specific request. Unlike a normal capability denial (a
+ * different message, e.g. "Insufficient Permission for X" or a
  * huf.permissions "not permitted" string), this means the session itself is
- * gone, not that one feature is unavailable - see
- * Tracks/safwan-erooth.AuthDebug/FINDINGS.md ("Bug C") in the workspace repo.
+ * gone, not that one feature is unavailable.
  */
 const NOT_WHITELISTED_PATTERN = /is not whitelisted/i;
 
@@ -38,4 +37,54 @@ export function notifySessionInvalidated(): void {
   if (notified) return;
   notified = true;
   handler?.();
+}
+
+interface SessionCheckRequestConfig extends InternalAxiosRequestConfig {
+  _sessionCheck?: boolean;
+}
+
+/**
+ * Create an axios response interceptor that detects the dead-session
+ * signature (403 + "is not whitelisted") and confirms it before logging the
+ * user out.
+ *
+ * A single request can hit this signature transiently: cold worker, cache
+ * clear, or a brief race where one request is processed before the session
+ * cookie is fully established. In those cases the session cookie is still
+ * valid, so forcing a logout is destructive. We make one lightweight
+ * confirmation call (bypassing this interceptor via `_sessionCheck`) and only
+ * trigger the global logout if that call also fails.
+ */
+export function createSessionInvalidationHandler(axiosInstance: AxiosInstance) {
+  let checking = false;
+
+  const confirmSessionInvalidated = async (): Promise<boolean> => {
+    if (checking) return true; // another request is already confirming; treat as dead for now
+    checking = true;
+    try {
+      await axiosInstance.get('/api/method/huf.ai.session_api.get_csrf_token', {
+        _sessionCheck: true,
+      } as SessionCheckRequestConfig);
+      // Token endpoint succeeded -> session is alive; the 403 was transient.
+      return false;
+    } catch {
+      // Confirmation also failed -> session is genuinely gone.
+      return true;
+    } finally {
+      checking = false;
+    }
+  };
+
+  return async (error: AxiosError<{ exception?: string }>) => {
+    const config = error.config as SessionCheckRequestConfig | undefined;
+
+    if (isSessionInvalidatedError(error) && !config?._sessionCheck) {
+      const isReallyDead = await confirmSessionInvalidated();
+      if (isReallyDead) {
+        notifySessionInvalidated();
+      }
+    }
+
+    return Promise.reject(error);
+  };
 }


### PR DESCRIPTION
## Problem
A 403 + "Function X is not whitelisted" was treated as an immediate logout. In practice this signature also appears for transient issues (cold worker, cache clear, cookie race), so users were being signed out during normal console usage.

## Change
Before triggering the global session-invalidated redirect, the frontend now confirms the session is actually dead by calling the already-whitelisted `huf.ai.session_api.get_csrf_token` endpoint.

- If the confirmation succeeds → session is alive, stay logged in.
- If the confirmation also fails → session is genuinely gone, trigger logout.

## Files changed
- `frontend/src/lib/sessionInvalidation.ts` — adds `createSessionInvalidationHandler(axiosInstance)` with a `_sessionCheck` bypass.
- `frontend/src/lib/frappe-sdk.ts` — wires the new handler into the axios response interceptor.
- `frontend/src/lib/sessionInvalidation.test.ts` — adds unit tests for transient, genuine, non-session, and recursive cases.

## Verification
- `npx vitest run src/lib/sessionInvalidation.test.ts` ✅ (10 tests)
- `npm run typecheck` ✅
- `npm run build` ✅

## Related
This blocks the console prompt work in #557; once merged, selecting providers in the console should no longer log the user out.