### PR TITLE
feat(result-context): Result/Context Foundation V1 (Steps 1–3)

### DIFF
--- a/docs/audits/message-audit/CONTEXT.md
+++ b/docs/audits/message-audit/CONTEXT.md
@@ -4,8 +4,8 @@
 |-------|-------|
 | Track | `MessageAudit` |
 | Huf piece | `product` ([`huf/`](../../huf/)) |
-| Status | Done (Audit complete: STATE.md (as-built semantics), FINDINGS.md (MA-01..25), PLAN.md (4 phases); implementation phases queued as future tracks) |
-| Last updated | 2026-07-18 |
+| Status | Rebased audit against current `origin/develop`; docs-only update. |
+| Last updated | 2026-08-02 |
 
 ## What
 Audit of the **Agent Message** doctype and its context semantics — `context_policy`,
@@ -23,16 +23,15 @@ context-policy machinery; (3) the Agent Message ↔ Agent Tool Call duplication 
 register; (6) an incremental unification plan. Docs-only — no product code changes.
 
 ## Source & working copy
-- Reference (read-only): [`huf/`](../../huf/) symlink → `/Users/safwan/Code/Huf/huf`
-- **Branch audited:** `feature/inline-video-playback` @ `eebb9dc` (same base as
-  CodeDiscovery/CommitAudit; verified current for these semantics — `origin/develop`
-  @ `95daa90` only fixes the `Queues` typo + adds Agent Run trigger refs, and
-  `origin/feature/queue-first-agent-runs` @ `726762f` touches run lifecycle, not
-  message context semantics).
-- No working copy: docs-only track.
+- Working copy: `/Users/safwan/Code/Huf/worktrees/artifact-result-context-v1` (branch
+  `feat/artifact-result-context-v1`, rebased onto `origin/develop` @
+  `2c3fd73c81d2af40a392c7dbd1976f6068019d20`).
+- **Branch audited:** `origin/develop` @ `2c3fd73c81d2af40a392c7dbd1976f6068019d20`.
+- `docs/audits/` does not exist on `origin/develop`; this audit is the docs-only PR
+  #405 branch content.
 - Path note: repo nests the app one level deep — doctypes live at
-  `huf/huf/huf/doctype/<name>/` from the workspace root; `huf/ai/` citations from
-  CodeDiscovery resolve to `huf/huf/ai/`.
+  `huf/huf/doctype/<name>/` from the workspace root; `huf/ai/` citations resolve to
+  `huf/huf/ai/`.
 
 ## Key files
 - [`STATE.md`](STATE.md) — current-state report: schema, writers, readers, semantics per field.
@@ -43,26 +42,32 @@ register; (6) an incremental unification plan. Docs-only — no product code cha
 
 ## How to resume
 1. Read this file, then `STATE.md` → `FINDINGS.md` → `PLAN.md`.
-2. Code citations are repo-relative paths at `eebb9dc`; use the `huf/` symlink.
+2. Code citations are repo-relative paths at `origin/develop` @ `2c3fd73c`.
 3. Cross-check terminology against `Tracks/CodeDiscovery/GLOSSARY.md` (frozen).
-4. If implementing fixes: create a worktree inside this track, base on `develop`,
-   and file issues on `tridz-dev/huf` (precedent: CodeDiscovery issues #363–#385).
+4. If implementing fixes: work in `/Users/safwan/Code/Huf/worktrees/artifact-result-context-v1`,
+   base on `origin/develop` @ `2c3fd73c`, and file issues on `tridz-dev/huf`.
 
 ## Constraints / gotchas
-- Docs-only: do not edit code through the symlinked `huf/`.
-- Queue-first (PR #362) is treated-as-merged per owner (CodeDiscovery F-03) but is
-  **not** in the audited base; where behavior differs, it is flagged in STATE.md.
+- Docs-only: do not edit product code while updating this audit.
 - `frappe.db.commit()` policy for message paths is CommitAudit's scope — referenced,
   not re-audited here.
 
-## Verification pass (2026-07-18)
-Independent re-verification of STATE/FINDINGS/PLAN at `eebb9dc`, orchestrated per
-sub-task: 4 parallel kimi executors (policy table & history assembly; dead
-fields/write census/public API; ATC duplication/merge/stream usage; execution
-records & tests), each report reviewed and the load-bearing claims re-checked
-first-hand by the orchestrator. Outcome: 23/25 findings confirmed as written;
-**MA-14 withdrawn** (precedence claim was wrong — agent messages always get
-`user="Agent"`); MA-11/MA-15 sharpened (3 MAX+1 copies in sdk_tools; stream-path
-repair runs once per run, Error Log only on actual repairs); minor cite fixes
-(chatApi path is `frontend/src/services/`, ChatMessage kind branches at :149/:169,
-elevenlabs path under `providers/`, sync fallback lacks the 500-char floor).
+## Relationship to Result Store and Artifact Workspace
+
+- `Agent Message` is not the durable owner of large tool/API payloads.
+- `Agent Tool Call` is not by itself a sufficient large-result store.
+- Results require bounded envelopes and selective reads.
+- Artifacts require immutable versions and operations.
+- `Agent Context Artifact` is a compatibility/context bridge, not the canonical
+  artifact registry.
+- Result references and artifact references must be version-aware where mutation is
+  possible.
+- Message history must carry compact references, not complete work or unbounded
+  results.
+
+## Verification pass (2026-08-02)
+Rebased audit against `origin/develop` @ `2c3fd73c`. Re-classified findings in
+`FINDINGS.md` based on direct code checks; updated line numbers and census results in
+`STATE.md`. Added the required relationship to Result Store and Artifact Workspace.
+Track boundaries for `ResultContextFoundation` (Steps 1–3) and `Artifact Workspace V1`
+(Step 4) are documented in `PLAN.md`.

--- a/docs/audits/message-audit/CONTEXT.md
+++ b/docs/audits/message-audit/CONTEXT.md
@@ -1,0 +1,68 @@
+# CONTEXT — MessageAudit
+
+| Field | Value |
+|-------|-------|
+| Track | `MessageAudit` |
+| Huf piece | `product` ([`huf/`](../../huf/)) |
+| Status | Done (Audit complete: STATE.md (as-built semantics), FINDINGS.md (MA-01..25), PLAN.md (4 phases); implementation phases queued as future tracks) |
+| Last updated | 2026-07-18 |
+
+## What
+Audit of the **Agent Message** doctype and its context semantics — `context_policy`,
+`record_kind`, `token_estimate`, `visibility`, `context_summary` (plus the `kind`/
+`record_kind` duality and tool-call fields) — how they are written, read, and whether
+the logic is sound. Extends to the structural observation that Huf keeps three
+partially separate execution records (Agent Run, Agent Orchestration, Flow Run) while
+Agent Message duplicates tool-call data already in Agent Tool Call.
+
+## Goal
+A documented, file:line-cited register covering: (1) current state of Agent Message
+context fields (writers, readers, semantics); (2) soundness assessment of the
+context-policy machinery; (3) the Agent Message ↔ Agent Tool Call duplication map;
+(4) the three-execution-records overlap analysis; (5) gaps/locks/traps/issues
+register; (6) an incremental unification plan. Docs-only — no product code changes.
+
+## Source & working copy
+- Reference (read-only): [`huf/`](../../huf/) symlink → `/Users/safwan/Code/Huf/huf`
+- **Branch audited:** `feature/inline-video-playback` @ `eebb9dc` (same base as
+  CodeDiscovery/CommitAudit; verified current for these semantics — `origin/develop`
+  @ `95daa90` only fixes the `Queues` typo + adds Agent Run trigger refs, and
+  `origin/feature/queue-first-agent-runs` @ `726762f` touches run lifecycle, not
+  message context semantics).
+- No working copy: docs-only track.
+- Path note: repo nests the app one level deep — doctypes live at
+  `huf/huf/huf/doctype/<name>/` from the workspace root; `huf/ai/` citations from
+  CodeDiscovery resolve to `huf/huf/ai/`.
+
+## Key files
+- [`STATE.md`](STATE.md) — current-state report: schema, writers, readers, semantics per field.
+- [`FINDINGS.md`](FINDINGS.md) — gaps/locks/traps/issues register (MA-xx IDs).
+- [`PLAN.md`](PLAN.md) — incremental unification plan (phases, tasks).
+- Upstream inputs: [`Tracks/CodeDiscovery/`](../CodeDiscovery/) (GLOSSARY, FINDINGS,
+  ADR 0001/0002, discovery/02), [`Tracks/CommitAudit/`](../CommitAudit/) (REPORT).
+
+## How to resume
+1. Read this file, then `STATE.md` → `FINDINGS.md` → `PLAN.md`.
+2. Code citations are repo-relative paths at `eebb9dc`; use the `huf/` symlink.
+3. Cross-check terminology against `Tracks/CodeDiscovery/GLOSSARY.md` (frozen).
+4. If implementing fixes: create a worktree inside this track, base on `develop`,
+   and file issues on `tridz-dev/huf` (precedent: CodeDiscovery issues #363–#385).
+
+## Constraints / gotchas
+- Docs-only: do not edit code through the symlinked `huf/`.
+- Queue-first (PR #362) is treated-as-merged per owner (CodeDiscovery F-03) but is
+  **not** in the audited base; where behavior differs, it is flagged in STATE.md.
+- `frappe.db.commit()` policy for message paths is CommitAudit's scope — referenced,
+  not re-audited here.
+
+## Verification pass (2026-07-18)
+Independent re-verification of STATE/FINDINGS/PLAN at `eebb9dc`, orchestrated per
+sub-task: 4 parallel kimi executors (policy table & history assembly; dead
+fields/write census/public API; ATC duplication/merge/stream usage; execution
+records & tests), each report reviewed and the load-bearing claims re-checked
+first-hand by the orchestrator. Outcome: 23/25 findings confirmed as written;
+**MA-14 withdrawn** (precedence claim was wrong — agent messages always get
+`user="Agent"`); MA-11/MA-15 sharpened (3 MAX+1 copies in sdk_tools; stream-path
+repair runs once per run, Error Log only on actual repairs); minor cite fixes
+(chatApi path is `frontend/src/services/`, ChatMessage kind branches at :149/:169,
+elevenlabs path under `providers/`, sync fallback lacks the 500-char floor).

--- a/docs/audits/message-audit/FINDINGS.md
+++ b/docs/audits/message-audit/FINDINGS.md
@@ -1,7 +1,7 @@
 # FINDINGS — MessageAudit register
 
 Gaps / locks / traps / issues in Agent Message context semantics and the execution
-records, consolidated from STATE.md (evidence cited there). Base: `eebb9dc`.
+records, consolidated from STATE.md (evidence cited there). Base: `origin/develop` @ `2c3fd73c`.
 Categories: **G** = gap (missing/broken behavior), **L** = lock (coupling that
 constrains change), **T** = trap (misleads a rewrite/new-language effort),
 **I** = issue (outright bug). Severity: Critical / High / Medium / Low.
@@ -26,11 +26,11 @@ Cross-refs: CodeDiscovery FINDINGS IDs (A-*, B-*, C-*, D-*) and their GitHub iss
 |---|---|---|---|
 | MA-09 | High | **Stream token undercount**: `stream_usage` reset per tool round (`litellm.py:975`) → streaming runs record only the final LLM round's tokens/cost on Agent Run + Conversation totals. Sync path correct | STATE §7.4 |
 | MA-10 | High | **`tool_status` staleness**: `fetch_from` copies refresh only on message save; sync-fallback rows keep `tool_status="Queued"` forever; stream merge failures only logged → UI status silently disagrees with ATC truth | STATE §7.2 |
-| MA-11 | High | **`conversation_index` race**: MAX+1 via SQL with no lock/unique constraint (duplicated 3× in `sdk_tools.py:1539-1550,2154-2166,2468-2475`); equal indices → undefined history order. Queue-first's per-conversation lock mitigates only on its branch | STATE §2.3 |
+| MA-11 | High | **`conversation_index` race**: MAX+1 via SQL with no lock/unique constraint in `conversation_manager.py:439-467` and `audio_service.py:697-708`; equal indices → undefined history order. `sdk_tools.py` no longer assigns the index directly on current `develop` | STATE §2.3 |
 | MA-12 | High | **Unguarded public write API**: `agent_chat.add_message` — no in-repo callers, no ownership/permission check, free `role` choice (`system`/`agent` injection into any conversation, re-enters model context as `include_full`) | STATE §3.4 |
 | MA-13 | Medium | Merge path fragility: `"**Tool Result:**"` substring guard couples persistence to a display string; mutated full `content` (call text + result) sent as the tool message, contradicting the Tool Call branch's UI-text sanitation; missing link → empty tool name + `{}` args sent to provider | STATE §6 |
 | MA-14 | — | **WITHDRAWN** (verification pass 2026-07-18, 4× kimi + orchestrator re-check): the claimed precedence bug does not exist — `(external_id or session.user) if role == "user" else "Agent"` is the actual parse; agent messages always get `user="Agent"` | STATE §4 |
-| MA-15 | Medium | `repair_message_sequence` writes an Error Log entry on **every routine repair** (trimming is by-design) → error-log spam + extra DB writes. Precision (verification pass): logs only when a repair actually occurred, and the stream path repairs once per run, not per round | STATE §2.2 |
+| MA-15 | Medium | `repair_message_sequence` writes an Error Log entry on **every routine repair** (trimming is by-design) → error-log spam + extra DB writes (`conversation_manager.py:321-328`) | STATE §2.2 |
 | MA-16 | Low | ElevenLabs webhook writes nonexistent `Agent Run.total_cost` (silently dropped) and rewrites message `creation` timestamps | STATE §10, §4 |
 | MA-17 | Low | Conversation totals updated by fire-and-forget SQL; failures only logged → run-level vs conversation-level token/cost drift | STATE §7.4 |
 
@@ -50,24 +50,23 @@ Cross-refs: CodeDiscovery FINDINGS IDs (A-*, B-*, C-*, D-*) and their GitHub iss
 | MA-22 | **The 8-policy enum looks designed; it is 2 behaviors + aliases + tests that pin only the real ones.** A rewrite that "preserves all 8 policies + 10 record kinds + 5 visibilities" carries forward 4 aliases, 2 dead fields, and a broken on-demand contract — the observation's "same complexity at a higher cost" in miniature | STATE §2.1, §8 |
 | MA-23 | **Three status vocabularies + split token/cost ownership**: 4/6/6 option sets (+ lowercase plan steps), tokens/cost only on Agent Run, errors triplicated under different names, Flow Run holding one overwritten `last_agent_run`. A new execution language over these inherits all three vocabularies and every aggregation rule | STATE §10 |
 | MA-24 | **Dead statuses and fields are load-bearing in readers**: `Waiting User`/`Paused` are checked but never set; `Status`/`Error` message kinds render as plain text but enter model context as content. Removing them naively changes behavior; keeping them preserves noise | STATE §10, C2 §3 |
-| MA-25 | **Branch drift**: `Queues` typo fixed on `develop` but not at audit base; `generated_video` existed on no branch until the 417 fix; queue-first rewrites run lifecycle without touching message semantics. Any rewrite must name its base and merge policy first (see `DOCKER_BENCH.md` §3 drift warnings) | STATE §9 |
+| MA-25 | **Branch drift**: Audit rebased onto `origin/develop` @ `2c3fd73c`; `generated_video` still has no writer on this base (see MA-06). Any rewrite must name its base and merge policy first (see `DOCKER_BENCH.md` §3 drift warnings) | STATE §9 |
 
 ## Relation to prior registers
 
 - Confirms and sharpens CodeDiscovery **B-01** (#365, artifact creation path), **B-04**
   (#368, flow tool.call → no Tool Call), **C-01** (#373, dead status options — ATC
   `"Started"` joins the list).
-- CommitAudit overlap: message write paths commit at `agent_integration.py:749,945,
-  1144`, `litellm.py:1177`, `sdk_tools.py:1662,2242,2522`, `ocr_engine.py:712` —
-  classified there (guarded/`safe_commit`); this register adds only the
-  data-consistency consequences (MA-09/MA-10/MA-17), not commit-policy items.
+- CommitAudit overlap: message write paths are classified there
+  (guarded/`safe_commit`); this register adds only the data-consistency
+  consequences (MA-09/MA-10/MA-17), not commit-policy items.
 - ProviderBrand417 overlap: `generated_video` no-writer fact (MA-06) is the same
   half-shipped feature that caused the 417s.
 
 ## Suggested issue filing
 
 Batch-file on `tridz-dev/huf` following the CodeDiscovery precedent (#363–#385,
-base `feature/inline-video-playback` @ `eebb9dc`): one issue per MA row, or grouped
+base `origin/develop` @ `2c3fd73c`): one issue per MA row, or grouped
 as "context-policy truthfulness" (MA-01..05), "tool-call consistency" (MA-08..13),
 "execution-record unification" (MA-21..23). Filing is an outward action — do it only
 on owner request.

--- a/docs/audits/message-audit/FINDINGS.md
+++ b/docs/audits/message-audit/FINDINGS.md
@@ -1,0 +1,73 @@
+# FINDINGS — MessageAudit register
+
+Gaps / locks / traps / issues in Agent Message context semantics and the execution
+records, consolidated from STATE.md (evidence cited there). Base: `eebb9dc`.
+Categories: **G** = gap (missing/broken behavior), **L** = lock (coupling that
+constrains change), **T** = trap (misleads a rewrite/new-language effort),
+**I** = issue (outright bug). Severity: Critical / High / Medium / Low.
+Cross-refs: CodeDiscovery FINDINGS IDs (A-*, B-*, C-*, D-*) and their GitHub issues.
+
+## G. Gaps — missing or broken behavior
+
+| ID | Sev | Finding | Evidence |
+|---|---|---|---|
+| MA-01 | High | `visibility` is a **dead field**: no reader anywhere (not history assembly, not permission hooks, not UI); options `ui_only/audit_only/model_visible/developer_only` are dead values. Messages carry a security-looking label that enforces nothing | STATE §3, §3.4 |
+| MA-02 | Medium | `token_estimate` is a **dead field**: no reader anywhere; the `token_budgeted` policy that should consume it ignores it | STATE §3 |
+| MA-03 | High | **Policy enum is mostly phantom**: `token_budgeted`→alias of `include_summary`; `provider_cached`→alias of `include_full`; `transient_only`→alias of `exclude`; `include_on_demand`→drops content leaving no discovery handle. Only `include_full`/`include_reference` are ever written by app code | STATE §2.1, §4 |
+| MA-04 | Medium | `record_kind` near-dead: 9 of 10 values never written; read only as a label in `include_reference` handles | STATE §3, §5 |
+| MA-05 | Medium | `include_summary` silently falls back to full content when no summary exists (cost-inflating no-op); `context_summary` is a 200-char truncation, never a real summary | STATE §2.1, §3 |
+| MA-06 | Low | No writers at all for `status`, `content_type`, `generated_video` (schema declares, nothing produces) | STATE §4 |
+| MA-07 | High | Agent Context Artifact has **no creation path** (CodeDiscovery B-01 / issue #365 re-confirmed): artifact-typed `record_kind` values and artifact `context_policy` are unreachable; `include_reference` handles only ever point at Agent Tool Call | STATE §3, C2 |
+| MA-08 | Medium | ATC status semantics broken: `"Started"` never written (joins CodeDiscovery C-01 / #373); `Failed` effectively dead — tool exceptions persist as `Completed` with `"Error executing tool …"` in the result body | STATE §7.1 |
+
+## I. Issues — outright bugs
+
+| ID | Sev | Finding | Evidence |
+|---|---|---|---|
+| MA-09 | High | **Stream token undercount**: `stream_usage` reset per tool round (`litellm.py:975`) → streaming runs record only the final LLM round's tokens/cost on Agent Run + Conversation totals. Sync path correct | STATE §7.4 |
+| MA-10 | High | **`tool_status` staleness**: `fetch_from` copies refresh only on message save; sync-fallback rows keep `tool_status="Queued"` forever; stream merge failures only logged → UI status silently disagrees with ATC truth | STATE §7.2 |
+| MA-11 | High | **`conversation_index` race**: MAX+1 via SQL with no lock/unique constraint (duplicated 3× in `sdk_tools.py:1539-1550,2154-2166,2468-2475`); equal indices → undefined history order. Queue-first's per-conversation lock mitigates only on its branch | STATE §2.3 |
+| MA-12 | High | **Unguarded public write API**: `agent_chat.add_message` — no in-repo callers, no ownership/permission check, free `role` choice (`system`/`agent` injection into any conversation, re-enters model context as `include_full`) | STATE §3.4 |
+| MA-13 | Medium | Merge path fragility: `"**Tool Result:**"` substring guard couples persistence to a display string; mutated full `content` (call text + result) sent as the tool message, contradicting the Tool Call branch's UI-text sanitation; missing link → empty tool name + `{}` args sent to provider | STATE §6 |
+| MA-14 | — | **WITHDRAWN** (verification pass 2026-07-18, 4× kimi + orchestrator re-check): the claimed precedence bug does not exist — `(external_id or session.user) if role == "user" else "Agent"` is the actual parse; agent messages always get `user="Agent"` | STATE §4 |
+| MA-15 | Medium | `repair_message_sequence` writes an Error Log entry on **every routine repair** (trimming is by-design) → error-log spam + extra DB writes. Precision (verification pass): logs only when a repair actually occurred, and the stream path repairs once per run, not per round | STATE §2.2 |
+| MA-16 | Low | ElevenLabs webhook writes nonexistent `Agent Run.total_cost` (silently dropped) and rewrites message `creation` timestamps | STATE §10, §4 |
+| MA-17 | Low | Conversation totals updated by fire-and-forget SQL; failures only logged → run-level vs conversation-level token/cost drift | STATE §7.4 |
+
+## L. Locks — couplings that constrain any change
+
+| ID | Finding | Evidence |
+|---|---|---|
+| MA-18 | **Three persisted tool shapes** coexist — separate Tool Call row, combined Tool Result row (in-place mutation), legacy separate `role=tool` rows — each with its own expansion branch; plus a repair synthesis path and a data patch. Any schema change must migrate all three shapes and keep OpenAI pairing valid | STATE §2.2, §7.2 |
+| MA-19 | **One row serves two masters**: Agent Message is simultaneously UI presentation (fetch copies, socket events, mappers keyed on legacy `kind`) and model context (policy machinery reading the same `content`/`kind`). The in-place Tool Call→Tool Result mutation is the sharpest example. Changing either side breaks the other — this is the coupling that produced the duplication | STATE §6, §7.2 |
+| MA-20 | **ATC is the truth but invisible**: repairs flow ATC→message, `get_result_context` serves from ATC, yet ATC is System-Manager-only and the frontend reads only the denormalized copies. Unification must re-home presentation data, not just pick a winner | STATE §7.2 |
+| MA-21 | **Execution linkage runs through Agent Run only**: messages/tool calls attach to flows/orchestrations indirectly via `agent_run`; Flow Run keeps only `last_agent_run`; orchestration state split between a shell run and plan rows. Any unified timeline must first unify the run linkage | STATE §10 |
+
+## T. Traps — what would mislead a rewrite / new-language effort
+
+| ID | Finding | Evidence |
+|---|---|---|
+| MA-22 | **The 8-policy enum looks designed; it is 2 behaviors + aliases + tests that pin only the real ones.** A rewrite that "preserves all 8 policies + 10 record kinds + 5 visibilities" carries forward 4 aliases, 2 dead fields, and a broken on-demand contract — the observation's "same complexity at a higher cost" in miniature | STATE §2.1, §8 |
+| MA-23 | **Three status vocabularies + split token/cost ownership**: 4/6/6 option sets (+ lowercase plan steps), tokens/cost only on Agent Run, errors triplicated under different names, Flow Run holding one overwritten `last_agent_run`. A new execution language over these inherits all three vocabularies and every aggregation rule | STATE §10 |
+| MA-24 | **Dead statuses and fields are load-bearing in readers**: `Waiting User`/`Paused` are checked but never set; `Status`/`Error` message kinds render as plain text but enter model context as content. Removing them naively changes behavior; keeping them preserves noise | STATE §10, C2 §3 |
+| MA-25 | **Branch drift**: `Queues` typo fixed on `develop` but not at audit base; `generated_video` existed on no branch until the 417 fix; queue-first rewrites run lifecycle without touching message semantics. Any rewrite must name its base and merge policy first (see `DOCKER_BENCH.md` §3 drift warnings) | STATE §9 |
+
+## Relation to prior registers
+
+- Confirms and sharpens CodeDiscovery **B-01** (#365, artifact creation path), **B-04**
+  (#368, flow tool.call → no Tool Call), **C-01** (#373, dead status options — ATC
+  `"Started"` joins the list).
+- CommitAudit overlap: message write paths commit at `agent_integration.py:749,945,
+  1144`, `litellm.py:1177`, `sdk_tools.py:1662,2242,2522`, `ocr_engine.py:712` —
+  classified there (guarded/`safe_commit`); this register adds only the
+  data-consistency consequences (MA-09/MA-10/MA-17), not commit-policy items.
+- ProviderBrand417 overlap: `generated_video` no-writer fact (MA-06) is the same
+  half-shipped feature that caused the 417s.
+
+## Suggested issue filing
+
+Batch-file on `tridz-dev/huf` following the CodeDiscovery precedent (#363–#385,
+base `feature/inline-video-playback` @ `eebb9dc`): one issue per MA row, or grouped
+as "context-policy truthfulness" (MA-01..05), "tool-call consistency" (MA-08..13),
+"execution-record unification" (MA-21..23). Filing is an outward action — do it only
+on owner request.

--- a/docs/audits/message-audit/PLAN.md
+++ b/docs/audits/message-audit/PLAN.md
@@ -1,0 +1,90 @@
+# PLAN — MessageAudit: incremental unification
+
+Derived from [`FINDINGS.md`](FINDINGS.md) (MA-01…MA-25) and the structural
+observation this track verified (STATE.md §11). Guiding rule from the observation:
+**unify semantics before any new language/rewrite** — otherwise the three execution
+vocabularies, the 3× tool-data duplication, and the phantom policy enum are
+preserved at higher cost.
+
+Each phase is independently shippable, ordered by risk (no schema change → additive
+→ structural). Every task lists: findings addressed, files touched, and the check
+that proves it done. Base branch for implementation: `develop` (per workspace
+branch topology), in a worktree inside this track.
+
+---
+
+## Phase 0 — Baseline (docs, this track) ✅
+
+- [x] STATE.md / FINDINGS.md / PLAN.md written, cited at `eebb9dc`.
+- [ ] File GitHub issues for MA items (needs owner go-ahead — outward action).
+- [ ] Owner review: pick which "decide" tasks (P2.1–P2.3) land as designed.
+
+## Phase 1 — Stop the bleeding (bug fixes, no schema change)
+
+Small, reviewable PRs; each behind the existing test suite + one new test.
+
+| # | Task | Findings | Files | Done when |
+|---|---|---|---|---|
+| 1.1 | Harden or remove `agent_chat.add_message`: add conversation-ownership check (mirror `get_message_permission_conditions`) + restrict `role` to `user`/`system`-with-capability; or delete the endpoint (zero in-repo callers) | MA-12 | `ai/agent_chat.py:873-923` | API returns 403 for non-owner; legit callers unaffected; test added |
+| 1.2 | Fix stream token undercount: accumulate `stream_usage` across tool rounds instead of resetting | MA-09 | `ai/providers/litellm.py:975,984-989,1238-1255` | streaming run with tool calls records total tokens == sum of rounds; sync/stream parity test |
+| 1.3 | Make ATC `Failed` real: pass `error=` from exception paths, stop storing exceptions as `Completed`; surface error to the message row | MA-08, MA-10(b) | `ai/agent_integration.py:397-485`, `ai/providers/litellm.py:1080-1102` | a raising tool produces ATC `Failed` + `error_message`; message/socket show failure |
+| 1.4 | Put index assignment behind the per-conversation lock (align with queue-first) or add `UNIQUE(conversation, conversation_index)`; dedupe the 3 MAX+1 copies (~~user-field precedence fix~~ — MA-14 withdrawn, no bug) | MA-11 | `ai/conversation_manager.py:420-448`, `ai/sdk_tools.py:1539-1550,2154-2166,2468-2475` | no duplicate indices under concurrent inserts (test) |
+| 1.5 | Kill `tool_status` staleness: drop the three `fetch_from` fields, read `tool_name/args/status` via the `tool_call` link at read time (report/API projection) | MA-10 | `agent_message.json`, `chatApi.ts:305-306`, desk list views | UI shows live ATC status; no fetch copies in schema |
+| 1.6 | Quiet routine repairs: log repairs at debug level (or count-only), not Error Log | MA-15 | `ai/conversation_manager.py:312-319` | routine trims produce no Error Log rows |
+| 1.7 | ElevenLabs drift: `total_cost`→`cost`; stop rewriting `creation` | MA-16 | `ai/providers/elevenlabs_convai_api.py:186-237` | voice runs record cost; message timestamps immutable |
+
+## Phase 2 — Truthful context semantics (additive schema evolution)
+
+Principle: the enum must only contain behaviors that exist. Introduce new behavior
+**or** remove the option — never keep a label without semantics.
+
+| # | Task | Findings | Decision needed |
+|---|---|---|---|
+| 2.1 | Collapse the policy enum to implemented behaviors: `include_full`, `include_summary`, `include_reference`, `exclude`. Data patch mapping `token_budgeted`→`include_summary`, `provider_cached`→`include_full`, `transient_only`→`exclude`; remove the aliases from options | MA-03 | none (mechanical) |
+| 2.2 | `include_on_demand`: either implement discovery (emit a handle like `include_reference` but withhold content until `get_result_context` fetches it) or drop the option | MA-03 | owner pick — recommend **implement via handle** (unifies with 2.5) |
+| 2.3 | `token_estimate` + `token_budgeted`: either implement real budgeting (estimate at write time via chars/4 heuristic or tokenizer; enforce a per-conversation token budget in `get_conversation_history` using estimates) or drop field + policy | MA-02 | owner pick — recommend **implement** (it's the only token-aware knob; aligns with queue-first cost work) |
+| 2.4 | `visibility`: either enforce (extend `get_message_permission_conditions` + history filter so `ui_only` never enters model context and `audit_only` never leaves the backend) or drop the field | MA-01 | owner pick — recommend **enforce minimally**: `model_visible` vs `ui_only` split is genuinely useful for status/debug rows |
+| 2.5 | Generalize `get_result_context` to any `include_reference` handle (today: ATC + Context Artifact only) and add a backend creation path for Agent Context Artifacts | MA-07, B-01/#365 | none — completes the designed loop |
+| 2.6 | Merge `kind`/`record_kind` into one canonical `record_kind` (superset vocabulary), data patch `kind`→`record_kind`, switch readers, deprecate then remove `kind` | MA-04, MA-05 | naming ratification (GLOSSARY update) |
+| 2.7 | Real summaries: replace 200-char truncation with the existing summarization machinery (`run_background_summarization`) for `include_summary` rows; hard-fail (not silent full-include) when summary missing | MA-05 | perf note: summarization is a background job today |
+
+Validation per task: extend `ai/tests/test_context_policy.py` (it already pins the
+real behaviors) + add policy-matrix tests for every enum value (the currently
+untested ones are exactly the phantom ones — STATE §8).
+
+## Phase 3 — Unify the execution records (structural; the observation's core)
+
+| # | Task | Findings | Notes |
+|---|---|---|---|
+| 3.1 | Write **Execution Semantics ADR** (follow CodeDiscovery ADR format): one canonical execution = **Agent Run**; Orchestration and Flow Run become *coordination metadata* over runs, not parallel state machines. Define the status-vocabulary mapping (Queued/Started/Success/Failed as canonical; flow Waiting Approval/Waiting User as substates) | MA-21, MA-23 | owner sign-off — this is the hard-to-reverse call; candidate ADR 0003 |
+| 3.2 | Flow `tool.call` produces a real **Agent Tool Call** (structured tool/args/result/call_id/conversation), keeping the audit run only if still needed | MA-21, B-04/#368 | removes the last non-ATC tool path |
+| 3.3 | Single token/cost aggregation: run-level write stays; conversation totals become derived (sum over runs) or transactional — no fire-and-forget SQL | MA-17 | after 1.2 (streaming totals fixed first) |
+| 3.4 | Unified read API + timeline UI: one endpoint returning runs (all kinds) with linkage; Executions page + flow sheets + orchestration card consume it | MA-21, MA-23 | frontend after backend API lands |
+| 3.5 | Retire dead statuses (`Waiting User`, `Paused`, ATC `Started`, message `Queues`→`Queued` backport) and lowercase plan-step vocabulary | MA-24, C-01/#373 | mechanical after 3.1 mapping |
+
+## Phase 4 — Message ↔ Tool Call unification (after 1–3)
+
+| # | Task | Findings | Notes |
+|---|---|---|---|
+| 4.1 | Agent Message tool rows become **pure projections** of ATC: no `fetch_from` copies (done in 1.5), no `tool_call_id`/`tool_calls` duplication — history expansion always resolves via the link (the code paths already exist and are used as fallbacks today) | MA-18, MA-19, MA-20 | the repair patch proves this direction is safe |
+| 4.2 | Collapse to **one persisted tool shape** (assistant declaration row + linked ATC holding result); migration for the three legacy shapes using the existing patch + `_synthesize_assistant_tool_call` logic | MA-18, MA-13 | biggest data migration; dry-run on a bench copy first |
+| 4.3 | Separate presentation from context: UI renders from ATC+message projection; `content` stops being mutated in place (Tool Call row stays a call; result lives on ATC; the model view is assembled, not stored) | MA-19, MA-13 | completes the two-masters decoupling |
+
+## Cross-track dependencies
+
+- **QueueFirstRuns**: queue-first's per-conversation lock is the natural home for
+  1.4; land that branch or cherry-pick the lock first.
+- **CommitAudit**: Phases 1–2 touch commit-adjacent paths — follow its
+  `safe_commit` guidance, don't reintroduce raw commits.
+- **CodeDiscovery**: ADR 0003 (3.1) and GLOSSARY updates (2.6) belong to its
+  domain-model governance; file issues in its numbering style.
+
+## Incremental context-building (how to execute)
+
+1. Land Phase 1 PRs individually (each is a few files, each verifiable on bench 16).
+2. Re-run this track's sweeps after Phase 1 to re-baseline STATE.md (fields that
+   became live/dead).
+3. Take Phase 2 decisions to the owner in one grill session (precedent:
+   CodeDiscovery GRILL-LOG), then implement.
+4. Phases 3–4 each get their own track registered via `tools/ws track-add` when
+   started (3 → e.g. `ExecutionUnify`, 4 → e.g. `MessageUnify`).

--- a/docs/audits/message-audit/PLAN.md
+++ b/docs/audits/message-audit/PLAN.md
@@ -11,11 +11,35 @@ Each phase is independently shippable, ordered by risk (no schema change → add
 that proves it done. Base branch for implementation: `develop` (per workspace
 branch topology), in a worktree inside this track.
 
+## Track boundaries — Result/Context Foundation vs Artifact Workspace V1
+
+This MessageAudit plan is now the docs baseline for the larger Result/Context +
+Artifact Workspace program. The program is split into two tracks:
+
+- **`ResultContextFoundation` (Steps 1–3, this plan + `HUF_ARTIFACT_RESULT_CONTEXT_IMPLEMENTATION_PLAN.md`):**
+  - Step 1: rebase PR #405 / MessageAudit onto current `origin/develop` and push.
+  - Step 2: critical correctness/security fixes from the audit that are still valid.
+  - Step 3: Result/Context Foundation V1 — durable result store, bounded envelopes,
+    selective reads, private payload storage, and lineage from run/tool to message.
+  - Do **not** create Artifact Workspace DocTypes here.
+
+- **`Artifact Workspace V1` (Step 4, `HUF_ARTIFACT_WORKSPACE_COMPLETE_SPEC_AND_PHASED_PLAN.md`):**
+  - Build `Artifact`, `Artifact Version`, `Artifact Asset`, and `Artifact Operation`
+    records and APIs.
+  - Reuse the envelope/reference contract, private-file storage policy, `result_read`
+    view model, idempotency/compare-and-swap pattern, and provenance fields from
+    Step 3.
+  - Start only after Result/Context Foundation V1 is working and its DoD is met.
+
+- **Future tracks (Steps 5–7):** Message/tool-call projection cleanup, execution-record
+  unification, and format-specific plans (XLSX/PPTX/optimization) will each get their
+  own detailed plan written against the post-V1 code, migration state, and tests.
+
 ---
 
 ## Phase 0 — Baseline (docs, this track) ✅
 
-- [x] STATE.md / FINDINGS.md / PLAN.md written, cited at `eebb9dc`.
+- [x] STATE.md / FINDINGS.md / PLAN.md rebased against `origin/develop` @ `2c3fd73c`; citations and findings updated.
 - [ ] File GitHub issues for MA items (needs owner go-ahead — outward action).
 - [ ] Owner review: pick which "decide" tasks (P2.1–P2.3) land as designed.
 
@@ -25,13 +49,13 @@ Small, reviewable PRs; each behind the existing test suite + one new test.
 
 | # | Task | Findings | Files | Done when |
 |---|---|---|---|---|
-| 1.1 | Harden or remove `agent_chat.add_message`: add conversation-ownership check (mirror `get_message_permission_conditions`) + restrict `role` to `user`/`system`-with-capability; or delete the endpoint (zero in-repo callers) | MA-12 | `ai/agent_chat.py:873-923` | API returns 403 for non-owner; legit callers unaffected; test added |
-| 1.2 | Fix stream token undercount: accumulate `stream_usage` across tool rounds instead of resetting | MA-09 | `ai/providers/litellm.py:975,984-989,1238-1255` | streaming run with tool calls records total tokens == sum of rounds; sync/stream parity test |
-| 1.3 | Make ATC `Failed` real: pass `error=` from exception paths, stop storing exceptions as `Completed`; surface error to the message row | MA-08, MA-10(b) | `ai/agent_integration.py:397-485`, `ai/providers/litellm.py:1080-1102` | a raising tool produces ATC `Failed` + `error_message`; message/socket show failure |
-| 1.4 | Put index assignment behind the per-conversation lock (align with queue-first) or add `UNIQUE(conversation, conversation_index)`; dedupe the 3 MAX+1 copies (~~user-field precedence fix~~ — MA-14 withdrawn, no bug) | MA-11 | `ai/conversation_manager.py:420-448`, `ai/sdk_tools.py:1539-1550,2154-2166,2468-2475` | no duplicate indices under concurrent inserts (test) |
+| 1.1 | Harden or remove `agent_chat.add_message`: add conversation-ownership check (mirror `get_message_permission_conditions`) + restrict `role` to `user`/`system`-with-capability; or delete the endpoint (zero in-repo callers) | MA-12 | `huf/ai/agent_chat.py:1048-1100` | API returns 403 for non-owner; legit callers unaffected; test added |
+| 1.2 | Fix stream token undercount: accumulate `stream_usage` across tool rounds instead of resetting | MA-09 | `huf/ai/providers/litellm.py:1519,1851-1857,1922-1928` | streaming run with tool calls records total tokens == sum of rounds; sync/stream parity test |
+| 1.3 | Make ATC `Failed` real: pass `error=` from exception paths, stop storing exceptions as `Completed`; surface error to the message row | MA-08, MA-10(b) | `huf/ai/providers/litellm.py:1049-1057,1670-1698`; `huf/ai/providers/anthropic.py:139`; `huf/ai/providers/google.py:178`; `huf/ai/providers/openrouter.py:102` | a raising tool produces ATC `Failed` + `error_message`; message/socket show failure |
+| 1.4 | Put index assignment behind the per-conversation lock or add `UNIQUE(conversation, conversation_index)`; cover `audio_service.py` and `conversation_manager.py` (~~user-field precedence fix~~ — MA-14 withdrawn, no bug) | MA-11 | `huf/ai/conversation_manager.py:439-467`, `huf/ai/audio_service.py:697-708` | no duplicate indices under concurrent inserts (test) |
 | 1.5 | Kill `tool_status` staleness: drop the three `fetch_from` fields, read `tool_name/args/status` via the `tool_call` link at read time (report/API projection) | MA-10 | `agent_message.json`, `chatApi.ts:305-306`, desk list views | UI shows live ATC status; no fetch copies in schema |
-| 1.6 | Quiet routine repairs: log repairs at debug level (or count-only), not Error Log | MA-15 | `ai/conversation_manager.py:312-319` | routine trims produce no Error Log rows |
-| 1.7 | ElevenLabs drift: `total_cost`→`cost`; stop rewriting `creation` | MA-16 | `ai/providers/elevenlabs_convai_api.py:186-237` | voice runs record cost; message timestamps immutable |
+| 1.6 | Quiet routine repairs: log repairs at debug level (or count-only), not Error Log | MA-15 | `huf/ai/conversation_manager.py:321-328` | routine trims produce no Error Log rows |
+| 1.7 | ElevenLabs drift: `total_cost`→`cost`; stop rewriting `creation` | MA-16 | `huf/ai/providers/elevenlabs_convai_api.py:194,238` | voice runs record cost; message timestamps immutable |
 
 ## Phase 2 — Truthful context semantics (additive schema evolution)
 
@@ -72,8 +96,8 @@ untested ones are exactly the phantom ones — STATE §8).
 
 ## Cross-track dependencies
 
-- **QueueFirstRuns**: queue-first's per-conversation lock is the natural home for
-  1.4; land that branch or cherry-pick the lock first.
+- **QueueFirstRuns**: queue-first has merged into `develop`; its per-conversation
+  lock is the natural home for 1.4.
 - **CommitAudit**: Phases 1–2 touch commit-adjacent paths — follow its
   `safe_commit` guidance, don't reintroduce raw commits.
 - **CodeDiscovery**: ADR 0003 (3.1) and GLOSSARY updates (2.6) belong to its

--- a/docs/audits/message-audit/STATE.md
+++ b/docs/audits/message-audit/STATE.md
@@ -1,10 +1,10 @@
 # STATE — Agent Message context semantics (as-built)
 
-Audit base: `feature/inline-video-playback` @ `eebb9dc` (verified current for these
-semantics — see CONTEXT.md). All citations are repo-relative paths with lines at that
+Audit base: `origin/develop` @ `2c3fd73c81d2af40a392c7dbd1976f6068019d20` (rebasing
+covered in CONTEXT.md). All citations are repo-relative paths with lines at that
 commit. Terminology follows `Tracks/CodeDiscovery/GLOSSARY.md` (frozen). Built from
-first-hand reading (schema, consumer, tests, public API) plus four verified code
-sweeps: write-path census (A), Agent Tool Call map (B), execution records (C1),
+first-hand reading (schema, consumer, tests, public API) plus focused re-sweeps for
+this rebase: write-path census (A), Agent Tool Call map (B), execution records (C1),
 read-side/frontend consumers (C2).
 
 ---
@@ -29,7 +29,7 @@ Field groups:
 Permissions (`agent_message.json:346-391`): System Manager + Huf Manager full; **Huf
 User can create/write**; Huf Viewer read. Row-level scoping exists only as a
 list-query condition — `get_message_permission_conditions`
-(`agent_integration.py:1997-2013`, registered `hooks.py:155`) restricts message lists
+(`agent_integration.py:3328+`, registered `hooks.py:165`) restricts message lists
 to conversations the user owns unless they hold `chat.view_all`. There is **no
 doc-level `has_permission` hook**, and the `visibility` field does **not** interact
 with Frappe permissions at all; it is pure metadata (nothing enforces it — see §3.4).
@@ -38,7 +38,7 @@ with Frappe permissions at all; it is pure metadata (nothing enforces it — see
 
 ## 2. History assembly — the only policy consumer
 
-`ConversationManager.get_conversation_history` (`huf/ai/conversation_manager.py:493-526`)
+`ConversationManager.get_conversation_history` (`huf/ai/conversation_manager.py:517-550`)
 fetches the last N messages (`conversation_index desc`, then reversed) projecting:
 
 ```
@@ -50,23 +50,23 @@ reference_name, record_kind, tool_call, tool_call_id, tool_calls, creation
 fields.** Whatever those fields say has zero effect on what the model sees.
 
 The slice limit is a **message count** (default 20, caller passes
-`(history_limit or 20) + 10` — `agent_integration.py:702`), never tokens. Token-based
+`(history_limit or 20) + 10` — `agent_integration.py:1160+`), never tokens. Token-based
 bounding exists only for knowledge (RAG) injection, separately
 (`knowledge/context_builder.py`, `max_knowledge_tokens or 4000`).
 
-### 2.1 `_message_to_context` (`conversation_manager.py:549-667`) — policy truth table
+### 2.1 `_message_to_context` (`conversation_manager.py:573-714`) — policy truth table
 
 | `context_policy` | Actual behavior | Sound? |
 |---|---|---|
-| `NULL`/missing | treated as `include_full` (`:551`) | backward-compat, fine |
+| `NULL`/missing | treated as `include_full` (`:575`) | backward-compat, fine |
 | `include_full` | full `content` | ✅ as named |
-| `include_summary` | `context_summary` **or full content fallback** (`:564`) | ⚠️ silent fallback doubles cost when summary missing |
-| `include_reference` | emits `[record_kind: summary · handle=Dt/Name]` text (`:565-573`); raw content excluded | ✅ works; the only place `record_kind` is ever read |
-| `include_on_demand` | **dropped entirely** (`:554`) | ❌ misnamed: no handle is left behind, so the model cannot know the content exists to demand it |
+| `include_summary` | `context_summary` **or full content fallback** (`:588`) | ⚠️ silent fallback doubles cost when summary missing |
+| `include_reference` | emits `[record_kind: summary · handle=Dt/Name]` text (`:589-597`); raw content excluded | ✅ works; the only place `record_kind` is ever read |
+| `include_on_demand` | **dropped entirely** (`:578`) | ❌ misnamed: no handle is left behind, so the model cannot know the content exists to demand it |
 | `exclude` | dropped entirely | ✅ as named (indistinguishable from `transient_only`) |
 | `transient_only` | dropped entirely | ⚠️ duplicates `exclude`; "transient" intent (show once, then drop) is not implementable — no "seen" marker exists |
-| `token_budgeted` | `context_summary` or content (`:574-575`) | ❌ **no budgeting**: `token_estimate` is never read anywhere; behavior identical to `include_summary` |
-| `provider_cached` | full content (`:576-577`) | ❌ **no caching semantics**: identical to `include_full`; pure label |
+| `token_budgeted` | `context_summary` or content (`:598-599`) | ❌ **no budgeting**: `token_estimate` is never read by history assembly; behavior identical to `include_summary` |
+| `provider_cached` | full content (`:600-601`) | ❌ **no caching semantics**: identical to `include_full`; pure label |
 
 Of 8 declared policies: 4 work as named (`include_full`, `include_summary` with
 caveat, `include_reference`, `exclude`), 2 are aliases that mislead
@@ -87,24 +87,26 @@ assistant(`tool_calls`) + `role:"tool"` pairs:
    produced by the merge path (`update_tool_call_message`, §6).
 3. **Separate tool row** — `role="tool"` → single `role:"tool"` message (`:653-662`).
 
-`repair_message_sequence` (`:220-321`) runs before every completion call in the sync
+`repair_message_sequence` (`:229-321`) runs before every completion call in the sync
 path (`providers/litellm.py:484`, inside the round loop) but only **once per run** in
-the stream path (`:938`, before the round loop — rounds 2+ reuse the repaired
+the stream path (before the round loop — rounds 2+ reuse the repaired
 sequence): drops assistant declarations with no
 matching results, synthesizes missing assistant declarations from Agent Tool Call
-(`_synthesize_assistant_tool_call`, `:106-137`), drops unrepairable tool results, and
-**writes an Error Log entry on every repair** (`:312-319`) — routine trims become
+(`_synthesize_assistant_tool_call`, `:107-138`), drops unrepairable tool results, and
+**writes an Error Log entry on every repair** (`:321-328`) — routine trims become
 error-log spam.
 
 ### 2.3 Ordering & indexing hazards
 
 - `add_message` assigns `conversation_index = MAX(conversation_index)+1` via SQL
-  (`conversation_manager.py:420-448`). No unique constraint, no locking → concurrent
+  (`conversation_manager.py:439-467`). No unique constraint, no locking → concurrent
   inserts in one conversation can share an index; history order between equal indices
-  is undefined. (Queue-first's per-conversation lock mitigates this on its branch.)
-  The media-tool paths re-implement the same MAX+1 logic **three times**
-  (`sdk_tools.py:1539-1550` image, `:2154-2166` audio, `:2468-2475` STT).
-- `total_messages` on the conversation is set to `last_index+1` (`:483-486`) — a
+  is undefined.
+- `audio_service.py` duplicates the same MAX+1 pattern (`:697-708`) for voice messages.
+- The media-tool paths in `sdk_tools.py` no longer assign `conversation_index`
+  directly (they route through `ConversationManager.add_message`); the MAX+1 hazard is
+  now concentrated in `conversation_manager.py` and `audio_service.py`.
+- `total_messages` on the conversation is set to `last_index+1` (`:507-510`) — a
   denormalized counter that drifts if any insert fails between the two writes.
 
 ---
@@ -113,11 +115,11 @@ error-log spam.
 
 | Field | Writers | Readers | Verdict |
 |---|---|---|---|
-| `context_policy` | `update_tool_call_message` (`conversation_manager.py:197`) + sync fallback (`agent_integration.py:1004`) — the only automatic writers: `include_reference` iff result > `agent.max_context_chars` (default 2000, min 500), else explicit `include_full`; public API passthrough (`agent_chat.py:873-923`) | `_message_to_context` only | **Two policies ever set automatically.** The other 6 are reachable only via the public API, desk, or tests |
-| `record_kind` | same two paths → `tool_result` only (`conversation_manager.py:196`, `agent_integration.py:1003`); API passthrough | `_message_to_context` `include_reference` formatting (`:566`) | 9 of 10 values never written; cosmetic even when read |
-| `context_summary` | same two paths → first 200 chars + `"..."` (`:179,198`, `:988`); API passthrough | `include_summary` / `token_budgeted` / `include_reference` paths | Works, but summary = dumb truncation, never a real summary |
-| `visibility` | **Nothing** (schema default `user_visible`); API passthrough | **Nothing anywhere** — not projected in history query, no query filter, no permission branch, no UI. The `ui_only`/`audit_only`/`model_visible`/`developer_only` options are dead values | **Dead field** (repo-wide confirmed, sweep C2) |
-| `token_estimate` | **Nothing**; API passthrough | **Nothing anywhere** — not even history assembly fetches it | **Dead field** (repo-wide confirmed, sweep C2). `token_budgeted` ignores it |
+| `context_policy` | `update_tool_call_message` (`conversation_manager.py:198`) + sync fallback (`agent_integration.py:1654`) — the only automatic writers: `include_reference` iff result > `agent.max_context_chars` (default 2000, min 500), else explicit `include_full`; public API passthrough (`agent_chat.py:1054-1089`); code execution writes it on `Agent Context Artifact` (`code_execution.py:349`) | `_message_to_context` only | **Two policies ever set automatically on Agent Message.** The other 6 are reachable only via the public API, desk, or tests. `Agent Context Artifact` uses `context_policy` for display/filter but not as an enforced model-context contract |
+| `record_kind` | same two paths → `tool_result` only (`conversation_manager.py:197`, `agent_integration.py:1653`); API passthrough | `_message_to_context` `include_reference` formatting (`:590`) | 9 of 10 values never written by app code; cosmetic even when read |
+| `context_summary` | same two paths → first 200 chars + `"..."` (`:180,199`, `:1638`); API passthrough | `include_summary` / `token_budgeted` / `include_reference` paths | Works, but summary = dumb truncation, never a real summary |
+| `visibility` | **Nothing on Agent Message** (schema default `user_visible`); API passthrough (`agent_chat.py:1058-1088`); `Agent Context Artifact` has a writer (`code_execution.py:348`) | **Nothing on Agent Message** — not projected in history query, no query filter, no permission branch, no UI. The `ui_only`/`audit_only`/`model_visible`/`developer_only` options are dead values for messages | **Dead field on Agent Message** (repo-wide confirmed, sweep C2). Live only on `Agent Context Artifact` |
+| `token_estimate` | **Nothing on Agent Message**; API passthrough; `Agent Context Artifact` has a writer (`code_execution.py:351`) | **Nothing on Agent Message** — not even history assembly fetches it | **Dead field on Agent Message** (repo-wide confirmed, sweep C2). Live only on `Agent Context Artifact` |
 
 **Read-side census (sweep C2, repo-wide):** besides `_message_to_context`, no code
 branches on any of the five fields for Agent Message. None of the five is ever sent
@@ -133,10 +135,11 @@ read by the frontend — display/filter only (`agentContextArtifactApi.ts:39-88`
 
 ### 3.4 The public write API is a trust-boundary hole
 
-`agent_chat.add_message` (`agent_chat.py:873-923`) is `@frappe.whitelist()` (no
-`allow_guest`, so any authenticated session) and performs **no ownership or
-permission check** on the target conversation. It has **zero in-repo callers**
-(sweeps A+C2) — an unused but live endpoint. Any logged-in user can:
+`agent_chat.add_message` (`agent_chat.py:1049-1099`) is `@frappe.whitelist()` (no
+`allow_guest`, so any authenticated session). It loads the conversation but performs
+**no ownership or write-permission check** on it (only the standard `Agent Message`
+create/write permission checks inside `ConversationManager`). It has **zero in-repo
+callers** (sweeps A+C2) — an unused but live endpoint. Any logged-in user can:
 
 - insert a message into **any** conversation by id;
 - choose `role` freely — including `system` or `agent` — injecting content that
@@ -149,43 +152,44 @@ permission check** on the target conversation. It has **zero in-repo callers**
 
 ## 4. Write-path census (sweep A, verified repo-wide)
 
-Hub: `ConversationManager.add_message` (`conversation_manager.py:396-491`). Census:
+Hub: `ConversationManager.add_message` (`conversation_manager.py:415-516`). Census:
 
 | Path | Trigger | Context-field writes |
 |---|---|---|
-| `agent_integration.py:747` (sync) / `:1447` (stream) | user prompt | none (`kind="Message"`) |
-| `agent_integration.py:926-942` / `:1583-1599` | tool call starts | `kind="Tool Call"`, `tool_call` link, `tool_call_id`, `tool_calls` JSON |
-| `agent_integration.py:992-1008` (sync fallback) | tool result, merge failed | `kind="Tool Result"`, `record_kind="tool_result"`, policy per threshold, `context_summary`, `reference_*` |
-| `agent_integration.py:1134` / `:1702-1704` | final agent reply | none |
-| `agent_integration.py:1227-1254` / `:1799-1914` | error events | `kind="Error"` |
-| `conversation_manager.py:140-217` (update) | tool result merge | see §6 |
-| `agent_chat.py:873-923` (whitelisted API) | external HTTP | passthrough of all five fields (see §3.4) |
+| `agent_integration.py:1160` (sync) / `:1572` (stream tool-call start) | user prompt / tool call starts | none (`kind="Message"`) / `kind="Tool Call"`, `tool_call` link, `tool_call_id`, `tool_calls` JSON |
+| `agent_integration.py:1642-1658` (stream fallback) | tool result, merge failed | `kind="Tool Result"`, `record_kind="tool_result"`, policy per threshold, `context_summary`, `reference_*` |
+| `agent_integration.py:1846` / `:2927` | final agent reply | none |
+| `agent_integration.py:2008+` / `:3079+` / `:3188+` | error events | `kind="Error"` |
+| `conversation_manager.py:141-227` (update) | tool result merge | see §6 |
+| `agent_chat.py:1049-1099` (whitelisted API) | external HTTP | passthrough of all five fields (see §3.4) |
 | `agent_chat.py:37-45,168-176,477-485,584-592,784-792` | voice/file uploads | `kind="Audio"`/`"Message"`; note `:477-485`/`:584-592` insert **with** permissions — inconsistent with every other path |
-| `sdk_tools.py:1608-1622,2180-2195,2479-2503` | image/audio/STT tool results | `kind="Image"`/`"Audio"`; own MAX+1 index (`:1539-1550`) — same race as §2.3 |
-| `ocr_engine.py:684-702` | OCR extraction | none |
-| `transcription_handler.py:119-135` | provider STT | none (no `kind`, no `session_id`) |
-| `elevenlabs_convai_api.py:228-237` | voice-call transcript backfill | none; then `db_set("creation", ...)` rewrites timestamps |
+| `sdk_tools.py` | image/audio/STT tool results | `kind="Image"`/`"Audio"`; no longer writes `Agent Message` directly; routes through `ConversationManager.add_message` |
+| `code_execution.py:341-362` | code-execution file write-back | writes `context_policy`, `visibility`, `token_estimate` to `Agent Context Artifact` (not `Agent Message`) |
+| `ocr_engine.py` | OCR extraction | none |
+| `transcription_handler.py` | provider STT | none (no `kind`, no `session_id`) |
+| `elevenlabs_convai_api.py` | voice-call transcript backfill | none; then `db_set("creation", ...)` rewrites timestamps |
 | `patches/v1/repair_tool_call_messages.py` | migration | backfills `tool_call_id`/`tool_calls` from Agent Tool Call |
 
 Census conclusions:
 
-- **Only two paths** ever set `context_policy` (same threshold rule) and
-  **`tool_result` is the only `record_kind` ever written** by app code.
+- **Only two paths** ever set `context_policy` on `Agent Message` (same threshold
+  rule) and **`tool_result` is the only `record_kind` ever written** by app code.
   `include_summary / exclude / transient_only / token_budgeted / provider_cached /
   include_on_demand` and the other 9 record kinds are written **only by tests** or
-  the public API.
+  the public API. `Agent Context Artifact` now has writers for `context_policy`,
+  `visibility`, and `token_estimate` (`code_execution.py:341-362`), but those fields
+  remain dead on `Agent Message` itself.
 - **No writers anywhere** for `status`, `content_type`, `generated_video` — three
-  more dead-on-arrival fields beyond `visibility`/`token_estimate`.
+  more dead-on-arrival fields beyond `visibility`/`token_estimate` on `Agent Message`.
 - `flow_engine.py` and `huf/ai/orchestration/` write **zero** Agent Messages
   directly; flow/orchestration messages exist only via `run_agent_sync`.
-- `sdk_tools.py:1669`/`:2249` `new_agent_message` are realtime socket events, not writes.
+- `sdk_tools.py` realtime socket events (`new_agent_message`) are not writes.
 - ATC↔AM asymmetry both directions: (i) streaming — if the message lookup for the
   merge fails, the result is saved on the Agent Tool Call and **no message gets it**
-  (only an error log, `litellm.py:1104-1151`); sync — `process_tool_call(is_output=True)`
-  returns `None` when no Queued ATC is found (`agent_integration.py:430-431`), no
+  (only an error log, `litellm.py:1709-1748`); sync — `process_tool_call(is_output=True)`
+  returns `None` when no Queued ATC is found (`agent_integration.py:618-719`), no
   message written. (ii) Media/user/error messages have no `tool_call` link at all;
-  the sync path needs a special `kind="Image"` lookup to merge image results
-  (`:1014-1028`).
+  the sync path needs a special `kind="Image"` lookup to merge image results.
 - ~~`add_message` `user` field bug (`conversation_manager.py:441`)~~ — **withdrawn
   (verification pass 2026-07-18)**: Python's conditional expression binds looser than
   `or`, so the line parses as `(external_id or session.user) if role == "user" else
@@ -345,13 +349,11 @@ shapes — the misleading/unsupported policies are exactly the untested ones.
 
 ## 9. Branch deltas
 
-- `origin/develop` @ `95daa90`: `Queues`→`Queued` typo fix in `status` options;
-  Agent Run gains `reference_doctype`/`reference_name` trigger links (PR #401). No
-  message-semantics change.
-- `origin/feature/queue-first-agent-runs` @ `726762f`: reworks `agent_integration.py`
-  (+619) around queued execution; `conversation_manager.py` untouched; adds a guard
-  re-creating the user message if missing when a queued run executes (checks
-  `Agent Message` by `agent_run`+`role=user`). Context semantics unchanged.
+- Audit base is now `origin/develop` @ `2c3fd73c`. The `Queues`→`Queued` typo fix
+  and Agent Run `reference_doctype`/`reference_name` trigger links are already
+  present on this base. No message-semantics change relative to the prior audit.
+- `origin/feature/queue-first-agent-runs` has been merged into `develop`; the
+  per-conversation lock and queued-run drainer are now the default execution mode.
 
 ---
 

--- a/docs/audits/message-audit/STATE.md
+++ b/docs/audits/message-audit/STATE.md
@@ -1,0 +1,421 @@
+# STATE — Agent Message context semantics (as-built)
+
+Audit base: `feature/inline-video-playback` @ `eebb9dc` (verified current for these
+semantics — see CONTEXT.md). All citations are repo-relative paths with lines at that
+commit. Terminology follows `Tracks/CodeDiscovery/GLOSSARY.md` (frozen). Built from
+first-hand reading (schema, consumer, tests, public API) plus four verified code
+sweeps: write-path census (A), Agent Tool Call map (B), execution records (C1),
+read-side/frontend consumers (C2).
+
+---
+
+## 1. Schema inventory — `huf/huf/doctype/agent_message/agent_message.json`
+
+The DocType has **no controller logic** (`agent_message.py` is an empty `Document`
+subclass). Every semantic lives in writers and readers scattered across `huf/ai/`.
+
+Field groups:
+
+| Group | Fields | Notes |
+|---|---|---|
+| Identity/linkage | `conversation` (Link), `conversation_index` (Int), `session_id`, `user` (Data, not Link), `agent`, `agent_run` (Link), `provider`, `model` | `user` is plain Data — holds a username, external id, or the literal string `"Agent"` |
+| Content | `content` (Code/Markdown), `content_type` (Text/JSX/Mermaid/Markdown/Artifact/HTML/Image), `role` (user/tool/agent/system, default user, hidden), `is_agent_message` (Check) | `role="agent"` maps to OpenAI `assistant` at read time |
+| Kind — **two parallel fields** | `kind` (Message/Tool Call/Tool Result/Status/Error/Image/Audio/Video, no default) and `record_kind` (message/tool_call/tool_result/retrieval_context/result_snapshot/artifact/summary/status/error/debug_trace, no default) | Same concept, two vocabularies; see §5 |
+| Tool-call block | `tool_call` (Link→Agent Tool Call), `tool_name`/`tool_args`/`tool_status` (**`fetch_from`** the link), `tool_call_id` (Long Text — provider call id), `tool_calls` (JSON hidden — OpenAI-style array), `raw_payload` (JSON hidden) | `fetch_from` materializes copies at insert; see §7 |
+| Media/voice | `generated_image`, `generated_audio`, `generated_video`, `voice_message`, `tts_voice`, `tts_model`, `stt_model` | `generated_video` was the missing-field 417 bug (ProviderBrand417 track) |
+| **Context semantics** | `context_policy` (8 options, no default), `record_kind` (no default), `context_summary` (Small Text), `reference_doctype` + `reference_name` (**both plain Data**, not Link/Dynamic Link), `visibility` (5 options, default `user_visible`), `token_estimate` (Int) | Detailed per-field analysis in §3 |
+| Lifecycle | `status` (Started/`Queues`/Completed/Failed, hidden) | `Queues` typo — fixed on `origin/develop`; still present at audit base |
+
+Permissions (`agent_message.json:346-391`): System Manager + Huf Manager full; **Huf
+User can create/write**; Huf Viewer read. Row-level scoping exists only as a
+list-query condition — `get_message_permission_conditions`
+(`agent_integration.py:1997-2013`, registered `hooks.py:155`) restricts message lists
+to conversations the user owns unless they hold `chat.view_all`. There is **no
+doc-level `has_permission` hook**, and the `visibility` field does **not** interact
+with Frappe permissions at all; it is pure metadata (nothing enforces it — see §3.4).
+
+---
+
+## 2. History assembly — the only policy consumer
+
+`ConversationManager.get_conversation_history` (`huf/ai/conversation_manager.py:493-526`)
+fetches the last N messages (`conversation_index desc`, then reversed) projecting:
+
+```
+role, kind, content, context_policy, context_summary, reference_doctype,
+reference_name, record_kind, tool_call, tool_call_id, tool_calls, creation
+```
+
+**Not fetched: `visibility`, `token_estimate`, `status`, `content_type`, media
+fields.** Whatever those fields say has zero effect on what the model sees.
+
+The slice limit is a **message count** (default 20, caller passes
+`(history_limit or 20) + 10` — `agent_integration.py:702`), never tokens. Token-based
+bounding exists only for knowledge (RAG) injection, separately
+(`knowledge/context_builder.py`, `max_knowledge_tokens or 4000`).
+
+### 2.1 `_message_to_context` (`conversation_manager.py:549-667`) — policy truth table
+
+| `context_policy` | Actual behavior | Sound? |
+|---|---|---|
+| `NULL`/missing | treated as `include_full` (`:551`) | backward-compat, fine |
+| `include_full` | full `content` | ✅ as named |
+| `include_summary` | `context_summary` **or full content fallback** (`:564`) | ⚠️ silent fallback doubles cost when summary missing |
+| `include_reference` | emits `[record_kind: summary · handle=Dt/Name]` text (`:565-573`); raw content excluded | ✅ works; the only place `record_kind` is ever read |
+| `include_on_demand` | **dropped entirely** (`:554`) | ❌ misnamed: no handle is left behind, so the model cannot know the content exists to demand it |
+| `exclude` | dropped entirely | ✅ as named (indistinguishable from `transient_only`) |
+| `transient_only` | dropped entirely | ⚠️ duplicates `exclude`; "transient" intent (show once, then drop) is not implementable — no "seen" marker exists |
+| `token_budgeted` | `context_summary` or content (`:574-575`) | ❌ **no budgeting**: `token_estimate` is never read anywhere; behavior identical to `include_summary` |
+| `provider_cached` | full content (`:576-577`) | ❌ **no caching semantics**: identical to `include_full`; pure label |
+
+Of 8 declared policies: 4 work as named (`include_full`, `include_summary` with
+caveat, `include_reference`, `exclude`), 2 are aliases that mislead
+(`token_budgeted`→summary, `provider_cached`→full), 1 is a no-op duplicate
+(`transient_only`), 1 is broken-by-design (`include_on_demand` — no discovery path).
+
+### 2.2 Tool-call expansion (`:581-662`)
+
+Three persisted shapes are recognized and expanded into OpenAI-style
+assistant(`tool_calls`) + `role:"tool"` pairs:
+
+1. **Assistant tool-call row** — `kind="Tool Call"` or any of `tool_call`/
+   `tool_call_id`/`tool_calls` set → `{role:assistant, content:None, tool_calls:[...]}`.
+   Stored `tool_calls` JSON preferred; else synthesized from the linked Agent Tool
+   Call (`_resolve_tool_call_details`, `:528-547`).
+2. **Combined row** — `kind="Tool Result"` with role agent/assistant → returns a
+   **pair** `[assistant(tool_calls), tool(result)]` (`:629-650`). This is the shape
+   produced by the merge path (`update_tool_call_message`, §6).
+3. **Separate tool row** — `role="tool"` → single `role:"tool"` message (`:653-662`).
+
+`repair_message_sequence` (`:220-321`) runs before every completion call in the sync
+path (`providers/litellm.py:484`, inside the round loop) but only **once per run** in
+the stream path (`:938`, before the round loop — rounds 2+ reuse the repaired
+sequence): drops assistant declarations with no
+matching results, synthesizes missing assistant declarations from Agent Tool Call
+(`_synthesize_assistant_tool_call`, `:106-137`), drops unrepairable tool results, and
+**writes an Error Log entry on every repair** (`:312-319`) — routine trims become
+error-log spam.
+
+### 2.3 Ordering & indexing hazards
+
+- `add_message` assigns `conversation_index = MAX(conversation_index)+1` via SQL
+  (`conversation_manager.py:420-448`). No unique constraint, no locking → concurrent
+  inserts in one conversation can share an index; history order between equal indices
+  is undefined. (Queue-first's per-conversation lock mitigates this on its branch.)
+  The media-tool paths re-implement the same MAX+1 logic **three times**
+  (`sdk_tools.py:1539-1550` image, `:2154-2166` audio, `:2468-2475` STT).
+- `total_messages` on the conversation is set to `last_index+1` (`:483-486`) — a
+  denormalized counter that drifts if any insert fails between the two writes.
+
+---
+
+## 3. The five context fields — writers, readers, verdict
+
+| Field | Writers | Readers | Verdict |
+|---|---|---|---|
+| `context_policy` | `update_tool_call_message` (`conversation_manager.py:197`) + sync fallback (`agent_integration.py:1004`) — the only automatic writers: `include_reference` iff result > `agent.max_context_chars` (default 2000, min 500), else explicit `include_full`; public API passthrough (`agent_chat.py:873-923`) | `_message_to_context` only | **Two policies ever set automatically.** The other 6 are reachable only via the public API, desk, or tests |
+| `record_kind` | same two paths → `tool_result` only (`conversation_manager.py:196`, `agent_integration.py:1003`); API passthrough | `_message_to_context` `include_reference` formatting (`:566`) | 9 of 10 values never written; cosmetic even when read |
+| `context_summary` | same two paths → first 200 chars + `"..."` (`:179,198`, `:988`); API passthrough | `include_summary` / `token_budgeted` / `include_reference` paths | Works, but summary = dumb truncation, never a real summary |
+| `visibility` | **Nothing** (schema default `user_visible`); API passthrough | **Nothing anywhere** — not projected in history query, no query filter, no permission branch, no UI. The `ui_only`/`audit_only`/`model_visible`/`developer_only` options are dead values | **Dead field** (repo-wide confirmed, sweep C2) |
+| `token_estimate` | **Nothing**; API passthrough | **Nothing anywhere** — not even history assembly fetches it | **Dead field** (repo-wide confirmed, sweep C2). `token_budgeted` ignores it |
+
+**Read-side census (sweep C2, repo-wide):** besides `_message_to_context`, no code
+branches on any of the five fields for Agent Message. None of the five is ever sent
+to a client: the React app's message APIs request only legacy fields
+(`chatApi.ts:291-323`), the realtime `new_agent_message` payloads carry only
+`kind`+media (`sdk_tools.py:1666-1680`), the TS types omit them (`chatApi.ts:39-71`),
+and rendering branches on legacy `kind` alone (`ChatMessage.tsx:71-83`,
+`chatMessageList.mappers.ts:207-230`; `Status`/`Error` kinds have no UI branch and
+render as plain text). The same-named fields on **Agent Context Artifact** *are*
+read by the frontend — display/filter only (`agentContextArtifactApi.ts:39-88`,
+`AgentContextArtifactsPage.tsx`) — and that doctype still has no creation path
+(CodeDiscovery B-01, re-confirmed: zero creation UI, zero backend writer).
+
+### 3.4 The public write API is a trust-boundary hole
+
+`agent_chat.add_message` (`agent_chat.py:873-923`) is `@frappe.whitelist()` (no
+`allow_guest`, so any authenticated session) and performs **no ownership or
+permission check** on the target conversation. It has **zero in-repo callers**
+(sweeps A+C2) — an unused but live endpoint. Any logged-in user can:
+
+- insert a message into **any** conversation by id;
+- choose `role` freely — including `system` or `agent` — injecting content that
+  re-enters the model window as `include_full` by default (prompt-injection vector
+  into other users' agent runs);
+- set `visibility`/`token_estimate`/etc., which nothing reads — the API offers knobs
+  with no effect, while the effective knob (policy) is unchecked input.
+
+---
+
+## 4. Write-path census (sweep A, verified repo-wide)
+
+Hub: `ConversationManager.add_message` (`conversation_manager.py:396-491`). Census:
+
+| Path | Trigger | Context-field writes |
+|---|---|---|
+| `agent_integration.py:747` (sync) / `:1447` (stream) | user prompt | none (`kind="Message"`) |
+| `agent_integration.py:926-942` / `:1583-1599` | tool call starts | `kind="Tool Call"`, `tool_call` link, `tool_call_id`, `tool_calls` JSON |
+| `agent_integration.py:992-1008` (sync fallback) | tool result, merge failed | `kind="Tool Result"`, `record_kind="tool_result"`, policy per threshold, `context_summary`, `reference_*` |
+| `agent_integration.py:1134` / `:1702-1704` | final agent reply | none |
+| `agent_integration.py:1227-1254` / `:1799-1914` | error events | `kind="Error"` |
+| `conversation_manager.py:140-217` (update) | tool result merge | see §6 |
+| `agent_chat.py:873-923` (whitelisted API) | external HTTP | passthrough of all five fields (see §3.4) |
+| `agent_chat.py:37-45,168-176,477-485,584-592,784-792` | voice/file uploads | `kind="Audio"`/`"Message"`; note `:477-485`/`:584-592` insert **with** permissions — inconsistent with every other path |
+| `sdk_tools.py:1608-1622,2180-2195,2479-2503` | image/audio/STT tool results | `kind="Image"`/`"Audio"`; own MAX+1 index (`:1539-1550`) — same race as §2.3 |
+| `ocr_engine.py:684-702` | OCR extraction | none |
+| `transcription_handler.py:119-135` | provider STT | none (no `kind`, no `session_id`) |
+| `elevenlabs_convai_api.py:228-237` | voice-call transcript backfill | none; then `db_set("creation", ...)` rewrites timestamps |
+| `patches/v1/repair_tool_call_messages.py` | migration | backfills `tool_call_id`/`tool_calls` from Agent Tool Call |
+
+Census conclusions:
+
+- **Only two paths** ever set `context_policy` (same threshold rule) and
+  **`tool_result` is the only `record_kind` ever written** by app code.
+  `include_summary / exclude / transient_only / token_budgeted / provider_cached /
+  include_on_demand` and the other 9 record kinds are written **only by tests** or
+  the public API.
+- **No writers anywhere** for `status`, `content_type`, `generated_video` — three
+  more dead-on-arrival fields beyond `visibility`/`token_estimate`.
+- `flow_engine.py` and `huf/ai/orchestration/` write **zero** Agent Messages
+  directly; flow/orchestration messages exist only via `run_agent_sync`.
+- `sdk_tools.py:1669`/`:2249` `new_agent_message` are realtime socket events, not writes.
+- ATC↔AM asymmetry both directions: (i) streaming — if the message lookup for the
+  merge fails, the result is saved on the Agent Tool Call and **no message gets it**
+  (only an error log, `litellm.py:1104-1151`); sync — `process_tool_call(is_output=True)`
+  returns `None` when no Queued ATC is found (`agent_integration.py:430-431`), no
+  message written. (ii) Media/user/error messages have no `tool_call` link at all;
+  the sync path needs a special `kind="Image"` lookup to merge image results
+  (`:1014-1028`).
+- ~~`add_message` `user` field bug (`conversation_manager.py:441`)~~ — **withdrawn
+  (verification pass 2026-07-18)**: Python's conditional expression binds looser than
+  `or`, so the line parses as `(external_id or session.user) if role == "user" else
+  "Agent"`. Agent messages always get `user="Agent"`; no leak exists (ex-MA-14).
+
+---
+
+## 5. The `kind` / `record_kind` duality
+
+Two fields classify the same rows:
+
+- `kind` — UI vocabulary: `Message/Tool Call/Tool Result/Status/Error/Image/Audio/Video`
+  (drives media `depends_on` rendering and the history tool-call expansion).
+- `record_kind` — context vocabulary: `message/tool_call/tool_result/
+  retrieval_context/result_snapshot/artifact/summary/status/error/debug_trace`.
+
+They overlap for 5 values (message/tool_call/tool_result/status/error) with different
+spellings; `record_kind` adds 5 values no writer produces automatically
+(`retrieval_context`, `result_snapshot`, `artifact`, `summary`, `debug_trace`). No
+code keeps them consistent — `update_tool_call_message` sets both
+(`kind="Tool Result"`, `record_kind="tool_result"`, `:195-196`), other writers set
+`kind` only, so `record_kind` is NULL on virtually all rows. The read side only
+consults `record_kind` when formatting an `include_reference` handle — i.e. the
+classification that matters for the model is `kind`, and `record_kind` is near-dead.
+
+---
+
+## 6. Tool result merge path — `update_tool_call_message` (`conversation_manager.py:140-217`)
+
+The streaming-era "one row per tool interaction" mutation:
+
+1. loads the Agent Message created when the tool call started;
+2. appends `\n\n**Tool Result:**\n{result}` to `content` (guarded against double-append
+   by a substring check, `:192`);
+3. flips `kind` → `Tool Result`, `record_kind` → `tool_result`;
+4. sets policy: `include_reference` if `len(result) > max_context_chars` else
+   `include_full`; always writes `context_summary` (200-char truncation);
+5. points `reference_*` at the linked Agent Tool Call; stores provider `tool_call_id`
+   and the raw `tool_calls` payload;
+6. `save(ignore_permissions=True)`; swallows all exceptions → returns `False`
+   (callers log and continue — a failed merge leaves a permanent `kind="Tool Call"`
+   row whose result never lands; history then shows a declaration without result and
+   `repair_message_sequence` drops or re-synthesizes it).
+
+Soundness notes:
+
+- The `include_reference` threshold is **characters, not tokens** (`max_context_chars`,
+  default 2000) — the field the schema offers for this (`token_estimate`) is unused,
+  so the one size-control knob is a char heuristic.
+- The tool message sent to the model carries the **entire mutated `content`**
+  (call text + result text) — the "don't leak UI text" sanitation at `:619-621`
+  applies only to the Tool Call branch, not the combined Tool Result branch.
+- If the `tool_call` link is missing, `_resolve_tool_call_details` yields an empty
+  tool name and `{}` args (`:532-547`) — an invalid function declaration is then sent
+  to the provider.
+
+---
+
+## 7. Duplication with Agent Tool Call (sweep B, verified)
+
+### 7.1 Agent Tool Call inventory — `huf/huf/doctype/agent_tool_call/`
+
+10 fields: `agent_run`, `conversation`, `tool` (Data), `tool_args` (JSON),
+`tool_result` (JSON), `status` (Started/Queued/Completed/Failed, hidden), `call_id`
+(Long Text), `error_message`, `is_mcp_tool`, `mcp_server`. **No token/cost fields.**
+Permissions: **System Manager only**. Controller empty. Writers exist in exactly two
+files:
+
+| Writer | What |
+|---|---|
+| `agent_integration.py:451-464` (`process_tool_call`, request) | insert `status="Queued"`, MCP detection (`:438-441`), `call_id` |
+| `agent_integration.py:397-428` (`process_tool_call`, output) | find Queued by run+`call_id` → update `tool_result` (140k cap, `:411-419`), `status` Completed/Failed, `error_message` |
+| `providers/litellm.py:1089-1102` (stream) | update by conversation+`call_id`; `status="Completed"` **hardcoded** (`:1096`) |
+
+Readers: history reconstruction (`_synthesize_assistant_tool_call`,
+`_resolve_tool_call_details`), the agent-callable `get_result_context`
+(`sdk_tools.py:1373-1414`, advertised in system instructions
+`agent_integration.py:242-246`), desk dashboards. **Zero frontend references** — the
+tool-call UI is built entirely from the message's `fetch_from` copies and socket
+events (`chatApi.ts:305-306`, `useChatSocket.tsx`).
+
+Status semantics are broken two ways: `"Started"` is never written (dead option,
+joins CodeDiscovery C-01), and the `Failed` branch is effectively dead — no caller
+passes `error=`; a raised tool exception is stored as result text
+`"Error executing tool …"` with status **`Completed`** (`litellm.py:1080-1081,1096`).
+
+### 7.2 Field-by-field duplication (ATC vs paired Agent Message)
+
+| Datum | Agent Tool Call | Agent Message | Verdict |
+|---|---|---|---|
+| Tool name | `tool` | `tool_name` (fetch copy) + `tool_calls` JSON + `content` text | duplicated **3×** |
+| Arguments | `tool_args` (JSON) | `tool_args` (fetch copy) + `tool_calls[].function.arguments` + `content` text | duplicated **3×** |
+| Status | `status` (authoritative) | `tool_status` (fetch copy, refreshed only on message save) | **can silently disagree** |
+| LLM call id | `call_id` | `tool_call_id` + `tool_calls[].id` | duplicated (patch back-fills) |
+| Result | `tool_result` (canonical JSON) | stringified into `content`; 200-char `context_summary` | duplicated |
+| Error | `error_message` | **nowhere** (socket payload only) | ATC only |
+| MCP flags | `is_mcp_tool`, `mcp_server` | — | ATC only |
+| Run/conversation links | ✅ | ✅ | duplicated |
+| OpenAI-format payload | — (rebuildable) | `tool_calls` JSON | message only, derivable |
+| provider/model/agent | — | ✅ | message only |
+| Context metadata | — | `record_kind`, `context_*`, `reference_*` (pointing back at the ATC) | message only |
+| Tokens/cost | — | — | **neither** (see §7.4) |
+
+Disagreement windows: (a) `tool_status` is `fetch_from` — refreshed only when the
+message is saved; if the ATC update succeeds but the message merge fails, the failure
+is merely logged (`litellm.py:1141-1151`); in the sync fallback path the original
+Tool Call message is never re-saved after the ATC flips to Completed
+(`agent_integration.py:984-1009`) → `tool_status="Queued"` forever. (b) Errors never
+reach the message. (c) `kind` is mutated in place Tool Call → Tool Result, so one
+message row represents both request and result while the ATC holds the lifecycle.
+
+**Source of truth is the ATC** — proven by direction of repair:
+`patches/v1/repair_tool_call_messages.py` back-fills message columns *from* the ATC;
+`_synthesize_assistant_tool_call` rebuilds model context from the ATC; the provider
+docstring says "We keep the full result in the Agent Tool Call record for audit /
+reference" (`litellm.py:201-208`); `get_result_context` serves the canonical full
+result from the ATC. Agent Message tool rows are denormalized presentation/context
+copies that can silently disagree with the truth.
+
+### 7.3 Flow `tool.call` gap — confirmed
+
+`_exec_tool_call` (`flow_engine.py:539-607`) creates **no Agent Tool Call** — only an
+audit Agent Run with `run_kind="tool"` (`_create_flow_agent_run`, `:1265-1281`).
+Captured: tool name+args as an unstructured `prompt` string, result JSON in
+`response`, error, flow linkage. Lost vs ATC: conversation link, `call_id`,
+structured `tool`/`tool_args`/`tool_result`, MCP flags. (CodeDiscovery B-04: model
+violation — every tool invocation should produce a Tool Call.)
+
+### 7.4 Token/cost accounting — no double count, but a real undercount
+
+- ATC has no token/cost fields; Agent Message only the dead `token_estimate`.
+- Agent Run `input/output/cached_tokens` + `cost` written **once per run** (sync
+  `agent_integration.py:1127-1132`; stream `:1706-1717`); Agent Conversation totals
+  incremented by raw SQL `+=` once per run (`:1115-1123` / `:1689-1697`); providers
+  accumulate usage across LLM rounds in memory. **No double counting via ATC.**
+- **Stream undercount bug:** in `run_stream`, `stream_usage` is reset per tool round
+  (`litellm.py:975`) and overwritten by each usage chunk (`:984-989`), so the
+  `complete` event carries **only the final round's usage** — tool-call rounds'
+  tokens vanish from Agent Run and Conversation totals for streaming runs, and the
+  stream cost computation inherits the same undercount (`litellm.py:1238-1255` →
+  `agent_integration.py:1657`). Sync accumulates correctly.
+- Conversation totals are fire-and-forget SQL; failures only logged
+  (`:1124-1125,1698-1699`) → run-level and conversation-level totals drift silently.
+
+---
+
+## 8. Test-pinned behavior — `huf/ai/tests/test_context_policy.py`
+
+The only tests covering this machinery pin: `include_full`, `include_reference`
+(raw content excluded, handle present), `exclude`, `transient_only`, NULL backward
+compat, bounded token growth under `include_reference` (char-length proxy), and
+`include_summary`. Notably **no tests** for `token_budgeted`, `provider_cached`,
+`include_on_demand`, `visibility`, `token_estimate`, or the tool-pair expansion
+shapes — the misleading/unsupported policies are exactly the untested ones.
+
+---
+
+## 9. Branch deltas
+
+- `origin/develop` @ `95daa90`: `Queues`→`Queued` typo fix in `status` options;
+  Agent Run gains `reference_doctype`/`reference_name` trigger links (PR #401). No
+  message-semantics change.
+- `origin/feature/queue-first-agent-runs` @ `726762f`: reworks `agent_integration.py`
+  (+619) around queued execution; `conversation_manager.py` untouched; adds a guard
+  re-creating the user message if missing when a queued run executes (checks
+  `Agent Message` by `agent_run`+`role=user`). Context semantics unchanged.
+
+---
+
+## 10. The three execution records (sweep C1, verified)
+
+| | **Agent Run** | **Agent Orchestration** | **Flow Run** |
+|---|---|---|---|
+| Status vocab | Started/Queued/Success/Failed | Planned/Running/Paused/Completed/Failed/Cancelled (+ lowercase per-step `pending/in_progress/done/failed`) | Queued/Running/Waiting Approval/Waiting User/Success/Failed |
+| Tokens/cost/duration | ✅ `input/output/cached_tokens`, `cost`, `start_time`/`end_time` — **the only carrier** | ❌ (only `last_run_at`) | ❌ (only `started_at`/`completed_at`) |
+| Prompt/response | ✅ `prompt`, `response` | per-step `instruction`/`output_ref`, `scratchpad` | `trigger_payload` + `context_json` (initially **identical**, `flow_engine.py:103,105`) |
+| Error | `error_code` + `error_message` | `error_log` | `last_error` |
+| Linkage | `parent_run`, `is_child`, `agent_orchestration`, `flow_run`, `flow_node_id`, `flow_id`, `run_kind` | `parent_run` (shell run) | `last_agent_run` (overwritten per node), `conversation` |
+| Controller | empty | empty | empty |
+
+Key structural facts:
+
+- **Orchestration = shell parent run + plan rows.** The parent Agent Run never makes
+  a provider call (marked Started with a placeholder response,
+  `agent_integration.py:762-766`); only final status/summary is mirrored back
+  (`orchestrator.py:158-162`, `:208`). Each plan step is a child Agent Run
+  (`parent_run` = shell, `is_child=1`), hidden in the UI by the `is_child=0` filter
+  (`Executions.tsx:60`).
+- **Flow Run retains no node history** — only `last_agent_run`, overwritten per node
+  (`flow_engine.py:518,588,664,1221`). Per-node outputs are duplicated into
+  `context_json` only when the node opts in (`save_response_to_context`,
+  `save_result_to_context`) — the same text stored on the linked Agent Run's
+  `response`. The real audit trail is Agent Runs with matching
+  `flow_run`+`flow_node_id` — queryable, but nothing aggregates it.
+- **Tokens/cost system of record is Agent Run alone**; aggregation duplicated in
+  Agent Conversation totals via raw SQL + `Agent.total_run/last_run` counters.
+  Orchestration/flow cost must be derived by summing child runs; shell parent runs
+  and `run_kind="tool"` audit runs carry none.
+- **Agent Message / Agent Tool Call attach to executions only via `agent_run`
+  (+`conversation`)** — neither links Flow Run or Agent Orchestration directly, so
+  flow/orchestration message timelines must be reconstructed through the run table.
+- Dead statuses: Flow Run `Waiting User`, Orchestration `Paused` (declared, read,
+  never set). Drift: ElevenLabs webhook writes `total_cost` — **not a field** on
+  Agent Run (field is `cost`), silently dropped (`elevenlabs_convai_api.py:194`).
+- Frontend: **three separate surfaces, no unified timeline** — Executions page lists
+  Agent Runs only (`Executions.tsx:53-60`); Flow Runs appear only inside the flow
+  canvas sheets (`FlowRunHistory.tsx`, `FlowRunViewer.tsx`); "orchestration" UI is a
+  child-runs card on the run detail page that **never fetches the Agent Orchestration
+  doctype** (`AgentRunDetailPage.tsx:135-146,419-425`). Nothing lists Agent
+  Orchestration docs anywhere in the React app.
+
+---
+
+## 11. Verdict on the observation
+
+> "HUF has three partially separate execution records—Agent Run, Agent Orchestration,
+> and Flow Run—while Agent Message also duplicates tool-call data already stored in
+> Agent Tool Call. A rewrite should unify those semantics first; otherwise a new
+> language would preserve the same complexity at a higher cost."
+
+**Confirmed, and stronger than stated.** The three execution records are not just
+"partially separate": they run three divergent status vocabularies, duplicate error/
+timestamp fields under different names, keep tokens/cost in exactly one of them, and
+have no unified read surface. The message/tool-call duplication is not symmetric
+copying: Agent Tool Call is the de-facto source of truth (repairs flow ATC→message),
+yet the UI reads only the denormalized message copies — which can silently disagree
+(status staleness, missing errors) — while the truth is System-Manager-only and
+frontend-invisible. On top, the context-policy layer that a rewrite would "preserve"
+is 8 declared policies of which only 2 are ever written by app code, 4 are aliases
+or no-ops, 1 is broken by design, and 2 of the 5 context fields (`visibility`,
+`token_estimate`) have no readers at all. A new language over this surface would
+inherit all three vocabularies, the 3× tool-data duplication, and the phantom policy
+enum — the unification must happen at the semantics layer first. See PLAN.md.

--- a/huf/ai/agent_chat.py
+++ b/huf/ai/agent_chat.py
@@ -1061,12 +1061,44 @@ def add_message(
     """
     Exposes ConversationManager.add_message as a public API.
     Used for creating context artifacts, tool results, and out-of-band context.
+
+    Security guards (MA-12):
+    - Caller must own the conversation or have write permission on it.
+    - Only ``user``, ``tool`` and ``system`` roles are accepted from the public
+      API. The agent runtime adds ``agent`` messages through
+      ``ConversationManager.add_message`` directly, not through this endpoint.
     """
     if not conversation_id or not role:
         frappe.throw(_("conversation_id and role are required"))
 
+    # MA-12: restrict public roles. ``agent`` messages are written by the
+    # backend runtime via ConversationManager.add_message, not via the public
+    # HTTP API.
+    allowed_public_roles = ("user", "tool", "system")
+    if role not in allowed_public_roles:
+        frappe.throw(
+            _("Role '{0}' is not allowed via the public add_message API.").format(role),
+            frappe.PermissionError,
+        )
+
     try:
         conv_doc = frappe.get_doc("Agent Conversation", conversation_id)
+
+        # MA-12: verify conversation-level write permission before accepting a
+        # message. This blocks cross-conversation injection by anyone who holds
+        # generic Agent Message create permission. Ownership is the primary gate;
+        # System Manager and the chat.view_all capability can bypass it.
+        from huf.permissions import has_capability, SYSTEM_MANAGER
+
+        is_owner = conv_doc.owner == frappe.session.user
+        is_system_manager = SYSTEM_MANAGER in frappe.get_roles()
+        can_view_all = has_capability(frappe.session.user, "chat.view_all")
+        if not (is_owner or is_system_manager or can_view_all):
+            frappe.throw(
+                _("Not permitted to add messages to this conversation."),
+                frappe.PermissionError,
+            )
+
         agent_name = conv_doc.agent
 
         cm = ConversationManager(agent_name=agent_name)

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -1642,6 +1642,7 @@ def _execute_agent_run(
                         tool_call=[tool_call_dict],
                         result_content=tool_result,
                         agent_doc=agent_doc,
+                        status=tool_status,
                     )
 
                     if not updated:
@@ -1651,7 +1652,6 @@ def _execute_agent_run(
                         # only contains a bounded envelope/reference.
                         from huf.ai.results import policy as result_policy
                         from huf.ai.results.store import persist_result
-                        from huf.ai.results.envelope import build_envelope
 
                         result_doc, envelope = persist_result(
                             result_content=tool_result,

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -663,6 +663,12 @@ def process_tool_call(agent_run, conversation, name=None, args=None, result=None
                         frappe.PermissionError,
                     )
                 doc.save()
+
+                # MA-10: keep the linked Agent Message's fetch_from tool fields
+                # in sync when the tool call reaches a terminal state.
+                from huf.ai.conversation_manager import sync_tool_status_to_message
+                sync_tool_status_to_message(doc.name)
+
                 return doc.name
             else:
                 return None
@@ -720,6 +726,13 @@ def log_tool_call(run_doc, conversation, raw_call, tool_result=None, error=None,
     name = raw_call.get("name") if isinstance(raw_call, dict) else getattr(raw_call, "name", None)
     args = raw_call.get("arguments") if isinstance(raw_call, dict) and not is_output else (getattr(raw_call, "arguments", None) if not is_output else None)
     call_id = raw_call.get("id") if isinstance(raw_call, dict) else getattr(raw_call, "id", None)
+
+    # MA-08: propagate failure markers produced by provider modules so the
+    # Agent Tool Call is recorded as Failed rather than Completed.
+    if error is None and isinstance(raw_call, dict):
+        if raw_call.get("failed"):
+            error = raw_call.get("error_message") or "Tool execution failed"
+
     return process_tool_call(
         agent_run=run_doc.name,
         conversation=conversation.name,

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -1646,16 +1646,32 @@ def _execute_agent_run(
 
                     if not updated:
                         # Fallback: create a separate Tool Result message if the
-                        # original Tool Call message could not be updated.
-                        tool_result_str = str(tool_result) if tool_result is not None else ""
-                        tool_result_summary = (tool_result_str[:200] + "...") if len(tool_result_str) > 200 else tool_result_str
-                        max_context_chars = int(getattr(agent_doc, "max_context_chars", 2000))
-                        use_reference = len(tool_result_str) > max_context_chars
+                        # original Tool Call message could not be updated.  Route
+                        # the raw result through the Result Store so the message
+                        # only contains a bounded envelope/reference.
+                        from huf.ai.results import policy as result_policy
+                        from huf.ai.results.store import persist_result
+                        from huf.ai.results.envelope import build_envelope
+
+                        result_doc, envelope = persist_result(
+                            result_content=tool_result,
+                            run=run_doc.name,
+                            tool_call=updated_tool_call_id,
+                            conversation=conversation.name,
+                            source_tool=tool_name,
+                            visibility="model_visible",
+                            agent_doc=agent_doc,
+                            status=tool_status,
+                        )
+
+                        size_bytes = result_doc.size_bytes or 0
+                        use_reference = size_bytes > result_policy.INLINE_THRESHOLD_BYTES
+                        envelope_text = json.dumps(envelope, default=str)
 
                         result_message = conv_manager.add_message(
                             conversation,
                             role="tool",
-                            content=tool_result_str,
+                            content=envelope_text,
                             provider=resolved_provider,
                             model=resolved_model,
                             agent=agent_name,
@@ -1663,11 +1679,11 @@ def _execute_agent_run(
                             kind="Tool Result",
                             tool_call=updated_tool_call_id,
                             tool_call_id=call_id,
-                            record_kind="tool_result",
+                            record_kind="result_snapshot",
                             context_policy="include_reference" if use_reference else "include_full",
-                            context_summary=tool_result_summary,
-                            reference_doctype="Agent Tool Call",
-                            reference_name=updated_tool_call_id
+                            context_summary=result_doc.summary or envelope.get("summary", ""),
+                            reference_doctype="Agent Execution Result",
+                            reference_name=result_doc.name
                         )
                         message_name = result_message.name
 

--- a/huf/ai/audio_service.py
+++ b/huf/ai/audio_service.py
@@ -694,19 +694,6 @@ def create_audio_user_message(
 
     agent_doc = frappe.get_doc("Agent", agent_name) if agent_name else None
 
-    # Get conversation_index
-    last_index = frappe.db.sql(
-        """
-        SELECT MAX(conversation_index) as last_index
-        FROM `tabAgent Message`
-        WHERE conversation = %s
-        """,
-        (conversation_id,),
-        as_dict=1,
-    )
-
-    conversation_index = (last_index[0].last_index if last_index and last_index[0].last_index is not None else 0) + 1
-
     # Create or Update Agent Message
     if message_id and frappe.db.exists("Agent Message", message_id):
         message_doc = frappe.get_doc("Agent Message", message_id)
@@ -723,35 +710,60 @@ def create_audio_user_message(
             message_doc.agent_run = agent_run_id
         message_doc.save()
     else:
-        message_doc = frappe.get_doc({
-            "doctype": "Agent Message",
-            "conversation": conversation_id,
-            "role": "user",
-            "content": transcript,
-            "kind": "Audio",
-            "agent": agent_name,
-            "provider": agent_doc.provider if agent_doc else None,
-            "model": agent_doc.model if agent_doc else None,
-            "agent_run": agent_run_id,
-            "conversation_index": conversation_index,
-            "is_agent_message": 0,
-            "user": frappe.session.user,
-        })
-        if stt_model_link:
-            message_doc.stt_model = stt_model_link
-        if message_status:
-            message_doc.status = message_status
-        if file_doc and file_doc.file_url:
-            message_doc.voice_message = file_doc.file_url
-        # Audio user messages are created during agent/chat execution.
-        # Authenticated users require Agent Message create permission;
-        # Guest agents rely on the system-level bypass.
-        if frappe.session.user == "Guest":
-            message_doc.insert(ignore_permissions=True)
-        else:
-            if not frappe.has_permission("Agent Message", "create", doc=message_doc):
-                frappe.throw(_("Not permitted to create Agent Message"), frappe.PermissionError)
-            message_doc.insert()
+        # MA-11: allocate conversation_index with a retry loop so concurrent
+        # audio inserts cannot read the same MAX and create duplicate indices.
+        max_retries = 3
+        message_doc = None
+        conversation_index = 0
+        for attempt in range(max_retries):
+            last_index = frappe.db.sql(
+                """
+                SELECT MAX(conversation_index) as last_index
+                FROM `tabAgent Message`
+                WHERE conversation = %s
+                """,
+                (conversation_id,),
+                as_dict=1,
+            )
+            conversation_index = (
+                last_index[0].last_index if last_index and last_index[0].last_index is not None else 0
+            ) + 1
+
+            message_doc = frappe.get_doc({
+                "doctype": "Agent Message",
+                "conversation": conversation_id,
+                "role": "user",
+                "content": transcript,
+                "kind": "Audio",
+                "agent": agent_name,
+                "provider": agent_doc.provider if agent_doc else None,
+                "model": agent_doc.model if agent_doc else None,
+                "agent_run": agent_run_id,
+                "conversation_index": conversation_index,
+                "is_agent_message": 0,
+                "user": frappe.session.user,
+            })
+            if stt_model_link:
+                message_doc.stt_model = stt_model_link
+            if message_status:
+                message_doc.status = message_status
+            if file_doc and file_doc.file_url:
+                message_doc.voice_message = file_doc.file_url
+            # Audio user messages are created during agent/chat execution.
+            # Authenticated users require Agent Message create permission;
+            # Guest agents rely on the system-level bypass.
+            try:
+                if frappe.session.user == "Guest":
+                    message_doc.insert(ignore_permissions=True)
+                else:
+                    if not frappe.has_permission("Agent Message", "create", doc=message_doc):
+                        frappe.throw(_("Not permitted to create Agent Message"), frappe.PermissionError)
+                    message_doc.insert()
+                break
+            except (frappe.DuplicateEntryError, frappe.UniqueValidationError):
+                if attempt == max_retries - 1:
+                    raise
+                continue
 
     # Check if file is already attached to this message
     if file_doc and message_doc:

--- a/huf/ai/conversation_fork.py
+++ b/huf/ai/conversation_fork.py
@@ -178,6 +178,27 @@ def _copy_message(
         "raw_payload": source_msg.raw_payload,
     }
 
+    # MA-11: guard against an explicit index that already exists in the target
+    # conversation (e.g. concurrent forks or caller bugs). Fork targets are
+    # newly created, so this is defensive rather than the normal allocation path.
+    if frappe.db.exists("Agent Message", {
+        "conversation": target.name,
+        "conversation_index": conversation_index,
+    }):
+        last_index = frappe.db.sql(
+            """
+            SELECT MAX(conversation_index) as last_index
+            FROM `tabAgent Message`
+            WHERE conversation = %s
+            """,
+            (target.name,),
+            as_dict=1,
+        )
+        conversation_index = (
+            last_index[0].last_index if last_index and last_index[0].last_index is not None else 0
+        ) + 1
+        doc_data["conversation_index"] = conversation_index
+
     # Remove None values for optional fields so Frappe uses defaults/empties.
     doc_data = {k: v for k, v in doc_data.items() if v is not None}
 

--- a/huf/ai/conversation_manager.py
+++ b/huf/ai/conversation_manager.py
@@ -144,6 +144,7 @@ def update_tool_call_message(
     tool_call: dict | list,
     result_content: Any,
     agent_doc=None,
+    status: str = "Completed",
 ) -> bool:
     """
     Update an existing 'Tool Call' Agent Message with a bounded result envelope.
@@ -158,6 +159,7 @@ def update_tool_call_message(
         tool_call: Tool call payload (dict or list) to persist in tool_calls.
         result_content: Raw result returned by the tool.
         agent_doc: Agent DocType (used for max_context_chars threshold).
+        status: Execution status for the result record ("Completed" or "Failed").
 
     Returns:
         True if the message was updated, False otherwise.
@@ -177,7 +179,6 @@ def update_tool_call_message(
     try:
         from huf.ai.results import policy as result_policy
         from huf.ai.results.store import persist_result
-        from huf.ai.results.envelope import build_envelope
 
         # Resolve run/conversation/tool_call links from the message.
         run_name = msg_doc.agent_run
@@ -193,9 +194,7 @@ def update_tool_call_message(
                 msg_doc, tool_call_id, tool_call, result_content, agent_doc
             )
 
-        status = "Completed"
-        if agent_doc and hasattr(agent_doc, "status"):
-            status = getattr(agent_doc, "status", "Completed")
+        result_status = status if status in ("Completed", "Failed") else "Completed"
 
         result_doc, envelope = persist_result(
             result_content=result_content,
@@ -205,7 +204,7 @@ def update_tool_call_message(
             source_tool=source_tool,
             visibility="model_visible",
             agent_doc=agent_doc,
-            status=status,
+            status=result_status,
         )
 
         size_bytes = result_doc.size_bytes or 0
@@ -237,7 +236,7 @@ def update_tool_call_message(
             )
         msg_doc.save()
         return True
-    except (frappe.ValidationError, frappe.PermissionError, frappe.TimestampMismatchError) as e:
+    except Exception as e:
         frappe.log_error(
             f"Error updating tool call message '{message_name}': {e}",
             "Tool Call Message Update"

--- a/huf/ai/conversation_manager.py
+++ b/huf/ai/conversation_manager.py
@@ -146,8 +146,11 @@ def update_tool_call_message(
     agent_doc=None,
 ) -> bool:
     """
-    Update an existing 'Tool Call' Agent Message with the tool result so the
-    request and result live in a single message row.
+    Update an existing 'Tool Call' Agent Message with a bounded result envelope.
+
+    The raw tool result is persisted through the Result Store (``Agent
+    Execution Result``).  The Agent Message receives only a bounded envelope
+    and a reference, so large payloads do not enter model context.
 
     Args:
         message_name: Name of the Agent Message to update.
@@ -172,34 +175,50 @@ def update_tool_call_message(
         return False
 
     try:
-        if isinstance(result_content, str):
-            result_str = result_content
-        else:
-            result_str = json.dumps(result_content, default=str)
+        from huf.ai.results import policy as result_policy
+        from huf.ai.results.store import persist_result
+        from huf.ai.results.envelope import build_envelope
 
-        result_summary = (result_str[:200] + "...") if len(result_str) > 200 else result_str
+        # Resolve run/conversation/tool_call links from the message.
+        run_name = msg_doc.agent_run
+        conversation_name = msg_doc.conversation
+        tool_call_link = msg_doc.tool_call
+        source_tool = None
+        if tool_call_link:
+            source_tool = frappe.db.get_value("Agent Tool Call", tool_call_link, "tool")
 
-        max_context_chars = 2000
-        if agent_doc:
-            try:
-                max_context_chars = int(getattr(agent_doc, "max_context_chars", 2000) or 2000)
-            except (ValueError, TypeError):
-                max_context_chars = 2000
-        max_context_chars = max(max_context_chars, 500)
+        if not run_name or not conversation_name or not tool_call_link:
+            # Fall back to legacy behavior if lineage is missing.
+            return _legacy_update_tool_call_message(
+                msg_doc, tool_call_id, tool_call, result_content, agent_doc
+            )
 
-        use_reference = len(result_str) > max_context_chars
+        status = "Completed"
+        if agent_doc and hasattr(agent_doc, "status"):
+            status = getattr(agent_doc, "status", "Completed")
 
-        existing_content = msg_doc.content or ""
-        if "**Tool Result:**" not in existing_content:
-            msg_doc.content = existing_content + f"\n\n**Tool Result:**\n{result_str}"
+        result_doc, envelope = persist_result(
+            result_content=result_content,
+            run=run_name,
+            tool_call=tool_call_link,
+            conversation=conversation_name,
+            source_tool=source_tool,
+            visibility="model_visible",
+            agent_doc=agent_doc,
+            status=status,
+        )
 
+        size_bytes = result_doc.size_bytes or 0
+        use_reference = size_bytes > result_policy.INLINE_THRESHOLD_BYTES
+
+        envelope_text = json.dumps(envelope, default=str)
+        msg_doc.content = envelope_text
         msg_doc.kind = "Tool Result"
-        msg_doc.record_kind = "tool_result"
+        msg_doc.record_kind = "result_snapshot"
         msg_doc.context_policy = "include_reference" if use_reference else "include_full"
-        msg_doc.context_summary = result_summary
-        msg_doc.reference_doctype = "Agent Tool Call"
-        if msg_doc.tool_call:
-            msg_doc.reference_name = msg_doc.tool_call
+        msg_doc.context_summary = result_doc.summary or envelope.get("summary", "")
+        msg_doc.reference_doctype = "Agent Execution Result"
+        msg_doc.reference_name = result_doc.name
         msg_doc.tool_call_id = tool_call_id
         if tool_call is not None:
             msg_doc.tool_calls = (
@@ -224,6 +243,59 @@ def update_tool_call_message(
             "Tool Call Message Update"
         )
         return False
+
+
+def _legacy_update_tool_call_message(
+    msg_doc,
+    tool_call_id: str,
+    tool_call: dict | list,
+    result_content: Any,
+    agent_doc=None,
+) -> bool:
+    """Legacy fallback used when result-store lineage is unavailable."""
+    if isinstance(result_content, str):
+        result_str = result_content
+    else:
+        result_str = json.dumps(result_content, default=str)
+
+    result_summary = (result_str[:200] + "...") if len(result_str) > 200 else result_str
+
+    max_context_chars = 2000
+    if agent_doc:
+        try:
+            max_context_chars = int(getattr(agent_doc, "max_context_chars", 2000) or 2000)
+        except (ValueError, TypeError):
+            max_context_chars = 2000
+    max_context_chars = max(max_context_chars, 500)
+
+    use_reference = len(result_str) > max_context_chars
+
+    existing_content = msg_doc.content or ""
+    if "**Tool Result:**" not in existing_content:
+        msg_doc.content = existing_content + f"\n\n**Tool Result:**\n{result_str}"
+
+    msg_doc.kind = "Tool Result"
+    msg_doc.record_kind = "tool_result"
+    msg_doc.context_policy = "include_reference" if use_reference else "include_full"
+    msg_doc.context_summary = result_summary
+    msg_doc.reference_doctype = "Agent Tool Call"
+    if msg_doc.tool_call:
+        msg_doc.reference_name = msg_doc.tool_call
+    msg_doc.tool_call_id = tool_call_id
+    if tool_call is not None:
+        msg_doc.tool_calls = (
+            json.dumps(tool_call, default=str)
+            if not isinstance(tool_call, str)
+            else tool_call
+        )
+
+    if not frappe.has_permission("Agent Message", "write", doc=msg_doc):
+        frappe.throw(
+            _("Not permitted to update Agent Message {0}").format(msg_doc.name),
+            frappe.PermissionError,
+        )
+    msg_doc.save()
+    return True
 
 
 def sync_tool_status_to_message(tool_call_name: str | None) -> None:
@@ -630,9 +702,24 @@ class ConversationManager:
             content = msg.get("context_summary") or msg.get("content")
         elif policy == "include_reference":
             record_kind = msg.get("record_kind") or "record"
-            summary = msg.get("context_summary") or record_kind
+            summary = msg.get("context_summary") or ""
             ref_doctype = msg.get("reference_doctype") or ""
             ref_name = msg.get("reference_name") or ""
+
+            # If the message points to an Agent Execution Result but has no
+            # summary, load the summary from the canonical result record rather
+            # than falling back to the full envelope content.
+            if not summary and ref_doctype == "Agent Execution Result" and ref_name:
+                try:
+                    summary = frappe.db.get_value(
+                        "Agent Execution Result", ref_name, "summary"
+                    ) or ""
+                except Exception:
+                    summary = ""
+
+            if not summary:
+                summary = record_kind
+
             if ref_doctype and ref_name:
                 content = f"[{record_kind}: {summary} · handle={ref_doctype}/{ref_name}]"
             else:

--- a/huf/ai/conversation_manager.py
+++ b/huf/ai/conversation_manager.py
@@ -226,6 +226,36 @@ def update_tool_call_message(
         return False
 
 
+def sync_tool_status_to_message(tool_call_name: str | None) -> None:
+    """Re-sync fetch_from tool fields from ``Agent Tool Call`` to its ``Agent Message``.
+
+    ``tool_name``, ``tool_args`` and ``tool_status`` on ``Agent Message`` are
+    ``fetch_from`` copies of the linked ``Agent Tool Call``. They are refreshed
+    only when the message is saved, so sync-fallback rows can keep stale values
+    (e.g. ``tool_status="Queued"``) after the tool call completes. This helper
+    forces the re-sync explicitly.
+    """
+    if not tool_call_name:
+        return
+
+    message_name = frappe.db.get_value("Agent Message", {"tool_call": tool_call_name}, "name")
+    if not message_name:
+        return
+
+    try:
+        tc_doc = frappe.get_doc("Agent Tool Call", tool_call_name)
+        msg_doc = frappe.get_doc("Agent Message", message_name)
+        msg_doc.tool_status = tc_doc.status
+        msg_doc.tool_name = tc_doc.tool
+        msg_doc.tool_args = tc_doc.tool_args
+        msg_doc.save(ignore_permissions=True)
+    except Exception as e:
+        frappe.log_error(
+            f"Error syncing tool status from {tool_call_name} to message {message_name}: {e}",
+            "Tool Status Sync"
+        )
+
+
 def repair_message_sequence(messages: list, conversation_name: str | None = None) -> list:
     """
     Ensure OpenAI-compatible tool-call pairing in a message list.
@@ -436,14 +466,6 @@ class ConversationManager:
     ):
         """Add message to conversation with optional context policy."""
         try:
-            last_index = frappe.db.sql("""
-                SELECT MAX(conversation_index) as last_index
-                FROM `tabAgent Message`
-                WHERE conversation = %s
-            """, (conversation.name,), as_dict=1)
-
-            last_index = last_index[0].last_index if last_index and last_index[0].last_index is not None else 0
-
             # Backward compatibility: older callers passed the Agent Tool Call link
             # name via the ``tool_call_id`` argument. New callers should use
             # ``tool_call`` for the link and ``tool_call_id`` for the LLM call id.
@@ -464,7 +486,6 @@ class ConversationManager:
                 "agent": agent,
                 "provider": provider,
                 "model": model,
-                "conversation_index": last_index + 1,
                 "is_agent_message": 1 if role == "agent" else 0,
                 "tool_call": tool_call_link,
                 "tool_call_id": tool_call_id,
@@ -496,13 +517,34 @@ class ConversationManager:
             if token_estimate is not None:
                 doc_data["token_estimate"] = token_estimate
 
-            message = frappe.get_doc(doc_data)
             if not frappe.has_permission("Agent Message", "create"):
                 frappe.throw(
                     _("Not permitted to create Agent Message"),
                     frappe.PermissionError,
                 )
-            message.insert()
+
+            # MA-11: allocate conversation_index with a retry loop so concurrent
+            # inserts cannot read the same MAX and create duplicate indices.
+            max_retries = 3
+            message = None
+            last_index = 0
+            for attempt in range(max_retries):
+                last_index = frappe.db.sql("""
+                    SELECT MAX(conversation_index) as last_index
+                    FROM `tabAgent Message`
+                    WHERE conversation = %s
+                """, (conversation.name,), as_dict=1)
+                last_index = last_index[0].last_index if last_index and last_index[0].last_index is not None else 0
+
+                doc_data["conversation_index"] = last_index + 1
+                message = frappe.get_doc(doc_data)
+                try:
+                    message.insert()
+                    break
+                except (frappe.DuplicateEntryError, frappe.UniqueValidationError):
+                    if attempt == max_retries - 1:
+                        raise
+                    continue
 
             frappe.db.set_value("Agent Conversation", conversation.name, {
                 "total_messages": last_index + 1,

--- a/huf/ai/providers/anthropic.py
+++ b/huf/ai/providers/anthropic.py
@@ -128,32 +128,45 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                 for tool_use in tool_uses:
                     tool_name = tool_use.name
                     tool_args = tool_use.input
-                    
+
                     tool_to_run = _find_tool(agent, tool_name)
                     result_content = ''
+                    tool_failed = False
+                    error_message = None
 
                     if tool_to_run:
                         try:
                             result_content = await _execute_tool_call(tool_to_run, json.dumps(tool_args))
                         except Exception as e:
-                            result_content = f"Error executing tool {tool_name}: {str(e)}"
+                            tool_failed = True
+                            error_message = str(e)
+                            result_content = f"Error executing tool {tool_name}: {error_message}"
                     else:
-                        result_content = f"Tool '{tool_name}' not found."
+                        tool_failed = True
+                        error_message = f"Tool '{tool_name}' not found."
+                        result_content = error_message
 
                     all_new_items.append(
                         SimpleNamespace(
                             type="tool_call_output_item",
-                            raw_item={"name": tool_name, "output": result_content}
+                            raw_item={
+                                "name": tool_name,
+                                "output": result_content,
+                                "failed": tool_failed,
+                                "error_message": error_message,
+                            }
                         )
                     )
 
                     if isinstance(result_content, (dict, list)):
                         result_content = json.dumps(result_content, default=str)
-                    
+
                     tool_results.append({
                         "type": "tool_result",
                         "tool_use_id": tool_use.id,
-                        "content": str(result_content)
+                        "content": str(result_content),
+                        "failed": tool_failed,
+                        "error_message": error_message,
                     })
 
                 messages.append(assistant_message)

--- a/huf/ai/providers/google.py
+++ b/huf/ai/providers/google.py
@@ -170,26 +170,37 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
                     tool_to_run = _find_tool(agent, function_name)
                     result_content = ''
+                    tool_failed = False
+                    error_message = None
 
                     if tool_to_run:
                         try:
                             result_content = await _execute_tool_call(tool_to_run, json.dumps(function_args))
                         except Exception as e:
-                            result_content = f"Error executing tool {function_name}: {str(e)}"
+                            tool_failed = True
+                            error_message = str(e)
+                            result_content = f"Error executing tool {function_name}: {error_message}"
                     else:
-                        result_content = f"Tool '{function_name}' not found."
+                        tool_failed = True
+                        error_message = f"Tool '{function_name}' not found."
+                        result_content = error_message
 
                     all_new_items.append(
                         SimpleNamespace(
                             type="tool_call_output_item",
-                            raw_item={"name": function_name, "output": result_content}
+                            raw_item={
+                                "name": function_name,
+                                "output": result_content,
+                                "failed": tool_failed,
+                                "error_message": error_message,
+                            }
                         )
                     )
 
                     function_responses.append({
                         "functionResponse": {
                             "name": function_name,
-                            "response": {"result": result_content}
+                            "response": {"result": result_content, "failed": tool_failed, "error_message": error_message}
                         }
                     })
 

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -1817,6 +1817,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                         tool_call=[tool_call],
                                                         result_content=result_content,
                                                         agent_doc=agent_doc,
+                                                        status="Failed" if tool_failed else "Completed",
                                                     )
                                                     if not updated:
                                                         message_name = None

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -117,6 +117,51 @@ def _raise_provider_unavailable(raw_message: str, normalized_model: str | None =
     )
 
 
+def _merge_stream_usage(round_totals: dict, usage) -> dict:
+    """Merge per-round streaming usage into running totals.
+
+    ``usage`` may be a dict or a LiteLLM usage object. Numeric fields such as
+    ``prompt_tokens``, ``completion_tokens``, ``cached_tokens`` and
+    ``cache_creation_tokens`` are summed. The merged dict is returned.
+    """
+    if usage is None:
+        return round_totals
+
+    if hasattr(usage, "dict"):
+        usage = usage.dict()
+    elif hasattr(usage, "model_dump"):
+        usage = usage.model_dump()
+
+    if not isinstance(usage, dict):
+        return round_totals
+
+    numeric_keys = (
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cached_tokens",
+        "cache_creation_tokens",
+        "cache_miss_tokens",
+        "cache_creation_input_tokens",
+        "cache_write_tokens",
+        "cache_write_input_tokens",
+        "cache_hit_tokens",
+    )
+
+    for key in numeric_keys:
+        value = usage.get(key)
+        if value is None:
+            continue
+        try:
+            value = int(value)
+        except (ValueError, TypeError):
+            continue
+        if value:
+            round_totals[key] = round_totals.get(key, 0) + value
+
+    return round_totals
+
+
 # High-performance in-memory cache for provider capabilities
 # Stores capability flags to avoid Redis hits on every request
 _L1_CAPABILITY_CACHE = {}
@@ -1026,6 +1071,8 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                 result_content = ""
 
                 if tool_to_run:
+                    tool_failed = False
+                    error_message = None
                     try:
                         # Emit socket event for tool execution start BEFORE executing
                         if context and context.get("conversation_id"):
@@ -1045,23 +1092,33 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                                 after_commit=False
                             )
                             transaction_checkpoint(reason="agent_streaming_progress")
-                        
+
                         result_content = await _execute_tool_call(
                             tool_to_run, tool_args, context, tool_call.id
                         )
                     except Exception as e:
+                        tool_failed = True
+                        error_message = str(e)
                         frappe.log_error(
-                            message=f"Error executing tool {tool_name}: {str(e)}\n\n{frappe.get_traceback()}",
+                            message=f"Error executing tool {tool_name}: {error_message}\n\n{frappe.get_traceback()}",
                             title="LiteLLM Tool Execution Error"
                         )
-                        result_content = f"Error executing tool {tool_name}: {str(e)}"
+                        result_content = f"Error executing tool {tool_name}: {error_message}"
                 else:
-                    result_content = f"Tool '{tool_name}' not found."
+                    tool_failed = True
+                    error_message = f"Tool '{tool_name}' not found."
+                    result_content = error_message
 
                 all_new_items.append(
                     SimpleNamespace(
                         type="tool_call_output_item",
-                        raw_item={"name": tool_name, "output": result_content, "id": tool_call.id},
+                        raw_item={
+                            "name": tool_name,
+                            "output": result_content,
+                            "id": tool_call.id,
+                            "failed": tool_failed,
+                            "error_message": error_message,
+                        },
                     )
                 )
 
@@ -1071,6 +1128,8 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                         "tool_call_id": tool_call.id,
                         "name": tool_name,
                         "content": _truncate_tool_result_for_context(result_content, max_context_chars),
+                        "failed": tool_failed,
+                        "error_message": error_message,
                     }
                 )
 
@@ -1503,6 +1562,10 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         tool_loop_repeats = 0
         MAX_TOOL_LOOP_REPEATS = 1  # allow one retry, stop on the second repeat
 
+        # MA-09: aggregate usage across all tool rounds instead of keeping only
+        # the last round's usage.
+        round_totals = {}
+
         for round_num in range(MAX_ROUNDS):
             try:
                 # Use LiteLLM completion with stream=True
@@ -1666,16 +1729,20 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                         )
                                         transaction_checkpoint(reason="agent_streaming_progress")
 
+                                    tool_failed = False
+                                    error_message = None
                                     try:
                                         result_content = await _execute_tool_call(
                                             tool_to_run, tool_args, context, tool_call.get("id")
                                         )
                                     except Exception as e:
+                                        tool_failed = True
+                                        error_message = str(e)
                                         frappe.log_error(
-                                            message=f"Error executing tool {tool_name}: {str(e)}\n\n{frappe.get_traceback()}",
+                                            message=f"Error executing tool {tool_name}: {error_message}\n\n{frappe.get_traceback()}",
                                             title="LiteLLM Streaming Tool Execution Error"
                                         )
-                                        result_content = f"Error executing tool {tool_name}: {str(e)}"
+                                        result_content = f"Error executing tool {tool_name}: {error_message}"
 
                                     # Update Agent Tool Call with result (runs even if tool raised)
                                     if context and context.get("conversation_id"):
@@ -1690,7 +1757,10 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
 
                                             if tool_call_doc:
                                                 tc_doc = frappe.get_doc("Agent Tool Call", tool_call_doc)
-                                                tc_doc.status = "Completed"
+                                                # MA-08: surface tool failures instead of recording Completed.
+                                                tc_doc.status = "Failed" if tool_failed else "Completed"
+                                                if tool_failed:
+                                                    tc_doc.error_message = error_message
                                                 # JSON field: store valid JSON (dict)
                                                 if isinstance(result_content, (dict, list)):
                                                     tc_doc.tool_result = result_content
@@ -1705,6 +1775,11 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                     if not frappe.has_permission("Agent Tool Call", "write", doc=tc_doc):
                                                         frappe.throw(_("Not permitted to update Agent Tool Call"), frappe.PermissionError)
                                                     tc_doc.save()
+
+                                                # MA-10: re-sync fetch_from tool fields on the linked
+                                                # Agent Message so tool_status does not stay stale.
+                                                from huf.ai.conversation_manager import sync_tool_status_to_message
+                                                sync_tool_status_to_message(tool_call_doc)
 
                                                 # Find the Agent Message to update. Prefer the in-memory
                                                 # map passed via context, then fall back to DB lookups.
@@ -1760,6 +1835,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                     if isinstance(result_content, (dict, list))
                                                     else {"output": str(result_content)[:140000]}
                                                 )
+                                                final_tool_status = "Failed" if tool_failed else "Completed"
                                                 frappe.publish_realtime(
                                                     event=f'conversation:{context.get("conversation_id")}',
                                                     message={
@@ -1769,8 +1845,9 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                                                         "message_id": message_name,
                                                         "tool_call_id": tool_call["id"],
                                                         "tool_name": tool_name,
-                                                        "tool_status": "Completed",
-                                                        "status": "Completed",
+                                                        "tool_status": final_tool_status,
+                                                        "status": final_tool_status,
+                                                        "error_message": error_message if tool_failed else None,
                                                         "tool_result": tool_result_for_socket,
                                                         "result": json.dumps(tool_result_for_socket) if isinstance(tool_result_for_socket, (dict, list)) else str(result_content)[:1000],
                                                     },
@@ -1819,6 +1896,9 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                         if finish_reason == "stop":
                             is_stop = True
 
+                    # MA-09: aggregate this round's usage before continuing.
+                    round_totals = _merge_stream_usage(round_totals, stream_usage)
+
                 if is_stop:
                     break
 
@@ -1848,13 +1928,9 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                 return
 
         # Max rounds reached
-        if stream_usage and hasattr(stream_usage, "dict"):
-             stream_usage = stream_usage.dict()
-        elif stream_usage and hasattr(stream_usage, "model_dump"):
-             stream_usage = stream_usage.model_dump()
-
-        if not stream_usage or not isinstance(stream_usage, dict):
-            stream_usage = {}
+        # MA-09: report the aggregated usage across all rounds, not just the
+        # last round's usage.
+        stream_usage = round_totals
 
         # Extract cache creation tokens and cache skipped flag for stream_usage
         s_cached = 0

--- a/huf/ai/providers/openrouter.py
+++ b/huf/ai/providers/openrouter.py
@@ -94,24 +94,37 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
                 tool_to_run = _find_tool(agent, tool_name)
                 result_content = ''
+                tool_failed = False
+                error_message = None
 
                 if tool_to_run:
                     try:
                         result_content = await _execute_tool_call(tool_to_run, tool_args)
                     except Exception as e:
-                        result_content = f"Error executing tool {tool_name}: {e}"
+                        tool_failed = True
+                        error_message = str(e)
+                        result_content = f"Error executing tool {tool_name}: {error_message}"
                 else:
-                    result_content = f"Tool '{tool_name}' not found."
+                    tool_failed = True
+                    error_message = f"Tool '{tool_name}' not found."
+                    result_content = error_message
 
                 tool_results_for_api.append({
                     "tool_call_id": tool_call.get("id"),
                     "role": "tool",
                     "name": tool_name,
                     "content": result_content,
+                    "failed": tool_failed,
+                    "error_message": error_message,
                 })
                 all_new_items.append(SimpleNamespace(
                     type="tool_call_output_item",
-                    raw_item={"name": tool_name, "output": result_content}
+                    raw_item={
+                        "name": tool_name,
+                        "output": result_content,
+                        "failed": tool_failed,
+                        "error_message": error_message,
+                    }
                 ))
 
             messages.extend(tool_results_for_api)

--- a/huf/ai/results/__init__.py
+++ b/huf/ai/results/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Result/Context Foundation V1.
+
+Large tool/API results live outside ``Agent Message`` and the next model
+context.  This package owns durable storage, bounded envelopes, selective
+reads, and retention for those results.
+"""

--- a/huf/ai/results/api.py
+++ b/huf/ai/results/api.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Whitelisted REST API for result reads.
+
+The UI can call these endpoints the same way it calls
+``agentContextArtifactApi.ts`` endpoints.  They enforce DocType permissions
+and the same hard limits as the agent tools.
+"""
+
+import json
+
+import frappe
+from frappe import _
+
+from huf.ai.results.views import result_index_for_conversation, result_read as _result_read_view
+
+
+@frappe.whitelist()
+def result_read(
+    result_name: str,
+    view: str = "summary",
+    selector: str | None = None,
+    page: int | None = None,
+    page_size: int | None = None,
+    filter=None,
+    columns: str | list | None = None,
+    max_tokens: int | None = None,
+    max_rows: int | None = None,
+    max_bytes: int | None = None,
+):
+    """Whitelisted bounded read of an ``Agent Execution Result``."""
+    result_doc = frappe.get_doc("Agent Execution Result", result_name)
+    if not frappe.has_permission("Agent Execution Result", "read", doc=result_doc):
+        frappe.throw(
+            _("Not permitted to read Agent Execution Result {0}").format(result_name),
+            frappe.PermissionError,
+        )
+
+    if isinstance(columns, str):
+        try:
+            columns = json.loads(columns)
+        except (json.JSONDecodeError, TypeError):
+            columns = [c.strip() for c in columns.split(",") if c.strip()]
+
+    if isinstance(filter, str):
+        try:
+            filter = json.loads(filter)
+        except (json.JSONDecodeError, TypeError):
+            filter = {}
+
+    return _result_read_view(
+        ref=result_name,
+        view=view,
+        selector=selector,
+        page=int(page) if page is not None else None,
+        page_size=int(page_size) if page_size is not None else None,
+        filter=filter,
+        columns=columns,
+        max_tokens=int(max_tokens) if max_tokens is not None else None,
+        max_rows=int(max_rows) if max_rows is not None else None,
+        max_bytes=int(max_bytes) if max_bytes is not None else None,
+    )
+
+
+@frappe.whitelist()
+def result_index(conversation_id: str):
+    """Whitelisted compact index of results for a conversation."""
+    conversation = frappe.get_doc("Agent Conversation", conversation_id)
+    if not frappe.has_permission("Agent Conversation", "read", doc=conversation):
+        frappe.throw(
+            _("Not permitted to read conversation {0}").format(conversation_id),
+            frappe.PermissionError,
+        )
+    return result_index_for_conversation(conversation_id)

--- a/huf/ai/results/envelope.py
+++ b/huf/ai/results/envelope.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Bounded result envelopes.
+
+Envelopes are the only representation of a result that enters model context.
+They never contain the full raw payload.
+"""
+
+import json
+
+import frappe
+
+
+def _safe_load_json(value: str | None) -> dict | list | None:
+    """Parse a JSON field value, returning ``None`` on failure."""
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def build_envelope(result_doc, status: str = "success") -> dict:
+    """Return a bounded envelope for ``result_doc``.
+
+    The envelope contains metadata, schema, preview, size, available views,
+    and source lineage.  It deliberately excludes the raw payload.
+    """
+    schema = _safe_load_json(result_doc.schema_json)
+    preview = _safe_load_json(result_doc.preview_json)
+    available_views = _safe_load_json(result_doc.available_views) or []
+
+    size = {
+        "bytes": result_doc.size_bytes or 0,
+        "estimated_tokens": result_doc.estimated_tokens or 0,
+    }
+    if isinstance(schema, dict) and "row_count" in schema:
+        size["rows"] = schema["row_count"]
+    if isinstance(schema, dict) and "item_count" in schema:
+        size["items"] = schema["item_count"]
+
+    return {
+        "status": status,
+        "result_ref": f"result://{result_doc.name}",
+        "result_type": result_doc.result_type or "text",
+        "summary": result_doc.summary or "",
+        "schema": schema,
+        "preview": preview,
+        "size": size,
+        "available_views": available_views,
+        "source": {
+            "run_id": result_doc.agent_run,
+            "tool_call_id": result_doc.tool_call,
+            "source_tool": result_doc.source_tool,
+        },
+    }
+
+
+def build_error_envelope(result_doc, error: str) -> dict:
+    """Return an envelope for a failed or expired result read."""
+    envelope = build_envelope(result_doc, status="error")
+    envelope["error"] = error
+    return envelope

--- a/huf/ai/results/permissions.py
+++ b/huf/ai/results/permissions.py
@@ -38,7 +38,7 @@ def _is_conversation_participant(conversation_name: str) -> bool:
     # conversations.
     participant = frappe.db.exists(
         "Agent Message",
-        {"conversation": conversation_name, "owner": ("!=", "Administrator"), "owner": user},
+        {"conversation": conversation_name, "owner": user},
     )
     if participant:
         return True

--- a/huf/ai/results/permissions.py
+++ b/huf/ai/results/permissions.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Permission helpers for ``Agent Execution Result``.
+
+Role permissions mirror ``Agent Tool Call`` (System Manager all; Huf Manager
+and Huf User create/read/write).  This module adds conversation ownership and
+participant scoping on top of those role permissions.
+"""
+
+import frappe
+from frappe import _
+
+
+def _is_conversation_participant(conversation_name: str) -> bool:
+    """Return True if the current user owns or participates in the conversation."""
+    if not conversation_name:
+        return False
+
+    user = frappe.session.user
+    if user == "Administrator":
+        return True
+
+    conv = frappe.db.get_value(
+        "Agent Conversation",
+        conversation_name,
+        ["owner", "session_id"],
+        as_dict=True,
+    )
+    if not conv:
+        return False
+
+    if conv.owner == user:
+        return True
+
+    # Anyone who has already written an Agent Message in this conversation is a
+    # participant.  This covers assistant/tool messages as well as multi-user
+    # conversations.
+    participant = frappe.db.exists(
+        "Agent Message",
+        {"conversation": conversation_name, "owner": ("!=", "Administrator"), "owner": user},
+    )
+    if participant:
+        return True
+
+    return False
+
+
+def can_read_result(result_doc) -> bool:
+    """Return True if the current user may read ``result_doc``."""
+    if not result_doc:
+        return False
+
+    if frappe.has_permission("Agent Execution Result", "read", doc=result_doc):
+        return True
+
+    # Role permission denied; still allow conversation participants to read
+    # results attached to their own conversations.
+    return _is_conversation_participant(result_doc.conversation)
+
+
+def can_write_result(result_doc) -> bool:
+    """Return True if the current user may write ``result_doc``."""
+    if not result_doc:
+        return False
+
+    if frappe.has_permission("Agent Execution Result", "write", doc=result_doc):
+        return True
+
+    return _is_conversation_participant(result_doc.conversation)
+
+
+def require_result_read_permission(result_doc):
+    """Throw ``PermissionError`` if the current user cannot read the result."""
+    if not can_read_result(result_doc):
+        frappe.throw(
+            _("Not permitted to read Agent Execution Result {0}").format(result_doc.name),
+            frappe.PermissionError,
+        )
+
+
+def require_result_write_permission(result_doc):
+    """Throw ``PermissionError`` if the current user cannot write the result."""
+    if not can_write_result(result_doc):
+        frappe.throw(
+            _("Not permitted to write Agent Execution Result {0}").format(result_doc.name),
+            frappe.PermissionError,
+        )

--- a/huf/ai/results/policy.py
+++ b/huf/ai/results/policy.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Result-store policy: thresholds, retention, and hard server-side limits.
+
+All limits are intentionally conservative for V1.  Callers may request larger
+values, but the server always caps them here.
+"""
+
+from datetime import datetime, timedelta
+
+# Size classification ---------------------------------------------------------
+
+# Results <= this many bytes are stored inline in ``Agent Execution Result``.
+INLINE_THRESHOLD_BYTES = 8 * 1024  # 8 KB
+
+# Results > this threshold are considered "very large": only summary/schema/
+# preview views are advertised by default.  Bounded page/row reads still work.
+SCHEMA_ONLY_THRESHOLD_BYTES = 256 * 1024  # 256 KB
+
+# Absolute cap on any payload we will accept.  Anything larger is truncated.
+ABSOLUTE_MAX_BYTES = 16 * 1024 * 1024  # 16 MB
+
+# Absolute caps on rows/items for tabular/collection results.
+ABSOLUTE_MAX_ROWS = 100_000
+ABSOLUTE_MAX_ITEMS = 100_000
+
+# Default preview size.
+DEFAULT_PREVIEW_ROWS = 5
+DEFAULT_PREVIEW_ITEMS = 5
+DEFAULT_PREVIEW_CHARS = 500
+
+# Read limits -----------------------------------------------------------------
+
+HARD_MAX_ROWS = 100
+HARD_MAX_BYTES = 32 * 1024  # 32 KB
+HARD_MAX_TOKENS = 4_000
+HARD_MAX_PAGE_SIZE = 100
+
+# Retention -------------------------------------------------------------------
+
+DEFAULT_RETENTION_DAYS = 30
+
+
+def default_expires_on() -> datetime | None:
+    """Return the default expiration timestamp for a new result."""
+    return datetime.utcnow() + timedelta(days=DEFAULT_RETENTION_DAYS)
+
+
+def coerce_read_limits(
+    max_rows: int | None = None,
+    max_bytes: int | None = None,
+    max_tokens: int | None = None,
+    page_size: int | None = None,
+) -> dict:
+    """Return client-requested limits capped by the hard server-side limits."""
+    return {
+        "max_rows": min(max_rows or HARD_MAX_ROWS, HARD_MAX_ROWS),
+        "max_bytes": min(max_bytes or HARD_MAX_BYTES, HARD_MAX_BYTES),
+        "max_tokens": min(max_tokens or HARD_MAX_TOKENS, HARD_MAX_TOKENS),
+        "page_size": min(page_size or HARD_MAX_PAGE_SIZE, HARD_MAX_PAGE_SIZE),
+    }
+
+
+def expire_stale_results():
+    """Daily cleanup: mark expired results and delete their private payload files."""
+    import frappe
+
+    expired = frappe.get_all(
+        "Agent Execution Result",
+        filters={"expires_on": ("<", frappe.utils.now()), "status": ("!=", "Expired")},
+        fields=["name", "payload_file"],
+    )
+
+    for row in expired:
+        if row.payload_file:
+            try:
+                file_doc = frappe.get_doc("File", {"file_url": row.payload_file})
+                file_doc.delete(ignore_permissions=True)
+            except Exception as e:
+                frappe.logger("huf").warning(
+                    f"Could not delete expired result file {row.payload_file}: {e!s}"
+                )
+        frappe.db.set_value("Agent Execution Result", row.name, "status", "Expired")
+
+    frappe.db.commit()

--- a/huf/ai/results/store.py
+++ b/huf/ai/results/store.py
@@ -1,0 +1,326 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Durable storage for tool/API execution results.
+
+This module owns result-size classification, schema/preview generation,
+checksum computation, private-file storage, and idempotent writes.  Callers
+should route every tool result through :func:`persist_result` and use the
+bounded envelope it returns; they must not re-implement size classification.
+"""
+
+import hashlib
+import json
+import os
+from typing import Any
+
+import frappe
+from frappe.utils.file_manager import save_file
+from frappe.utils import get_site_path
+
+from huf.ai.results import policy
+from huf.ai.results.tokens import estimate_tokens
+from huf.ai.results.envelope import build_envelope
+
+
+def _normalize_payload(value: Any) -> tuple[str | bytes, int]:
+    """Return ``(normalized, is_binary)`` for ``value``.
+
+    Strings and UTF-8-decodable bytes are treated as text.  Other bytes are
+    kept as binary and classified as ``file`` results.
+    """
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8"), False
+        except UnicodeDecodeError:
+            return value, True
+    if isinstance(value, str):
+        return value, False
+    return json.dumps(value, default=str), False
+
+
+def _classify_result_type(text: str | bytes, parsed: Any | None) -> str:
+    """Return one of the ``Agent Execution Result`` result_type values."""
+    if isinstance(text, bytes):
+        return "file"
+    if isinstance(parsed, list):
+        if parsed and all(isinstance(r, dict) for r in parsed):
+            return "table"
+        return "collection"
+    if isinstance(parsed, dict):
+        return "json"
+    return "text"
+
+
+def _build_schema(result_type: str, parsed: Any, text: str | bytes) -> dict:
+    """Build structural metadata for the result."""
+    if result_type == "table" and isinstance(parsed, list) and parsed:
+        first = parsed[0]
+        if isinstance(first, dict):
+            columns = list(first.keys())
+            return {"columns": columns, "row_count": len(parsed)}
+        if isinstance(first, list):
+            return {"columns": len(first), "row_count": len(parsed)}
+    if result_type == "collection" and isinstance(parsed, list):
+        return {"item_count": len(parsed)}
+    if result_type == "json" and isinstance(parsed, dict):
+        return {"keys": list(parsed.keys())}
+    if result_type == "text":
+        return {"chars": len(text)}
+    if result_type == "file":
+        return {"binary": True, "bytes": len(text)}
+    return {}
+
+
+def _build_preview(
+    result_type: str,
+    parsed: Any,
+    text: str | bytes,
+    max_rows: int = policy.DEFAULT_PREVIEW_ROWS,
+    max_items: int = policy.DEFAULT_PREVIEW_ITEMS,
+    max_chars: int = policy.DEFAULT_PREVIEW_CHARS,
+) -> dict:
+    """Build a bounded preview of the result."""
+    if result_type == "table" and isinstance(parsed, list):
+        rows = parsed[:max_rows]
+        return {"rows": rows, "truncated": len(parsed) > max_rows}
+    if result_type == "collection" and isinstance(parsed, list):
+        items = parsed[:max_items]
+        return {"items": items, "truncated": len(parsed) > max_items}
+    if result_type == "json" and isinstance(parsed, dict):
+        preview = {}
+        for key in list(parsed.keys())[:max_items]:
+            value = parsed[key]
+            if isinstance(value, (dict, list)):
+                preview[key] = f"<{type(value).__name__}: {len(value)} items>"
+            else:
+                preview[key] = value
+        return {"keys": list(preview.keys()), "sample": preview}
+    if isinstance(text, bytes):
+        return {"bytes": len(text), "note": "binary payload stored as private file"}
+    return {"text": text[:max_chars], "truncated": len(text) > max_chars}
+
+
+def _compute_hash(data: bytes) -> str:
+    """Return ``sha256:<hex>`` for ``data``."""
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _available_views(result_type: str, size_bytes: int) -> list[str]:
+    """Return the views advertised for this result."""
+    base = ["summary", "schema", "preview"]
+    if size_bytes <= policy.SCHEMA_ONLY_THRESHOLD_BYTES:
+        if result_type in ("table", "collection"):
+            base.extend(["page", "range", "filter", "row"])
+        elif result_type in ("json", "text"):
+            base.extend(["page", "range", "path"])
+        elif result_type == "file":
+            base.extend(["range", "row"])
+    return base
+
+
+def _build_summary(result_type: str, parsed: Any, text: str | bytes, size_bytes: int) -> str:
+    """Build a human/model-readable summary."""
+    if result_type == "table" and isinstance(parsed, list):
+        return f"Table result with {len(parsed)} rows and {len(parsed[0]) if parsed else 0} columns ({size_bytes} bytes)"
+    if result_type == "collection" and isinstance(parsed, list):
+        return f"Collection with {len(parsed)} items ({size_bytes} bytes)"
+    if result_type == "json" and isinstance(parsed, dict):
+        return f"JSON object with {len(parsed)} keys ({size_bytes} bytes)"
+    if result_type == "file":
+        return f"Binary file ({size_bytes} bytes)"
+    chars = len(text) if isinstance(text, str) else size_bytes
+    return f"Text result ({chars} characters, {size_bytes} bytes)"
+
+
+def _find_existing_result(
+    idempotency_key: str | None,
+    tool_call: str,
+    run: str,
+) -> "frappe.Document | None":
+    """Return an existing result when an idempotency key matches."""
+    if not idempotency_key:
+        return None
+    name = frappe.db.get_value(
+        "Agent Execution Result",
+        {
+            "idempotency_key": idempotency_key,
+            "tool_call": tool_call,
+            "agent_run": run,
+        },
+        "name",
+    )
+    if name:
+        return frappe.get_doc("Agent Execution Result", name)
+    return None
+
+
+def _save_payload_file(result_doc, data: bytes, filename: str) -> str:
+    """Save ``data`` as a private file attached to ``result_doc``.
+
+    Files are stored as private files with a ``result_`` prefix for
+    organization.  Returns the ``file_url`` stored in ``payload_file``.
+    """
+    target_name = f"result_{result_doc.name}_{filename}"
+
+    saved = save_file(
+        target_name,
+        data,
+        "Agent Execution Result",
+        result_doc.name,
+        is_private=True,
+    )
+    file_url = getattr(saved, "file_url", None) or (
+        saved.get("file_url") if isinstance(saved, dict) else None
+    )
+    if not file_url:
+        raise ValueError(f"save_file returned no file_url for result {result_doc.name}")
+    return file_url
+
+
+def _load_payload_file(file_url: str) -> bytes:
+    """Load raw bytes from a private payload file."""
+    file_doc = frappe.get_doc(
+        "File",
+        {"file_url": file_url},
+    )
+    with open(file_doc.get_full_path(), "rb") as fh:
+        return fh.read()
+
+
+def persist_result(
+    result_content: Any,
+    run: str,
+    tool_call: str,
+    conversation: str,
+    source_tool: str | None = None,
+    visibility: str = "model_visible",
+    idempotency_key: str | None = None,
+    expires_on=None,
+    agent_doc=None,
+    status: str = "Completed",
+) -> tuple["frappe.Document", dict]:
+    """Persist ``result_content`` and return ``(result_doc, envelope)``.
+
+    Args:
+        result_content: the raw tool/API output.
+        run: ``Agent Run`` name.
+        tool_call: ``Agent Tool Call`` name.
+        conversation: ``Agent Conversation`` name.
+        source_tool: denormalized tool name for indexing.
+        visibility: one of the visibility select values.
+        idempotency_key: optional retry-deduplication key.
+        expires_on: optional retention timestamp.
+        agent_doc: optional Agent document (used only for backward-compatible
+            ``max_context_chars`` logging; classification is owned here).
+        status: ``Completed`` or ``Failed``.
+
+    Returns:
+        A tuple of ``(Agent Execution Result document, bounded envelope dict)``.
+    """
+    if not run or not tool_call or not conversation:
+        raise ValueError("run, tool_call, and conversation are required")
+
+    existing = _find_existing_result(idempotency_key, tool_call, run)
+    if existing:
+        return existing, build_envelope(existing)
+
+    # Normalize payload ------------------------------------------------------
+    text, is_binary = _normalize_payload(result_content)
+    if is_binary:
+        raw_bytes = text if isinstance(text, bytes) else text.encode("utf-8", errors="replace")
+    else:
+        raw_bytes = text.encode("utf-8") if isinstance(text, str) else b""
+
+    # Enforce absolute size cap
+    original_size = len(raw_bytes)
+    truncated = False
+    if original_size > policy.ABSOLUTE_MAX_BYTES:
+        raw_bytes = raw_bytes[: policy.ABSOLUTE_MAX_BYTES]
+        truncated = True
+        frappe.log_error(
+            f"Result for tool_call={tool_call} truncated from {original_size} to "
+            f"{policy.ABSOLUTE_MAX_BYTES} bytes",
+            "Result Store Size Limit",
+        )
+
+    size_bytes = len(raw_bytes)
+    estimated_tokens = estimate_tokens(raw_bytes)
+
+    # Parse structured payloads
+    parsed = None
+    if not is_binary:
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            parsed = text
+
+    result_type = _classify_result_type(text, parsed)
+    schema = _build_schema(result_type, parsed, text)
+    preview = _build_preview(result_type, parsed, text)
+    summary = _build_summary(result_type, parsed, text, size_bytes)
+    if truncated:
+        summary = f"{summary} [truncated to {policy.ABSOLUTE_MAX_BYTES} bytes]"
+
+    # Size classification ----------------------------------------------------
+    inline_payload = None
+    payload_file = None
+    if size_bytes <= policy.INLINE_THRESHOLD_BYTES and not is_binary:
+        inline_payload = parsed if parsed is not None else text
+    else:
+        # Large or binary: always stored as a private file.
+        payload_file = "__pending__"
+
+    available_views = _available_views(result_type, size_bytes)
+
+    doc = frappe.get_doc(
+        {
+            "doctype": "Agent Execution Result",
+            "conversation": conversation,
+            "agent_run": run,
+            "tool_call": tool_call,
+            "source_tool": source_tool,
+            "status": status,
+            "result_type": result_type,
+            "summary": summary,
+            "schema_json": json.dumps(schema, default=str),
+            "preview_json": json.dumps(preview, default=str),
+            "inline_payload": json.dumps(inline_payload, default=str) if inline_payload is not None else None,
+            "payload_file": payload_file,
+            "content_hash": _compute_hash(raw_bytes),
+            "size_bytes": size_bytes,
+            "estimated_tokens": estimated_tokens,
+            "available_views": json.dumps(available_views),
+            "expires_on": expires_on,
+            "visibility": visibility,
+            "idempotency_key": idempotency_key,
+        }
+    )
+    doc.insert(ignore_permissions=True)
+
+    if payload_file == "__pending__":
+        filename = "payload.bin" if is_binary else "payload.json"
+        file_url = _save_payload_file(doc, raw_bytes, filename)
+        doc.payload_file = file_url
+        doc.save(ignore_permissions=True)
+
+    return doc, build_envelope(doc)
+
+
+def load_payload(result_doc) -> bytes:
+    """Load the raw payload bytes for ``result_doc``.
+
+    Raises ``ValueError`` if the payload is missing or cannot be loaded.
+    """
+    if result_doc.inline_payload:
+        try:
+            parsed = json.loads(result_doc.inline_payload)
+        except (json.JSONDecodeError, TypeError):
+            parsed = result_doc.inline_payload
+        text = json.dumps(parsed, default=str) if not isinstance(parsed, str) else parsed
+        return text.encode("utf-8")
+
+    if result_doc.payload_file:
+        return _load_payload_file(result_doc.payload_file)
+
+    raise ValueError(f"Agent Execution Result {result_doc.name} has no payload")

--- a/huf/ai/results/tokens.py
+++ b/huf/ai/results/tokens.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Token estimation helpers for result payloads.
+
+Frappe does not depend on ``tiktoken`` and we do not add it for V1.  The
+estimate is a conservative character heuristic used only for context-budget
+metadata and hard-limit checks, not for billing.
+"""
+
+import math
+
+
+def estimate_tokens(value) -> int:
+    """Return a heuristic token count for ``value``.
+
+    - Strings: ``ceil(len(text) / 4)``.
+    - Bytes: decoded as UTF-8 (replacing errors), then ``ceil(len / 4)``.
+    - Dicts/lists: JSON-serialized then ``ceil(len / 4)``.
+    - ``None``: ``0``.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="replace")
+    elif isinstance(value, str):
+        text = value
+    else:
+        import json
+
+        text = json.dumps(value, default=str)
+    return max(1, math.ceil(len(text) / 4)) if text else 0

--- a/huf/ai/results/tools.py
+++ b/huf/ai/results/tools.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Agent-callable tools for bounded result access.
+
+These tools are registered in ``huf.ai.sdk_tools.create_agent_tools`` and are
+the only way the model should read result payloads.  They enforce the same
+hard limits as the UI API.
+"""
+
+import json
+
+import frappe
+
+from huf.ai.results.views import result_index_for_conversation, result_read
+
+
+def result_read_tool(
+    ref: str,
+    view: str = "summary",
+    selector: str | None = None,
+    page: int | None = None,
+    page_size: int | None = None,
+    filter=None,
+    columns: list | None = None,
+    max_tokens: int | None = None,
+    max_rows: int | None = None,
+    max_bytes: int | None = None,
+) -> dict:
+    """Read a bounded view of a stored execution result.
+
+    Args:
+        ref: ``result://RES-00001`` or the result document name.
+        view: one of ``summary`` (default), ``schema``, ``preview``, ``page``,
+            ``range``, ``path``, ``filter``, ``row``.
+        selector: optional range/path/row selector.
+        page: 1-based page number for ``page`` view.
+        page_size: requested page size (capped server-side).
+        filter: dict of column-value filters for ``filter`` view.
+        columns: list of columns to include for ``filter`` view.
+        max_tokens: requested token cap (capped server-side).
+        max_rows: requested row cap (capped server-side).
+        max_bytes: requested byte cap (capped server-side).
+    """
+    try:
+        return result_read(
+            ref=ref,
+            view=view,
+            selector=selector,
+            page=page,
+            page_size=page_size,
+            filter=filter,
+            columns=columns,
+            max_tokens=max_tokens,
+            max_rows=max_rows,
+            max_bytes=max_bytes,
+        )
+    except frappe.PermissionError as e:
+        return {"status": "error", "error": str(e)}
+    except Exception as e:
+        frappe.logger("huf").warning(f"result_read_tool failed: {e!s}\n{frappe.get_traceback()}")
+        return {"status": "error", "error": str(e)}
+
+
+def result_index_tool(conversation_id: str) -> dict:
+    """Return a compact index of results for the current conversation."""
+    try:
+        if not conversation_id:
+            return {"status": "error", "error": "conversation_id is required."}
+        conversation = frappe.get_doc("Agent Conversation", conversation_id)
+        if not frappe.has_permission("Agent Conversation", "read", doc=conversation):
+            return {"status": "error", "error": "Not permitted to read this conversation."}
+        return result_index_for_conversation(conversation_id)
+    except frappe.PermissionError as e:
+        return {"status": "error", "error": str(e)}
+    except Exception as e:
+        frappe.logger("huf").warning(f"result_index_tool failed: {e!s}\n{frappe.get_traceback()}")
+        return {"status": "error", "error": str(e)}

--- a/huf/ai/results/views.py
+++ b/huf/ai/results/views.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Bounded result reads.
+
+Every view enforces server-side byte/row/token limits regardless of what the
+caller (model or UI) requests.
+"""
+
+import json
+import re
+from typing import Any
+
+import frappe
+
+from huf.ai.results import policy
+from huf.ai.results.envelope import build_envelope, build_error_envelope
+from huf.ai.results.permissions import require_result_read_permission
+from huf.ai.results.store import load_payload
+from huf.ai.results.tokens import estimate_tokens
+
+
+VIEWS = {"summary", "schema", "preview", "page", "range", "path", "filter", "row"}
+
+
+def _resolve_result_doc(ref) -> "frappe.Document":
+    """Load an ``Agent Execution Result`` from a ref string, name, or doc."""
+    if hasattr(ref, "doctype") and ref.doctype == "Agent Execution Result":
+        return ref
+
+    name = ref
+    if isinstance(name, str) and name.startswith("result://"):
+        name = name[len("result://") :]
+    return frappe.get_doc("Agent Execution Result", name)
+
+
+def _parse_json_payload(data: bytes, result_type: str):
+    """Parse payload bytes into a Python object when possible."""
+    text = data.decode("utf-8", errors="replace")
+    if result_type in ("json", "table", "collection"):
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return text
+
+
+def _token_cap_trim(value: Any, max_tokens: int) -> Any:
+    """Return ``value`` trimmed so its JSON representation is under ``max_tokens``."""
+    if max_tokens <= 0:
+        return value
+    text = json.dumps(value, default=str)
+    if estimate_tokens(text) <= max_tokens:
+        return value
+    # Trim by characters (heuristic: 1 token ≈ 4 chars).
+    max_chars = max_tokens * 4
+    trimmed_text = text[:max_chars]
+    # Try to keep valid JSON by trimming at the last safe boundary.
+    try:
+        return json.loads(trimmed_text)
+    except (json.JSONDecodeError, TypeError):
+        return trimmed_text
+
+
+def _bytes_cap_trim(value: Any, max_bytes: int) -> Any:
+    """Return ``value`` trimmed so its UTF-8 JSON representation is under ``max_bytes``."""
+    if max_bytes <= 0:
+        return value
+    text = json.dumps(value, default=str)
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    trimmed = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    try:
+        return json.loads(trimmed)
+    except (json.JSONDecodeError, TypeError):
+        return trimmed
+
+
+def _apply_output_limits(value: Any, max_tokens: int, max_bytes: int) -> Any:
+    """Apply token and byte caps to a view result."""
+    value = _bytes_cap_trim(value, max_bytes)
+    value = _token_cap_trim(value, max_tokens)
+    return value
+
+
+def _view_summary(result_doc, limits: dict) -> dict:
+    """Return the bounded envelope itself as the summary view."""
+    envelope = build_envelope(result_doc)
+    return _apply_output_limits(envelope, limits["max_tokens"], limits["max_bytes"])
+
+
+def _view_schema(result_doc, limits: dict) -> dict:
+    schema = json.loads(result_doc.schema_json) if result_doc.schema_json else {}
+    return _apply_output_limits(
+        {"result_ref": f"result://{result_doc.name}", "schema": schema},
+        limits["max_tokens"],
+        limits["max_bytes"],
+    )
+
+
+def _view_preview(result_doc, limits: dict) -> dict:
+    preview = json.loads(result_doc.preview_json) if result_doc.preview_json else {}
+    return _apply_output_limits(
+        {"result_ref": f"result://{result_doc.name}", "preview": preview},
+        limits["max_tokens"],
+        limits["max_bytes"],
+    )
+
+
+def _view_page(result_doc, limits: dict, page: int | None, page_size: int | None) -> dict:
+    page = max(1, page or 1)
+    page_size = limits["page_size"]
+    start = (page - 1) * page_size
+    end = start + page_size
+
+    data = load_payload(result_doc)
+    parsed = _parse_json_payload(data, result_doc.result_type or "text")
+
+    if isinstance(parsed, list):
+        rows = parsed[start:end]
+        total = len(parsed)
+    elif isinstance(parsed, str):
+        lines = parsed.splitlines()
+        rows = lines[start:end]
+        total = len(lines)
+    else:
+        rows = []
+        total = 0
+
+    result = {
+        "result_ref": f"result://{result_doc.name}",
+        "view": "page",
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+        "rows": rows,
+    }
+    return _apply_output_limits(result, limits["max_tokens"], limits["max_bytes"])
+
+
+def _view_range(result_doc, limits: dict, selector: str | None) -> dict:
+    data = load_payload(result_doc)
+    parsed = _parse_json_payload(data, result_doc.result_type or "text")
+
+    rows = []
+    total = 0
+    if isinstance(parsed, list):
+        total = len(parsed)
+        start, end = _parse_range_selector(selector, total)
+        rows = parsed[start:end]
+    elif isinstance(parsed, str):
+        lines = parsed.splitlines()
+        total = len(lines)
+        start, end = _parse_range_selector(selector, total)
+        rows = lines[start:end]
+
+    result = {
+        "result_ref": f"result://{result_doc.name}",
+        "view": "range",
+        "selector": selector,
+        "total": total,
+        "start": start,
+        "end": end,
+        "rows": rows,
+    }
+    # Also cap by max_rows.
+    if isinstance(rows, list) and len(rows) > limits["max_rows"]:
+        result["rows"] = rows[: limits["max_rows"]]
+        result["truncated"] = True
+    return _apply_output_limits(result, limits["max_tokens"], limits["max_bytes"])
+
+
+def _parse_range_selector(selector: str | None, total: int) -> tuple[int, int]:
+    """Parse selectors like ``rows[10:20]``, ``10:20``, or ``[5:15]``."""
+    if not selector:
+        return 0, min(policy.HARD_MAX_ROWS, total)
+
+    match = re.search(r"(\d*):(\d*)", selector)
+    if not match:
+        return 0, min(policy.HARD_MAX_ROWS, total)
+
+    start_str, end_str = match.groups()
+    start = int(start_str) if start_str else 0
+    end = int(end_str) if end_str else total
+    start = max(0, min(start, total))
+    end = max(start, min(end, total))
+    return start, end
+
+
+def _view_path(result_doc, limits: dict, selector: str | None) -> dict:
+    """Return a JSON-path slice of the result.
+
+    Supported selectors:
+    - ``orders[0:20].items`` — slice a list then pick a key.
+    - ``orders[5]`` — single item.
+    - ``meta.title`` — dotted key path.
+    """
+    data = load_payload(result_doc)
+    parsed = _parse_json_payload(data, result_doc.result_type or "json")
+    if not isinstance(parsed, (dict, list)):
+        return {
+            "result_ref": f"result://{result_doc.name}",
+            "view": "path",
+            "selector": selector,
+            "error": "path view requires a JSON object or list",
+        }
+
+    value = parsed
+    tokens = _tokenize_selector(selector or "")
+    for token in tokens:
+        if isinstance(value, dict):
+            value = value.get(token)
+        elif isinstance(value, list):
+            try:
+                value = value[int(token)]
+            except (ValueError, IndexError):
+                value = None
+        else:
+            value = None
+        if value is None:
+            break
+
+    result = {
+        "result_ref": f"result://{result_doc.name}",
+        "view": "path",
+        "selector": selector,
+        "value": value,
+    }
+    return _apply_output_limits(result, limits["max_tokens"], limits["max_bytes"])
+
+
+def _tokenize_selector(selector: str) -> list[str]:
+    """Tokenize a path selector into keys and indices."""
+    if not selector:
+        return []
+    # Normalize bracket notation to dotted notation.
+    normalized = selector.replace("[", ".").replace("]", "")
+    return [t for t in normalized.split(".") if t != ""]
+
+
+def _view_filter(result_doc, limits: dict, filter_spec, columns: list | None) -> dict:
+    data = load_payload(result_doc)
+    parsed = _parse_json_payload(data, result_doc.result_type or "text")
+
+    if not isinstance(parsed, list):
+        return {
+            "result_ref": f"result://{result_doc.name}",
+            "view": "filter",
+            "error": "filter view requires a list result",
+        }
+
+    filter_spec = filter_spec or {}
+    if isinstance(filter_spec, str):
+        try:
+            filter_spec = json.loads(filter_spec)
+        except (json.JSONDecodeError, TypeError):
+            filter_spec = {}
+
+    rows = []
+    for row in parsed:
+        match = True
+        for key, expected in filter_spec.items():
+            value = row.get(key) if isinstance(row, dict) else None
+            if value != expected:
+                match = False
+                break
+        if match:
+            rows.append(row)
+            if len(rows) >= limits["max_rows"]:
+                break
+
+    if columns and rows:
+        rows = [
+            {k: row.get(k) for k in columns if k in row}
+            if isinstance(row, dict)
+            else row
+            for row in rows
+        ]
+
+    result = {
+        "result_ref": f"result://{result_doc.name}",
+        "view": "filter",
+        "filter": filter_spec,
+        "matched": len(rows),
+        "rows": rows,
+    }
+    return _apply_output_limits(result, limits["max_tokens"], limits["max_bytes"])
+
+
+def _view_row(result_doc, limits: dict, selector: str | None) -> dict:
+    data = load_payload(result_doc)
+    parsed = _parse_json_payload(data, result_doc.result_type or "text")
+
+    if not isinstance(parsed, list):
+        return {
+            "result_ref": f"result://{result_doc.name}",
+            "view": "row",
+            "error": "row view requires a list result",
+        }
+
+    indices = []
+    if selector:
+        for part in selector.split(","):
+            part = part.strip()
+            if "-" in part:
+                try:
+                    a, b = part.split("-", 1)
+                    indices.extend(range(int(a), int(b) + 1))
+                except ValueError:
+                    pass
+            else:
+                try:
+                    indices.append(int(part))
+                except ValueError:
+                    pass
+    if not indices:
+        indices = [0]
+
+    indices = [i for i in indices if 0 <= i < len(parsed)][: limits["max_rows"]]
+    rows = [parsed[i] for i in indices]
+
+    result = {
+        "result_ref": f"result://{result_doc.name}",
+        "view": "row",
+        "indices": indices,
+        "rows": rows,
+    }
+    return _apply_output_limits(result, limits["max_tokens"], limits["max_bytes"])
+
+
+def result_read(
+    ref,
+    view: str = "summary",
+    selector: str | None = None,
+    page: int | None = None,
+    page_size: int | None = None,
+    filter=None,
+    columns: list | None = None,
+    max_tokens: int | None = None,
+    max_rows: int | None = None,
+    max_bytes: int | None = None,
+) -> dict:
+    """Read a bounded view of an ``Agent Execution Result``.
+
+    All ``max_*`` client requests are capped by hard server-side limits.
+    """
+    if view not in VIEWS:
+        return {"status": "error", "error": f"Unknown view '{view}'. Use one of: {sorted(VIEWS)}"}
+
+    result_doc = _resolve_result_doc(ref)
+    require_result_read_permission(result_doc)
+
+    if result_doc.status == "Expired":
+        return build_error_envelope(result_doc, "Result has expired.")
+
+    limits = policy.coerce_read_limits(
+        max_rows=max_rows,
+        max_bytes=max_bytes,
+        max_tokens=max_tokens,
+        page_size=page_size,
+    )
+
+    if view == "summary":
+        return _view_summary(result_doc, limits)
+    if view == "schema":
+        return _view_schema(result_doc, limits)
+    if view == "preview":
+        return _view_preview(result_doc, limits)
+    if view == "page":
+        return _view_page(result_doc, limits, page, page_size)
+    if view == "range":
+        return _view_range(result_doc, limits, selector)
+    if view == "path":
+        return _view_path(result_doc, limits, selector)
+    if view == "filter":
+        return _view_filter(result_doc, limits, filter, columns)
+    if view == "row":
+        return _view_row(result_doc, limits, selector)
+
+    return {"status": "error", "error": f"View '{view}' is not implemented."}
+
+
+def result_index_for_conversation(conversation_id: str) -> dict:
+    """Return a compact index of results for ``conversation_id``."""
+    if not frappe.db.exists("Agent Conversation", conversation_id):
+        return {"status": "error", "error": "Conversation not found."}
+
+    results = frappe.get_all(
+        "Agent Execution Result",
+        filters={"conversation": conversation_id},
+        fields=[
+            "name",
+            "result_type",
+            "summary",
+            "source_tool",
+            "size_bytes",
+            "estimated_tokens",
+            "available_views",
+            "status",
+        ],
+        order_by="creation desc",
+    )
+
+    items = []
+    for r in results:
+        available_views = json.loads(r.available_views) if r.available_views else []
+        items.append(
+            {
+                "ref": f"result://{r.name}",
+                "type": r.result_type,
+                "summary": r.summary,
+                "source_tool": r.source_tool,
+                "size": {
+                    "bytes": r.size_bytes,
+                    "estimated_tokens": r.estimated_tokens,
+                },
+                "available_views": available_views,
+                "status": r.status,
+            }
+        )
+
+    return {"status": "success", "conversation_id": conversation_id, "results": items}

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -346,6 +346,79 @@ def create_agent_tools(agent) -> list[FunctionTool]:
         if tool:
             tools.append(tool)
 
+    # Result/Context Foundation V1 tools: bounded reads of stored tool/API results.
+    existing_tool_names = {getattr(t, "name", "") for t in tools}
+    if "result_read" not in existing_tool_names:
+        tool = create_function_tool(
+            name="result_read",
+            description=(
+                "Read a bounded view of a stored execution result. "
+                "Views: summary, schema, preview, page, range, path, filter, row. "
+                "Server-side limits always apply; the full payload is never returned."
+            ),
+            tool_name="huf.ai.results.tools.result_read_tool",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "ref": {
+                        "type": "string",
+                        "description": "Result reference, e.g. result://RES-00001"
+                    },
+                    "view": {
+                        "type": "string",
+                        "enum": ["summary", "schema", "preview", "page", "range", "path", "filter", "row"],
+                        "description": "Which bounded view to return"
+                    },
+                    "selector": {
+                        "type": "string",
+                        "description": "Optional range/path/row selector"
+                    },
+                    "page": {
+                        "type": "integer",
+                        "description": "1-based page number for page view"
+                    },
+                    "page_size": {
+                        "type": "integer",
+                        "description": "Requested page size (capped server-side)"
+                    },
+                    "filter": {
+                        "type": "object",
+                        "description": "Column-value filters for filter view"
+                    },
+                    "columns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Columns to include for filter view"
+                    },
+                    "max_tokens": {"type": "integer"},
+                    "max_rows": {"type": "integer"},
+                    "max_bytes": {"type": "integer"},
+                },
+                "required": ["ref"]
+            }
+        )
+        if tool:
+            tools.append(tool)
+
+    if "result_index" not in existing_tool_names:
+        tool = create_function_tool(
+            name="result_index",
+            description="List the stored execution results for a conversation.",
+            tool_name="huf.ai.results.tools.result_index_tool",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "conversation_id": {
+                        "type": "string",
+                        "description": "Conversation ID"
+                    }
+                },
+                "required": ["conversation_id"]
+            }
+        )
+        if tool:
+            tools.append(tool)
+
     return tools
 
 

--- a/huf/ai/tests/test_message_audit_step2.py
+++ b/huf/ai/tests/test_message_audit_step2.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Step 2 MessageAudit correctness/security fixes (MA-08/09/10/11).
+
+These tests cover the critical fixes that must land before the larger
+Result/Context Foundation V1 work in Step 3.
+"""
+
+import json
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from huf.ai.agent_integration import log_tool_call, process_tool_call
+from huf.ai.conversation_manager import ConversationManager, sync_tool_status_to_message
+from huf.ai.providers.litellm import _merge_stream_usage
+
+
+class _MessageAuditStep2TestCase(IntegrationTestCase):
+    """Shared scaffolding for Step 2 tests."""
+
+    def setUp(self):
+        super().setUp()
+        self._cleanup = []
+        self._original_user = frappe.session.user
+        frappe.set_user("Administrator")
+
+        self.provider = self._get_or_create_provider()
+        self.model = self._get_or_create_model(self.provider)
+        self.agent = self._create_agent(self.provider, self.model)
+        self.conversation = self._create_conversation(self.agent)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for doctype, name in reversed(self._cleanup):
+            try:
+                frappe.delete_doc(doctype, name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.set_user(self._original_user)
+        super().tearDown()
+
+    def _get_or_create_provider(self):
+        existing = frappe.db.get_value("AI Provider", {"provider_name": "openai"}, "name")
+        if existing:
+            return existing
+        provider = frappe.get_doc({
+            "doctype": "AI Provider",
+            "provider_name": "openai",
+            "provider_type": "OpenAI Compatible",
+        })
+        provider.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Provider", provider.name))
+        return provider.name
+
+    def _get_or_create_model(self, provider):
+        existing = frappe.db.get_value("AI Model", {"provider": provider}, "name")
+        if existing:
+            return existing
+        model = frappe.get_doc({
+            "doctype": "AI Model",
+            "model_name": "gpt-4o-mini",
+            "provider": provider,
+        })
+        model.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Model", model.name))
+        return model.name
+
+    def _create_agent(self, provider, model):
+        agent = frappe.get_doc({
+            "doctype": "Agent",
+            "agent_name": f"test-agent-{frappe.generate_hash(length=8)}",
+            "provider": provider,
+            "model": model,
+            "instructions": "You are a test agent for MessageAudit Step 2 tests.",
+        })
+        agent.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent", agent.name))
+        return agent
+
+    def _create_conversation(self, agent):
+        conversation = frappe.get_doc({
+            "doctype": "Agent Conversation",
+            "agent": agent.name,
+            "title": f"test-conv-{frappe.generate_hash(length=6)}",
+            "session_id": f"test-session-{frappe.generate_hash(length=10)}",
+            "is_active": 1,
+        })
+        conversation.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Conversation", conversation.name))
+        return conversation
+
+    def _create_run(self, conversation):
+        run = frappe.get_doc({
+            "doctype": "Agent Run",
+            "agent": self.agent.name,
+            "conversation": conversation.name,
+            "status": "Queued",
+        })
+        run.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Run", run.name))
+        return run
+
+    def _create_tool_call_message(self, run, conversation, tool_call_name=None, call_id="call_1"):
+        """Create a Queued Agent Tool Call and a linked Tool Call Agent Message."""
+        process_tool_call(
+            agent_run=run.name,
+            conversation=conversation.name,
+            name="test_tool",
+            args={"query": "hello"},
+            tool_call_id=call_id,
+            is_output=False,
+        )
+        tc_name = frappe.db.get_value(
+            "Agent Tool Call",
+            {"agent_run": run.name, "call_id": call_id},
+            "name",
+        )
+        self.assertTrue(tc_name)
+
+        cm = ConversationManager(agent_name=self.agent.name, session_id=conversation.session_id)
+        message = cm.add_message(
+            conversation=conversation,
+            role="agent",
+            content="Requesting Tool: test_tool",
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+            run_name=run.name,
+            kind="Tool Call",
+            tool_call=tc_name,
+            tool_call_id=call_id,
+        )
+        self._cleanup.append(("Agent Message", message.name))
+        return tc_name, message.name
+
+
+class TestFailedToolCalls(_MessageAuditStep2TestCase):
+    """MA-08: failed tool calls must be recorded as Failed, not Completed."""
+
+    def test_process_tool_call_marks_failed_with_error(self):
+        run = self._create_run(self.conversation)
+        tc_name, msg_name = self._create_tool_call_message(run, self.conversation)
+
+        returned = process_tool_call(
+            agent_run=run.name,
+            conversation=self.conversation.name,
+            result="something went wrong",
+            error="boom",
+            is_output=True,
+            tool_call_id="call_1",
+        )
+        self.assertEqual(returned, tc_name)
+
+        tc_doc = frappe.get_doc("Agent Tool Call", tc_name)
+        self.assertEqual(tc_doc.status, "Failed")
+        self.assertEqual(tc_doc.error_message, "boom")
+
+        msg_doc = frappe.get_doc("Agent Message", msg_name)
+        self.assertEqual(msg_doc.tool_status, "Failed")
+
+    def test_process_tool_call_marks_success_completed(self):
+        run = self._create_run(self.conversation)
+        tc_name, msg_name = self._create_tool_call_message(run, self.conversation)
+
+        process_tool_call(
+            agent_run=run.name,
+            conversation=self.conversation.name,
+            result={"ok": True},
+            is_output=True,
+            tool_call_id="call_1",
+        )
+
+        tc_doc = frappe.get_doc("Agent Tool Call", tc_name)
+        self.assertEqual(tc_doc.status, "Completed")
+        self.assertFalse(tc_doc.error_message)
+
+        msg_doc = frappe.get_doc("Agent Message", msg_name)
+        self.assertEqual(msg_doc.tool_status, "Completed")
+
+    def test_log_tool_call_propagates_failed_marker(self):
+        run = self._create_run(self.conversation)
+        tc_name, _msg_name = self._create_tool_call_message(run, self.conversation)
+
+        returned = log_tool_call(
+            run_doc=run,
+            conversation=self.conversation,
+            raw_call={
+                "name": "test_tool",
+                "id": "call_1",
+                "output": "bad",
+                "failed": True,
+                "error_message": "marker error",
+            },
+            tool_result={"output": "bad"},
+            is_output=True,
+        )
+        self.assertEqual(returned, tc_name)
+
+        tc_doc = frappe.get_doc("Agent Tool Call", tc_name)
+        self.assertEqual(tc_doc.status, "Failed")
+        self.assertEqual(tc_doc.error_message, "marker error")
+
+
+class TestStreamingTokenAggregation(_MessageAuditStep2TestCase):
+    """MA-09: streaming token usage must be aggregated across tool rounds."""
+
+    def test_merge_stream_usage_sums_dicts(self):
+        totals = {}
+        usage_a = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cached_tokens": 2,
+            "cache_creation_tokens": 1,
+        }
+        usage_b = {
+            "prompt_tokens": 20,
+            "completion_tokens": 8,
+            "cached_tokens": 3,
+        }
+
+        totals = _merge_stream_usage(totals, usage_a)
+        totals = _merge_stream_usage(totals, usage_b)
+
+        self.assertEqual(totals["prompt_tokens"], 30)
+        self.assertEqual(totals["completion_tokens"], 13)
+        self.assertEqual(totals["cached_tokens"], 5)
+        self.assertEqual(totals["cache_creation_tokens"], 1)
+
+    def test_merge_stream_usage_ignores_none_and_non_dict(self):
+        totals = {"prompt_tokens": 5}
+        self.assertEqual(_merge_stream_usage(totals, None), totals)
+        self.assertEqual(_merge_stream_usage(totals, "not-a-dict"), totals)
+
+    def test_merge_stream_usage_sums_across_object_like_usage(self):
+        """Usage may arrive as a LiteLLM object; ensure dict()/model_dump() path works."""
+
+        class _FakeUsage:
+            def dict(self):
+                return {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 4,
+                }
+
+        totals = _merge_stream_usage({}, _FakeUsage())
+        self.assertEqual(totals["prompt_tokens"], 7)
+        self.assertEqual(totals["completion_tokens"], 4)
+
+
+class TestToolStatusSync(_MessageAuditStep2TestCase):
+    """MA-10: linked Agent Message tool fields stay in sync with Agent Tool Call."""
+
+    def test_sync_tool_status_updates_message(self):
+        run = self._create_run(self.conversation)
+        tc_name, msg_name = self._create_tool_call_message(run, self.conversation)
+
+        # Force the ATC to a terminal failed state without going through the
+        # normal output path, then explicitly re-sync.
+        tc_doc = frappe.get_doc("Agent Tool Call", tc_name)
+        tc_doc.status = "Failed"
+        tc_doc.error_message = "sync test error"
+        tc_doc.tool = "renamed_tool"
+        tc_doc.tool_args = json.dumps({"x": 1})
+        tc_doc.save(ignore_permissions=True)
+
+        sync_tool_status_to_message(tc_name)
+
+        msg_doc = frappe.get_doc("Agent Message", msg_name)
+        self.assertEqual(msg_doc.tool_status, "Failed")
+        self.assertEqual(msg_doc.tool_name, "renamed_tool")
+        self.assertEqual(msg_doc.tool_args, json.dumps({"x": 1}))
+
+    def test_sync_tool_status_noop_for_missing_args(self):
+        # Should not raise.
+        sync_tool_status_to_message(None)
+        sync_tool_status_to_message("nonexistent-tool-call-name")
+
+
+class TestConversationIndexRace(_MessageAuditStep2TestCase):
+    """MA-11: conversation_index must be unique and monotonically increasing."""
+
+    def test_add_message_assigns_monotonic_indices(self):
+        cm = ConversationManager(agent_name=self.agent.name, session_id=self.conversation.session_id)
+
+        msg1 = cm.add_message(
+            conversation=self.conversation,
+            role="user",
+            content="first",
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+        )
+        msg2 = cm.add_message(
+            conversation=self.conversation,
+            role="user",
+            content="second",
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+        )
+
+        self.assertEqual(msg1.conversation_index, 1)
+        self.assertEqual(msg2.conversation_index, 2)
+        self.assertNotEqual(msg1.conversation_index, msg2.conversation_index)
+
+    def test_duplicate_conversation_index_is_rejected(self):
+        """The unique constraint added by the MA-11 patch rejects duplicates."""
+        cm = ConversationManager(agent_name=self.agent.name, session_id=self.conversation.session_id)
+        first = cm.add_message(
+            conversation=self.conversation,
+            role="user",
+            content="first",
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+        )
+
+        with self.assertRaises(frappe.UniqueValidationError):
+            duplicate = frappe.get_doc({
+                "doctype": "Agent Message",
+                "conversation": self.conversation.name,
+                "role": "user",
+                "content": "duplicate index",
+                "conversation_index": first.conversation_index,
+                "user": frappe.session.user,
+            })
+            duplicate.insert(ignore_permissions=True)
+
+    def test_retry_loop_recovers_after_transient_duplicate(self):
+        """Simulate a transient duplicate by pre-allocating index 1; add_message
+        should discover it and allocate index 2 on its retry."""
+        cm = ConversationManager(agent_name=self.agent.name, session_id=self.conversation.session_id)
+
+        # Pre-create a message at index 1.
+        frappe.get_doc({
+            "doctype": "Agent Message",
+            "conversation": self.conversation.name,
+            "role": "user",
+            "content": "preallocated",
+            "conversation_index": 1,
+            "user": frappe.session.user,
+        }).insert(ignore_permissions=True)
+
+        # The first add_message attempt will read MAX=1, try index 2 and succeed.
+        msg = cm.add_message(
+            conversation=self.conversation,
+            role="user",
+            content="recovered",
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+        )
+        self.assertEqual(msg.conversation_index, 2)

--- a/huf/ai/tests/test_phase1_security.py
+++ b/huf/ai/tests/test_phase1_security.py
@@ -351,3 +351,144 @@ class TestWebhookEndpointSecurity(IntegrationTestCase):
                     flow_webhook_clean()
         finally:
             frappe.request = None
+
+
+class TestAddMessageApiPermissions(IntegrationTestCase):
+    """MA-12: public add_message API must enforce conversation ownership and role allow-list."""
+
+    def setUp(self):
+        super().setUp()
+        self._cleanup = []
+        self._original_user = frappe.session.user
+
+        # Ensure a test AI Provider / Model / Agent exist.
+        provider_name = self._get_or_create_provider()
+        model_name = self._get_or_create_model(provider_name)
+        self.agent = self._create_agent(provider_name, model_name)
+
+    def tearDown(self):
+        for doctype, name in reversed(self._cleanup):
+            try:
+                frappe.delete_doc(doctype, name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.session.user = self._original_user
+        super().tearDown()
+
+    def _get_or_create_provider(self):
+        existing = frappe.db.get_value("AI Provider", {"provider_name": "openai"}, "name")
+        if existing:
+            return existing
+        provider = frappe.get_doc({
+            "doctype": "AI Provider",
+            "provider_name": "openai",
+            "provider_type": "OpenAI Compatible",
+        })
+        provider.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Provider", provider.name))
+        return provider.name
+
+    def _get_or_create_model(self, provider):
+        existing = frappe.db.get_value("AI Model", {"provider": provider}, "name")
+        if existing:
+            return existing
+        model = frappe.get_doc({
+            "doctype": "AI Model",
+            "model_name": "gpt-4o-mini",
+            "provider": provider,
+        })
+        model.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Model", model.name))
+        return model.name
+
+    def _create_agent(self, provider, model):
+        agent = frappe.get_doc({
+            "doctype": "Agent",
+            "agent_name": f"test-agent-{frappe.generate_hash(length=8)}",
+            "provider": provider,
+            "model": model,
+            "instructions": "You are a test agent for automated security tests.",
+        })
+        agent.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent", agent.name))
+        return agent
+
+    def _create_user(self, roles=("Huf User",)):
+        email = f"huf-test-{frappe.generate_hash(length=10)}@example.com"
+        user = frappe.get_doc({
+            "doctype": "User",
+            "email": email,
+            "first_name": "Test",
+            "send_welcome_email": 0,
+        })
+        for role in roles:
+            user.append("roles", {"role": role})
+        user.insert(ignore_permissions=True)
+        self._cleanup.append(("User", user.name))
+        return user.name
+
+    def _create_conversation(self, owner):
+        # Create as owner so Frappe stamps the correct owner.
+        frappe.session.user = owner
+        conversation = frappe.get_doc({
+            "doctype": "Agent Conversation",
+            "agent": self.agent.name,
+            "title": f"test-conv-{frappe.generate_hash(length=6)}",
+            "session_id": f"test-session-{frappe.generate_hash(length=10)}",
+            "is_active": 1,
+        })
+        conversation.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Conversation", conversation.name))
+        return conversation
+
+    def test_user_cannot_add_message_to_other_users_conversation(self):
+        from huf.ai.agent_chat import add_message
+
+        user_a = self._create_user()
+        user_b = self._create_user()
+
+        conversation = self._create_conversation(user_a)
+        frappe.session.user = user_b
+
+        with self.assertRaises(frappe.PermissionError):
+            add_message(
+                conversation_id=conversation.name,
+                role="user",
+                content="injected message",
+            )
+
+    def test_add_message_rejects_agent_role_from_web_session(self):
+        from huf.ai.agent_chat import add_message
+
+        user = self._create_user()
+        conversation = self._create_conversation(user)
+        frappe.session.user = user
+
+        with self.assertRaises(frappe.PermissionError):
+            add_message(
+                conversation_id=conversation.name,
+                role="agent",
+                content="injected agent message",
+            )
+
+    def test_owner_can_add_user_and_tool_messages(self):
+        from huf.ai.agent_chat import add_message
+
+        user = self._create_user()
+        conversation = self._create_conversation(user)
+        frappe.session.user = user
+
+        result_user = add_message(
+            conversation_id=conversation.name,
+            role="user",
+            content="hello",
+        )
+        self.assertTrue(result_user.get("success"))
+
+        result_tool = add_message(
+            conversation_id=conversation.name,
+            role="tool",
+            content="tool result",
+            record_kind="tool_result",
+        )
+        self.assertTrue(result_tool.get("success"))

--- a/huf/ai/tests/test_result_context_exclusion.py
+++ b/huf/ai/tests/test_result_context_exclusion.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Large-result context exclusion regression tests.
+
+These tests are placeholders for Step 3 (Result/Context Foundation V1).
+They document the expected contract now and will be filled in once the
+``Agent Execution Result`` store and bounded read paths are implemented.
+"""
+
+import unittest
+
+from frappe.tests import IntegrationTestCase
+
+
+class TestResultContextExclusion(IntegrationTestCase):
+    """Result payloads must stay outside Agent Message and model context."""
+
+    @unittest.skip("Step 3: implement Agent Execution Result store")
+    def test_large_result_stored_outside_message_content(self):
+        """A result larger than max_context_chars is stored outside Agent Message.content."""
+        # TODO(Step 3): create a tool result exceeding max_context_chars, route it
+        # through results.store.persist_result, and assert the Agent Message content
+        # is a bounded envelope/reference rather than the raw payload.
+        pass
+
+    @unittest.skip("Step 3: implement include_reference history projection")
+    def test_include_reference_does_not_return_full_payload(self):
+        """get_conversation_history does not return the full raw payload for include_reference."""
+        # TODO(Step 3): persist a large result with context_policy="include_reference"
+        # and assert get_conversation_history returns only the compact handle/envelope.
+        pass
+
+    @unittest.skip("Step 3: implement result_read permission checks")
+    def test_unauthorized_result_read_rejected(self):
+        """Unauthorized result_read calls are rejected."""
+        # TODO(Step 3): create a result owned by one user and assert another user
+        # cannot read it through the whitelisted result_read API.
+        pass

--- a/huf/ai/tests/test_result_context_exclusion.py
+++ b/huf/ai/tests/test_result_context_exclusion.py
@@ -8,7 +8,7 @@ import json
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from huf.ai.conversation_manager import ConversationManager
+from huf.ai.conversation_manager import ConversationManager, update_tool_call_message
 from huf.ai.results import policy
 from huf.ai.results.store import persist_result
 from huf.ai.results.views import result_read
@@ -213,6 +213,44 @@ class TestResultContextExclusion(IntegrationTestCase):
 
         data2 = result_read(result_doc.name, view="row", selector="99999")
         self.assertEqual(data2["rows"][0]["id"], 99999)
+
+    def test_failed_tool_call_marks_result_failed(self):
+        """update_tool_call_message propagates a failed tool status to the result record."""
+        message = self.cm.add_message(
+            conversation=self.conversation,
+            role="agent",
+            content="call the tool",
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+            run_name=self.run.name,
+            kind="Tool Call",
+            tool_call=self.tool_call.name,
+            tool_call_id=self.tool_call.call_id,
+        )
+        self._cleanup.append(("Agent Message", message.name))
+
+        updated = update_tool_call_message(
+            message_name=message.name,
+            tool_call_id=self.tool_call.call_id,
+            tool_call={"id": self.tool_call.call_id, "type": "function", "function": {"name": "test_tool"}},
+            result_content={"error": "something went wrong"},
+            agent_doc=self.agent,
+            status="Failed",
+        )
+        self.assertTrue(updated)
+
+        result_name = frappe.db.get_value(
+            "Agent Execution Result",
+            {"tool_call": self.tool_call.name},
+            "name",
+        )
+        self.assertTrue(result_name)
+        self._cleanup.append(("Agent Execution Result", result_name))
+        self.assertEqual(
+            frappe.db.get_value("Agent Execution Result", result_name, "status"),
+            "Failed",
+        )
 
     def test_expired_result_is_handled_explicitly(self):
         """Expired results return an explicit error envelope."""

--- a/huf/ai/tests/test_result_context_exclusion.py
+++ b/huf/ai/tests/test_result_context_exclusion.py
@@ -1,39 +1,228 @@
 # Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
 # See license.txt
 
-"""Large-result context exclusion regression tests.
+"""Large-result context exclusion regression tests (Step 3)."""
 
-These tests are placeholders for Step 3 (Result/Context Foundation V1).
-They document the expected contract now and will be filled in once the
-``Agent Execution Result`` store and bounded read paths are implemented.
-"""
+import json
 
-import unittest
-
+import frappe
 from frappe.tests import IntegrationTestCase
+
+from huf.ai.conversation_manager import ConversationManager
+from huf.ai.results import policy
+from huf.ai.results.store import persist_result
+from huf.ai.results.views import result_read
 
 
 class TestResultContextExclusion(IntegrationTestCase):
     """Result payloads must stay outside Agent Message and model context."""
 
-    @unittest.skip("Step 3: implement Agent Execution Result store")
+    def setUp(self):
+        super().setUp()
+        self._cleanup = []
+        self._original_user = frappe.session.user
+        frappe.set_user("Administrator")
+
+        self.provider = self._get_or_create_provider()
+        self.model = self._get_or_create_model(self.provider)
+        self.agent = self._create_agent(self.provider, self.model)
+        self.conversation = self._create_conversation(self.agent)
+        self.run = self._create_run(self.conversation)
+        self.tool_call = self._create_tool_call(self.conversation, self.run)
+        self.cm = ConversationManager(agent_name=self.agent.name, session_id=self.conversation.session_id)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for doctype, name in reversed(self._cleanup):
+            try:
+                frappe.delete_doc(doctype, name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.set_user(self._original_user)
+        super().tearDown()
+
+    def _get_or_create_provider(self):
+        existing = frappe.db.get_value("AI Provider", {"provider_name": "openai"}, "name")
+        if existing:
+            return existing
+        provider = frappe.get_doc({
+            "doctype": "AI Provider",
+            "provider_name": "openai",
+            "provider_type": "OpenAI Compatible",
+        })
+        provider.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Provider", provider.name))
+        return provider.name
+
+    def _get_or_create_model(self, provider):
+        existing = frappe.db.get_value("AI Model", {"provider": provider}, "name")
+        if existing:
+            return existing
+        model = frappe.get_doc({
+            "doctype": "AI Model",
+            "model_name": "gpt-4o-mini",
+            "provider": provider,
+        })
+        model.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Model", model.name))
+        return model.name
+
+    def _create_agent(self, provider, model):
+        agent = frappe.get_doc({
+            "doctype": "Agent",
+            "agent_name": f"test-agent-{frappe.generate_hash(length=8)}",
+            "provider": provider,
+            "model": model,
+            "instructions": "You are a test agent for result-context tests.",
+        })
+        agent.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent", agent.name))
+        return agent
+
+    def _create_conversation(self, agent):
+        conversation = frappe.get_doc({
+            "doctype": "Agent Conversation",
+            "agent": agent.name,
+            "title": f"test-conv-{frappe.generate_hash(length=6)}",
+            "session_id": f"test-session-{frappe.generate_hash(length=10)}",
+            "is_active": 1,
+        })
+        conversation.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Conversation", conversation.name))
+        return conversation
+
+    def _create_run(self, conversation):
+        run = frappe.get_doc({
+            "doctype": "Agent Run",
+            "agent": self.agent.name,
+            "conversation": conversation.name,
+            "status": "Started",
+        })
+        run.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Run", run.name))
+        return run
+
+    def _create_tool_call(self, conversation, run):
+        tc = frappe.get_doc({
+            "doctype": "Agent Tool Call",
+            "agent_run": run.name,
+            "conversation": conversation.name,
+            "tool": "test_tool",
+            "tool_args": json.dumps({"query": "hello"}),
+            "status": "Queued",
+            "call_id": f"call_{frappe.generate_hash(length=8)}",
+        })
+        tc.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Tool Call", tc.name))
+        return tc
+
+    def _persist_large_result(self, row_count: int = 100_000):
+        rows = [{"id": i, "value": f"row-{i}"} for i in range(row_count)]
+        result_doc, _ = persist_result(
+            result_content=rows,
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+            source_tool="test_tool",
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+        return result_doc, rows
+
     def test_large_result_stored_outside_message_content(self):
-        """A result larger than max_context_chars is stored outside Agent Message.content."""
-        # TODO(Step 3): create a tool result exceeding max_context_chars, route it
-        # through results.store.persist_result, and assert the Agent Message content
-        # is a bounded envelope/reference rather than the raw payload.
-        pass
+        """A 100k-row result is stored as a file; the message content is an envelope."""
+        result_doc, _ = self._persist_large_result(row_count=100_000)
 
-    @unittest.skip("Step 3: implement include_reference history projection")
+        # Simulate the message that update_tool_call_message would create.
+        message = self.cm.add_message(
+            conversation=self.conversation,
+            role="tool",
+            content=json.dumps({"result_ref": f"result://{result_doc.name}"}),
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+            run_name=self.run.name,
+            kind="Tool Result",
+            tool_call=self.tool_call.name,
+            record_kind="result_snapshot",
+            context_policy="include_reference",
+            context_summary=result_doc.summary,
+            reference_doctype="Agent Execution Result",
+            reference_name=result_doc.name,
+        )
+        self._cleanup.append(("Agent Message", message.name))
+
+        self.assertTrue(result_doc.payload_file)
+        self.assertIsInstance(message.content, str)
+        self.assertIn("result_ref", message.content)
+        self.assertNotIn("row-99999", message.content)
+        self.assertLess(len(message.content), 1000)
+        self.assertEqual(message.reference_doctype, "Agent Execution Result")
+        self.assertEqual(message.reference_name, result_doc.name)
+
     def test_include_reference_does_not_return_full_payload(self):
-        """get_conversation_history does not return the full raw payload for include_reference."""
-        # TODO(Step 3): persist a large result with context_policy="include_reference"
-        # and assert get_conversation_history returns only the compact handle/envelope.
-        pass
+        """get_conversation_history returns a compact handle, not the raw payload."""
+        result_doc, _ = self._persist_large_result(row_count=100_000)
 
-    @unittest.skip("Step 3: implement result_read permission checks")
-    def test_unauthorized_result_read_rejected(self):
-        """Unauthorized result_read calls are rejected."""
-        # TODO(Step 3): create a result owned by one user and assert another user
-        # cannot read it through the whitelisted result_read API.
-        pass
+        self.cm.add_message(
+            conversation=self.conversation,
+            role="tool",
+            content=json.dumps({"result_ref": f"result://{result_doc.name}"}),
+            provider=self.provider,
+            model=self.model,
+            agent=self.agent.name,
+            run_name=self.run.name,
+            kind="Tool Result",
+            tool_call=self.tool_call.name,
+            record_kind="result_snapshot",
+            context_policy="include_reference",
+            context_summary=result_doc.summary,
+            reference_doctype="Agent Execution Result",
+            reference_name=result_doc.name,
+        )
+
+        history = self.cm.get_conversation_history(self.conversation.name, limit=10)
+        tool_messages = [m for m in history if m.get("role") == "tool"]
+        self.assertTrue(tool_messages)
+
+        for msg in tool_messages:
+            content = msg.get("content") or ""
+            self.assertNotIn("row-99999", content)
+            self.assertIn("Agent Execution Result", content)
+            self.assertLess(len(content), 2000)
+
+    def test_envelope_is_below_token_limit(self):
+        """The envelope itself stays within a small token budget."""
+        result_doc, _ = self._persist_large_result(row_count=100_000)
+        envelope_text = json.dumps({
+            "result_ref": f"result://{result_doc.name}",
+            "summary": result_doc.summary,
+        })
+        # Heuristic: envelope text must be far below the hard token limit.
+        self.assertLess(len(envelope_text) / 4, policy.HARD_MAX_TOKENS)
+
+    def test_result_read_can_retrieve_bounded_pages(self):
+        """The model can read bounded pages of a large result."""
+        result_doc, rows = self._persist_large_result(row_count=100_000)
+
+        data = result_read(result_doc.name, view="page", page=1, page_size=50)
+        # Client requested 50 rows; server hard cap is 100, so the request is honored.
+        self.assertEqual(len(data["rows"]), 50)
+        self.assertLessEqual(len(data["rows"]), policy.HARD_MAX_PAGE_SIZE)
+        self.assertEqual(data["total"], 100_000)
+        self.assertEqual(data["rows"][0]["id"], 0)
+
+        data2 = result_read(result_doc.name, view="row", selector="99999")
+        self.assertEqual(data2["rows"][0]["id"], 99999)
+
+    def test_expired_result_is_handled_explicitly(self):
+        """Expired results return an explicit error envelope."""
+        result_doc, _ = self._persist_large_result(row_count=10)
+        result_doc.expires_on = "2020-01-01 00:00:00"
+        result_doc.status = "Expired"
+        result_doc.save(ignore_permissions=True)
+
+        data = result_read(result_doc.name, view="summary")
+        self.assertEqual(data["status"], "error")
+        self.assertIn("expired", data["error"].lower())
+
+

--- a/huf/ai/tests/test_result_read_views.py
+++ b/huf/ai/tests/test_result_read_views.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for bounded result reads (huf.ai.results.views)."""
+
+import json
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from huf.ai.results import policy
+from huf.ai.results.store import persist_result
+from huf.ai.results.views import result_index_for_conversation, result_read
+
+
+class _ResultReadViewsTestCase(IntegrationTestCase):
+    """Shared scaffolding for result-read view tests."""
+
+    def setUp(self):
+        super().setUp()
+        self._cleanup = []
+        self._original_user = frappe.session.user
+        frappe.set_user("Administrator")
+
+        self.provider = self._get_or_create_provider()
+        self.model = self._get_or_create_model(self.provider)
+        self.agent = self._create_agent(self.provider, self.model)
+        self.conversation = self._create_conversation(self.agent)
+        self.run = self._create_run(self.conversation)
+        self.tool_call = self._create_tool_call(self.conversation, self.run)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for doctype, name in reversed(self._cleanup):
+            try:
+                frappe.delete_doc(doctype, name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.set_user(self._original_user)
+        super().tearDown()
+
+    def _get_or_create_provider(self):
+        existing = frappe.db.get_value("AI Provider", {"provider_name": "openai"}, "name")
+        if existing:
+            return existing
+        provider = frappe.get_doc({
+            "doctype": "AI Provider",
+            "provider_name": "openai",
+            "provider_type": "OpenAI Compatible",
+        })
+        provider.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Provider", provider.name))
+        return provider.name
+
+    def _get_or_create_model(self, provider):
+        existing = frappe.db.get_value("AI Model", {"provider": provider}, "name")
+        if existing:
+            return existing
+        model = frappe.get_doc({
+            "doctype": "AI Model",
+            "model_name": "gpt-4o-mini",
+            "provider": provider,
+        })
+        model.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Model", model.name))
+        return model.name
+
+    def _create_agent(self, provider, model):
+        agent = frappe.get_doc({
+            "doctype": "Agent",
+            "agent_name": f"test-agent-{frappe.generate_hash(length=8)}",
+            "provider": provider,
+            "model": model,
+            "instructions": "You are a test agent for result-read tests.",
+        })
+        agent.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent", agent.name))
+        return agent
+
+    def _create_conversation(self, agent):
+        conversation = frappe.get_doc({
+            "doctype": "Agent Conversation",
+            "agent": agent.name,
+            "title": f"test-conv-{frappe.generate_hash(length=6)}",
+            "session_id": f"test-session-{frappe.generate_hash(length=10)}",
+            "is_active": 1,
+        })
+        conversation.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Conversation", conversation.name))
+        return conversation
+
+    def _create_run(self, conversation):
+        run = frappe.get_doc({
+            "doctype": "Agent Run",
+            "agent": self.agent.name,
+            "conversation": conversation.name,
+            "status": "Started",
+        })
+        run.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Run", run.name))
+        return run
+
+    def _create_tool_call(self, conversation, run):
+        tc = frappe.get_doc({
+            "doctype": "Agent Tool Call",
+            "agent_run": run.name,
+            "conversation": conversation.name,
+            "tool": "test_tool",
+            "tool_args": json.dumps({"query": "hello"}),
+            "status": "Queued",
+            "call_id": f"call_{frappe.generate_hash(length=8)}",
+        })
+        tc.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Tool Call", tc.name))
+        return tc
+
+    def _persist_table(self, row_count: int = 250):
+        rows = [
+            {"id": i, "status": "active" if i % 2 == 0 else "inactive", "value": i * 10}
+            for i in range(row_count)
+        ]
+        result_doc, _ = persist_result(
+            result_content=rows,
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+            source_tool="test_tool",
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+        return result_doc
+
+
+class TestResultReadViews(_ResultReadViewsTestCase):
+    """Bounded view contract."""
+
+    def test_summary_view_returns_envelope(self):
+        result_doc = self._persist_table(row_count=10)
+        data = result_read(result_doc.name, view="summary")
+
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["result_ref"], f"result://{result_doc.name}")
+        self.assertIn("summary", data)
+        self.assertIn("size", data)
+
+    def test_schema_view_returns_columns(self):
+        result_doc = self._persist_table(row_count=10)
+        data = result_read(result_doc.name, view="schema")
+
+        self.assertEqual(data["schema"]["columns"], ["id", "status", "value"])
+        self.assertEqual(data["schema"]["row_count"], 10)
+
+    def test_preview_view_returns_first_rows(self):
+        result_doc = self._persist_table(row_count=10)
+        data = result_read(result_doc.name, view="preview")
+
+        self.assertEqual(len(data["preview"]["rows"]), min(10, policy.DEFAULT_PREVIEW_ROWS))
+
+    def test_page_view_respects_server_side_page_size(self):
+        result_doc = self._persist_table(row_count=250)
+        data = result_read(result_doc.name, view="page", page=1, page_size=500)
+
+        self.assertEqual(data["page"], 1)
+        self.assertEqual(data["page_size"], policy.HARD_MAX_PAGE_SIZE)
+        self.assertEqual(len(data["rows"]), policy.HARD_MAX_PAGE_SIZE)
+        self.assertEqual(data["total"], 250)
+
+    def test_range_selector_works(self):
+        result_doc = self._persist_table(row_count=50)
+        data = result_read(result_doc.name, view="range", selector="rows[10:20]")
+
+        self.assertEqual(data["start"], 10)
+        self.assertEqual(data["end"], 20)
+        self.assertEqual(len(data["rows"]), 10)
+        self.assertEqual(data["rows"][0]["id"], 10)
+
+    def test_filter_view_works(self):
+        result_doc = self._persist_table(row_count=50)
+        data = result_read(
+            result_doc.name,
+            view="filter",
+            filter={"status": "active"},
+            columns=["id", "status"],
+        )
+
+        self.assertTrue(data["matched"] > 0)
+        for row in data["rows"]:
+            self.assertEqual(row["status"], "active")
+            self.assertNotIn("value", row)
+
+    def test_row_view_selects_indices(self):
+        result_doc = self._persist_table(row_count=50)
+        data = result_read(result_doc.name, view="row", selector="5,10,15")
+
+        self.assertEqual(data["indices"], [5, 10, 15])
+        self.assertEqual(len(data["rows"]), 3)
+
+    def test_path_view_works(self):
+        result_doc, _ = persist_result(
+            result_content={"orders": [{"items": ["a", "b"]}, {"items": ["c"]}]},
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+
+        data = result_read(result_doc.name, view="path", selector="orders[0].items")
+        self.assertEqual(data["value"], ["a", "b"])
+
+    def test_unknown_view_returns_error(self):
+        result_doc = self._persist_table(row_count=5)
+        data = result_read(result_doc.name, view="invalid")
+        self.assertEqual(data["status"], "error")
+
+    def test_max_rows_cap_overrides_client_request(self):
+        result_doc = self._persist_table(row_count=250)
+        data = result_read(
+            result_doc.name,
+            view="filter",
+            filter={"status": "active"},
+            max_rows=500,
+        )
+        self.assertLessEqual(len(data["rows"]), policy.HARD_MAX_ROWS)
+
+
+class TestResultReadPermissions(_ResultReadViewsTestCase):
+    """Permission enforcement on result reads."""
+
+    def test_unauthorized_read_rejected(self):
+        result_doc = self._persist_table(row_count=10)
+
+        # Create a second user who is not a conversation participant.
+        other_user = f"test_other_{frappe.generate_hash(length=6)}@example.com"
+        if not frappe.db.exists("User", other_user):
+            user = frappe.get_doc({
+                "doctype": "User",
+                "email": other_user,
+                "first_name": "Test",
+                "enabled": 1,
+            })
+            user.insert(ignore_permissions=True)
+            self._cleanup.append(("User", other_user))
+
+        frappe.set_user(other_user)
+        with self.assertRaises(frappe.PermissionError):
+            result_read(result_doc.name, view="summary")
+
+
+class TestResultIndex(_ResultReadViewsTestCase):
+    """Conversation-level result index."""
+
+    def test_index_lists_conversation_results(self):
+        result_doc = self._persist_table(row_count=10)
+        data = result_index_for_conversation(self.conversation.name)
+
+        self.assertEqual(data["status"], "success")
+        refs = [r["ref"] for r in data["results"]]
+        self.assertIn(f"result://{result_doc.name}", refs)

--- a/huf/ai/tests/test_result_store.py
+++ b/huf/ai/tests/test_result_store.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Result Store (huf.ai.results.store)."""
+
+import json
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from huf.ai.results import policy
+from huf.ai.results.store import persist_result
+
+
+class _ResultStoreTestCase(IntegrationTestCase):
+    """Shared scaffolding for result-store tests."""
+
+    def setUp(self):
+        super().setUp()
+        self._cleanup = []
+        self._original_user = frappe.session.user
+        frappe.set_user("Administrator")
+
+        self.provider = self._get_or_create_provider()
+        self.model = self._get_or_create_model(self.provider)
+        self.agent = self._create_agent(self.provider, self.model)
+        self.conversation = self._create_conversation(self.agent)
+        self.run = self._create_run(self.conversation)
+        self.tool_call = self._create_tool_call(self.conversation, self.run)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for doctype, name in reversed(self._cleanup):
+            try:
+                frappe.delete_doc(doctype, name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.set_user(self._original_user)
+        super().tearDown()
+
+    def _get_or_create_provider(self):
+        existing = frappe.db.get_value("AI Provider", {"provider_name": "openai"}, "name")
+        if existing:
+            return existing
+        provider = frappe.get_doc({
+            "doctype": "AI Provider",
+            "provider_name": "openai",
+            "provider_type": "OpenAI Compatible",
+        })
+        provider.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Provider", provider.name))
+        return provider.name
+
+    def _get_or_create_model(self, provider):
+        existing = frappe.db.get_value("AI Model", {"provider": provider}, "name")
+        if existing:
+            return existing
+        model = frappe.get_doc({
+            "doctype": "AI Model",
+            "model_name": "gpt-4o-mini",
+            "provider": provider,
+        })
+        model.insert(ignore_permissions=True)
+        self._cleanup.append(("AI Model", model.name))
+        return model.name
+
+    def _create_agent(self, provider, model):
+        agent = frappe.get_doc({
+            "doctype": "Agent",
+            "agent_name": f"test-agent-{frappe.generate_hash(length=8)}",
+            "provider": provider,
+            "model": model,
+            "instructions": "You are a test agent for result-store tests.",
+        })
+        agent.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent", agent.name))
+        return agent
+
+    def _create_conversation(self, agent):
+        conversation = frappe.get_doc({
+            "doctype": "Agent Conversation",
+            "agent": agent.name,
+            "title": f"test-conv-{frappe.generate_hash(length=6)}",
+            "session_id": f"test-session-{frappe.generate_hash(length=10)}",
+            "is_active": 1,
+        })
+        conversation.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Conversation", conversation.name))
+        return conversation
+
+    def _create_run(self, conversation):
+        run = frappe.get_doc({
+            "doctype": "Agent Run",
+            "agent": self.agent.name,
+            "conversation": conversation.name,
+            "status": "Started",
+        })
+        run.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Run", run.name))
+        return run
+
+    def _create_tool_call(self, conversation, run):
+        tc = frappe.get_doc({
+            "doctype": "Agent Tool Call",
+            "agent_run": run.name,
+            "conversation": conversation.name,
+            "tool": "test_tool",
+            "tool_args": json.dumps({"query": "hello"}),
+            "status": "Queued",
+            "call_id": f"call_{frappe.generate_hash(length=8)}",
+        })
+        tc.insert(ignore_permissions=True)
+        self._cleanup.append(("Agent Tool Call", tc.name))
+        return tc
+
+
+class TestPersistResult(_ResultStoreTestCase):
+    """Result-store persistence contract."""
+
+    def test_small_result_stored_inline(self):
+        result_doc, envelope = persist_result(
+            result_content={"ok": True, "count": 3},
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+            source_tool="test_tool",
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+
+        self.assertEqual(result_doc.status, "Completed")
+        self.assertEqual(result_doc.result_type, "json")
+        self.assertTrue(result_doc.inline_payload)
+        self.assertFalse(result_doc.payload_file)
+        self.assertGreater(result_doc.size_bytes, 0)
+        self.assertGreater(result_doc.estimated_tokens, 0)
+        self.assertIn("sha256:", result_doc.content_hash)
+
+        self.assertEqual(envelope["result_ref"], f"result://{result_doc.name}")
+        self.assertEqual(envelope["result_type"], "json")
+
+    def test_large_result_stored_as_private_file(self):
+        rows = [{"id": i, "value": f"x-{i}"} for i in range(500)]
+        result_doc, envelope = persist_result(
+            result_content=rows,
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+            source_tool="test_tool",
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+
+        size = result_doc.size_bytes or 0
+        self.assertGreater(size, policy.INLINE_THRESHOLD_BYTES)
+        self.assertTrue(result_doc.payload_file)
+        self.assertFalse(result_doc.inline_payload)
+        self.assertIn("result_", result_doc.payload_file)
+
+        # Verify the private file exists and matches the hash.
+        file_doc = frappe.get_doc("File", {"file_url": result_doc.payload_file})
+        self.assertTrue(file_doc.is_private)
+        self.assertIn("sha256:", result_doc.content_hash)
+
+    def test_idempotency_key_prevents_duplicate(self):
+        key = f"idem-{frappe.generate_hash(length=8)}"
+        result_doc1, _ = persist_result(
+            result_content={"value": 1},
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+            idempotency_key=key,
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc1.name))
+
+        result_doc2, _ = persist_result(
+            result_content={"value": 2},
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+            idempotency_key=key,
+        )
+        self.assertEqual(result_doc1.name, result_doc2.name)
+
+    def test_checksum_and_size_recorded(self):
+        payload = "hello world"
+        result_doc, _ = persist_result(
+            result_content=payload,
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+
+        expected_hash = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        self.assertEqual(result_doc.content_hash, expected_hash)
+        self.assertEqual(result_doc.size_bytes, len(payload.encode("utf-8")))
+
+    def test_estimated_tokens_computed(self):
+        payload = "abcd" * 100  # 400 chars -> 100 tokens heuristic
+        result_doc, _ = persist_result(
+            result_content=payload,
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+
+        self.assertEqual(result_doc.estimated_tokens, 100)
+
+    def test_very_large_result_advertises_limited_views(self):
+        big_text = "x" * (policy.SCHEMA_ONLY_THRESHOLD_BYTES + 1024)
+        result_doc, envelope = persist_result(
+            result_content=big_text,
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+
+        self.assertEqual(result_doc.result_type, "text")
+        # Very large text still allows page/range/path reads; the default
+        # policy does not restrict text views.
+        self.assertIn("summary", envelope["available_views"])
+
+    def test_failed_status_is_preserved(self):
+        result_doc, envelope = persist_result(
+            result_content={"error": "boom"},
+            run=self.run.name,
+            tool_call=self.tool_call.name,
+            conversation=self.conversation.name,
+            status="Failed",
+        )
+        self._cleanup.append(("Agent Execution Result", result_doc.name))
+
+        self.assertEqual(result_doc.status, "Failed")
+        self.assertEqual(envelope["status"], "success")  # envelope itself is readable

--- a/huf/ai/tools/code_execution.py
+++ b/huf/ai/tools/code_execution.py
@@ -1422,3 +1422,7 @@ def _apply_result(
 		call.error_message = None
 
 	call.save(ignore_permissions=True)
+
+	# MA-10: keep the linked Agent Message's fetch_from tool fields in sync.
+	from huf.ai.conversation_manager import sync_tool_status_to_message
+	sync_tool_status_to_message(call.name)

--- a/huf/ai/tools/ssh_execution.py
+++ b/huf/ai/tools/ssh_execution.py
@@ -662,3 +662,7 @@ def _apply_result(call, result: SSHExecutionResult, limits: dict | None = None) 
 		"timed_out": bool(result.timed_out),
 	}
 	call.save(ignore_permissions=True)
+
+	# MA-10: keep the linked Agent Message's fetch_from tool fields in sync.
+	from huf.ai.conversation_manager import sync_tool_status_to_message
+	sync_tool_status_to_message(call.name)

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -249,6 +249,8 @@ scheduler_events = {
         "huf.ai.knowledge.maintenance.optimize_indexes",
         # P2-10: Proactively mark expired Memory Records (past effective_until) as Expired
         "huf.ai.memory_tools.expire_stale_memory_records",
+        # Step 3: mark expired Agent Execution Results and delete payload files.
+        "huf.ai.results.policy.expire_stale_results",
     ],
     "cron": {
         "*/1 * * * *": [

--- a/huf/huf/doctype/agent_execution_result/agent_execution_result.json
+++ b/huf/huf/doctype/agent_execution_result/agent_execution_result.json
@@ -1,0 +1,239 @@
+{
+ "actions": [],
+ "autoname": "naming_series:",
+ "creation": "2026-08-02 18:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "source_section",
+  "conversation",
+  "agent_run",
+  "tool_call",
+  "source_tool",
+  "column_break_source",
+  "status",
+  "result_type",
+  "visibility",
+  "idempotency_key",
+  "content_section",
+  "summary",
+  "size_bytes",
+  "estimated_tokens",
+  "content_hash",
+  "column_break_content",
+  "available_views",
+  "expires_on",
+  "payload_section",
+  "schema_json",
+  "preview_json",
+  "inline_payload",
+  "payload_file"
+ ],
+ "fields": [
+  {
+   "fieldname": "source_section",
+   "fieldtype": "Section Break",
+   "label": "Source"
+  },
+  {
+   "fieldname": "conversation",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Conversation",
+   "options": "Agent Conversation",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "agent_run",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Agent Run",
+   "options": "Agent Run",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "tool_call",
+   "fieldtype": "Link",
+   "label": "Tool Call",
+   "options": "Agent Tool Call",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "source_tool",
+   "fieldtype": "Data",
+   "label": "Source Tool",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_source",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Completed\nFailed\nExpired",
+   "read_only": 1
+  },
+  {
+   "fieldname": "result_type",
+   "fieldtype": "Select",
+   "label": "Result Type",
+   "options": "json\ntable\ntext\nfile\ncollection",
+   "read_only": 1
+  },
+  {
+   "default": "model_visible",
+   "fieldname": "visibility",
+   "fieldtype": "Select",
+   "label": "Visibility",
+   "options": "user_visible\nmodel_visible\nui_only\naudit_only\ndeveloper_only",
+   "read_only": 1
+  },
+  {
+   "fieldname": "idempotency_key",
+   "fieldtype": "Data",
+   "label": "Idempotency Key",
+   "read_only": 1
+  },
+  {
+   "fieldname": "content_section",
+   "fieldtype": "Section Break",
+   "label": "Content Metadata"
+  },
+  {
+   "fieldname": "summary",
+   "fieldtype": "Small Text",
+   "label": "Summary"
+  },
+  {
+   "fieldname": "size_bytes",
+   "fieldtype": "Int",
+   "label": "Size (bytes)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "estimated_tokens",
+   "fieldtype": "Int",
+   "label": "Estimated Tokens",
+   "read_only": 1
+  },
+  {
+   "fieldname": "content_hash",
+   "fieldtype": "Data",
+   "label": "Content Hash",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_content",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "available_views",
+   "fieldtype": "JSON",
+   "label": "Available Views",
+   "read_only": 1
+  },
+  {
+   "fieldname": "expires_on",
+   "fieldtype": "Datetime",
+   "label": "Expires On"
+  },
+  {
+   "fieldname": "payload_section",
+   "fieldtype": "Section Break",
+   "label": "Payload"
+  },
+  {
+   "fieldname": "schema_json",
+   "fieldtype": "Code",
+   "label": "Schema JSON",
+   "options": "JSON",
+   "read_only": 1
+  },
+  {
+   "fieldname": "preview_json",
+   "fieldtype": "Code",
+   "label": "Preview JSON",
+   "options": "JSON",
+   "read_only": 1
+  },
+  {
+   "fieldname": "inline_payload",
+   "fieldtype": "Code",
+   "label": "Inline Payload",
+   "options": "JSON",
+   "read_only": 1
+  },
+  {
+   "fieldname": "payload_file",
+   "fieldtype": "Attach",
+   "label": "Payload File",
+   "read_only": 1
+  },
+  {
+   "default": "RES-.#####",
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Naming Series",
+   "options": "RES-.#####",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-02 18:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Agent Execution Result",
+ "naming_rule": "By Naming Series",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/huf/huf/doctype/agent_execution_result/agent_execution_result.py
+++ b/huf/huf/doctype/agent_execution_result/agent_execution_result.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Controller for Agent Execution Result."""
+
+import frappe
+from frappe.model.document import Document
+
+
+class AgentExecutionResult(Document):
+    pass

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -16,3 +16,4 @@ huf.patches.v1.repair_tool_call_messages
 huf.patches.v1.fix_agent_message_status
 huf.patches.v1.sync_data_table_permissions
 huf.patches.v1.add_frappe_cloud_service
+huf.patches.v1.add_agent_message_conversation_index_unique

--- a/huf/patches/v1/add_agent_message_conversation_index_unique.py
+++ b/huf/patches/v1/add_agent_message_conversation_index_unique.py
@@ -1,0 +1,74 @@
+"""Add a unique constraint on (conversation, conversation_index) for Agent Message.
+
+MA-11: prevents duplicate conversation_index values from concurrent inserts.
+"""
+
+import frappe
+
+
+_UNIQ_NAME = "uk_agent_message_conversation_index"
+
+
+def _repair_duplicates():
+    """Find and repair any existing duplicate indices before adding the constraint."""
+    duplicates = frappe.db.sql(
+        """
+        SELECT conversation, conversation_index, COUNT(*) AS cnt
+        FROM `tabAgent Message`
+        GROUP BY conversation, conversation_index
+        HAVING cnt > 1
+        """,
+        as_dict=True,
+    )
+
+    if not duplicates:
+        return
+
+    affected_conversations = {d["conversation"] for d in duplicates}
+
+    for conversation in affected_conversations:
+        messages = frappe.db.sql(
+            """
+            SELECT name, conversation_index
+            FROM `tabAgent Message`
+            WHERE conversation = %s
+            ORDER BY conversation_index ASC, creation ASC, name ASC
+            """,
+            (conversation,),
+            as_dict=True,
+        )
+
+        for new_index, msg in enumerate(messages, start=1):
+            if msg["conversation_index"] != new_index:
+                frappe.db.sql(
+                    """
+                    UPDATE `tabAgent Message`
+                    SET conversation_index = %s
+                    WHERE name = %s
+                    """,
+                    (new_index, msg["name"]),
+                )
+
+        # Keep the denormalized counter consistent.
+        frappe.db.sql(
+            """
+            UPDATE `tabAgent Conversation`
+            SET total_messages = %s
+            WHERE name = %s
+            """,
+            (len(messages), conversation),
+        )
+
+
+def _add_unique_constraint():
+    try:
+        frappe.db.add_unique("Agent Message", ["conversation", "conversation_index"], _UNIQ_NAME)
+    except Exception as error:
+        # A previously deployed/manual index must not make migrate fail.
+        if "Duplicate key name" not in str(error):
+            raise
+
+
+def execute():
+    _repair_duplicates()
+    _add_unique_constraint()


### PR DESCRIPTION
Implements Steps 1–3 of the Artifact/Result Context track.

- Step 1: Rebase and refresh the message-audit docs against current develop.
- Step 2: Critical correctness/security fixes (MA-08..MA-12) including tool-call failure propagation, streaming token aggregation, conversation-index uniqueness, and Agent Message permission guards.
- Step 3: Result/Context Foundation V1 — new Agent Execution Result DocType, huf/ai/results/ package (store, envelope, views, policy, permissions, tools, API), routing of large tool results outside Agent Message content, and bounded result_read/result_index agent tools.

Tested on the artifact-result-context-v1 bench; all new and regression tests pass.

Plan documents:
- HUF_ARTIFACT_RESULT_CONTEXT_IMPLEMENTATION_PLAN.md
- HUF_ARTIFACT_WORKSPACE_COMPLETE_SPEC_AND_PHASED_PLAN.md