### PR TITLE
fix(deps): add bleach and tinycss2 for document artifact rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,15 @@ dependencies = [
     "serpapi",
     "youtube-transcript-api",
     "paramiko>=3.4.0",
+    # HTML sanitization for document artifact rendering
+    # (huf.ai.artifacts.render.html). bleach.css_sanitizer.CSSSanitizer needs
+    # tinycss2, pinned here at the version weasyprint (below) also needs —
+    # depend on it directly rather than via bleach's "css" extra, which pins
+    # an older tinycss2 and would downgrade it.
+    "bleach>=6.0",
+    "tinycss2>=1.5.0",
+    # PDF export for document artifacts (huf.ai.artifacts.render.pdf/safety).
+    "weasyprint>=68.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- `huf/ai/artifacts/render/{html,pdf,safety}.py` (added in #574) import `bleach` (HTML sanitization before PDF/DOCX conversion) and `weasyprint` (PDF export) — real production code on the `export_artifact` / `redline_artifact` path, not test-only.
- Neither was declared in `pyproject.toml`, nor was `tinycss2` (needed by `bleach.css_sanitizer.CSSSanitizer` for inline `style="..."` support). It only worked wherever something else pulled them in transitively; CI's fresh `bench run-tests` environment didn't, so the job failed at test *discovery* with `ModuleNotFoundError` before a single test ran — first on `bleach`, then (once that alone was added) on `weasyprint`, which had been transitively present on the bench I originally verified against and masked the second gap.
- Depends on `tinycss2` directly rather than via bleach's `[css]` extra: that extra pins an older `tinycss2` than `weasyprint` requires, which would downgrade it and throw a pip resolver conflict.

## Test plan
- [x] Built a **clean venv containing only the newly declared packages** (`bleach`, `tinycss2`, `weasyprint`) plus their own transitive deps — not the ambient bench environment, specifically to rule out further masking. All imports resolve.
- [x] Called `render_document_html()` directly with an injected `<script>` tag — sanitizer strips it, legitimate content survives.
- [x] `bench --site <site> run-tests --app huf --module huf.ai.tests.test_document_render` — 27/27 passing (previously failed to even import, twice, for two different missing deps).