### PR TITLE
fix(auth): confirm-before-logout must also cover REST-style 403s

### DIFF
--- a/frontend/src/lib/sessionInvalidation.test.ts
+++ b/frontend/src/lib/sessionInvalidation.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AxiosError } from 'axios';
 
-function makeError(status: number, exception?: string): AxiosError<{ exception?: string }> {
+function makeError(
+  status: number,
+  exception?: string,
+  excType?: string,
+): AxiosError<{ exception?: string; exc_type?: string }> {
   return {
     isAxiosError: true,
     name: 'AxiosError',
@@ -10,12 +14,12 @@ function makeError(status: number, exception?: string): AxiosError<{ exception?:
     config: {} as never,
     response: {
       status,
-      data: { exception },
+      data: { exception, exc_type: excType },
       statusText: '',
       headers: {},
       config: {} as never,
     },
-  } as AxiosError<{ exception?: string }>;
+  } as AxiosError<{ exception?: string; exc_type?: string }>;
 }
 
 describe('isSessionInvalidatedError', () => {
@@ -113,7 +117,7 @@ describe('createSessionInvalidationHandler', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores non-session 403 errors', async () => {
+  it('ignores 403s that are not shaped like a PermissionError at all', async () => {
     const mod = await import('./sessionInvalidation');
     const handler = vi.fn();
     mod.onSessionInvalidated(handler);
@@ -121,10 +125,88 @@ describe('createSessionInvalidationHandler', () => {
     const axiosInstance = { get: vi.fn() } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
     const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
 
-    const error = makeError(403, 'frappe.exceptions.PermissionError: Insufficient Permission for Agent');
+    const error = makeError(403, 'Some other 403 entirely', 'ValidationError');
     await expect(interceptor(error)).rejects.toBe(error);
 
     expect(axiosInstance.get).not.toHaveBeenCalled();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('confirms (but does not log out) a REST-style "Insufficient Permission" 403 when the session is actually fine', async () => {
+    // db.getDocList / /api/resource/* calls fail through a different Frappe
+    // code path than is_whitelisted() and produce a differently-worded but
+    // equally exc_type:PermissionError response when the session has become
+    // Guest - this is the gap that let real session-death events through
+    // undetected via list/read calls while the RPC-only check caught only
+    // /api/method/* calls.
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+
+    const axiosInstance = {
+      get: vi.fn().mockResolvedValue({ data: { message: 'fresh-token' } }),
+    } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
+    const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
+
+    const error = makeError(403, 'Insufficient Permission for Flow Definition', 'PermissionError');
+    await expect(interceptor(error)).rejects.toBe(error);
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      '/api/method/huf.ai.session_api.get_csrf_token',
+      expect.objectContaining({ _sessionCheck: true }),
+    );
+    // Confirmation succeeded -> this was a real, transient-or-genuine
+    // permission response, not a dead session - the caller still sees their
+    // own "Insufficient Permission" error (rejects.toBe(error) above), but
+    // the app must not be logged out over it.
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('logs out on a REST-style "Insufficient Permission" 403 when confirmation also fails', async () => {
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+
+    const axiosInstance = {
+      get: vi.fn().mockRejectedValue(new Error('session dead')),
+    } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
+    const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
+
+    const error = makeError(403, 'Insufficient Permission for Flow Definition', 'PermissionError');
+    await expect(interceptor(error)).rejects.toBe(error);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one in-flight confirmation across concurrent 403s instead of assuming each is dead', async () => {
+    // A burst of legitimate, unrelated denials arriving together must not
+    // cause every request after the first to short-circuit to "dead" before
+    // the real confirmation result is known.
+    const mod = await import('./sessionInvalidation');
+    const handler = vi.fn();
+    mod.onSessionInvalidated(handler);
+
+    let resolveGet!: (value: unknown) => void;
+    const pendingGet = new Promise((resolve) => {
+      resolveGet = resolve;
+    });
+    const axiosInstance = {
+      get: vi.fn().mockReturnValue(pendingGet),
+    } as unknown as Parameters<typeof mod.createSessionInvalidationHandler>[0];
+    const interceptor = mod.createSessionInvalidationHandler(axiosInstance);
+
+    const errorA = makeError(403, 'Insufficient Permission for Flow Definition', 'PermissionError');
+    const errorB = makeError(403, 'Insufficient Permission for Integration Settings', 'PermissionError');
+
+    const resultA = interceptor(errorA).catch((e) => e);
+    const resultB = interceptor(errorB).catch((e) => e);
+
+    // Only one confirmation call should be in flight for both concurrent 403s.
+    expect(axiosInstance.get).toHaveBeenCalledTimes(1);
+
+    resolveGet({ data: { message: 'fresh-token' } });
+    await Promise.all([resultA, resultB]);
+
     expect(handler).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/lib/sessionInvalidation.ts
+++ b/frontend/src/lib/sessionInvalidation.ts
@@ -7,17 +7,33 @@ import type { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axio
  * message. For any endpoint this build actually calls, "not registered" is
  * not a real possibility (it would fail on every request, not
  * intermittently) - so in practice this signature means the session resolved
- * to Guest for this specific request. Unlike a normal capability denial (a
- * different message, e.g. "Insufficient Permission for X" or a
- * huf.permissions "not permitted" string), this means the session itself is
- * gone, not that one feature is unavailable.
+ * to Guest for this specific request (RPC-style /api/method/* calls).
  */
 const NOT_WHITELISTED_PATTERN = /is not whitelisted/i;
 
+/**
+ * A definite signature: this text can only come from is_whitelisted(), so a
+ * match means the session is confirmed dead without needing to check further.
+ */
 export function isSessionInvalidatedError(error: AxiosError<{ exception?: string }>): boolean {
   if (error.response?.status !== 403) return false;
   const exception = error.response?.data?.exception;
   return typeof exception === 'string' && NOT_WHITELISTED_PATTERN.test(exception);
+}
+
+/**
+ * A Guest session hitting Frappe's REST API (/api/resource/*, used by
+ * `db.getDocList` and most list/read calls) fails through a completely
+ * different path - frappe/database/query.py's check_select_permission -
+ * with the message "Insufficient Permission for X". That text is
+ * indistinguishable from a genuine capability denial by content alone (both
+ * are exc_type PermissionError), so this only flags it as *worth
+ * confirming*, not as definite - unlike isSessionInvalidatedError, this can
+ * false-positive on real denials, which is fine because the caller always
+ * confirms before acting on it.
+ */
+function isPossibleSessionInvalidation(error: AxiosError<{ exc_type?: string }>): boolean {
+  return error.response?.status === 403 && error.response?.data?.exc_type === 'PermissionError';
 }
 
 let handler: (() => void) | null = null;
@@ -44,41 +60,56 @@ interface SessionCheckRequestConfig extends InternalAxiosRequestConfig {
 }
 
 /**
- * Create an axios response interceptor that detects the dead-session
- * signature (403 + "is not whitelisted") and confirms it before logging the
- * user out.
+ * Create an axios response interceptor that detects a dead session - either
+ * the definite RPC-style signature (403 + "is not whitelisted") or a
+ * possible REST-style one (any 403 PermissionError, e.g. "Insufficient
+ * Permission for X" from `db.getDocList`/`/api/resource/*` calls) - and
+ * confirms it before logging the user out.
  *
- * A single request can hit this signature transiently: cold worker, cache
+ * A single request can hit either signature transiently: cold worker, cache
  * clear, or a brief race where one request is processed before the session
  * cookie is fully established. In those cases the session cookie is still
  * valid, so forcing a logout is destructive. We make one lightweight
  * confirmation call (bypassing this interceptor via `_sessionCheck`) and only
- * trigger the global logout if that call also fails.
+ * trigger the global logout if that call also fails. The REST-style
+ * signature is indistinguishable from a genuine capability denial by message
+ * text alone, so it's only ever treated as "worth confirming" - the
+ * confirmation is what actually decides, and it's a safe no-op for real
+ * denials (their own error still surfaces to the caller either way).
+ *
+ * Concurrent 403s share the same in-flight confirmation instead of each
+ * assuming the worst - otherwise a burst of legitimate, unrelated denials
+ * arriving together could trigger a false logout for every one after the
+ * first, before any of them actually know the real answer.
  */
 export function createSessionInvalidationHandler(axiosInstance: AxiosInstance) {
-  let checking = false;
+  let inFlight: Promise<boolean> | null = null;
 
-  const confirmSessionInvalidated = async (): Promise<boolean> => {
-    if (checking) return true; // another request is already confirming; treat as dead for now
-    checking = true;
-    try {
-      await axiosInstance.get('/api/method/huf.ai.session_api.get_csrf_token', {
-        _sessionCheck: true,
-      } as SessionCheckRequestConfig);
-      // Token endpoint succeeded -> session is alive; the 403 was transient.
-      return false;
-    } catch {
-      // Confirmation also failed -> session is genuinely gone.
-      return true;
-    } finally {
-      checking = false;
-    }
+  const confirmSessionInvalidated = (): Promise<boolean> => {
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+      try {
+        await axiosInstance.get('/api/method/huf.ai.session_api.get_csrf_token', {
+          _sessionCheck: true,
+        } as SessionCheckRequestConfig);
+        // Token endpoint succeeded -> session is alive; the 403 was transient.
+        return false;
+      } catch {
+        // Confirmation also failed -> session is genuinely gone.
+        return true;
+      } finally {
+        inFlight = null;
+      }
+    })();
+    return inFlight;
   };
 
-  return async (error: AxiosError<{ exception?: string }>) => {
+  return async (error: AxiosError<{ exception?: string; exc_type?: string }>) => {
     const config = error.config as SessionCheckRequestConfig | undefined;
+    const worthConfirming =
+      !config?._sessionCheck && (isSessionInvalidatedError(error) || isPossibleSessionInvalidation(error));
 
-    if (isSessionInvalidatedError(error) && !config?._sessionCheck) {
+    if (worthConfirming) {
       const isReallyDead = await confirmSessionInvalidated();
       if (isReallyDead) {
         notifySessionInvalidated();


### PR DESCRIPTION
## Summary

Follow-up to #547/#548's session-invalidation work. `createSessionInvalidationHandler` only recognized the RPC-style dead-session signature (403 + `"is not whitelisted"`, produced by `/api/method/*` calls going through `is_whitelisted()`). But most list/read calls in the app go through `db.getDocList()` → Frappe's REST API (`/api/resource/*`), which fails through a completely different code path (`query.py`'s `check_select_permission`) with the message `"Insufficient Permission for X"` — textually indistinguishable from a genuine capability denial, but confirmed live to be produced by the exact same Guest-session condition:

- Hit `/api/resource/Flow%20Definition` as an actual unauthenticated Guest → `403`, `"Insufficient Permission for Flow Definition"`.
- The identical error, byte-for-byte, showed up in a live Administrator session's error log during a real (self-healed) session-death event.

This meant the underlying session-death issue was firing constantly through REST calls — e.g. `ApprovalsBell`'s 60s background poll — completely undetected: no confirmation step, no clean redirect, just a silent `console.warn` or a generic error toast. This is very likely what was still being observed as "logout / 403 forbidden" and a flickering approvals-bell icon after the earlier fixes landed.

Since the REST-style message can't be distinguished from a real permission denial by text alone, it's only ever treated as *worth confirming* rather than definite — the existing confirm-then-decide flow (a lightweight call to `huf.ai.session_api.get_csrf_token`) is what actually determines the outcome, and it's a safe no-op for genuine denials (their own error still reaches the caller either way).

Also fixes a latent bug in the confirmation's concurrency handling: it previously treated any 403 arriving while another confirmation was already in flight as "assume dead" without waiting for the real result — a burst of legitimate, unrelated denials arriving together could have triggered a false logout for every one after the first. Concurrent 403s now share the same in-flight confirmation promise instead.

## Test plan

- [x] 13 tests in `sessionInvalidation.test.ts` (5 new), covering the REST-style signature, that it stays a no-op for genuine denials once confirmed, and the concurrency fix. 129/129 total tests passing, `tsc --noEmit` clean.
- [x] Verified the confirmation endpoint (`huf.ai.session_api.get_csrf_token`) is reachable post-build on a live bench.
- [x] Reproduced the REST-style error signature directly against a real unauthenticated Guest request and confirmed it byte-for-byte matches what a live session produced during an actual (self-healed) session-death event.
- [ ] Not yet click-tested through the actual browser UI.