### PR TITLE
feat(tools): link Agent Tool Functions to their Integration Service

### DIFF
--- a/frontend/src/components/tools/SelectToolsModal.tsx
+++ b/frontend/src/components/tools/SelectToolsModal.tsx
@@ -21,10 +21,19 @@ import { getToolFunctions, getToolTypes, createToolFunction, getAgentsUsingTool 
 import type { AgentToolFunctionRef, AgentToolType } from '@/types/agent.types';
 import type { ToolTemplate, ToolFormData } from '@/types/toolTemplate.types';
 import { getToolTypeDisplayLabel } from '@/data/ai';
+import { getIntegrationSettings } from '@/services/integrationApi';
+import type { IntegrationSettingsDoc } from '@/types/integration.types';
+import { getCategoryIcon } from './toolCategoryIcon';
+import { formatServiceLabel } from './toolPresentation';
 import { toast } from 'sonner';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
 import toolTemplatesConfig from '@/config/toolTemplates.json';
 import { Badge } from '../ui/badge';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const UNCATEGORIZED_GROUP = '__uncategorized__';
+const UNCATEGORIZED_LABEL = 'Other Tools';
 
 interface SelectToolsModalProps {
   open: boolean;
@@ -48,6 +57,9 @@ export function SelectToolsModal({
     new Set(selectedTools.map((t) => t.name))
   );
   const [toolUsageMap, setToolUsageMap] = useState<Map<string, string[]>>(new Map());
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  /** Integration Service keys with at least one active Integration Settings. */
+  const [connectedServices, setConnectedServices] = useState<Set<string>>(new Set());
   
   // Tab and view state
   const [activeTab, setActiveTab] = useState<'tool-library' | 'create-new'>('tool-library');
@@ -65,11 +77,23 @@ export function SelectToolsModal({
       Promise.all([
         getToolTypes(),
         getToolFunctions(),
+        // Which services actually have credentials configured — lets the
+        // picker warn before a tool is attached rather than at run time.
+        getIntegrationSettings().catch(() => [] as IntegrationSettingsDoc[]),
       ])
-        .then(async ([types, tools]) => {
+        .then(async ([types, tools, settings]) => {
           setToolTypes(types);
           setAllTools(tools);
-          
+
+          const settingsList = Array.isArray(settings) ? settings : settings.items;
+          setConnectedServices(
+            new Set(
+              settingsList
+                .filter((s) => s.is_active && s.service)
+                .map((s) => s.service)
+            )
+          );
+
           // Load tool usage data
           const usageMap = new Map<string, string[]>();
           await Promise.all(
@@ -102,6 +126,7 @@ export function SelectToolsModal({
       setActiveTab('tool-library');
       setCreateView('templates');
       setSelectedTemplate(null);
+      setExpandedGroups(new Set());
     }
   }, [open, selectedTools]);
 
@@ -148,6 +173,152 @@ export function SelectToolsModal({
       return matchesSearch && matchesToolType;
     });
   }, [allTools, searchQuery, toolTypeFilter]);
+
+  // Two sections, because they answer different questions.
+  //
+  // "From your connected apps" groups by `service` — the Integration Service a
+  // tool needs credentials for. That is the same object the /integrations page
+  // manages, so connecting Slack there now visibly unlocks the Slack tools
+  // here, and a tool whose account is missing can say so up front.
+  //
+  // "Built-in" is everything with no service: platform capabilities that always
+  // work (Memory, Builder, Documents, ...). Those group by Agent Tool Type.
+  //
+  // Neither section uses the `types` field: it records the implementation
+  // mechanism and is "App Provided" for ~90% of tools.
+  const { serviceGroups, builtinGroups } = useMemo(() => {
+    const byService = new Map<string, AgentToolFunctionRef[]>();
+    const byToolType = new Map<string, { label: string; tools: AgentToolFunctionRef[] }>();
+
+    filteredTools.forEach((tool) => {
+      if (tool.service) {
+        const list = byService.get(tool.service) ?? [];
+        list.push(tool);
+        byService.set(tool.service, list);
+        return;
+      }
+      const key = tool.tool_type || UNCATEGORIZED_GROUP;
+      const rawLabel = tool.tool_type
+        ? toolTypesMap.get(tool.tool_type)?.name1 || tool.tool_type
+        : UNCATEGORIZED_LABEL;
+      const entry = byToolType.get(key) ?? {
+        label: getToolTypeDisplayLabel(rawLabel),
+        tools: [],
+      };
+      entry.tools.push(tool);
+      byToolType.set(key, entry);
+    });
+
+    return {
+      serviceGroups: Array.from(byService.entries())
+        .map(([service, tools]) => ({
+          key: `service:${service}`,
+          label: formatServiceLabel(service),
+          tools,
+          connected: connectedServices.has(service),
+        }))
+        // Connected apps first — those are usable right now.
+        .sort((a, b) =>
+          a.connected !== b.connected
+            ? Number(b.connected) - Number(a.connected)
+            : b.tools.length - a.tools.length
+        ),
+      builtinGroups: Array.from(byToolType.entries())
+        .map(([key, { label, tools }]) => ({ key, label, tools, connected: true }))
+        .sort((a, b) => {
+          if (a.key === UNCATEGORIZED_GROUP) return 1;
+          if (b.key === UNCATEGORIZED_GROUP) return -1;
+          return b.tools.length - a.tools.length;
+        }),
+    };
+  }, [filteredTools, toolTypesMap, connectedServices]);
+
+  // Collapsed by default so the modal opens as a short list of categories
+  // rather than a scroll of 130+ rows. An active search expands everything,
+  // since a filtered result set is the thing the user wants to see at once.
+  const isSearching = searchQuery.trim() !== '' || toolTypeFilter !== 'all';
+  const toggleGroup = (key: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const renderGroup = ({
+    key,
+    label,
+    tools,
+    connected,
+  }: {
+    key: string;
+    label: string;
+    tools: AgentToolFunctionRef[];
+    connected: boolean;
+  }) => {
+    const Icon = getCategoryIcon(label);
+    const expanded = isSearching || expandedGroups.has(key);
+    const selectedHere = tools.filter((t) => selectedToolIds.has(t.name)).length;
+    const isService = key.startsWith('service:');
+
+    return (
+      <div key={key} className="mb-2 last:mb-0">
+        <button
+          type="button"
+          onClick={() => toggleGroup(key)}
+          aria-expanded={expanded}
+          className={cn(
+            'flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors',
+            'hover:bg-paper-deep focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+          )}
+        >
+          <ChevronRight
+            className={cn(
+              'h-4 w-4 shrink-0 text-steel-soft transition-transform',
+              expanded && 'rotate-90'
+            )}
+            aria-hidden="true"
+          />
+          <Icon className="h-4 w-4 shrink-0 text-steel-soft" aria-hidden="true" />
+          <span className="text-sm font-medium text-foreground">{label}</span>
+          <span className="text-xs text-steel-soft">{tools.length}</span>
+          {isService && !connected && (
+            <Badge variant="outline" className="shrink-0 text-[10px] font-normal">
+              Needs setup
+            </Badge>
+          )}
+          {selectedHere > 0 && (
+            <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
+              {selectedHere} selected
+            </Badge>
+          )}
+        </button>
+        {expanded && (
+          <div className="mt-1 space-y-2 pl-6">
+            {isService && !connected && (
+              <p className="pb-1 text-xs text-steel-soft">
+                These tools need a connected {label} account.{' '}
+                <a href="/huf/integrations" className="underline hover:text-foreground">
+                  Connect {label}
+                </a>{' '}
+                to use them.
+              </p>
+            )}
+            {tools.map((tool) => (
+              <ToolCard
+                key={tool.name}
+                tool={tool}
+                selected={selectedToolIds.has(tool.name)}
+                onSelect={handleToolToggle}
+                usedByAgents={toolUsageMap.get(tool.name) || []}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  };
 
   const handleToolToggle = (tool: AgentToolFunctionRef) => {
     const newSelectedIds = new Set(selectedToolIds);
@@ -318,17 +489,27 @@ export function SelectToolsModal({
                   </div>
                 </div>
               ) : (
-                filteredTools.map((tool) => (
-                  <ToolCard
-                    key={tool.name}
-                    tool={tool}
-                    selected={selectedToolIds.has(tool.name)}
-                    onSelect={handleToolToggle}
-                    compact
-                    toolTypesMap={toolTypesMap}
-                    usedByAgents={toolUsageMap.get(tool.name) || []}
-                  />
-                ))
+                <>
+                  {serviceGroups.length > 0 && (
+                    <section>
+                      <h3 className="px-2 pb-1 text-xs font-semibold uppercase tracking-wide text-steel">
+                        From your connected apps
+                      </h3>
+                      {serviceGroups.map(renderGroup)}
+                    </section>
+                  )}
+                  {builtinGroups.length > 0 && (
+                    <section className={cn(serviceGroups.length > 0 && 'mt-4 border-t border-line pt-4')}>
+                      <h3 className="px-2 pb-1 text-xs font-semibold uppercase tracking-wide text-steel">
+                        Built-in
+                      </h3>
+                      <p className="px-2 pb-2 text-xs text-steel-soft">
+                        Always available — no account to connect.
+                      </p>
+                      {builtinGroups.map(renderGroup)}
+                    </section>
+                  )}
+                </>
               )}
             </div>
           </TabsContent>

--- a/frontend/src/components/tools/ToolCard.tsx
+++ b/frontend/src/components/tools/ToolCard.tsx
@@ -1,27 +1,24 @@
 import { Badge } from '../ui/badge';
 import { Checkbox } from '../ui/checkbox';
 import { cn } from '@/lib/utils';
-import { getToolTypeDisplayLabel } from '@/data/ai';
-import type { AgentToolFunctionRef, AgentToolType } from '@/types/agent.types';
+import { presentToolName, summarizeDescription } from './toolPresentation';
+import type { AgentToolFunctionRef } from '@/types/agent.types';
 import { Users } from 'lucide-react';
 
 interface ToolCardProps {
   tool: AgentToolFunctionRef;
   selected?: boolean;
   onSelect?: (tool: AgentToolFunctionRef) => void;
-  compact?: boolean;
   className?: string;
-  toolTypesMap?: Map<string, AgentToolType>; // Map of tool_type name -> AgentToolType for lookup
-  usedByAgents?: string[]; // List of agent names using this tool
+  /** Agent names already using this tool. */
+  usedByAgents?: string[];
 }
 
 export function ToolCard({
   tool,
   selected = false,
   onSelect,
-  compact = false,
   className,
-  toolTypesMap,
   usedByAgents = [],
 }: ToolCardProps) {
   const isShared = usedByAgents.length > 0;
@@ -31,59 +28,60 @@ export function ToolCard({
     }
   };
 
-  // Get tool type display name from tool_type link field
-  const toolTypeDisplayName = tool.tool_type && toolTypesMap?.get(tool.tool_type)?.name1;
+  const rawName = tool.tool_name || tool.name;
+  // Lead with what the tool does, not how it was declared: the snake_case
+  // function name becomes the headline, the service it talks to becomes a
+  // chip, and the model-facing description is trimmed to its first sentence.
+  const { title, provider } = presentToolName(rawName);
+  const summary = summarizeDescription(tool.description);
 
   return (
     <div
       onClick={handleClick}
+      onKeyDown={(e) => {
+        if (onSelect && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      role={onSelect ? 'button' : undefined}
+      tabIndex={onSelect ? 0 : undefined}
+      aria-pressed={onSelect ? selected : undefined}
       className={cn(
         'flex items-start gap-3 rounded-lg border p-3 transition-colors',
         'hover:bg-paper-deep cursor-pointer',
+        onSelect && 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         selected && 'border-primary bg-primary/5',
         className
       )}
     >
       {onSelect && (
         <div className="pt-0.5" onClick={(e) => e.stopPropagation()}>
-          <Checkbox
-            checked={selected}
-            onCheckedChange={() => onSelect(tool)}
-          />
+          <Checkbox checked={selected} onCheckedChange={() => onSelect(tool)} />
         </div>
       )}
-      <div className="flex-1 min-w-0">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2 mb-1 flex-wrap">
-              <h4 className="font-medium text-sm">{tool.tool_name || tool.name}</h4>
-              {tool.types && (
-                <Badge variant="secondary" className="text-[10px] uppercase shrink-0">
-                  {getToolTypeDisplayLabel(tool.types)}
-                </Badge>
-              )}
-              {toolTypeDisplayName && (
-                <Badge variant="outline" className="text-xs shrink-0">
-                  {getToolTypeDisplayLabel(toolTypeDisplayName)}
-                </Badge>
-              )}
-              {isShared && (
-                <Badge variant="secondary" className="text-[10px] flex items-center gap-1 shrink-0">
-                  <Users className="w-3 h-3" />
-                  Used by {usedByAgents.length} agent{usedByAgents.length > 1 ? 's' : ''}
-                </Badge>
-              )}
-            </div>
-            {tool.description && (
-              <p className={cn(
-                'text-muted-foreground',
-                compact ? 'text-xs line-clamp-1' : 'text-xs line-clamp-2'
-              )}>
-                {tool.description}
-              </p>
-            )}
-          </div>
+      <div className="min-w-0 flex-1">
+        <div className="mb-0.5 flex flex-wrap items-center gap-2">
+          <h4 className="text-sm font-medium">{title}</h4>
+          {provider && (
+            <Badge variant="outline" className="shrink-0 text-[10px]">
+              {provider}
+            </Badge>
+          )}
+          {isShared && (
+            <Badge variant="secondary" className="flex shrink-0 items-center gap-1 text-[10px]">
+              <Users className="h-3 w-3" aria-hidden="true" />
+              Used by {usedByAgents.length} agent{usedByAgents.length > 1 ? 's' : ''}
+            </Badge>
+          )}
+        </div>
+        {summary && (
+          <p className="text-xs text-muted-foreground line-clamp-2" title={tool.description}>
+            {summary}
+          </p>
+        )}
+        <p className="mt-1 font-mono text-[10px] text-steel-soft">{rawName}</p>
       </div>
     </div>
   );
 }
-

--- a/frontend/src/components/tools/toolCategoryIcon.ts
+++ b/frontend/src/components/tools/toolCategoryIcon.ts
@@ -1,0 +1,52 @@
+import {
+  Cloud,
+  MessageSquare,
+  Wrench,
+  Search,
+  Code,
+  MapPin,
+  Brain,
+  FileText,
+  Workflow,
+  Package,
+  Mic,
+  AudioLines,
+  ScanText,
+  Sparkles,
+  LifeBuoy,
+  Users,
+  Globe,
+  type LucideIcon,
+} from 'lucide-react';
+
+/**
+ * Icon for an Agent Tool Type (the curated, product-facing category such as
+ * "Frappe Cloud" or "Communication Tools"). Matched on keywords rather than
+ * exact names so categories added later still get a sensible icon instead of
+ * falling back to the generic one.
+ */
+const KEYWORD_ICONS: Array<[RegExp, LucideIcon]> = [
+  [/frappe cloud/i, Cloud],
+  [/transcription/i, Mic],
+  [/audio/i, AudioLines],
+  [/ocr/i, ScanText],
+  [/generation/i, Sparkles],
+  [/serp|search/i, Search],
+  [/places|maps/i, MapPin],
+  [/google/i, Globe],
+  [/communication|raven|chat/i, MessageSquare],
+  [/builder/i, Wrench],
+  [/developer/i, Code],
+  [/memory/i, Brain],
+  [/document|report/i, FileText],
+  [/workflow|flow/i, Workflow],
+  [/helpdesk|support/i, LifeBuoy],
+  [/crm/i, Users],
+  [/erpnext|inventory/i, Package],
+];
+
+export function getCategoryIcon(category?: string): LucideIcon {
+  if (!category) return Wrench;
+  const hit = KEYWORD_ICONS.find(([pattern]) => pattern.test(category));
+  return hit ? hit[1] : Wrench;
+}

--- a/frontend/src/components/tools/toolPresentation.ts
+++ b/frontend/src/components/tools/toolPresentation.ts
@@ -1,0 +1,115 @@
+/**
+ * Turns developer-facing tool records into product-facing copy.
+ *
+ * A tool is stored the way engineers wrote it: a snake_case function name
+ * (`fc_list_sites`), a description authored for the LLM ("... Use this when
+ * the user asks to ..."), and an implementation enum (`types`, which is
+ * "App Provided" for ~90% of tools and therefore useless as a category).
+ *
+ * The picker should read like a product surface, so here we derive:
+ *   - a human title      `fc_list_sites`   -> "List Sites"
+ *   - the integration    `fc_list_sites`   -> "Frappe Cloud"
+ *   - a one-line summary (the declarative first sentence, without the
+ *     model-steering imperatives that follow it)
+ */
+
+/** Prefixes that encode which service a tool talks to. Longest match wins,
+ * so `google_meet_` resolves before any shorter `g*` prefix. */
+const PROVIDER_PREFIXES: Record<string, string> = {
+  fc_: 'Frappe Cloud',
+  gcalendar_: 'Google Calendar',
+  gdrive_: 'Google Drive',
+  gmail_: 'Gmail',
+  gmaps_: 'Google Maps',
+  gsheets_: 'Google Sheets',
+  gplaces_: 'Google Places',
+  google_meet_: 'Google Meet',
+  discord_: 'Discord',
+  slack_: 'Slack',
+  github_: 'GitHub',
+  serp_: 'Search',
+  erpnext_: 'ERPNext',
+};
+
+const SORTED_PREFIXES = Object.keys(PROVIDER_PREFIXES).sort((a, b) => b.length - a.length);
+
+/** Tokens that should not be title-cased into "Ssh" / "Pr" / "Ocr". */
+const ACRONYMS: Record<string, string> = {
+  ssh: 'SSH',
+  pr: 'PR',
+  ocr: 'OCR',
+  crm: 'CRM',
+  api: 'API',
+  url: 'URL',
+  id: 'ID',
+  ai: 'AI',
+  ui: 'UI',
+  pdf: 'PDF',
+  sql: 'SQL',
+  json: 'JSON',
+  csv: 'CSV',
+  http: 'HTTP',
+  serp: 'SERP',
+  erpnext: 'ERPNext',
+  huf: 'huf',
+};
+
+function titleCaseToken(token: string): string {
+  const acronym = ACRONYMS[token.toLowerCase()];
+  if (acronym) return acronym;
+  return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+/** Turns an Integration Service key into a label: `google_calendar` -> "Google Calendar". */
+export function formatServiceLabel(service: string): string {
+  return (service || '')
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map(titleCaseToken)
+    .join(' ');
+}
+
+export type ToolPresentation = {
+  /** Human-readable action, with any integration prefix removed. */
+  title: string;
+  /** The service this tool talks to, when the name encodes one. */
+  provider?: string;
+};
+
+export function presentToolName(toolName: string): ToolPresentation {
+  const raw = (toolName || '').trim();
+  if (!raw) return { title: '' };
+
+  const prefix = SORTED_PREFIXES.find((p) => raw.toLowerCase().startsWith(p));
+  const provider = prefix ? PROVIDER_PREFIXES[prefix] : undefined;
+  const remainder = prefix ? raw.slice(prefix.length) : raw;
+
+  // A bare integration name (e.g. `telegram`, `erpnext`) has no action part —
+  // keep the whole thing as the title rather than rendering an empty row.
+  const source = remainder || raw;
+  const title = source
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map(titleCaseToken)
+    .join(' ');
+
+  return { title: title || raw, provider };
+}
+
+/**
+ * Descriptions are written for the model and often continue "Use this when
+ * the user asks to ...". Humans only need the declarative opening sentence;
+ * the rest stays available as the full text on demand.
+ */
+export function summarizeDescription(description?: string): string | undefined {
+  const text = (description || '').trim();
+  if (!text) return undefined;
+
+  const match = text.match(/^.*?[.!?](?=\s|$)/);
+  const first = (match ? match[0] : text).trim();
+
+  // Guard against splitting on an abbreviation ("e.g.", "etc.") and ending up
+  // with a fragment — fall back to the full text if the result is too short.
+  if (first.length < 25 && text.length > first.length) return text;
+  return first;
+}

--- a/frontend/src/services/toolApi.ts
+++ b/frontend/src/services/toolApi.ts
@@ -78,7 +78,7 @@ export async function getToolTypes(): Promise<AgentToolType[]> {
 export async function getToolFunctions(toolTypeFilter?: string): Promise<AgentToolFunctionRef[]> {
   try {
     const options = {
-      fields: ["name", "tool_name", "description", "tool_type", "types", "reference_doctype"],
+      fields: ["name", "tool_name", "description", "tool_type", "types", "reference_doctype", "service"],
       limit: 1000,
       filters: [] as Array<{ field: string; operator: string; value: string }>,
     };
@@ -105,7 +105,7 @@ export async function getToolFunctionsByName(toolNames: string[]): Promise<Agent
     if (toolNames.length === 0) return [];
     
     const tools = await db.getDocList(doctype['Agent Tool Function'], {
-      fields: ["name", "tool_name", "description", "tool_type", "types", "reference_doctype"],
+      fields: ["name", "tool_name", "description", "tool_type", "types", "reference_doctype", "service"],
       filters: [["name", "in", toolNames]],
       limit: 1000,
     });

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -65,6 +65,7 @@ export type AgentToolFunctionRef = {
   function_path?: string;
   provider_app?: string;
   tool_type?: string; // Link to Agent Tool Type
+  service?: string; // Link to Integration Service that must be connected
 };
 
 export type AgentToolType = {

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1763,12 +1763,21 @@ FRAPPE_CLOUD_TOOLS = [
 	},
 ]
 
+def _with_service(tools: list[dict], service: str) -> list[dict]:
+	"""Stamp the owning Integration Service key onto each tool definition.
+
+	Tools are already grouped one list per service in this file, so the
+	association is declared once here instead of repeated on every entry. The
+	key must match an `Integration Service` docname, because that link is what
+	lets the UI tell a user which account a tool needs before they attach it.
+	An entry that already names a service keeps its own value.
+	"""
+	return [{**tool, "service": tool.get("service") or service} for tool in tools]
+
+
 ALL_INTEGRATION_TOOLS = (
+	# Platform capabilities — no external account to connect.
 	RECIPIENT_TOOLS
-	+ SLACK_TOOLS
-	+ DISCORD_TOOLS
-	+ TELEGRAM_TOOLS
-	+ GITHUB_TOOLS
 	+ CRM_TOOLS
 	+ HELPDESK_TOOLS
 	+ RAVEN_TOOLS
@@ -1776,18 +1785,26 @@ ALL_INTEGRATION_TOOLS = (
 	+ ERPNEXT_CRM_TOOLS
 	+ ERPNEXT_INVENTORY_TOOLS
 	+ ERPNEXT_REPORT_TOOLS
-	+ GMAIL_TOOLS
-	+ GOOGLE_SHEETS_TOOLS
-	+ GOOGLE_CALENDAR_TOOLS
-	+ GOOGLE_MAPS_TOOLS
-	+ GOOGLE_PLACES_TOOLS
-	+ GOOGLE_DRIVE_TOOLS
-	+ GOOGLE_MEET_TOOLS
-	+ SERP_HOTEL_TOOLS
-	+ SERP_REVIEW_TOOLS
-	+ SERP_YOUTUBE_TOOLS
 	+ BUILDER_TOOLS
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS
-	+ FRAPPE_CLOUD_TOOLS
+	# Tools backed by a connectable service. Keys match Integration Service
+	# docnames and the SERVICE_NAME each tool module uses for credentials.
+	+ _with_service(SLACK_TOOLS, "slack")
+	+ _with_service(DISCORD_TOOLS, "discord")
+	+ _with_service(TELEGRAM_TOOLS, "telegram")
+	+ _with_service(GITHUB_TOOLS, "github")
+	+ _with_service(GMAIL_TOOLS, "gmail")
+	+ _with_service(GOOGLE_SHEETS_TOOLS, "google_sheets")
+	+ _with_service(GOOGLE_CALENDAR_TOOLS, "google_calendar")
+	+ _with_service(GOOGLE_MAPS_TOOLS, "google_maps")
+	# Places is part of Google Maps Platform and shares its API key —
+	# `google_places.py` sets SERVICE_NAME = "google_maps".
+	+ _with_service(GOOGLE_PLACES_TOOLS, "google_maps")
+	+ _with_service(GOOGLE_DRIVE_TOOLS, "google_drive")
+	+ _with_service(GOOGLE_MEET_TOOLS, "google_meet")
+	+ _with_service(SERP_HOTEL_TOOLS, "serpapi")
+	+ _with_service(SERP_REVIEW_TOOLS, "serpapi")
+	+ _with_service(SERP_YOUTUBE_TOOLS, "serpapi")
+	+ FRAPPE_CLOUD_TOOLS  # entries already declare service="frappe_cloud"
 )

--- a/huf/ai/tools/integration_utils.py
+++ b/huf/ai/tools/integration_utils.py
@@ -9,47 +9,19 @@ import frappe
 from frappe import _
 
 
-SERVICE_TOOL_TYPE_MAP = {
-    "frappe_cloud": "Frappe Cloud",
-}
-
-
-def _service_to_tool_type(service: str) -> Optional[str]:
-    """Map an Integration Service key to an Agent Tool Type name."""
-    if not service:
-        return None
-    service = service.lower().strip()
-    if service in SERVICE_TOOL_TYPE_MAP:
-        return SERVICE_TOOL_TYPE_MAP[service]
-    # Fallback: title-case the service key (e.g. "frappe_cloud" -> "Frappe Cloud")
-    return " ".join(part.title() for part in service.replace("-", "_").split("_"))
-
-
-def _get_tool_type_name(service: str) -> str:
-    """Return the Agent Tool Type name for a service, raising if missing."""
-    tool_type = _service_to_tool_type(service)
-    if not tool_type or not frappe.db.exists("Agent Tool Type", tool_type):
-        frappe.throw(_("No tools found for service '{0}'").format(service))
-    return tool_type
-
-
 def _get_tools_for_service(service: str) -> list[dict]:
-    """Return Agent Tool Function docs that belong to the given service."""
-    # Prefer the explicit service field; fall back to tool_type mapping.
-    filters = [["service", "=", service]]
-    tools_by_service = frappe.get_all(
-        "Agent Tool Function",
-        filters=filters,
-        fields=["name", "tool_name", "description", "tool_type", "service"],
-        order_by="tool_name",
-    )
-    if tools_by_service:
-        return tools_by_service
+    """Return Agent Tool Function docs that belong to the given service.
 
-    tool_type = _get_tool_type_name(service)
+    The `service` link is authoritative: it is stamped during tool sync from
+    the per-service lists in `_registry.py`. There is deliberately no
+    tool_type-guessing fallback — the previous one title-cased the service key
+    ("slack" -> Agent Tool Type "Slack") and silently missed, because those
+    tools are typed "Communication Tools". An empty result means the service
+    genuinely has no tools, which the caller should surface as such.
+    """
     return frappe.get_all(
         "Agent Tool Function",
-        filters={"tool_type": tool_type},
+        filters=[["service", "=", service]],
         fields=["name", "tool_name", "description", "tool_type", "service"],
         order_by="tool_name",
     )

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -16,3 +16,4 @@ huf.patches.v1.repair_tool_call_messages
 huf.patches.v1.fix_agent_message_status
 huf.patches.v1.sync_data_table_permissions
 huf.patches.v1.add_frappe_cloud_service
+huf.patches.v1.backfill_tool_service_links

--- a/huf/patches/v1/backfill_tool_service_links.py
+++ b/huf/patches/v1/backfill_tool_service_links.py
@@ -1,0 +1,73 @@
+import json
+
+import frappe
+
+
+BUILTIN_SERVICES = {
+	"frappe_cloud": {
+		"category": "Cloud",
+		"description": "Manage Frappe Cloud benches, sites, apps, webhooks, and SSH access.",
+		"required_credentials": [
+			{"key": "api_key", "label": "API Key", "required": True},
+			{"key": "api_secret", "label": "API Secret", "required": True},
+			{
+				"key": "server_url",
+				"label": "Server URL",
+				"required": False,
+				"secret": False,
+				"description": "Optional Frappe Cloud base URL (defaults to https://cloud.frappe.io)",
+			},
+		],
+	},
+}
+
+
+def execute():
+	"""Link every Agent Tool Function to the Integration Service it needs.
+
+	Until now only the 45 Frappe Cloud tools carried a `service` value, so
+	`get_service_tools` returned nothing for Slack, Gmail, GitHub, SERP and the
+	rest — the picker could not tell a user which account a tool depends on.
+	`_registry.py` now stamps the service onto every tool list, so re-running
+	the sync backfills existing rows.
+
+	Also re-asserts the built-in service records. `add_frappe_cloud_service`
+	already ran on existing sites, so a record deleted since then would never
+	come back; this patch is written to be safely re-assertable.
+	"""
+	_ensure_builtin_services()
+	_resync_tools()
+
+
+def _ensure_builtin_services():
+	for service_name, spec in BUILTIN_SERVICES.items():
+		try:
+			if frappe.db.exists("Integration Service", service_name):
+				doc = frappe.get_doc("Integration Service", service_name)
+			else:
+				doc = frappe.get_doc(
+					{"doctype": "Integration Service", "service_name": service_name}
+				)
+
+			doc.category = spec["category"]
+			doc.description = spec["description"]
+			doc.required_credentials = json.dumps(spec["required_credentials"])
+			doc.is_builtin = 1
+			doc.save(ignore_permissions=True)
+		except Exception as e:
+			frappe.log_error(
+				f"Could not assert Integration Service '{service_name}': {e}",
+				"Backfill Tool Service Links",
+			)
+
+
+def _resync_tools():
+	try:
+		from huf.ai.tool_registry import sync_discovered_tools
+
+		sync_discovered_tools(use_cache=False)
+	except Exception as e:
+		frappe.log_error(
+			f"Tool re-sync failed during service backfill: {e}",
+			"Backfill Tool Service Links",
+		)


### PR DESCRIPTION
## Summary
- `Agent Tool Function.service` was only populated on the 45 Frappe Cloud tools; every Slack/Gmail/GitHub/Drive/Calendar/Sheets/Maps/SERP tool had it empty, so `get_service_tools` resolved 12 of 13 catalog services to "No tools found" (verified on a live bench before/after — see Test plan).
- `_registry.py` now stamps `service` on every per-service tool list via `_with_service()`, keyed by each tool module's own `SERVICE_NAME` (not guessed — e.g. `google_places.py` already declares `SERVICE_NAME = "google_maps"` since Places shares the Maps Platform key).
- `integration_utils.py` drops the tool_type-guessing fallback now that `service` is authoritative (it used to title-case `"slack"` → `"Slack"` and miss, since Slack tools are typed `"Communication Tools"`).
- New re-runnable patch (`backfill_tool_service_links`) backfills `service` on existing rows via tool re-sync and re-asserts built-in Integration Service records — written re-assertable because the existing `add_frappe_cloud_service` patch had already run yet its record was missing on the bench I tested against.
- Add Tool's Tool Library tab now renders two sections: **"From your connected apps"** (grouped by service, unconnected ones badged "Needs setup" with a link to `/integrations`) and **"Built-in"** (always available, no account needed). Tool rows lead with a humanized name (`fc_add_ssh_key` → "Add SSH Key" [Frappe Cloud chip]) and a trimmed first-sentence description instead of the raw snake_case function name and a "types" badge that was `"App Provided"` on 90% of tools.

## Test plan
- [x] `cd frontend && npm run build` — zero TypeScript errors
- [x] `python3 -m ast` syntax check on all changed/new Python files
- [x] Deployed to a live bench (`artifact-identity-v1`, huf app), ran the new patch, and called `get_service_tools` for all 13 catalog services directly in `bench console`:
  before: 1/13 resolve (only `frappe_cloud`) · after: 12/13 resolve (`jira` correctly returns 0 — it has no tools, no longer throws)
- [x] Confirmed tool count unchanged at 138 after the backfill (caught and fixed a `docker cp` mistake mid-verification that had briefly dropped 4 unrelated artifact tools on that bench — restored via `git checkout` on the bench checkout, not part of this diff)
- [ ] Not done: live screenshot of the picker UI (blocked on Browser-pane origin approval in my session) and no automated Python test suite exists for `integration_utils.py` / `tool_registry.py` to run — this PR doesn't add one; flagging as a gap rather than silently skipping
- [ ] Needs a human click-through on a real bench with Slack/Gmail credentials connected to confirm the "Needs setup" → "Connect X" link round-trips correctly end to end