### PR TITLE
fix(seed): use AI models with correct modalities in Hub Orchestrator seed

### DIFF
--- a/huf/huf/agents/hub-orchestrator.json
+++ b/huf/huf/agents/hub-orchestrator.json
@@ -26,6 +26,6 @@
   "agent_color": "#0EA5E9",
   "allow_file_upload": 1,
   "image_generation_model": "nano-banana-pro",
-  "tts_model": "gemini-3.1-flash-lite",
-  "audio_transcription_model": "gemini-3.1-flash-lite"
+  "tts_model": "gemini-3.1-flash-tts-preview",
+  "audio_transcription_model": "gpt-4o-mini-transcribe"
 }


### PR DESCRIPTION
The Hub Orchestrator seed used `gemini-3.1-flash-lite` as both TTS and audio transcription model, which only has Text/Vision modalities. This caused Agent validation to fail during `after_migrate`, so the Hub Orchestrator was never created on production.

Use `gemini-3.1-flash-tts-preview` (Text-to-Speech) and `gpt-4o-mini-transcribe` (Transcription), matching the demo models created by `create_demo_ai_models`.