### PR TITLE
feat: restore approval inbox with safe custom API

### DIFF
--- a/huf/ai/flow_api.py
+++ b/huf/ai/flow_api.py
@@ -283,8 +283,7 @@ def approve_flow_run(flow_run_id: str, comment: str | None = None) -> dict:
 	Returns:
 	    dict with status and current_node_id
 	"""
-	if not frappe.has_permission("Flow Run", "read"):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
+	_verify_pending_approval_permission(flow_run_id)
 
 	from huf.ai.flow_engine import approve_flow_run as engine_approve
 
@@ -310,8 +309,7 @@ def reject_flow_run(flow_run_id: str, comment: str | None = None) -> dict:
 	Returns:
 	    dict with status and current_node_id
 	"""
-	if not frappe.has_permission("Flow Run", "write"):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
+	_verify_pending_approval_permission(flow_run_id)
 
 	from huf.ai.flow_engine import approve_flow_run as engine_approve
 
@@ -323,6 +321,48 @@ def reject_flow_run(flow_run_id: str, comment: str | None = None) -> dict:
 		"status": doc.status,
 		"current_node_id": doc.current_node_id,
 	}
+
+
+def _verify_pending_approval_permission(flow_run_id: str):
+	"""Verify the current user is allowed to act on the pending flow approval."""
+	user = frappe.session.user
+	pending = frappe.get_all(
+		"Pending Approval",
+		filters={
+			"reference_doctype": "Flow Run",
+			"reference_name": flow_run_id,
+			"status": "Pending",
+		},
+		fields=["name", "approval_type", "approver_role", "approver_user", "approver_users"],
+	)
+
+	if not pending:
+		# Fallback for in-flight approvals created before the Pending Approval DocType existed.
+		flow_run = frappe.get_doc("Flow Run", flow_run_id)
+		if flow_run.status != "Waiting Approval":
+			frappe.throw(_("Flow Run is not waiting for approval"), frappe.PermissionError)
+		from huf.ai.flow_engine import _verify_approval_permission
+		_verify_approval_permission(json.loads(flow_run.waiting or "{}"))
+		return
+
+	approval = pending[0]
+	approval_type = approval.approval_type or "role"
+
+	if approval_type == "role":
+		role = approval.approver_role
+		if role and role in frappe.get_roles(user):
+			return
+	elif approval_type == "user":
+		if approval.approver_user and approval.approver_user == user:
+			return
+	elif approval_type == "users":
+		users = approval.approver_users or ""
+		if isinstance(users, str):
+			users = [u.strip() for u in users.split(",") if u.strip()]
+		if user in users:
+			return
+
+	frappe.throw(_("Not permitted"), frappe.PermissionError)
 
 
 # ---------------------------------------------------------------------------
@@ -1103,86 +1143,87 @@ def handle_approve_flow_run(flow_run_id: str, decision: str = "approved", commen
 # ---------------------------------------------------------------------------
 
 
-# TEMPORARILY DISABLED (2026-08-02):
-# get_pending_approvals returns 403 even for Administrator, so the Approval
-# Inbox bell is disabled until the permission check is fixed/replaced.
-# See UnifiedHeader.tsx and ApprovalsBell.tsx for the related UI removal.
-# ---------------------------------------------------------------------------
-# @frappe.whitelist()
-# def get_pending_approvals(limit: int = 50) -> list:
-# 	"""
-# 	Get list of flow runs waiting for approval that the current user can approve.
-# 	
-# 	This endpoint is used by the Approval Inbox feature to show users
-# 	all pending approvals that require their attention.
-# 	
-# 	Args:
-# 	    limit: Maximum number of results (default 50)
-# 	
-# 	Returns:
-# 	    list of pending approval items with flow details
-# 	"""
-# 	if not frappe.has_permission("Flow Run", "read"):
-# 		frappe.throw(_("Not permitted"), frappe.PermissionError)
-# 
-# 	user = frappe.session.user
-# 	user_roles = set(frappe.get_roles(user))
-# 
-# 	# Get all flow runs waiting for approval
-# 	pending_runs = frappe.get_all(
-# 		"Flow Run",
-# 		filters={"status": "Waiting Approval"},
-# 		fields=[
-# 			"name",
-# 			"flow_id",
-# 			"flow_version",
-# 			"current_node_id",
-# 			"status",
-# 			"waiting",
-# 			"started_at",
-# 			"modified",
-# 		],
-# 		order_by="modified desc",
-# 		limit_page_length=limit,
-# 	)
-# 
-# 	results = []
-# 
-# 	for run in pending_runs:
-# 		try:
-# 			waiting = json.loads(run.waiting) if run.waiting else {}
-# 		except (json.JSONDecodeError, TypeError):
-# 			waiting = {}
-# 
-# 		approval_type = waiting.get("approval_type", "role")
-# 		can_approve = False
-# 
-# 		# Check if current user can approve this flow run
-# 		if approval_type == "role":
-# 			approver_role = waiting.get("approver_role")
-# 			if approver_role and approver_role in user_roles:
-# 				can_approve = True
-# 		elif approval_type in ("user", "users"):
-# 			approver_users = waiting.get("approver_users", [])
-# 			if isinstance(approver_users, str):
-# 				approver_users = [u.strip() for u in approver_users.split(",") if u.strip()]
-# 			if user in approver_users:
-# 				can_approve = True
-# 
-# 		if can_approve:
-# 			results.append({
-# 				"flow_run_id": run.name,
-# 				"flow_id": run.flow_id,
-# 				"flow_version": run.flow_version,
-# 				"current_node_id": run.current_node_id,
-# 				"title": waiting.get("title", "Approval Required"),
-# 				"instructions": waiting.get("instructions", ""),
-# 				"approval_type": approval_type,
-# 				"approver_role": waiting.get("approver_role"),
-# 				"approver_users": waiting.get("approver_users", []),
-# 				"started_at": str(run.started_at) if run.started_at else None,
-# 				"waiting_since": str(run.modified) if run.modified else None,
-# 				"view_link": f"/huf/flows/{run.flow_id}?run={run.name}",
-# 			})
-# 
-# 	return results
+@frappe.whitelist()
+def get_pending_approvals(limit: int = 50) -> list:
+	"""
+	Get list of pending approvals that the current user can act on.
+
+	This endpoint is used by the Approval Inbox feature to show users
+	all pending approvals that require their attention.
+
+	Args:
+	    limit: Maximum number of results (default 50)
+
+	Returns:
+	    list of pending approval items with flow details
+	"""
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.PermissionError)
+
+	# The Pending Approval DocType uses a permission_query_conditions hook
+	# (huf.huf.doctype.pending_approval.pending_approval.get_permission_query_conditions)
+	# to scope list queries to records where the current user is a designated approver.
+	pending = frappe.get_all(
+		"Pending Approval",
+		filters={"status": "Pending"},
+		fields=[
+			"name",
+			"reference_name",
+			"reference_link",
+			"feature",
+			"flow_id",
+			"current_node_id",
+			"title",
+			"instructions",
+			"approval_type",
+			"approver_role",
+			"approver_user",
+			"approver_users",
+			"creation",
+			"modified",
+		],
+		order_by="modified desc",
+		limit_page_length=limit,
+	)
+
+	results = []
+	user = frappe.session.user
+	user_roles = set(frappe.get_roles(user))
+
+	for approval in pending:
+		approval_type = approval.approval_type or "role"
+		can_approve = False
+		returned_users = []
+
+		if approval_type == "role":
+			role = approval.approver_role
+			if role and role in user_roles:
+				can_approve = True
+		elif approval_type == "user":
+			if approval.approver_user and approval.approver_user == user:
+				can_approve = True
+		elif approval_type == "users":
+			approver_users = approval.approver_users or ""
+			if isinstance(approver_users, str):
+				approver_users = [u.strip() for u in approver_users.split(",") if u.strip()]
+			if user in approver_users:
+				can_approve = True
+				returned_users = approver_users
+
+		if can_approve:
+			results.append({
+				"flow_run_id": approval.reference_name,
+				"flow_id": approval.flow_id,
+				"flow_version": None,
+				"current_node_id": approval.current_node_id,
+				"title": approval.title or "Approval Required",
+				"instructions": approval.instructions or "",
+				"approval_type": approval_type,
+				"approver_role": approval.approver_role,
+				"approver_users": returned_users,
+				"started_at": str(approval.creation) if approval.creation else None,
+				"waiting_since": str(approval.modified) if approval.modified else None,
+				"view_link": approval.reference_link or f"/huf/flows/{approval.flow_id}?run={approval.reference_name}",
+			})
+
+	return results

--- a/huf/ai/flow_engine.py
+++ b/huf/ai/flow_engine.py
@@ -176,7 +176,10 @@ def resume_flow_run(flow_run_name: str, user_input: dict | None = None):
 		flow_run.db_set("context_json", json.dumps(ctx, default=str))
 
 	# Clear waiting state
+	was_waiting_approval = flow_run.status == "Waiting Approval"
 	flow_run.db_set({"waiting": None, "status": "Running"})
+	if was_waiting_approval:
+		_close_pending_approvals_for_flow_run(flow_run, status="Expired")
 	commit_if_background()
 
 	# Continue execution
@@ -200,7 +203,22 @@ def approve_flow_run(flow_run_name: str, decision: str, comment: str | None = No
 
 	# Verify current user has approval permissions
 	waiting = json.loads(flow_run.waiting) if flow_run.waiting else {}
-	_verify_approval_permission(waiting)
+	pending_approval_name = waiting.get("pending_approval")
+
+	if pending_approval_name:
+		pending_approval = frappe.get_doc("Pending Approval", pending_approval_name)
+		if not pending_approval._user_can_see(frappe.session.user):
+			frappe.throw(
+				_("You are not authorized to approve this flow run"),
+				frappe.PermissionError,
+			)
+		# Record decision on the Pending Approval document.
+		pending_approval._record_decision(
+			"Approved" if decision == "approved" else "Rejected", comment
+		)
+	else:
+		# Fallback for in-flight approvals created before the Pending Approval DocType existed.
+		_verify_approval_permission(waiting)
 
 	# Store decision in context
 	ctx = _load_context(flow_run)
@@ -782,6 +800,11 @@ def _exec_human_approval(flow_run, node: dict, config: dict, settings: dict) -> 
 		"store_decision_in_context": config.get("store_decision_in_context", "approval"),
 	}
 
+	# Create a Pending Approval record for the universal approval inbox.
+	# We store its name in waiting_data so approve/reject can close it.
+	pending_approval = _create_pending_approval_for_flow_run(flow_run, node, config, waiting_data)
+	waiting_data["pending_approval"] = pending_approval.name
+
 	flow_run.db_set(
 		{
 			"status": "Waiting Approval",
@@ -794,6 +817,83 @@ def _exec_human_approval(flow_run, node: dict, config: dict, settings: dict) -> 
 	_send_approval_notifications(flow_run, node, config, waiting_data)
 
 	return {"status": "waiting_approval"}
+
+
+def _create_pending_approval_for_flow_run(flow_run, node: dict, config: dict, waiting_data: dict):
+	"""Create a Pending Approval document for a Flow Run approval node."""
+	approval_type = waiting_data.get("approval_type", "role")
+	raw_approver_users = waiting_data.get("approver_users", [])
+	if isinstance(raw_approver_users, str):
+		raw_approver_users = [u.strip() for u in raw_approver_users.split(",") if u.strip()]
+
+	approver_user = None
+	approver_users_str = None
+	if approval_type == "user" and raw_approver_users:
+		approver_user = raw_approver_users[0]
+	elif approval_type == "users":
+		approver_users_str = ", ".join(str(u).strip() for u in raw_approver_users if str(u).strip())
+
+	pa = frappe.get_doc(
+		{
+			"doctype": "Pending Approval",
+			"reference_doctype": "Flow Run",
+			"reference_name": flow_run.name,
+			"reference_link": f"/huf/flows/{flow_run.flow_id}?run={flow_run.name}",
+			"feature": "flow",
+			"flow_id": flow_run.flow_id,
+			"current_node_id": node.get("id"),
+			"title": waiting_data.get("title", "Approval Required"),
+			"instructions": waiting_data.get("instructions", ""),
+			"requester": flow_run.owner,
+			"approval_type": approval_type,
+			"approver_role": waiting_data.get("approver_role") if approval_type == "role" else None,
+			"approver_user": approver_user,
+			"approver_users": approver_users_str,
+			"status": "Pending",
+			"level": 1,
+			"payload": json.dumps(
+				{
+					"node_id": node.get("id"),
+					"context_summary": waiting_data.get("context_summary", ""),
+					"reference_doctype": waiting_data.get("reference_doctype", ""),
+					"reference_name": waiting_data.get("reference_name", ""),
+					"store_decision_in_context": waiting_data.get("store_decision_in_context", "approval"),
+				},
+				default=str,
+			),
+		}
+	)
+	pa.insert(ignore_permissions=True)
+	commit_if_background()
+	return pa
+
+
+def _close_pending_approvals_for_flow_run(flow_run, status: str = "Expired"):
+	"""Mark all still-pending Pending Approval records for a Flow Run as closed."""
+	try:
+		pending = frappe.get_all(
+			"Pending Approval",
+			filters={
+				"reference_doctype": "Flow Run",
+				"reference_name": flow_run.name,
+				"status": "Pending",
+			},
+			pluck="name",
+		)
+		for name in pending:
+			frappe.get_doc("Pending Approval", name).db_set(
+				{
+					"status": status,
+					"actioned_by": frappe.session.user,
+					"actioned_at": now_datetime(),
+				},
+				update_modified=False,
+			)
+		if pending:
+			commit_if_background()
+	except Exception:
+		# Cleanup is best-effort.
+		frappe.log_error(frappe.get_traceback(), "Close Pending Approval Error")
 
 
 def _send_approval_notifications(flow_run, node: dict, config: dict, waiting_data: dict):
@@ -1443,6 +1543,7 @@ def _complete_flow_run(flow_run):
 			"completed_at": now_datetime(),
 		}
 	)
+	_close_pending_approvals_for_flow_run(flow_run, status="Expired")
 	commit_if_background()
 
 
@@ -1455,6 +1556,7 @@ def _fail_flow_run(flow_run, error_msg: str):
 			"completed_at": now_datetime(),
 		}
 	)
+	_close_pending_approvals_for_flow_run(flow_run, status="Expired")
 	commit_if_background()
 	_publish_flow_event(flow_run, "flow_failed", {"error": error_msg})
 

--- a/huf/doctype/pending_approval/pending_approval.json
+++ b/huf/doctype/pending_approval/pending_approval.json
@@ -1,0 +1,211 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-08-02 09:45:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "reference_section",
+  "reference_doctype",
+  "reference_name",
+  "reference_link",
+  "feature",
+  "flow_id",
+  "current_node_id",
+  "approval_section",
+  "title",
+  "instructions",
+  "requester",
+  "approval_type",
+  "approver_role",
+  "approver_user",
+  "approver_users",
+  "level",
+  "due_date",
+  "payload",
+  "decision_section",
+  "status",
+  "actioned_by",
+  "actioned_at",
+  "comment"
+ ],
+ "fields": [
+  {
+   "fieldname": "reference_section",
+   "fieldtype": "Section Break",
+   "label": "Reference"
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Reference DocType"
+  },
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Reference Name"
+  },
+  {
+   "fieldname": "reference_link",
+   "fieldtype": "Data",
+   "label": "Reference Link"
+  },
+  {
+   "fieldname": "feature",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Feature",
+   "description": "E.g. flow, agent, mcp. Used to group approvals by source feature."
+  },
+  {
+   "fieldname": "flow_id",
+   "fieldtype": "Data",
+   "label": "Flow ID",
+   "description": "For flow approvals: the Flow Definition ID."
+  },
+  {
+   "fieldname": "current_node_id",
+   "fieldtype": "Data",
+   "label": "Current Node ID",
+   "description": "For flow approvals: the node that is waiting."
+  },
+  {
+   "fieldname": "approval_section",
+   "fieldtype": "Section Break",
+   "label": "Approval"
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title"
+  },
+  {
+   "fieldname": "instructions",
+   "fieldtype": "Text",
+   "label": "Instructions"
+  },
+  {
+   "fieldname": "requester",
+   "fieldtype": "Link",
+   "label": "Requester",
+   "options": "User"
+  },
+  {
+   "default": "role",
+   "fieldname": "approval_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Approval Type",
+   "options": "role\nuser\nusers"
+  },
+  {
+   "fieldname": "approver_role",
+   "fieldtype": "Link",
+   "label": "Approver Role",
+   "options": "Role"
+  },
+  {
+   "fieldname": "approver_user",
+   "fieldtype": "Link",
+   "label": "Approver User",
+   "options": "User"
+  },
+  {
+   "description": "Comma-separated list of user IDs for multi-user approvals.",
+   "fieldname": "approver_users",
+   "fieldtype": "Data",
+   "label": "Approver Users"
+  },
+  {
+   "default": "1",
+   "fieldname": "level",
+   "fieldtype": "Int",
+   "label": "Level",
+   "description": "For future multi-level approval chains."
+  },
+  {
+   "fieldname": "due_date",
+   "fieldtype": "Datetime",
+   "label": "Due Date"
+  },
+  {
+   "fieldname": "payload",
+   "fieldtype": "JSON",
+   "label": "Payload",
+   "description": "Opaque context needed by the source feature."
+  },
+  {
+   "fieldname": "decision_section",
+   "fieldtype": "Section Break",
+   "label": "Decision"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Pending\nApproved\nRejected\nExpired",
+   "reqd": 1
+  },
+  {
+   "fieldname": "actioned_by",
+   "fieldtype": "Link",
+   "label": "Actioned By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "actioned_at",
+   "fieldtype": "Datetime",
+   "label": "Actioned At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "comment",
+   "fieldtype": "Text",
+   "label": "Comment"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-02 09:45:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Pending Approval",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 0,
+   "print": 1,
+   "read": 1,
+   "report": 0,
+   "role": "All",
+   "share": 0,
+   "write": 0
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/huf/doctype/pending_approval/pending_approval.py
+++ b/huf/doctype/pending_approval/pending_approval.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import get_datetime, now_datetime
+
+
+def get_permission_query_conditions(user=None):
+	"""List-query filter: users only see approvals they are designated to act on."""
+	if not user:
+		user = frappe.session.user
+
+	if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+		return ""
+
+	escaped_user = frappe.db.escape(user)
+	return f"""
+		(
+			`tabPending Approval`.`approver_user` = {escaped_user}
+			OR FIND_IN_SET({escaped_user}, `tabPending Approval`.`approver_users`) > 0
+			OR `tabPending Approval`.`approver_role` IN (
+				SELECT `role` FROM `tabHas Role`
+				WHERE `parenttype` = 'User' AND `parent` = {escaped_user}
+			)
+		)
+	"""
+
+
+class PendingApproval(Document):
+	"""
+	Generic pending approval record.
+
+	Used by the Approval Inbox to surface items a user is allowed to act on,
+	regardless of the source feature (Flow, Agent, MCP, etc.). The DocType
+	permissions allow broad read access so approvers can see their items;
+	actual scoping is enforced by the API methods and by this controller.
+	"""
+
+	def has_permission(self, permission_type=None, verbose=False):
+		user = frappe.session.user
+
+		# System-level users have full access.
+		if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+			return True
+
+		# Read-level access is allowed only for items the user can approve.
+		if permission_type in ("read", "print", "email", "report", "access"):
+			return self._user_can_see(user)
+
+		# Create / write / delete are restricted to system processes that use
+		# ignore_permissions (e.g. the flow engine creating a record).
+		return False
+
+	def _user_can_see(self, user: str) -> bool:
+		"""Return True if *user* is a designated approver for this record."""
+		approval_type = self.approval_type or "role"
+
+		if approval_type == "role":
+			role = self.approver_role
+			if role and role in frappe.get_roles(user):
+				return True
+		elif approval_type == "user":
+			if self.approver_user and self.approver_user == user:
+				return True
+		elif approval_type == "users":
+			users = self.approver_users or ""
+			if isinstance(users, str):
+				users = [u.strip() for u in users.split(",") if u.strip()]
+			if user in users:
+				return True
+
+		return False
+
+	def before_insert(self):
+		# Ensure actioned_* fields are blank on creation.
+		if self.status == "Pending":
+			self.actioned_by = None
+			self.actioned_at = None
+
+	def validate(self):
+		# Basic coherence checks.
+		if self.status in ("Approved", "Rejected") and not self.actioned_by:
+			frappe.throw(_("Actioned By is required for Approved/Rejected approvals"))
+
+		if self.actioned_at and isinstance(self.actioned_at, str):
+			self.actioned_at = get_datetime(self.actioned_at)
+
+	@frappe.whitelist()
+	def approve(self, comment: str | None = None):
+		"""Mark this approval as approved. Caller must already be authorized."""
+		self._record_decision("Approved", comment)
+
+	@frappe.whitelist()
+	def reject(self, comment: str | None = None):
+		"""Mark this approval as rejected. Caller must already be authorized."""
+		self._record_decision("Rejected", comment)
+
+	def _record_decision(self, status: str, comment: str | None):
+		if self.status != "Pending":
+			frappe.throw(_("Approval is not pending (status: {0})").format(self.status))
+
+		self.status = status
+		self.actioned_by = frappe.session.user
+		self.actioned_at = now_datetime()
+		if comment is not None:
+			self.comment = comment
+
+		self.save(ignore_permissions=True)

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -164,6 +164,7 @@ permission_query_conditions = {
     "Agent Conversation": "huf.ai.agent_integration.get_conversation_permission_conditions",
     "Agent Message": "huf.ai.agent_integration.get_message_permission_conditions",
     "Agent Run": "huf.ai.agent_integration.get_run_permission_conditions",
+    "Pending Approval": "huf.huf.doctype.pending_approval.pending_approval.get_permission_query_conditions",
 }
 #
 # has_permission = {


### PR DESCRIPTION
Restores the approval inbox bell after the temporary removal in #567.

### Problem
`get_pending_approvals` was returning 403 even for Administrator because it gated the request on `frappe.has_permission("Flow Run", "read")`. That check appears to be failing across the board (likely a role-permission or custom-permission-hook issue), so the endpoint and UI were disabled temporarily.

### Solution
Introduce a dedicated **`Pending Approval`** DocType and make the approval inbox use it instead of querying `Flow Run` directly.

This gives us:
- A clean permission model with no `ignore_permissions=True` on `Flow Run`.
- Built-in audit trail (`status`, `actioned_by`, `actioned_at`, `comment`).
- A universal inbox: any feature (Flow, Agent, MCP, etc.) can create a `Pending Approval` record.
- A foundation for future multi-level approvals.

### Files changed
- **New** `huf/huf/doctype/pending_approval/` — DocType JSON + controller + `__init__.py`
- `huf/hooks.py` — registered `permission_query_conditions` for `Pending Approval`
- `huf/ai/flow_engine.py` — creates/closes `Pending Approval` records around `human.approval` nodes
- `huf/ai/flow_api.py` — `get_pending_approvals`, `approve_flow_run`, and `reject_flow_run` now use `Pending Approval`
- `frontend/src/layouts/UnifiedHeader.tsx` — re-enables `<ApprovalsBell />` (was commented out in #567)

### Permission model
- The `Pending Approval` DocType grants read access broadly, but a `permission_query_conditions` hook scopes list queries so users only see records where they are the designated approver (`approver_role`, `approver_user`, or in `approver_users`).
- Direct doc access is further restricted by the controller's `has_permission`.
- Create/write/delete are reserved for system processes (the flow engine inserts with `ignore_permissions=True`).
- No `ignore_permissions=True` is used on `Flow Run`.

### Test checklist before merging
Please verify in a real browser/session:

- [ ] `bench migrate` installs the new `Pending Approval` DocType without errors.
- [ ] Starting a flow with a `human.approval` node creates a `Pending Approval` record.
- [ ] **Administrator** sees approvals where the Admin role or user is configured as approver.
- [ ] **User with an approver role** sees only approvals assigned to that role.
- [ ] **User listed in `approver_users`** sees only approvals assigned to them.
- [ ] **Unrelated user** sees an empty list (not a 403 error).
- [ ] **Guest** receives a 403 / is redirected to login.
- [ ] Clicking **Approve** or **Reject** from the bell updates the `Pending Approval` record and resumes/rejects the flow.
- [ ] Flow completion or failure marks linked `Pending Approval` records as `Expired`.
- [ ] Badge count updates after `frappe:flow_paused`, `frappe:flow_completed`, or `frappe:flow_error` events.
- [ ] No 403 console errors on page load for normal authenticated users.

### Deployment note
Merge this only after #567 (or its equivalent removal) has been validated. If both PRs are merged independently there may be a trivial conflict in `UnifiedHeader.tsx` and `flow_api.py` that needs to be resolved in favor of this PR's changes.

### Future work (out of scope)
- Migrate `Agent Execution Approval` to use `Pending Approval` or a common base so the bell becomes truly universal.
- Add multi-level approval chains via the `level` field and a child table.
