### PR TITLE
fix(chat): use square-asterisk icon for Open Agent header button

### DIFF
--- a/frontend/src/components/chat/ChatWindowHeader.tsx
+++ b/frontend/src/components/chat/ChatWindowHeader.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
-import { Bot, PanelLeftOpen } from "lucide-react";
+import { PanelLeftOpen, SquareAsterisk } from "lucide-react";
 import { Button } from "../ui/button";
 import { Badge } from "../ui/badge";
 import ChatAvatar from "./ChatAvatar";
@@ -179,7 +179,7 @@ export function ChatWindowHeader({
                 <Link to={`/agents/${agent.name}`}>
                     <Button asChild variant="outline" className="gap-x-2 text-xs text-muted-foreground" size="sm">
                         <div>
-                            <Bot className="w-4 h-4" />
+                            <SquareAsterisk className="w-4 h-4" />
                             <span>Open Agent</span>
                         </div>
                     </Button>


### PR DESCRIPTION
Replaces the robot (Bot) icon in the chat window header's "Open Agent" button with the lucide-square-asterisk icon, matching the sidebar convention.