### PR TITLE
feat(tools): add Jira, Linear, ClickUp, Trello, Notion, Zendesk, Cal.com, and Zoom tools

### DIFF
--- a/frontend/src/types/integration.types.ts
+++ b/frontend/src/types/integration.types.ts
@@ -143,25 +143,33 @@ export function buildCredentialsPayload(
 ): IntegrationCredentialRow[] {
   const existingMap = credentialsToMap(existingCredentials);
 
-  return schema.map((item) => {
+  return schema.flatMap((item) => {
     const formValue = formValues[item.key]?.trim() ?? '';
     const existingRow = existingCredentials?.find((c) => c.key === item.key);
+    const isRequired = item.required !== false;
 
     if (isNew) {
-      return {
+      if (!isRequired && !formValue) {
+        return [];
+      }
+      return [{
         key: item.key,
         value: formValue,
         description: item.label,
-      };
+      }];
     }
 
     // On edit: blank field keeps existing value
     const value = formValue || existingMap[item.key] || '';
-    return {
+    if (!isRequired && !value) {
+      return [];
+    }
+
+    return [{
       ...(existingRow?.name ? { name: existingRow.name } : {}),
       key: item.key,
       value,
       description: item.label,
-    };
+    }];
   });
 }

--- a/huf/ai/tests/test_calcom_tools.py
+++ b/huf/ai/tests/test_calcom_tools.py
@@ -13,8 +13,10 @@ from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, CALCOM_TOOLS
 MODULE = "huf.ai.tools.calcom"
 
 
-def _mock_response(payload):
+def _mock_response(payload, status_code=200):
 	resp = MagicMock()
+	resp.ok = status_code < 400
+	resp.status_code = status_code
 	resp.json.return_value = payload
 	resp.text = json.dumps(payload)
 	resp.raise_for_status = MagicMock()
@@ -25,6 +27,37 @@ def _result(raw):
 	return json.loads(raw)
 
 
+class TestListEventTypes(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="cal_live_key")
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_event_types(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"status": "success",
+				"data": [
+					{
+						"id": 6590907,
+						"title": "15 min meeting",
+						"slug": "15min",
+						"description": "",
+						"lengthInMinutes": 15,
+						"bookingUrl": "https://cal.com/fero-pod-anhzwm/15min",
+						"hidden": False,
+					}
+				],
+			}
+		)
+
+		out = _result(calcom.handle_list_event_types())
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["id"], 6590907)
+		self.assertEqual(out["results"][0]["duration_minutes"], 15)
+		headers = mock_request.call_args.kwargs["headers"]
+		self.assertEqual(headers["cal-api-version"], calcom.EVENT_TYPES_API_VERSION)
+
+
 class TestListBookings(unittest.TestCase):
 	@patch(f"{MODULE}.update_last_error")
 	@patch(f"{MODULE}.require_credential", return_value="cal_live_key")
@@ -32,16 +65,17 @@ class TestListBookings(unittest.TestCase):
 	def test_lists_bookings(self, mock_request, _cred, _err):
 		mock_request.return_value = _mock_response(
 			{
-				"bookings": [
+				"status": "success",
+				"data": [
 					{
 						"uid": "b1",
 						"title": "1:1",
-						"startTime": "2026-08-10T15:00:00Z",
-						"endTime": "2026-08-10T15:30:00Z",
+						"start": "2026-08-10T15:00:00Z",
+						"end": "2026-08-10T15:30:00Z",
 						"status": "accepted",
 						"attendees": [{"email": "a@example.com"}],
 					}
-				]
+				],
 			}
 		)
 
@@ -50,9 +84,17 @@ class TestListBookings(unittest.TestCase):
 		self.assertTrue(out["success"])
 		self.assertEqual(out["results"][0]["uid"], "b1")
 
-		params = mock_request.call_args.kwargs["params"]
-		self.assertEqual(params["apiKey"], "cal_live_key")
-		self.assertEqual(params["status"], "upcoming")
+		headers = mock_request.call_args.kwargs["headers"]
+		self.assertEqual(headers["Authorization"], "Bearer cal_live_key")
+		self.assertEqual(headers["cal-api-version"], calcom.LIST_BOOKINGS_API_VERSION)
+		self.assertEqual(mock_request.call_args.kwargs["params"]["status"], "upcoming")
+
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="cal_live_key")
+	def test_rejects_invalid_status(self, _cred, _err):
+		out = _result(calcom.handle_list_bookings(status="accepted"))
+		self.assertFalse(out["success"])
+		self.assertIn("status must be one of", out["error"])
 
 
 class TestGetBooking(unittest.TestCase):
@@ -62,15 +104,16 @@ class TestGetBooking(unittest.TestCase):
 	def test_get_booking(self, mock_request, _cred, _err):
 		mock_request.return_value = _mock_response(
 			{
-				"booking": {
+				"status": "success",
+				"data": {
 					"uid": "b1",
 					"title": "1:1",
 					"description": "sync",
-					"startTime": "2026-08-10T15:00:00Z",
-					"endTime": "2026-08-10T15:30:00Z",
+					"start": "2026-08-10T15:00:00Z",
+					"end": "2026-08-10T15:30:00Z",
 					"status": "accepted",
 					"attendees": [{"email": "a@example.com"}],
-				}
+				},
 			}
 		)
 
@@ -78,6 +121,8 @@ class TestGetBooking(unittest.TestCase):
 
 		self.assertTrue(out["success"])
 		self.assertEqual(out["results"]["attendees"], ["a@example.com"])
+		headers = mock_request.call_args.kwargs["headers"]
+		self.assertEqual(headers["cal-api-version"], calcom.BOOKING_API_VERSION)
 
 	def test_requires_booking_uid(self):
 		out = _result(calcom.handle_get_booking())
@@ -91,7 +136,15 @@ class TestCreateBooking(unittest.TestCase):
 	@patch(f"{MODULE}.requests.request")
 	def test_creates_booking(self, mock_request, _cred, _err):
 		mock_request.return_value = _mock_response(
-			{"booking": {"uid": "b2", "title": "New", "startTime": "2026-08-10T15:00:00Z", "status": "accepted"}}
+			{
+				"status": "success",
+				"data": {
+					"uid": "b2",
+					"title": "New",
+					"start": "2026-08-10T15:00:00Z",
+					"status": "accepted",
+				},
+			}
 		)
 
 		out = _result(
@@ -108,18 +161,39 @@ class TestCreateBooking(unittest.TestCase):
 
 		body = mock_request.call_args.kwargs["json"]
 		self.assertEqual(body["eventTypeId"], 42)
-		self.assertEqual(body["responses"], {"name": "Jane", "email": "jane@example.com"})
-		self.assertEqual(body["timeZone"], "UTC")
+		self.assertEqual(
+			body["attendee"],
+			{
+				"name": "Jane",
+				"email": "jane@example.com",
+				"timeZone": "UTC",
+				"language": "en",
+			},
+		)
 
 	def test_requires_all_fields(self):
 		out = _result(calcom.handle_create_booking(event_type_id=42))
 		self.assertFalse(out["success"])
 		self.assertIn("start", out["error"])
 
+	@patch(f"{MODULE}.update_last_error")
+	def test_rejects_non_numeric_event_type_id(self, _err):
+		out = _result(
+			calcom.handle_create_booking(
+				event_type_id="default",
+				start="2026-08-10T15:00:00Z",
+				attendee_name="Jane",
+				attendee_email="jane@example.com",
+			)
+		)
+		self.assertFalse(out["success"])
+		self.assertIn("event_type_id must be a numeric", out["error"])
+
 
 class TestRegistry(unittest.TestCase):
 	def test_all_tools_registered(self):
 		expected = {
+			"calcom_list_event_types": "handle_list_event_types",
 			"calcom_list_bookings": "handle_list_bookings",
 			"calcom_get_booking": "handle_get_booking",
 			"calcom_create_booking": "handle_create_booking",

--- a/huf/ai/tests/test_calcom_tools.py
+++ b/huf/ai/tests/test_calcom_tools.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Cal.com integration tools. All HTTP calls are mocked."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import calcom
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, CALCOM_TOOLS
+
+MODULE = "huf.ai.tools.calcom"
+
+
+def _mock_response(payload):
+	resp = MagicMock()
+	resp.json.return_value = payload
+	resp.text = json.dumps(payload)
+	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+class TestListBookings(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="cal_live_key")
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_bookings(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"bookings": [
+					{
+						"uid": "b1",
+						"title": "1:1",
+						"startTime": "2026-08-10T15:00:00Z",
+						"endTime": "2026-08-10T15:30:00Z",
+						"status": "accepted",
+						"attendees": [{"email": "a@example.com"}],
+					}
+				]
+			}
+		)
+
+		out = _result(calcom.handle_list_bookings(status="upcoming"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["uid"], "b1")
+
+		params = mock_request.call_args.kwargs["params"]
+		self.assertEqual(params["apiKey"], "cal_live_key")
+		self.assertEqual(params["status"], "upcoming")
+
+
+class TestGetBooking(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="cal_live_key")
+	@patch(f"{MODULE}.requests.request")
+	def test_get_booking(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"booking": {
+					"uid": "b1",
+					"title": "1:1",
+					"description": "sync",
+					"startTime": "2026-08-10T15:00:00Z",
+					"endTime": "2026-08-10T15:30:00Z",
+					"status": "accepted",
+					"attendees": [{"email": "a@example.com"}],
+				}
+			}
+		)
+
+		out = _result(calcom.handle_get_booking(booking_uid="b1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["attendees"], ["a@example.com"])
+
+	def test_requires_booking_uid(self):
+		out = _result(calcom.handle_get_booking())
+		self.assertFalse(out["success"])
+		self.assertIn("booking_uid", out["error"])
+
+
+class TestCreateBooking(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="cal_live_key")
+	@patch(f"{MODULE}.requests.request")
+	def test_creates_booking(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{"booking": {"uid": "b2", "title": "New", "startTime": "2026-08-10T15:00:00Z", "status": "accepted"}}
+		)
+
+		out = _result(
+			calcom.handle_create_booking(
+				event_type_id=42,
+				start="2026-08-10T15:00:00Z",
+				attendee_name="Jane",
+				attendee_email="jane@example.com",
+			)
+		)
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["uid"], "b2")
+
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["eventTypeId"], 42)
+		self.assertEqual(body["responses"], {"name": "Jane", "email": "jane@example.com"})
+		self.assertEqual(body["timeZone"], "UTC")
+
+	def test_requires_all_fields(self):
+		out = _result(calcom.handle_create_booking(event_type_id=42))
+		self.assertFalse(out["success"])
+		self.assertIn("start", out["error"])
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"calcom_list_bookings": "handle_list_bookings",
+			"calcom_get_booking": "handle_get_booking",
+			"calcom_create_booking": "handle_create_booking",
+		}
+		by_name = {t["tool_name"]: t for t in CALCOM_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			self.assertEqual(by_name[tool_name]["function_path"], f"huf.ai.tools.calcom.{handler}")
+			self.assertTrue(callable(getattr(calcom, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in CALCOM_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "calcom")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_clickup_tools.py
+++ b/huf/ai/tests/test_clickup_tools.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the ClickUp integration tools. All HTTP calls are mocked."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import clickup
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, CLICKUP_TOOLS
+
+MODULE = "huf.ai.tools.clickup"
+
+
+def _mock_response(payload):
+	resp = MagicMock()
+	resp.json.return_value = payload
+	resp.text = json.dumps(payload)
+	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+class TestListTasks(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="pk_token")
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_tasks(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"tasks": [
+					{
+						"id": "abc123",
+						"name": "Ship feature",
+						"status": {"status": "in progress"},
+						"assignees": [{"username": "jane"}],
+						"due_date": None,
+						"url": "https://app.clickup.com/t/abc123",
+					}
+				]
+			}
+		)
+
+		out = _result(clickup.handle_list_tasks(list_id="list-1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["id"], "abc123")
+		self.assertEqual(out["results"][0]["status"], "in progress")
+		self.assertEqual(out["results"][0]["assignees"], ["jane"])
+
+		kwargs = mock_request.call_args.kwargs
+		self.assertEqual(kwargs["headers"]["Authorization"], "pk_token")
+
+	def test_requires_list_id(self):
+		out = _result(clickup.handle_list_tasks())
+		self.assertFalse(out["success"])
+		self.assertIn("list_id", out["error"])
+
+
+class TestGetTask(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="pk_token")
+	@patch(f"{MODULE}.requests.request")
+	def test_get_task(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"id": "abc123",
+				"name": "Ship feature",
+				"description": "Details",
+				"status": {"status": "open"},
+				"assignees": [],
+				"priority": {"priority": "high"},
+				"due_date": "1700000000000",
+				"url": "https://app.clickup.com/t/abc123",
+			}
+		)
+
+		out = _result(clickup.handle_get_task(task_id="abc123"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["priority"], "high")
+
+	def test_requires_task_id(self):
+		out = _result(clickup.handle_get_task())
+		self.assertFalse(out["success"])
+		self.assertIn("task_id", out["error"])
+
+
+class TestCreateTask(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="pk_token")
+	@patch(f"{MODULE}.requests.request")
+	def test_create_task(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{"id": "abc999", "name": "New task", "url": "https://app.clickup.com/t/abc999"}
+		)
+
+		out = _result(clickup.handle_create_task(list_id="list-1", name="New task", description="desc"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["id"], "abc999")
+
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["name"], "New task")
+		self.assertEqual(body["description"], "desc")
+
+	def test_requires_name(self):
+		out = _result(clickup.handle_create_task(list_id="list-1"))
+		self.assertFalse(out["success"])
+		self.assertIn("name", out["error"])
+
+
+class TestErrorHandling(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=ValueError("Credential not found"))
+	def test_missing_credentials_returns_envelope(self, _cred, mock_err):
+		out = _result(clickup.handle_list_tasks(list_id="list-1"))
+		self.assertFalse(out["success"])
+		mock_err.assert_called_once()
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"clickup_list_tasks": "handle_list_tasks",
+			"clickup_get_task": "handle_get_task",
+			"clickup_create_task": "handle_create_task",
+		}
+		by_name = {t["tool_name"]: t for t in CLICKUP_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			self.assertEqual(by_name[tool_name]["function_path"], f"huf.ai.tools.clickup.{handler}")
+			self.assertTrue(callable(getattr(clickup, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in CLICKUP_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "clickup")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_jira_tools.py
+++ b/huf/ai/tests/test_jira_tools.py
@@ -18,14 +18,10 @@ MODULE = "huf.ai.tools.jira"
 
 def _mock_response(payload=None, status_code=200):
 	resp = MagicMock()
+	resp.ok = status_code < 400
 	resp.status_code = status_code
 	resp.json.return_value = payload if payload is not None else {}
 	resp.text = json.dumps(payload or {})
-	resp.raise_for_status = MagicMock()
-	if status_code >= 400:
-		import requests
-
-		resp.raise_for_status.side_effect = requests.HTTPError(f"{status_code} error")
 	return resp
 
 
@@ -35,6 +31,23 @@ def _result(raw):
 
 def _fake_credential(service, key):
 	return {"base_url": "https://example.atlassian.net", "email": "bot@example.com", "api_token": "tok-123"}[key]
+
+
+class TestListProjects(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_list_projects(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{"values": [{"key": "ABC", "name": "Alpha", "projectTypeKey": "software", "style": "classic"}]}
+		)
+
+		out = _result(jira.handle_list_projects())
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["key"], "ABC")
+		kwargs = mock_request.call_args.kwargs
+		self.assertEqual(kwargs["params"]["maxResults"], 50)
 
 
 class TestSearchIssues(unittest.TestCase):
@@ -70,7 +83,9 @@ class TestSearchIssues(unittest.TestCase):
 		self.assertIn("ABC-1", issue["url"])
 
 		kwargs = mock_request.call_args.kwargs
-		self.assertEqual(kwargs["params"]["jql"], "project = ABC")
+		self.assertEqual(kwargs["json"]["jql"], "project = ABC")
+		self.assertEqual(mock_request.call_args.args[0], "POST")
+		self.assertIn("search/jql", mock_request.call_args.args[1])
 
 	def test_requires_jql(self):
 		out = _result(jira.handle_search_issues())
@@ -162,11 +177,15 @@ class TestErrorHandling(unittest.TestCase):
 	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
 	@patch(f"{MODULE}.requests.request")
 	def test_http_error_returns_envelope(self, mock_request, _cred, mock_err):
-		mock_request.return_value = _mock_response({"errorMessages": ["not found"]}, status_code=404)
+		mock_request.return_value = _mock_response(
+			{"errorMessages": ["Issue does not exist"], "errors": {}},
+			status_code=404,
+		)
 
 		out = _result(jira.handle_get_issue(issue_key="ABC-999"))
 
 		self.assertFalse(out["success"])
+		self.assertIn("Issue does not exist", out["error"])
 		mock_err.assert_called_once()
 
 	@patch(f"{MODULE}.update_last_error")
@@ -180,6 +199,7 @@ class TestErrorHandling(unittest.TestCase):
 class TestRegistry(unittest.TestCase):
 	def test_all_tools_registered(self):
 		expected = {
+			"jira_list_projects": "handle_list_projects",
 			"jira_search_issues": "handle_search_issues",
 			"jira_get_issue": "handle_get_issue",
 			"jira_create_issue": "handle_create_issue",

--- a/huf/ai/tests/test_jira_tools.py
+++ b/huf/ai/tests/test_jira_tools.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Jira integration tools.
+
+All HTTP calls and credential lookups are mocked — no live Jira instance is required.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import jira
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, JIRA_TOOLS
+
+MODULE = "huf.ai.tools.jira"
+
+
+def _mock_response(payload=None, status_code=200):
+	resp = MagicMock()
+	resp.status_code = status_code
+	resp.json.return_value = payload if payload is not None else {}
+	resp.text = json.dumps(payload or {})
+	resp.raise_for_status = MagicMock()
+	if status_code >= 400:
+		import requests
+
+		resp.raise_for_status.side_effect = requests.HTTPError(f"{status_code} error")
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+def _fake_credential(service, key):
+	return {"base_url": "https://example.atlassian.net", "email": "bot@example.com", "api_token": "tok-123"}[key]
+
+
+class TestSearchIssues(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_search_returns_normalized_issues(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"issues": [
+					{
+						"key": "ABC-1",
+						"fields": {
+							"summary": "Fix bug",
+							"status": {"name": "In Progress"},
+							"issuetype": {"name": "Bug"},
+							"assignee": {"displayName": "Jane Doe"},
+							"priority": {"name": "High"},
+						},
+					}
+				]
+			}
+		)
+
+		out = _result(jira.handle_search_issues(jql="project = ABC"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["count"], 1)
+		issue = out["results"][0]
+		self.assertEqual(issue["key"], "ABC-1")
+		self.assertEqual(issue["status"], "In Progress")
+		self.assertEqual(issue["assignee"], "Jane Doe")
+		self.assertIn("ABC-1", issue["url"])
+
+		kwargs = mock_request.call_args.kwargs
+		self.assertEqual(kwargs["params"]["jql"], "project = ABC")
+
+	def test_requires_jql(self):
+		out = _result(jira.handle_search_issues())
+		self.assertFalse(out["success"])
+		self.assertIn("jql", out["error"])
+
+
+class TestGetIssue(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_get_issue(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"key": "ABC-1",
+				"fields": {
+					"summary": "Fix bug",
+					"status": {"name": "Open"},
+					"issuetype": {"name": "Bug"},
+					"assignee": None,
+					"reporter": {"displayName": "John"},
+					"priority": {"name": "Low"},
+					"created": "2026-01-01T00:00:00Z",
+					"updated": "2026-01-02T00:00:00Z",
+				},
+			}
+		)
+
+		out = _result(jira.handle_get_issue(issue_key="ABC-1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["key"], "ABC-1")
+		self.assertEqual(out["results"]["reporter"], "John")
+		self.assertIsNone(out["results"]["assignee"])
+
+	def test_requires_issue_key(self):
+		out = _result(jira.handle_get_issue())
+		self.assertFalse(out["success"])
+		self.assertIn("issue_key", out["error"])
+
+
+class TestCreateIssue(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_create_issue_builds_adf_description(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"key": "ABC-2", "id": "10001"})
+
+		out = _result(
+			jira.handle_create_issue(project_key="ABC", summary="New task", description="Some details")
+		)
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["key"], "ABC-2")
+		self.assertIn("ABC-2", out["results"]["url"])
+
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["fields"]["project"], {"key": "ABC"})
+		self.assertEqual(body["fields"]["summary"], "New task")
+		self.assertEqual(body["fields"]["issuetype"], {"name": "Task"})
+		self.assertEqual(body["fields"]["description"]["type"], "doc")
+
+	def test_requires_project_key_and_summary(self):
+		out = _result(jira.handle_create_issue(summary="No project"))
+		self.assertFalse(out["success"])
+		self.assertIn("project_key", out["error"])
+
+
+class TestAddComment(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_add_comment(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"id": "999", "created": "2026-01-01T00:00:00Z"})
+
+		out = _result(jira.handle_add_comment(issue_key="ABC-1", comment="Looks good"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["id"], "999")
+
+	def test_requires_comment(self):
+		out = _result(jira.handle_add_comment(issue_key="ABC-1"))
+		self.assertFalse(out["success"])
+		self.assertIn("comment", out["error"])
+
+
+class TestErrorHandling(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_http_error_returns_envelope(self, mock_request, _cred, mock_err):
+		mock_request.return_value = _mock_response({"errorMessages": ["not found"]}, status_code=404)
+
+		out = _result(jira.handle_get_issue(issue_key="ABC-999"))
+
+		self.assertFalse(out["success"])
+		mock_err.assert_called_once()
+
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=ValueError("Credential not found"))
+	def test_missing_credentials_returns_envelope(self, _cred, mock_err):
+		out = _result(jira.handle_search_issues(jql="project = ABC"))
+		self.assertFalse(out["success"])
+		mock_err.assert_called_once()
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"jira_search_issues": "handle_search_issues",
+			"jira_get_issue": "handle_get_issue",
+			"jira_create_issue": "handle_create_issue",
+			"jira_add_comment": "handle_add_comment",
+		}
+		by_name = {t["tool_name"]: t for t in JIRA_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			tool = by_name[tool_name]
+			self.assertEqual(tool["function_path"], f"huf.ai.tools.jira.{handler}")
+			self.assertTrue(callable(getattr(jira, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in JIRA_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "jira")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_linear_tools.py
+++ b/huf/ai/tests/test_linear_tools.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Linear integration tools (GraphQL). All HTTP calls are mocked."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import linear
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, LINEAR_TOOLS
+
+MODULE = "huf.ai.tools.linear"
+
+
+def _mock_response(payload):
+	resp = MagicMock()
+	resp.json.return_value = payload
+	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+class TestListIssues(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="lin_api_key")
+	@patch(f"{MODULE}.requests.post")
+	def test_lists_issues_with_team_filter(self, mock_post, _cred, _err):
+		mock_post.return_value = _mock_response(
+			{
+				"data": {
+					"issues": {
+						"nodes": [
+							{
+								"identifier": "ENG-1",
+								"title": "Fix crash",
+								"state": {"name": "In Progress"},
+								"assignee": {"name": "Jane"},
+								"priority": 2,
+								"url": "https://linear.app/eng-1",
+							}
+						]
+					}
+				}
+			}
+		)
+
+		out = _result(linear.handle_list_issues(team_key="ENG"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["identifier"], "ENG-1")
+		self.assertEqual(out["results"][0]["status"], "In Progress")
+
+		kwargs = mock_post.call_args.kwargs
+		self.assertEqual(kwargs["headers"]["Authorization"], "lin_api_key")
+		self.assertEqual(kwargs["json"]["variables"]["teamKey"], "ENG")
+
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="lin_api_key")
+	@patch(f"{MODULE}.requests.post")
+	def test_graphql_errors_surface_as_failure(self, mock_post, _cred, mock_err):
+		mock_post.return_value = _mock_response({"errors": [{"message": "Invalid token"}]})
+
+		out = _result(linear.handle_list_issues())
+
+		self.assertFalse(out["success"])
+		self.assertIn("Invalid token", out["error"])
+		mock_err.assert_called_once()
+
+
+class TestGetIssue(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="lin_api_key")
+	@patch(f"{MODULE}.requests.post")
+	def test_get_issue(self, mock_post, _cred, _err):
+		mock_post.return_value = _mock_response(
+			{
+				"data": {
+					"issue": {
+						"identifier": "ENG-1",
+						"title": "Fix crash",
+						"description": "Details",
+						"state": {"name": "Done"},
+						"assignee": None,
+						"priority": 1,
+						"url": "https://linear.app/eng-1",
+						"createdAt": "2026-01-01T00:00:00Z",
+						"updatedAt": "2026-01-02T00:00:00Z",
+					}
+				}
+			}
+		)
+
+		out = _result(linear.handle_get_issue(issue_id="ENG-1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["identifier"], "ENG-1")
+		self.assertIsNone(out["results"]["assignee"])
+
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="lin_api_key")
+	@patch(f"{MODULE}.requests.post")
+	def test_not_found(self, mock_post, _cred, _err):
+		mock_post.return_value = _mock_response({"data": {"issue": None}})
+
+		out = _result(linear.handle_get_issue(issue_id="ENG-999"))
+
+		self.assertFalse(out["success"])
+		self.assertIn("not found", out["error"])
+
+	def test_requires_issue_id(self):
+		out = _result(linear.handle_get_issue())
+		self.assertFalse(out["success"])
+		self.assertIn("issue_id", out["error"])
+
+
+class TestCreateIssue(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="lin_api_key")
+	@patch(f"{MODULE}.requests.post")
+	def test_resolves_team_then_creates(self, mock_post, _cred, _err):
+		mock_post.side_effect = [
+			_mock_response({"data": {"teams": {"nodes": [{"id": "team-uuid"}]}}}),
+			_mock_response(
+				{
+					"data": {
+						"issueCreate": {
+							"success": True,
+							"issue": {"identifier": "ENG-2", "title": "New issue", "url": "https://linear.app/eng-2"},
+						}
+					}
+				}
+			),
+		]
+
+		out = _result(linear.handle_create_issue(team_key="ENG", title="New issue"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["identifier"], "ENG-2")
+		self.assertEqual(mock_post.call_count, 2)
+		second_call_vars = mock_post.call_args_list[1].kwargs["json"]["variables"]
+		self.assertEqual(second_call_vars["input"]["teamId"], "team-uuid")
+
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="lin_api_key")
+	@patch(f"{MODULE}.requests.post")
+	def test_unknown_team_key(self, mock_post, _cred, _err):
+		mock_post.return_value = _mock_response({"data": {"teams": {"nodes": []}}})
+
+		out = _result(linear.handle_create_issue(team_key="MISSING", title="x"))
+
+		self.assertFalse(out["success"])
+		self.assertIn("MISSING", out["error"])
+
+	def test_requires_team_key_and_title(self):
+		out = _result(linear.handle_create_issue(title="x"))
+		self.assertFalse(out["success"])
+		self.assertIn("team_key", out["error"])
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"linear_list_issues": "handle_list_issues",
+			"linear_get_issue": "handle_get_issue",
+			"linear_create_issue": "handle_create_issue",
+		}
+		by_name = {t["tool_name"]: t for t in LINEAR_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			self.assertEqual(by_name[tool_name]["function_path"], f"huf.ai.tools.linear.{handler}")
+			self.assertTrue(callable(getattr(linear, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in LINEAR_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "linear")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_notion_tools.py
+++ b/huf/ai/tests/test_notion_tools.py
@@ -17,7 +17,17 @@ def _mock_response(payload):
 	resp = MagicMock()
 	resp.json.return_value = payload
 	resp.text = json.dumps(payload)
+	resp.ok = True
 	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _mock_error_response(status_code, message):
+	resp = MagicMock()
+	resp.ok = False
+	resp.status_code = status_code
+	resp.text = json.dumps({"message": message})
+	resp.json.return_value = {"message": message}
 	return resp
 
 
@@ -33,6 +43,66 @@ SAMPLE_PAGE = {
 	"archived": False,
 	"properties": {"Name": {"type": "title", "title": [{"plain_text": "Task One"}]}},
 }
+
+SAMPLE_DATABASE = {
+	"id": "db-1",
+	"object": "database",
+	"url": "https://notion.so/db-1",
+	"title": [{"plain_text": "Tasks"}],
+	"properties": {
+		"Name": {"type": "title", "title": {}},
+		"Status": {
+			"type": "status",
+			"status": {"options": [{"name": "Not started"}, {"name": "Done"}]},
+		},
+	},
+}
+
+
+class TestSearch(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_search_pages(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{"results": [{**SAMPLE_PAGE, "object": "page"}], "has_more": False}
+		)
+
+		out = _result(notion.handle_search(query="task", object_type="page"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["title"], "Task One")
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["query"], "task")
+		self.assertEqual(body["filter"], {"property": "object", "value": "page"})
+
+
+class TestListDatabases(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_databases(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"results": [SAMPLE_DATABASE], "has_more": False})
+
+		out = _result(notion.handle_list_databases())
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["title"], "Tasks")
+		self.assertEqual(mock_request.call_args.kwargs["json"]["filter"]["value"], "database")
+
+
+class TestGetDatabase(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_get_database_schema(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(SAMPLE_DATABASE)
+
+		out = _result(notion.handle_get_database(database_id="db-1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["title"], "Tasks")
+		self.assertEqual(out["results"]["properties"]["Status"]["options"], ["Not started", "Done"])
 
 
 class TestQueryDatabase(unittest.TestCase):
@@ -63,6 +133,21 @@ class TestQueryDatabase(unittest.TestCase):
 		self.assertTrue(out["success"])
 		self.assertIn("databases/db-default/query", mock_request.call_args.args[1])
 
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_passes_filter_and_sorts(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"results": []})
+		filter_json = '{"property":"Status","status":{"equals":"Done"}}'
+		sorts_json = '[{"property":"Due","direction":"ascending"}]'
+
+		out = _result(notion.handle_query_database(database_id="db-1", filter=filter_json, sorts=sorts_json))
+
+		self.assertTrue(out["success"])
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["filter"]["property"], "Status")
+		self.assertEqual(body["sorts"][0]["property"], "Due")
+
 	@patch(f"{MODULE}.get_credential", return_value=None)
 	def test_requires_database_id(self, _default_db):
 		out = _result(notion.handle_query_database())
@@ -88,6 +173,34 @@ class TestGetPage(unittest.TestCase):
 		self.assertIn("page_id", out["error"])
 
 
+class TestGetPageContent(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_get_page_content(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"results": [
+					{
+						"type": "heading_1",
+						"heading_1": {"rich_text": [{"plain_text": "Overview"}]},
+					},
+					{
+						"type": "paragraph",
+						"paragraph": {"rich_text": [{"plain_text": "Details here."}]},
+					},
+				],
+				"has_more": False,
+			}
+		)
+
+		out = _result(notion.handle_get_page_content(page_id="page-1"))
+
+		self.assertTrue(out["success"])
+		self.assertIn("Overview", out["content"])
+		self.assertIn("Details here.", out["content"])
+
+
 class TestCreatePage(unittest.TestCase):
 	@patch(f"{MODULE}.update_last_error")
 	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
@@ -110,12 +223,65 @@ class TestCreatePage(unittest.TestCase):
 		self.assertIn("title", out["error"])
 
 
+class TestUpdatePage(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_updates_page_properties(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(SAMPLE_PAGE)
+		properties = '{"Status":{"status":{"name":"Done"}}}'
+
+		out = _result(notion.handle_update_page(page_id="page-1", properties=properties))
+
+		self.assertTrue(out["success"])
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["properties"]["Status"]["status"]["name"], "Done")
+
+	def test_requires_properties(self):
+		out = _result(notion.handle_update_page(page_id="page-1"))
+		self.assertFalse(out["success"])
+		self.assertIn("properties", out["error"])
+
+
+class TestArchivePage(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_archives_page(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"id": "page-1", "archived": True})
+
+		out = _result(notion.handle_archive_page(page_id="page-1"))
+
+		self.assertTrue(out["success"])
+		self.assertTrue(out["results"]["archived"])
+		self.assertEqual(mock_request.call_args.kwargs["json"], {"archived": True})
+
+
+class TestErrorHandling(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_surfaces_notion_api_message(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_error_response(404, "Could not find page")
+
+		out = _result(notion.handle_get_page(page_id="missing"))
+
+		self.assertFalse(out["success"])
+		self.assertIn("Could not find page", out["error"])
+
+
 class TestRegistry(unittest.TestCase):
 	def test_all_tools_registered(self):
 		expected = {
+			"notion_search": "handle_search",
+			"notion_list_databases": "handle_list_databases",
+			"notion_get_database": "handle_get_database",
 			"notion_query_database": "handle_query_database",
 			"notion_get_page": "handle_get_page",
+			"notion_get_page_content": "handle_get_page_content",
 			"notion_create_page": "handle_create_page",
+			"notion_update_page": "handle_update_page",
+			"notion_archive_page": "handle_archive_page",
 		}
 		by_name = {t["tool_name"]: t for t in NOTION_TOOLS}
 		self.assertEqual(set(by_name), set(expected))

--- a/huf/ai/tests/test_notion_tools.py
+++ b/huf/ai/tests/test_notion_tools.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Notion integration tools. All HTTP calls are mocked."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import notion
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, NOTION_TOOLS
+
+MODULE = "huf.ai.tools.notion"
+
+
+def _mock_response(payload):
+	resp = MagicMock()
+	resp.json.return_value = payload
+	resp.text = json.dumps(payload)
+	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+SAMPLE_PAGE = {
+	"id": "page-1",
+	"url": "https://notion.so/page-1",
+	"created_time": "2026-01-01T00:00:00Z",
+	"last_edited_time": "2026-01-02T00:00:00Z",
+	"archived": False,
+	"properties": {"Name": {"type": "title", "title": [{"plain_text": "Task One"}]}},
+}
+
+
+class TestQueryDatabase(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_queries_database(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"results": [SAMPLE_PAGE]})
+
+		out = _result(notion.handle_query_database(database_id="db-1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["title"], "Task One")
+
+		kwargs = mock_request.call_args.kwargs
+		self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret_abc")
+		self.assertEqual(kwargs["headers"]["Notion-Version"], "2022-06-28")
+
+	@patch(f"{MODULE}.get_credential", return_value="db-default")
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_falls_back_to_default_database_id(self, mock_request, _cred, _err, _default_db):
+		mock_request.return_value = _mock_response({"results": []})
+
+		out = _result(notion.handle_query_database())
+
+		self.assertTrue(out["success"])
+		self.assertIn("databases/db-default/query", mock_request.call_args.args[1])
+
+	@patch(f"{MODULE}.get_credential", return_value=None)
+	def test_requires_database_id(self, _default_db):
+		out = _result(notion.handle_query_database())
+		self.assertFalse(out["success"])
+		self.assertIn("database_id", out["error"])
+
+
+class TestGetPage(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_get_page(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(SAMPLE_PAGE)
+
+		out = _result(notion.handle_get_page(page_id="page-1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["title"], "Task One")
+
+	def test_requires_page_id(self):
+		out = _result(notion.handle_get_page())
+		self.assertFalse(out["success"])
+		self.assertIn("page_id", out["error"])
+
+
+class TestCreatePage(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", return_value="secret_abc")
+	@patch(f"{MODULE}.requests.request")
+	def test_creates_page_with_title_property(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"id": "page-2", "url": "https://notion.so/page-2"})
+
+		out = _result(notion.handle_create_page(title="New task", database_id="db-1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["id"], "page-2")
+
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["parent"], {"database_id": "db-1"})
+		self.assertEqual(body["properties"]["Name"]["title"][0]["text"]["content"], "New task")
+
+	def test_requires_title(self):
+		out = _result(notion.handle_create_page(database_id="db-1"))
+		self.assertFalse(out["success"])
+		self.assertIn("title", out["error"])
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"notion_query_database": "handle_query_database",
+			"notion_get_page": "handle_get_page",
+			"notion_create_page": "handle_create_page",
+		}
+		by_name = {t["tool_name"]: t for t in NOTION_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			self.assertEqual(by_name[tool_name]["function_path"], f"huf.ai.tools.notion.{handler}")
+			self.assertTrue(callable(getattr(notion, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in NOTION_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "notion")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_trello_tools.py
+++ b/huf/ai/tests/test_trello_tools.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Trello integration tools. All HTTP calls are mocked."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import trello
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, TRELLO_TOOLS
+
+MODULE = "huf.ai.tools.trello"
+
+
+def _mock_response(payload):
+	resp = MagicMock()
+	resp.json.return_value = payload
+	resp.text = json.dumps(payload)
+	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+def _fake_credential(service, key):
+	return {"api_key": "key-1", "token": "token-1"}[key]
+
+
+class TestListBoards(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_boards(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			[{"id": "board1", "name": "Roadmap", "url": "https://trello.com/b/board1", "closed": False}]
+		)
+
+		out = _result(trello.handle_list_boards())
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["name"], "Roadmap")
+
+		params = mock_request.call_args.kwargs["params"]
+		self.assertEqual(params["key"], "key-1")
+		self.assertEqual(params["token"], "token-1")
+
+
+class TestListCards(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_cards(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			[{"id": "card1", "name": "Task 1", "idList": "list1", "due": None, "url": "https://trello.com/c/card1", "closed": False}]
+		)
+
+		out = _result(trello.handle_list_cards(board_id="board1"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["id"], "card1")
+
+	def test_requires_board_id(self):
+		out = _result(trello.handle_list_cards())
+		self.assertFalse(out["success"])
+		self.assertIn("board_id", out["error"])
+
+
+class TestCreateCard(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_creates_card(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"id": "card2", "name": "New card", "url": "https://trello.com/c/card2"})
+
+		out = _result(trello.handle_create_card(list_id="list1", name="New card", description="desc"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["id"], "card2")
+
+		params = mock_request.call_args.kwargs["params"]
+		self.assertEqual(params["idList"], "list1")
+		self.assertEqual(params["desc"], "desc")
+
+	def test_requires_list_id_and_name(self):
+		out = _result(trello.handle_create_card(list_id="list1"))
+		self.assertFalse(out["success"])
+		self.assertIn("name", out["error"])
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"trello_list_boards": "handle_list_boards",
+			"trello_list_cards": "handle_list_cards",
+			"trello_create_card": "handle_create_card",
+		}
+		by_name = {t["tool_name"]: t for t in TRELLO_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			self.assertEqual(by_name[tool_name]["function_path"], f"huf.ai.tools.trello.{handler}")
+			self.assertTrue(callable(getattr(trello, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in TRELLO_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "trello")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_zendesk_tools.py
+++ b/huf/ai/tests/test_zendesk_tools.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Zendesk integration tools. All HTTP calls are mocked."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import zendesk
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, ZENDESK_TOOLS
+
+MODULE = "huf.ai.tools.zendesk"
+
+
+def _mock_response(payload):
+	resp = MagicMock()
+	resp.json.return_value = payload
+	resp.text = json.dumps(payload)
+	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+def _fake_credential(service, key):
+	return {"username": "bot@example.com", "password": "api-tok", "company_name": "acme"}[key]
+
+
+class TestListTickets(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_and_filters_tickets(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"tickets": [
+					{"id": 1, "subject": "Open one", "status": "open", "priority": "high", "requester_id": 10, "created_at": "x"},
+					{"id": 2, "subject": "Solved one", "status": "solved", "priority": "low", "requester_id": 11, "created_at": "y"},
+				]
+			}
+		)
+
+		out = _result(zendesk.handle_list_tickets(status="open"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["count"], 1)
+		self.assertEqual(out["results"][0]["id"], 1)
+
+		call_args = mock_request.call_args
+		self.assertIn("acme.zendesk.com", call_args.args[1])
+		self.assertEqual(call_args.kwargs["auth"], ("bot@example.com/token", "api-tok"))
+
+
+class TestGetTicket(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_get_ticket(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"ticket": {
+					"id": 1,
+					"subject": "Help",
+					"description": "Details",
+					"status": "new",
+					"priority": "normal",
+					"requester_id": 10,
+					"assignee_id": None,
+					"created_at": "x",
+					"updated_at": "y",
+				}
+			}
+		)
+
+		out = _result(zendesk.handle_get_ticket(ticket_id=1))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["subject"], "Help")
+
+	def test_requires_ticket_id(self):
+		out = _result(zendesk.handle_get_ticket())
+		self.assertFalse(out["success"])
+		self.assertIn("ticket_id", out["error"])
+
+
+class TestCreateTicket(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.request")
+	def test_creates_ticket(self, mock_request, _cred, _err):
+		mock_request.return_value = _mock_response({"ticket": {"id": 5, "subject": "New", "status": "new"}})
+
+		out = _result(zendesk.handle_create_ticket(subject="New", comment="Body text", priority="high"))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["id"], 5)
+
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["ticket"]["subject"], "New")
+		self.assertEqual(body["ticket"]["comment"], {"body": "Body text"})
+		self.assertEqual(body["ticket"]["priority"], "high")
+
+	def test_requires_subject_and_comment(self):
+		out = _result(zendesk.handle_create_ticket(subject="New"))
+		self.assertFalse(out["success"])
+		self.assertIn("comment", out["error"])
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"zendesk_list_tickets": "handle_list_tickets",
+			"zendesk_get_ticket": "handle_get_ticket",
+			"zendesk_create_ticket": "handle_create_ticket",
+		}
+		by_name = {t["tool_name"]: t for t in ZENDESK_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			self.assertEqual(by_name[tool_name]["function_path"], f"huf.ai.tools.zendesk.{handler}")
+			self.assertTrue(callable(getattr(zendesk, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in ZENDESK_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "zendesk")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_zoom_tools.py
+++ b/huf/ai/tests/test_zoom_tools.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+"""Tests for the Zoom integration tools (Server-to-Server OAuth). All HTTP calls
+and Frappe cache access are mocked."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.tools import zoom
+from huf.ai.tools._registry import ALL_INTEGRATION_TOOLS, ZOOM_TOOLS
+
+MODULE = "huf.ai.tools.zoom"
+
+
+def _mock_response(payload):
+	resp = MagicMock()
+	resp.json.return_value = payload
+	resp.text = json.dumps(payload)
+	resp.raise_for_status = MagicMock()
+	return resp
+
+
+def _result(raw):
+	return json.loads(raw)
+
+
+def _fake_credential(service, key):
+	return {"account_id": "acct-1", "client_id": "cid", "client_secret": "csecret"}[key]
+
+
+class TestAccessTokenCaching(unittest.TestCase):
+	@patch(f"{MODULE}.frappe")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.post")
+	def test_fetches_and_caches_token_on_miss(self, mock_post, _cred, mock_frappe):
+		cache = MagicMock()
+		cache.get_value.return_value = None
+		mock_frappe.cache.return_value = cache
+		mock_post.return_value = _mock_response({"access_token": "tok-1", "expires_in": 3600})
+
+		token = zoom._get_access_token()
+
+		self.assertEqual(token, "tok-1")
+		mock_post.assert_called_once()
+		self.assertEqual(mock_post.call_args.kwargs["auth"], ("cid", "csecret"))
+		cache.set_value.assert_called_once_with("zoom_s2s_access_token", "tok-1", expires_in_sec=3540)
+
+	@patch(f"{MODULE}.frappe")
+	@patch(f"{MODULE}.require_credential", side_effect=_fake_credential)
+	@patch(f"{MODULE}.requests.post")
+	def test_cache_hit_skips_oauth_call(self, mock_post, _cred, mock_frappe):
+		cache = MagicMock()
+		cache.get_value.return_value = "cached-tok"
+		mock_frappe.cache.return_value = cache
+
+		token = zoom._get_access_token()
+
+		self.assertEqual(token, "cached-tok")
+		mock_post.assert_not_called()
+
+
+class TestListMeetings(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}._get_access_token", return_value="tok-1")
+	@patch(f"{MODULE}.requests.request")
+	def test_lists_meetings(self, mock_request, _token, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"meetings": [
+					{
+						"id": 123,
+						"topic": "Weekly sync",
+						"start_time": "2026-08-10T15:00:00Z",
+						"duration": 30,
+						"join_url": "https://zoom.us/j/123",
+					}
+				]
+			}
+		)
+
+		out = _result(zoom.handle_list_meetings())
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"][0]["id"], 123)
+
+		headers = mock_request.call_args.kwargs["headers"]
+		self.assertEqual(headers["Authorization"], "Bearer tok-1")
+
+
+class TestGetMeeting(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}._get_access_token", return_value="tok-1")
+	@patch(f"{MODULE}.requests.request")
+	def test_get_meeting(self, mock_request, _token, _err):
+		mock_request.return_value = _mock_response(
+			{
+				"id": 123,
+				"topic": "Weekly sync",
+				"agenda": "",
+				"start_time": "2026-08-10T15:00:00Z",
+				"duration": 30,
+				"timezone": "UTC",
+				"join_url": "https://zoom.us/j/123",
+				"host_email": "host@example.com",
+			}
+		)
+
+		out = _result(zoom.handle_get_meeting(meeting_id=123))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["host_email"], "host@example.com")
+
+	def test_requires_meeting_id(self):
+		out = _result(zoom.handle_get_meeting())
+		self.assertFalse(out["success"])
+		self.assertIn("meeting_id", out["error"])
+
+
+class TestCreateMeeting(unittest.TestCase):
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}._get_access_token", return_value="tok-1")
+	@patch(f"{MODULE}.requests.request")
+	def test_creates_scheduled_meeting(self, mock_request, _token, _err):
+		mock_request.return_value = _mock_response(
+			{"id": 456, "topic": "Kickoff", "join_url": "https://zoom.us/j/456", "start_url": "https://zoom.us/s/456"}
+		)
+
+		out = _result(zoom.handle_create_meeting(topic="Kickoff", start_time="2026-08-10T15:00:00Z", duration=45))
+
+		self.assertTrue(out["success"])
+		self.assertEqual(out["results"]["id"], 456)
+
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["type"], 2)
+		self.assertEqual(body["duration"], 45)
+
+	@patch(f"{MODULE}.update_last_error")
+	@patch(f"{MODULE}._get_access_token", return_value="tok-1")
+	@patch(f"{MODULE}.requests.request")
+	def test_instant_meeting_when_no_start_time(self, mock_request, _token, _err):
+		mock_request.return_value = _mock_response({"id": 789, "topic": "Now", "join_url": "x", "start_url": "y"})
+
+		zoom.handle_create_meeting(topic="Now")
+
+		body = mock_request.call_args.kwargs["json"]
+		self.assertEqual(body["type"], 1)
+		self.assertNotIn("start_time", body)
+
+	def test_requires_topic(self):
+		out = _result(zoom.handle_create_meeting())
+		self.assertFalse(out["success"])
+		self.assertIn("topic", out["error"])
+
+
+class TestRegistry(unittest.TestCase):
+	def test_all_tools_registered(self):
+		expected = {
+			"zoom_list_meetings": "handle_list_meetings",
+			"zoom_get_meeting": "handle_get_meeting",
+			"zoom_create_meeting": "handle_create_meeting",
+		}
+		by_name = {t["tool_name"]: t for t in ZOOM_TOOLS}
+		self.assertEqual(set(by_name), set(expected))
+		for tool_name, handler in expected.items():
+			self.assertEqual(by_name[tool_name]["function_path"], f"huf.ai.tools.zoom.{handler}")
+			self.assertTrue(callable(getattr(zoom, handler)))
+
+	def test_registered_in_all_integration_tools(self):
+		by_name = {t["tool_name"]: t for t in ALL_INTEGRATION_TOOLS}
+		for tool in ZOOM_TOOLS:
+			self.assertIn(tool["tool_name"], by_name)
+			self.assertEqual(by_name[tool["tool_name"]]["service"], "zoom")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -256,12 +256,27 @@ GITHUB_TOOLS = [
 
 JIRA_TOOLS = [
 	{
+		"tool_name": "jira_list_projects",
+		"description": (
+			"List Jira projects visible to the connected account. Use this before "
+			"jira_create_issue to pick a valid project_key. Requires JIRA_BASE_URL, "
+			"JIRA_EMAIL, JIRA_API_TOKEN."
+		),
+		"function_path": "huf.ai.tools.jira.handle_list_projects",
+		"category": "Project Management Tools",
+		"parameters": [_p("max_results", type="int", description="Max projects to return (default 50)")],
+	},
+	{
 		"tool_name": "jira_search_issues",
-		"description": "Search Jira issues using JQL (Jira Query Language). Requires JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN.",
+		"description": (
+			"Search Jira issues using JQL (Jira Query Language). Requires bounded JQL "
+			"(include a filter such as project = ABC). Requires JIRA_BASE_URL, JIRA_EMAIL, "
+			"JIRA_API_TOKEN."
+		),
 		"function_path": "huf.ai.tools.jira.handle_search_issues",
 		"category": "Project Management Tools",
 		"parameters": [
-			_p("jql", required=True, description="JQL query, e.g. 'project = ABC AND status = \"In Progress\"'"),
+			_p("jql", required=True, description="Bounded JQL query, e.g. 'project = ABC AND status = \"In Progress\"'"),
 			_p("max_results", type="int", description="Max issues to return (default 20)"),
 		],
 	},
@@ -274,11 +289,18 @@ JIRA_TOOLS = [
 	},
 	{
 		"tool_name": "jira_create_issue",
-		"description": "Create a Jira issue. Requires JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN.",
+		"description": (
+			"Create a Jira issue. Requires JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN. "
+			"Call jira_list_projects first (or ask the user) to obtain a valid project_key."
+		),
 		"function_path": "huf.ai.tools.jira.handle_create_issue",
 		"category": "Project Management Tools",
 		"parameters": [
-			_p("project_key", required=True, description="Project key, e.g. 'ABC'"),
+			_p(
+				"project_key",
+				required=True,
+				description="Jira project key from jira_list_projects (e.g. 'ABC'). Do not guess.",
+			),
 			_p("summary", required=True, description="Issue summary/title"),
 			_p("issue_type", description="Issue type name, e.g. 'Task', 'Bug', 'Story' (default 'Task')"),
 			_p("description", description="Issue description text"),

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -254,6 +254,254 @@ GITHUB_TOOLS = [
 	},
 ]
 
+JIRA_TOOLS = [
+	{
+		"tool_name": "jira_search_issues",
+		"description": "Search Jira issues using JQL (Jira Query Language). Requires JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN.",
+		"function_path": "huf.ai.tools.jira.handle_search_issues",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("jql", required=True, description="JQL query, e.g. 'project = ABC AND status = \"In Progress\"'"),
+			_p("max_results", type="int", description="Max issues to return (default 20)"),
+		],
+	},
+	{
+		"tool_name": "jira_get_issue",
+		"description": "Get details of a Jira issue by key. Requires JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN.",
+		"function_path": "huf.ai.tools.jira.handle_get_issue",
+		"category": "Project Management Tools",
+		"parameters": [_p("issue_key", required=True, description="Issue key, e.g. 'ABC-123'")],
+	},
+	{
+		"tool_name": "jira_create_issue",
+		"description": "Create a Jira issue. Requires JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN.",
+		"function_path": "huf.ai.tools.jira.handle_create_issue",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("project_key", required=True, description="Project key, e.g. 'ABC'"),
+			_p("summary", required=True, description="Issue summary/title"),
+			_p("issue_type", description="Issue type name, e.g. 'Task', 'Bug', 'Story' (default 'Task')"),
+			_p("description", description="Issue description text"),
+		],
+	},
+	{
+		"tool_name": "jira_add_comment",
+		"description": "Add a comment to a Jira issue. Requires JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN.",
+		"function_path": "huf.ai.tools.jira.handle_add_comment",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("issue_key", required=True, description="Issue key, e.g. 'ABC-123'"),
+			_p("comment", required=True, description="Comment text"),
+		],
+	},
+]
+
+LINEAR_TOOLS = [
+	{
+		"tool_name": "linear_list_issues",
+		"description": "List Linear issues, optionally filtered by team. Requires LINEAR_API_KEY.",
+		"function_path": "huf.ai.tools.linear.handle_list_issues",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("team_key", description="Team key to filter by, e.g. 'ENG'"),
+			_p("limit", type="int", description="Max issues to return (default 20)"),
+		],
+	},
+	{
+		"tool_name": "linear_get_issue",
+		"description": "Get details of a Linear issue by its identifier (e.g. 'ENG-123'). Requires LINEAR_API_KEY.",
+		"function_path": "huf.ai.tools.linear.handle_get_issue",
+		"category": "Project Management Tools",
+		"parameters": [_p("issue_id", required=True, description="Issue identifier, e.g. 'ENG-123'")],
+	},
+	{
+		"tool_name": "linear_create_issue",
+		"description": "Create a Linear issue. Requires LINEAR_API_KEY.",
+		"function_path": "huf.ai.tools.linear.handle_create_issue",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("team_key", required=True, description="Team key, e.g. 'ENG'"),
+			_p("title", required=True, description="Issue title"),
+			_p("description", description="Issue description (Markdown)"),
+		],
+	},
+]
+
+CLICKUP_TOOLS = [
+	{
+		"tool_name": "clickup_list_tasks",
+		"description": "List tasks in a ClickUp list. Requires CLICKUP_API_KEY.",
+		"function_path": "huf.ai.tools.clickup.handle_list_tasks",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("list_id", required=True, description="ClickUp list ID"),
+			_p("include_closed", type="bool", description="Include closed tasks (default false)"),
+		],
+	},
+	{
+		"tool_name": "clickup_get_task",
+		"description": "Get details of a ClickUp task by ID. Requires CLICKUP_API_KEY.",
+		"function_path": "huf.ai.tools.clickup.handle_get_task",
+		"category": "Project Management Tools",
+		"parameters": [_p("task_id", required=True, description="ClickUp task ID")],
+	},
+	{
+		"tool_name": "clickup_create_task",
+		"description": "Create a task in a ClickUp list. Requires CLICKUP_API_KEY.",
+		"function_path": "huf.ai.tools.clickup.handle_create_task",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("list_id", required=True, description="ClickUp list ID"),
+			_p("name", required=True, description="Task name"),
+			_p("description", description="Task description"),
+		],
+	},
+]
+
+TRELLO_TOOLS = [
+	{
+		"tool_name": "trello_list_boards",
+		"description": "List Trello boards for the authenticated user. Requires TRELLO_API_KEY, TRELLO_TOKEN.",
+		"function_path": "huf.ai.tools.trello.handle_list_boards",
+		"category": "Project Management Tools",
+		"parameters": [],
+	},
+	{
+		"tool_name": "trello_list_cards",
+		"description": "List cards on a Trello board. Requires TRELLO_API_KEY, TRELLO_TOKEN.",
+		"function_path": "huf.ai.tools.trello.handle_list_cards",
+		"category": "Project Management Tools",
+		"parameters": [_p("board_id", required=True, description="Trello board ID")],
+	},
+	{
+		"tool_name": "trello_create_card",
+		"description": "Create a card on a Trello list. Requires TRELLO_API_KEY, TRELLO_TOKEN.",
+		"function_path": "huf.ai.tools.trello.handle_create_card",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("list_id", required=True, description="Trello list ID"),
+			_p("name", required=True, description="Card name"),
+			_p("description", description="Card description"),
+		],
+	},
+]
+
+NOTION_TOOLS = [
+	{
+		"tool_name": "notion_query_database",
+		"description": "Query a Notion database, optionally with a filter/sort payload. Requires NOTION_API_KEY; defaults to NOTION_DATABASE_ID if database_id is omitted.",
+		"function_path": "huf.ai.tools.notion.handle_query_database",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("database_id", description="Notion database ID (defaults to NOTION_DATABASE_ID credential)"),
+			_p("page_size", type="int", description="Max results to return (default 20)"),
+		],
+	},
+	{
+		"tool_name": "notion_get_page",
+		"description": "Get a Notion page's properties by ID. Requires NOTION_API_KEY.",
+		"function_path": "huf.ai.tools.notion.handle_get_page",
+		"category": "Project Management Tools",
+		"parameters": [_p("page_id", required=True, description="Notion page ID")],
+	},
+	{
+		"tool_name": "notion_create_page",
+		"description": "Create a page (row) in a Notion database with a title property. Requires NOTION_API_KEY; defaults to NOTION_DATABASE_ID if database_id is omitted.",
+		"function_path": "huf.ai.tools.notion.handle_create_page",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("title", required=True, description="Title for the new page"),
+			_p("database_id", description="Notion database ID (defaults to NOTION_DATABASE_ID credential)"),
+		],
+	},
+]
+
+ZENDESK_TOOLS = [
+	{
+		"tool_name": "zendesk_list_tickets",
+		"description": "List Zendesk tickets. Requires ZENDESK_USERNAME, ZENDESK_PASSWORD, ZENDESK_COMPANY_NAME.",
+		"function_path": "huf.ai.tools.zendesk.handle_list_tickets",
+		"category": "Support Tools",
+		"parameters": [_p("status", description="Filter by status: new, open, pending, hold, solved, closed")],
+	},
+	{
+		"tool_name": "zendesk_get_ticket",
+		"description": "Get details of a Zendesk ticket by ID. Requires ZENDESK_USERNAME, ZENDESK_PASSWORD, ZENDESK_COMPANY_NAME.",
+		"function_path": "huf.ai.tools.zendesk.handle_get_ticket",
+		"category": "Support Tools",
+		"parameters": [_p("ticket_id", required=True, description="Zendesk ticket ID")],
+	},
+	{
+		"tool_name": "zendesk_create_ticket",
+		"description": "Create a Zendesk ticket. Requires ZENDESK_USERNAME, ZENDESK_PASSWORD, ZENDESK_COMPANY_NAME.",
+		"function_path": "huf.ai.tools.zendesk.handle_create_ticket",
+		"category": "Support Tools",
+		"parameters": [
+			_p("subject", required=True, description="Ticket subject"),
+			_p("comment", required=True, description="Initial comment/description body"),
+			_p("priority", description="Priority: low, normal, high, urgent"),
+		],
+	},
+]
+
+CALCOM_TOOLS = [
+	{
+		"tool_name": "calcom_list_bookings",
+		"description": "List Cal.com bookings. Requires CALCOM_API_KEY.",
+		"function_path": "huf.ai.tools.calcom.handle_list_bookings",
+		"category": "Scheduling Tools",
+		"parameters": [_p("status", description="Filter by status: upcoming, past, cancelled")],
+	},
+	{
+		"tool_name": "calcom_get_booking",
+		"description": "Get details of a Cal.com booking by UID. Requires CALCOM_API_KEY.",
+		"function_path": "huf.ai.tools.calcom.handle_get_booking",
+		"category": "Scheduling Tools",
+		"parameters": [_p("booking_uid", required=True, description="Cal.com booking UID")],
+	},
+	{
+		"tool_name": "calcom_create_booking",
+		"description": "Create a Cal.com booking for an event type. Requires CALCOM_API_KEY.",
+		"function_path": "huf.ai.tools.calcom.handle_create_booking",
+		"category": "Scheduling Tools",
+		"parameters": [
+			_p("event_type_id", required=True, type="int", description="Cal.com event type ID"),
+			_p("start", required=True, description="ISO 8601 start time, e.g. '2026-08-10T15:00:00Z'"),
+			_p("attendee_name", required=True, description="Attendee full name"),
+			_p("attendee_email", required=True, description="Attendee email address"),
+			_p("timezone", description="Attendee IANA timezone, e.g. 'America/New_York' (default 'UTC')"),
+		],
+	},
+]
+
+ZOOM_TOOLS = [
+	{
+		"tool_name": "zoom_list_meetings",
+		"description": "List scheduled Zoom meetings for the authenticated user. Requires ZOOM_ACCOUNT_ID, ZOOM_CLIENT_ID, ZOOM_CLIENT_SECRET.",
+		"function_path": "huf.ai.tools.zoom.handle_list_meetings",
+		"category": "Communication Tools",
+		"parameters": [],
+	},
+	{
+		"tool_name": "zoom_get_meeting",
+		"description": "Get details of a Zoom meeting by ID. Requires ZOOM_ACCOUNT_ID, ZOOM_CLIENT_ID, ZOOM_CLIENT_SECRET.",
+		"function_path": "huf.ai.tools.zoom.handle_get_meeting",
+		"category": "Communication Tools",
+		"parameters": [_p("meeting_id", required=True, description="Zoom meeting ID")],
+	},
+	{
+		"tool_name": "zoom_create_meeting",
+		"description": "Create a scheduled Zoom meeting. Requires ZOOM_ACCOUNT_ID, ZOOM_CLIENT_ID, ZOOM_CLIENT_SECRET.",
+		"function_path": "huf.ai.tools.zoom.handle_create_meeting",
+		"category": "Communication Tools",
+		"parameters": [
+			_p("topic", required=True, description="Meeting topic/title"),
+			_p("start_time", description="ISO 8601 start time, e.g. '2026-08-10T15:00:00Z' (omit for instant meeting)"),
+			_p("duration", type="int", description="Duration in minutes (default 30)"),
+		],
+	},
+]
+
 # ---------------------------------------------------------------------------
 # Frappe App Tools  (added in this branch — consolidated action-based)
 # ---------------------------------------------------------------------------
@@ -1856,5 +2104,13 @@ ALL_INTEGRATION_TOOLS = (
 	+ _with_service(SERP_HOTEL_TOOLS, "serpapi")
 	+ _with_service(SERP_REVIEW_TOOLS, "serpapi")
 	+ _with_service(SERP_YOUTUBE_TOOLS, "serpapi")
+	+ _with_service(JIRA_TOOLS, "jira")
+	+ _with_service(LINEAR_TOOLS, "linear")
+	+ _with_service(CLICKUP_TOOLS, "clickup")
+	+ _with_service(TRELLO_TOOLS, "trello")
+	+ _with_service(NOTION_TOOLS, "notion")
+	+ _with_service(ZENDESK_TOOLS, "zendesk")
+	+ _with_service(CALCOM_TOOLS, "calcom")
+	+ _with_service(ZOOM_TOOLS, "zoom")
 	+ FRAPPE_CLOUD_TOOLS  # entries already declare service="frappe_cloud"
 )

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -410,13 +410,63 @@ TRELLO_TOOLS = [
 
 NOTION_TOOLS = [
 	{
+		"tool_name": "notion_search",
+		"description": (
+			"Search Notion pages and databases by title. Use this to find page/database IDs "
+			"before calling other Notion tools. Requires NOTION_API_KEY."
+		),
+		"function_path": "huf.ai.tools.notion.handle_search",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("query", description="Text to search for in page/database titles"),
+			_p("object_type", description="Limit results to 'page' or 'database'"),
+			_p("page_size", type="int", description="Max results to return (default 20)"),
+		],
+	},
+	{
+		"tool_name": "notion_list_databases",
+		"description": (
+			"List Notion databases the integration can access. Call this first to discover "
+			"valid database_id values. Requires NOTION_API_KEY."
+		),
+		"function_path": "huf.ai.tools.notion.handle_list_databases",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("query", description="Optional title filter"),
+			_p("page_size", type="int", description="Max results to return (default 20)"),
+		],
+	},
+	{
+		"tool_name": "notion_get_database",
+		"description": (
+			"Get a Notion database schema (property names, types, and select/status options). "
+			"Requires NOTION_API_KEY; defaults to NOTION_DATABASE_ID if database_id is omitted."
+		),
+		"function_path": "huf.ai.tools.notion.handle_get_database",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("database_id", description="Notion database ID (defaults to NOTION_DATABASE_ID credential)"),
+		],
+	},
+	{
 		"tool_name": "notion_query_database",
-		"description": "Query a Notion database, optionally with a filter/sort payload. Requires NOTION_API_KEY; defaults to NOTION_DATABASE_ID if database_id is omitted.",
+		"description": (
+			"Query rows in a Notion database. Use notion_get_database first to learn property names. "
+			"Requires NOTION_API_KEY; defaults to NOTION_DATABASE_ID if database_id is omitted."
+		),
 		"function_path": "huf.ai.tools.notion.handle_query_database",
 		"category": "Project Management Tools",
 		"parameters": [
 			_p("database_id", description="Notion database ID (defaults to NOTION_DATABASE_ID credential)"),
 			_p("page_size", type="int", description="Max results to return (default 20)"),
+			_p(
+				"filter",
+				description='Optional Notion filter JSON, e.g. {"property":"Status","status":{"equals":"Done"}}',
+			),
+			_p(
+				"sorts",
+				description='Optional sort JSON array, e.g. [{"property":"Due","direction":"ascending"}]',
+			),
 		],
 	},
 	{
@@ -427,14 +477,59 @@ NOTION_TOOLS = [
 		"parameters": [_p("page_id", required=True, description="Notion page ID")],
 	},
 	{
+		"tool_name": "notion_get_page_content",
+		"description": (
+			"Read the body content of a Notion page as plain text (paragraphs, headings, lists). "
+			"Requires NOTION_API_KEY."
+		),
+		"function_path": "huf.ai.tools.notion.handle_get_page_content",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("page_id", required=True, description="Notion page ID"),
+			_p("page_size", type="int", description="Max blocks to return (default 50)"),
+		],
+	},
+	{
 		"tool_name": "notion_create_page",
-		"description": "Create a page (row) in a Notion database with a title property. Requires NOTION_API_KEY; defaults to NOTION_DATABASE_ID if database_id is omitted.",
+		"description": (
+			"Create a page (row) in a Notion database. Call notion_list_databases or notion_get_database "
+			"first to get database_id and property names. Requires NOTION_API_KEY."
+		),
 		"function_path": "huf.ai.tools.notion.handle_create_page",
 		"category": "Project Management Tools",
 		"parameters": [
 			_p("title", required=True, description="Title for the new page"),
 			_p("database_id", description="Notion database ID (defaults to NOTION_DATABASE_ID credential)"),
+			_p("title_property", description="Name of the title property column (default 'Name')"),
+			_p(
+				"properties",
+				description="Optional extra property values as Notion JSON, merged into the create payload",
+			),
 		],
+	},
+	{
+		"tool_name": "notion_update_page",
+		"description": (
+			"Update properties on an existing Notion page. Pass properties as Notion API JSON. "
+			"Requires NOTION_API_KEY."
+		),
+		"function_path": "huf.ai.tools.notion.handle_update_page",
+		"category": "Project Management Tools",
+		"parameters": [
+			_p("page_id", required=True, description="Notion page ID"),
+			_p(
+				"properties",
+				required=True,
+				description='Property updates as JSON, e.g. {"Status":{"status":{"name":"Done"}}}',
+			),
+		],
+	},
+	{
+		"tool_name": "notion_archive_page",
+		"description": "Archive (soft-delete) a Notion page. Requires NOTION_API_KEY.",
+		"function_path": "huf.ai.tools.notion.handle_archive_page",
+		"category": "Project Management Tools",
+		"parameters": [_p("page_id", required=True, description="Notion page ID")],
 	},
 ]
 

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -446,11 +446,31 @@ ZENDESK_TOOLS = [
 
 CALCOM_TOOLS = [
 	{
+		"tool_name": "calcom_list_event_types",
+		"description": (
+			"List Cal.com event types for the connected account. Use this before "
+			"calcom_create_booking to pick a valid event_type_id. Requires CALCOM_API_KEY."
+		),
+		"function_path": "huf.ai.tools.calcom.handle_list_event_types",
+		"category": "Scheduling Tools",
+		"parameters": [
+			_p(
+				"username",
+				description="Optional Cal.com username to filter event types (defaults to the authenticated account)",
+			)
+		],
+	},
+	{
 		"tool_name": "calcom_list_bookings",
 		"description": "List Cal.com bookings. Requires CALCOM_API_KEY.",
 		"function_path": "huf.ai.tools.calcom.handle_list_bookings",
 		"category": "Scheduling Tools",
-		"parameters": [_p("status", description="Filter by status: upcoming, past, cancelled")],
+		"parameters": [
+			_p(
+				"status",
+				description="Filter by status: upcoming, recurring, past, cancelled, or unconfirmed",
+			)
+		],
 	},
 	{
 		"tool_name": "calcom_get_booking",
@@ -461,11 +481,23 @@ CALCOM_TOOLS = [
 	},
 	{
 		"tool_name": "calcom_create_booking",
-		"description": "Create a Cal.com booking for an event type. Requires CALCOM_API_KEY.",
+		"description": (
+			"Create a Cal.com booking for an event type. Requires CALCOM_API_KEY. "
+			"Call calcom_list_event_types first (or ask the user) to obtain a valid "
+			"numeric event_type_id."
+		),
 		"function_path": "huf.ai.tools.calcom.handle_create_booking",
 		"category": "Scheduling Tools",
 		"parameters": [
-			_p("event_type_id", required=True, type="int", description="Cal.com event type ID"),
+			_p(
+				"event_type_id",
+				required=True,
+				type="int",
+				description=(
+					"Numeric Cal.com event type ID from calcom_list_event_types (or ask the user). "
+					"Do not use slugs like '30min'."
+				),
+			),
 			_p("start", required=True, description="ISO 8601 start time, e.g. '2026-08-10T15:00:00Z'"),
 			_p("attendee_name", required=True, description="Attendee full name"),
 			_p("attendee_email", required=True, description="Attendee email address"),

--- a/huf/ai/tools/calcom.py
+++ b/huf/ai/tools/calcom.py
@@ -1,7 +1,7 @@
 """
 Cal.com integration tools for booking listing, retrieval, and creation.
-Uses HUF Integration Settings for Cal.com credentials (api_key). Cal.com's v1
-REST API authenticates via an `apiKey` query parameter.
+Uses HUF Integration Settings for Cal.com credentials (api_key). Cal.com API v2
+authenticates with a Bearer token and requires a cal-api-version header.
 """
 
 import json
@@ -14,21 +14,107 @@ from huf.ai.tools.credentials import require_credential, update_last_error
 logger = frappe.logger("huf")
 
 SERVICE_NAME = "calcom"
-CALCOM_API_BASE = "https://api.cal.com/v1"
+CALCOM_API_BASE = "https://api.cal.com/v2"
+LIST_BOOKINGS_API_VERSION = "2026-05-01"
+BOOKING_API_VERSION = "2026-02-25"
+EVENT_TYPES_API_VERSION = "2024-06-14"
+VALID_LIST_STATUSES = {"upcoming", "recurring", "past", "cancelled", "unconfirmed"}
 
 
-def _auth_params():
-	return {"apiKey": require_credential(SERVICE_NAME, "api_key")}
+def _headers(api_version: str) -> dict:
+	return {
+		"Authorization": f"Bearer {require_credential(SERVICE_NAME, 'api_key')}",
+		"Content-Type": "application/json",
+		"cal-api-version": api_version,
+	}
 
 
-def _make_calcom_request(method: str, endpoint: str, json_data=None, params=None):
-	all_params = _auth_params()
-	all_params.update(params or {})
+def _unwrap_response(payload: dict) -> dict | list:
+	if not isinstance(payload, dict):
+		return payload
 
+	if payload.get("status") == "error":
+		error = payload.get("error") or payload.get("message") or "Cal.com API error"
+		if isinstance(error, dict):
+			error = error.get("message") or json.dumps(error)
+		raise ValueError(str(error))
+
+	if "data" in payload:
+		return payload["data"]
+	return payload
+
+
+def _booking_items(payload: dict) -> list:
+	data = _unwrap_response(payload)
+	if isinstance(data, list):
+		return data
+	if isinstance(data, dict):
+		return data.get("items") or data.get("bookings") or []
+	return []
+
+
+def _normalize_booking(booking: dict) -> dict:
+	return {
+		"uid": booking.get("uid"),
+		"title": booking.get("title"),
+		"start_time": booking.get("startTime") or booking.get("start"),
+		"end_time": booking.get("endTime") or booking.get("end"),
+		"status": booking.get("status"),
+		"attendees": [a.get("email") for a in (booking.get("attendees") or []) if a.get("email")],
+	}
+
+
+def _normalize_event_type(event_type: dict) -> dict:
+	return {
+		"id": event_type.get("id"),
+		"title": event_type.get("title"),
+		"slug": event_type.get("slug"),
+		"description": event_type.get("description"),
+		"duration_minutes": event_type.get("lengthInMinutes") or event_type.get("duration"),
+		"booking_url": event_type.get("bookingUrl"),
+		"hidden": event_type.get("hidden"),
+	}
+
+
+def _parse_event_type_id(value) -> int:
+	raw = str(value or "").strip()
+	if not raw.isdigit():
+		raise ValueError(
+			"event_type_id must be a numeric Cal.com event type ID. "
+			"Ask the user for the ID from Cal.com → Event Types → event settings."
+		)
+	return int(raw)
+
+
+def _make_calcom_request(
+	method: str,
+	endpoint: str,
+	api_version: str,
+	json_data=None,
+	params=None,
+):
 	response = requests.request(
-		method, f"{CALCOM_API_BASE}/{endpoint}", params=all_params, json=json_data, timeout=30
+		method,
+		f"{CALCOM_API_BASE}/{endpoint}",
+		headers=_headers(api_version),
+		params=params or None,
+		json=json_data,
+		timeout=30,
 	)
-	response.raise_for_status()
+	if not response.ok:
+		message = response.text
+		try:
+			payload = response.json()
+			if isinstance(payload, dict):
+				error = payload.get("error") or payload.get("message")
+				if isinstance(error, dict):
+					error = error.get("message") or json.dumps(error)
+				if error:
+					message = str(error)
+		except ValueError:
+			pass
+		raise ValueError(f"Cal.com API error ({response.status_code}): {message}")
+
 	return response.json() if response.text else {}
 
 
@@ -38,26 +124,47 @@ def handle_list_bookings(**kwargs) -> str:
 		params = {}
 		status = kwargs.get("status")
 		if status:
+			status = str(status).strip().lower()
+			if status not in VALID_LIST_STATUSES:
+				return json.dumps(
+					{
+						"success": False,
+						"error": (
+							f"status must be one of: {', '.join(sorted(VALID_LIST_STATUSES))}"
+						),
+					},
+					default=str,
+				)
 			params["status"] = status
 
-		data = _make_calcom_request("GET", "bookings", params=params)
-
-		bookings = []
-		for booking in data.get("bookings", []):
-			bookings.append(
-				{
-					"uid": booking.get("uid"),
-					"title": booking.get("title"),
-					"start_time": booking.get("startTime"),
-					"end_time": booking.get("endTime"),
-					"status": booking.get("status"),
-					"attendees": [a.get("email") for a in booking.get("attendees", [])],
-				}
-			)
+		data = _make_calcom_request("GET", "bookings", LIST_BOOKINGS_API_VERSION, params=params)
+		bookings = [_normalize_booking(booking) for booking in _booking_items(data)]
 
 		return json.dumps({"success": True, "count": len(bookings), "results": bookings})
 	except Exception as e:
 		error_msg = f"Cal.com List Bookings Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_list_event_types(**kwargs) -> str:
+	"""List Cal.com event types for the authenticated account."""
+	try:
+		params = {}
+		username = kwargs.get("username")
+		if username:
+			params["username"] = username
+
+		data = _make_calcom_request("GET", "event-types", EVENT_TYPES_API_VERSION, params=params)
+		event_types = _unwrap_response(data)
+		if not isinstance(event_types, list):
+			event_types = []
+
+		results = [_normalize_event_type(event_type) for event_type in event_types]
+		return json.dumps({"success": True, "count": len(results), "results": results})
+	except Exception as e:
+		error_msg = f"Cal.com List Event Types Error: {e!s}"
 		logger.warning(error_msg)
 		update_last_error(SERVICE_NAME, error_msg)
 		return json.dumps({"success": False, "error": str(e)}, default=str)
@@ -70,18 +177,18 @@ def handle_get_booking(**kwargs) -> str:
 		if not booking_uid:
 			return json.dumps({"success": False, "error": "booking_uid is required"}, default=str)
 
-		data = _make_calcom_request("GET", f"bookings/{booking_uid}")
-		booking = data.get("booking", data)
+		data = _make_calcom_request("GET", f"bookings/{booking_uid}", BOOKING_API_VERSION)
+		booking = _unwrap_response(data)
+		if isinstance(booking, list):
+			booking = booking[0] if booking else {}
+		if not isinstance(booking, dict) or not booking.get("uid"):
+			return json.dumps(
+				{"success": False, "error": f"Booking '{booking_uid}' not found"},
+				default=str,
+			)
 
-		booking_data = {
-			"uid": booking.get("uid"),
-			"title": booking.get("title"),
-			"description": booking.get("description"),
-			"start_time": booking.get("startTime"),
-			"end_time": booking.get("endTime"),
-			"status": booking.get("status"),
-			"attendees": [a.get("email") for a in booking.get("attendees", [])],
-		}
+		booking_data = _normalize_booking(booking)
+		booking_data["description"] = booking.get("description")
 
 		return json.dumps({"success": True, "results": booking_data})
 	except Exception as e:
@@ -107,17 +214,24 @@ def handle_create_booking(**kwargs) -> str:
 				default=str,
 			)
 
+		parsed_event_type_id = _parse_event_type_id(event_type_id)
 		payload = {
-			"eventTypeId": int(event_type_id),
+			"eventTypeId": parsed_event_type_id,
 			"start": start,
-			"responses": {"name": attendee_name, "email": attendee_email},
-			"timeZone": kwargs.get("timezone") or "UTC",
-			"language": "en",
-			"metadata": {},
+			"attendee": {
+				"name": attendee_name,
+				"email": attendee_email,
+				"timeZone": kwargs.get("timezone") or "UTC",
+				"language": "en",
+			},
 		}
 
-		data = _make_calcom_request("POST", "bookings", json_data=payload)
-		booking = data.get("booking", data)
+		data = _make_calcom_request("POST", "bookings", BOOKING_API_VERSION, json_data=payload)
+		booking = _unwrap_response(data)
+		if isinstance(booking, list):
+			booking = booking[0] if booking else {}
+		if not isinstance(booking, dict):
+			booking = {}
 
 		return json.dumps(
 			{
@@ -125,7 +239,7 @@ def handle_create_booking(**kwargs) -> str:
 				"results": {
 					"uid": booking.get("uid"),
 					"title": booking.get("title"),
-					"start_time": booking.get("startTime"),
+					"start_time": booking.get("startTime") or booking.get("start"),
 					"status": booking.get("status"),
 				},
 			}

--- a/huf/ai/tools/calcom.py
+++ b/huf/ai/tools/calcom.py
@@ -1,0 +1,137 @@
+"""
+Cal.com integration tools for booking listing, retrieval, and creation.
+Uses HUF Integration Settings for Cal.com credentials (api_key). Cal.com's v1
+REST API authenticates via an `apiKey` query parameter.
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "calcom"
+CALCOM_API_BASE = "https://api.cal.com/v1"
+
+
+def _auth_params():
+	return {"apiKey": require_credential(SERVICE_NAME, "api_key")}
+
+
+def _make_calcom_request(method: str, endpoint: str, json_data=None, params=None):
+	all_params = _auth_params()
+	all_params.update(params or {})
+
+	response = requests.request(
+		method, f"{CALCOM_API_BASE}/{endpoint}", params=all_params, json=json_data, timeout=30
+	)
+	response.raise_for_status()
+	return response.json() if response.text else {}
+
+
+def handle_list_bookings(**kwargs) -> str:
+	"""List Cal.com bookings, optionally filtered by status."""
+	try:
+		params = {}
+		status = kwargs.get("status")
+		if status:
+			params["status"] = status
+
+		data = _make_calcom_request("GET", "bookings", params=params)
+
+		bookings = []
+		for booking in data.get("bookings", []):
+			bookings.append(
+				{
+					"uid": booking.get("uid"),
+					"title": booking.get("title"),
+					"start_time": booking.get("startTime"),
+					"end_time": booking.get("endTime"),
+					"status": booking.get("status"),
+					"attendees": [a.get("email") for a in booking.get("attendees", [])],
+				}
+			)
+
+		return json.dumps({"success": True, "count": len(bookings), "results": bookings})
+	except Exception as e:
+		error_msg = f"Cal.com List Bookings Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_booking(**kwargs) -> str:
+	"""Get details of a Cal.com booking by UID."""
+	try:
+		booking_uid = kwargs.get("booking_uid")
+		if not booking_uid:
+			return json.dumps({"success": False, "error": "booking_uid is required"}, default=str)
+
+		data = _make_calcom_request("GET", f"bookings/{booking_uid}")
+		booking = data.get("booking", data)
+
+		booking_data = {
+			"uid": booking.get("uid"),
+			"title": booking.get("title"),
+			"description": booking.get("description"),
+			"start_time": booking.get("startTime"),
+			"end_time": booking.get("endTime"),
+			"status": booking.get("status"),
+			"attendees": [a.get("email") for a in booking.get("attendees", [])],
+		}
+
+		return json.dumps({"success": True, "results": booking_data})
+	except Exception as e:
+		error_msg = f"Cal.com Get Booking Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_booking(**kwargs) -> str:
+	"""Create a Cal.com booking for an event type."""
+	try:
+		event_type_id = kwargs.get("event_type_id")
+		start = kwargs.get("start")
+		attendee_name = kwargs.get("attendee_name")
+		attendee_email = kwargs.get("attendee_email")
+		if not all([event_type_id, start, attendee_name, attendee_email]):
+			return json.dumps(
+				{
+					"success": False,
+					"error": "event_type_id, start, attendee_name, and attendee_email are required",
+				},
+				default=str,
+			)
+
+		payload = {
+			"eventTypeId": int(event_type_id),
+			"start": start,
+			"responses": {"name": attendee_name, "email": attendee_email},
+			"timeZone": kwargs.get("timezone") or "UTC",
+			"language": "en",
+			"metadata": {},
+		}
+
+		data = _make_calcom_request("POST", "bookings", json_data=payload)
+		booking = data.get("booking", data)
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {
+					"uid": booking.get("uid"),
+					"title": booking.get("title"),
+					"start_time": booking.get("startTime"),
+					"status": booking.get("status"),
+				},
+			}
+		)
+	except Exception as e:
+		error_msg = f"Cal.com Create Booking Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/clickup.py
+++ b/huf/ai/tools/clickup.py
@@ -1,0 +1,125 @@
+"""
+ClickUp integration tools for task listing, retrieval, and creation.
+Uses HUF Integration Settings for ClickUp credentials (api_key).
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "clickup"
+CLICKUP_API_BASE = "https://api.clickup.com/api/v2"
+
+
+def _get_clickup_headers():
+	api_key = require_credential(SERVICE_NAME, "api_key")
+	return {"Authorization": api_key, "Content-Type": "application/json"}
+
+
+def _make_clickup_request(method: str, endpoint: str, json_data=None, params=None):
+	response = requests.request(
+		method,
+		f"{CLICKUP_API_BASE}/{endpoint}",
+		headers=_get_clickup_headers(),
+		json=json_data,
+		params=params,
+		timeout=30,
+	)
+	response.raise_for_status()
+	return response.json() if response.text else {}
+
+
+def handle_list_tasks(**kwargs) -> str:
+	"""List tasks in a ClickUp list."""
+	try:
+		list_id = kwargs.get("list_id")
+		if not list_id:
+			return json.dumps({"success": False, "error": "list_id is required"}, default=str)
+
+		include_closed = bool(kwargs.get("include_closed"))
+		data = _make_clickup_request(
+			"GET",
+			f"list/{list_id}/task",
+			params={"archived": "false", "include_closed": str(include_closed).lower()},
+		)
+
+		tasks = []
+		for task in data.get("tasks", []):
+			tasks.append(
+				{
+					"id": task.get("id"),
+					"name": task.get("name"),
+					"status": (task.get("status") or {}).get("status"),
+					"assignees": [a.get("username") for a in task.get("assignees", [])],
+					"due_date": task.get("due_date"),
+					"url": task.get("url"),
+				}
+			)
+
+		return json.dumps({"success": True, "count": len(tasks), "results": tasks})
+	except Exception as e:
+		error_msg = f"ClickUp List Tasks Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_task(**kwargs) -> str:
+	"""Get details of a ClickUp task by ID."""
+	try:
+		task_id = kwargs.get("task_id")
+		if not task_id:
+			return json.dumps({"success": False, "error": "task_id is required"}, default=str)
+
+		data = _make_clickup_request("GET", f"task/{task_id}")
+
+		task_data = {
+			"id": data.get("id"),
+			"name": data.get("name"),
+			"description": data.get("description"),
+			"status": (data.get("status") or {}).get("status"),
+			"assignees": [a.get("username") for a in data.get("assignees", [])],
+			"priority": (data.get("priority") or {}).get("priority") if data.get("priority") else None,
+			"due_date": data.get("due_date"),
+			"url": data.get("url"),
+		}
+
+		return json.dumps({"success": True, "results": task_data})
+	except Exception as e:
+		error_msg = f"ClickUp Get Task Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_task(**kwargs) -> str:
+	"""Create a task in a ClickUp list."""
+	try:
+		list_id = kwargs.get("list_id")
+		name = kwargs.get("name")
+		if not all([list_id, name]):
+			return json.dumps({"success": False, "error": "list_id and name are required"}, default=str)
+
+		payload = {"name": name}
+		description = kwargs.get("description")
+		if description:
+			payload["description"] = description
+
+		data = _make_clickup_request("POST", f"list/{list_id}/task", json_data=payload)
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {"id": data.get("id"), "name": data.get("name"), "url": data.get("url")},
+			}
+		)
+	except Exception as e:
+		error_msg = f"ClickUp Create Task Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/credentials.py
+++ b/huf/ai/tools/credentials.py
@@ -15,6 +15,7 @@
 #       service_name instead.
 
 import os
+
 import frappe
 
 from huf.ai.transaction import commit_if_background
@@ -53,22 +54,22 @@ def require_credential(service: str, key: str) -> str:
 					return cred.get_password("value")
 	except Exception:
 		pass
-	
+
 	# Fallback to environment variable
 	# Construct env var name: SERVICE_KEY (uppercase, underscore separated)
 	env_var_name = f"{service.upper()}_{key.upper()}"
 	value = os.getenv(env_var_name)
-	
+
 	if value:
 		return value
-	
+
 	# Also try common alternative naming patterns
 	alt_names = _get_alt_env_names(service, key)
 	for alt_name in alt_names:
 		value = os.getenv(alt_name)
 		if value:
 			return value
-	
+
 	# If still not found, raise error
 	raise ValueError(
 		f"Credential not found for service '{service}', key '{key}'. "
@@ -79,7 +80,7 @@ def require_credential(service: str, key: str) -> str:
 def _get_alt_env_names(service: str, key: str) -> list:
 	"""Get alternative environment variable names for common services."""
 	alt_names = []
-	
+
 	# Common patterns
 	if key == "api_key":
 		alt_names.append(f"{service.upper()}_API_KEY")
@@ -94,7 +95,7 @@ def _get_alt_env_names(service: str, key: str) -> list:
 	elif key == "client_secret":
 		alt_names.append(f"{service.upper()}_CLIENT_SECRET")
 		alt_names.append(f"{service.upper()}_SECRET")
-	
+
 	# Service-specific patterns
 	service_patterns = {
 		"openai": ["OPENAI_API_KEY"],
@@ -112,6 +113,7 @@ def _get_alt_env_names(service: str, key: str) -> list:
 		"calcom": ["CALCOM_API_KEY"],
 		"clickup": ["CLICKUP_API_KEY", "CLICKUP_SPACE_ID"],
 		"giphy": ["GIPHY_API_KEY"],
+		"jira": ["JIRA_BASE_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"],
 		"linear": ["LINEAR_API_KEY"],
 		"notion": ["NOTION_API_KEY", "NOTION_DATABASE_ID"],
 		"openweather": ["OPENWEATHER_API_KEY"],
@@ -126,12 +128,12 @@ def _get_alt_env_names(service: str, key: str) -> list:
 		"zendesk": ["ZENDESK_USERNAME", "ZENDESK_PASSWORD", "ZENDESK_COMPANY_NAME"],
 		"zoom": ["ZOOM_ACCOUNT_ID", "ZOOM_CLIENT_ID", "ZOOM_CLIENT_SECRET"],
 	}
-	
+
 	if service in service_patterns:
 		for pattern in service_patterns[service]:
 			if pattern not in alt_names:
 				alt_names.append(pattern)
-	
+
 	return alt_names
 
 
@@ -170,7 +172,7 @@ def update_last_error(service: str, error: str):
 			order_by="is_default DESC, modified DESC",
 			limit=1
 		)
-		
+
 		if settings:
 			doc = frappe.get_doc("Integration Settings", settings[0].name)
 			doc.last_error = error[:140]  # Truncate to field length

--- a/huf/ai/tools/jira.py
+++ b/huf/ai/tools/jira.py
@@ -1,0 +1,184 @@
+"""
+Jira Cloud integration tools for issue search, retrieval, and creation.
+Uses HUF Integration Settings for Jira credentials (base_url, email, api_token).
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import get_credential, require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "jira"
+
+
+def _get_jira_config():
+	"""Return (base_url, auth) for authenticated Jira REST API requests."""
+	base_url = require_credential(SERVICE_NAME, "base_url").rstrip("/")
+	email = require_credential(SERVICE_NAME, "email")
+	api_token = require_credential(SERVICE_NAME, "api_token")
+	return base_url, (email, api_token)
+
+
+def _make_jira_request(method: str, path: str, json_data=None, params=None):
+	base_url, auth = _get_jira_config()
+	url = f"{base_url}/rest/api/3/{path}"
+
+	response = requests.request(
+		method,
+		url,
+		auth=auth,
+		headers={"Accept": "application/json", "Content-Type": "application/json"},
+		json=json_data,
+		params=params,
+		timeout=30,
+	)
+	response.raise_for_status()
+	return response.json() if response.text else {}
+
+
+def _adf_text(text: str) -> dict:
+	"""Wrap plain text in Jira's Atlassian Document Format, required by the v3 API."""
+	return {
+		"type": "doc",
+		"version": 1,
+		"content": [{"type": "paragraph", "content": [{"type": "text", "text": text}]}],
+	}
+
+
+def handle_search_issues(**kwargs) -> str:
+	"""Search Jira issues using JQL."""
+	try:
+		jql = kwargs.get("jql")
+		if not jql:
+			return json.dumps({"success": False, "error": "jql is required"}, default=str)
+
+		max_results = int(kwargs.get("max_results") or 20)
+		data = _make_jira_request(
+			"GET",
+			"search",
+			params={
+				"jql": jql,
+				"maxResults": max_results,
+				"fields": "summary,status,issuetype,assignee,priority",
+			},
+		)
+
+		issues = []
+		for issue in data.get("issues", []):
+			fields = issue.get("fields", {})
+			issues.append(
+				{
+					"key": issue.get("key"),
+					"summary": fields.get("summary"),
+					"status": (fields.get("status") or {}).get("name"),
+					"issue_type": (fields.get("issuetype") or {}).get("name"),
+					"assignee": ((fields.get("assignee") or {}).get("displayName")),
+					"priority": (fields.get("priority") or {}).get("name"),
+					"url": f"{require_credential(SERVICE_NAME, 'base_url').rstrip('/')}/browse/{issue.get('key')}",
+				}
+			)
+
+		return json.dumps({"success": True, "count": len(issues), "results": issues})
+	except Exception as e:
+		error_msg = f"Jira Search Issues Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_issue(**kwargs) -> str:
+	"""Get details of a Jira issue by key."""
+	try:
+		issue_key = kwargs.get("issue_key")
+		if not issue_key:
+			return json.dumps({"success": False, "error": "issue_key is required"}, default=str)
+
+		data = _make_jira_request("GET", f"issue/{issue_key}")
+		fields = data.get("fields", {})
+
+		issue_data = {
+			"key": data.get("key"),
+			"summary": fields.get("summary"),
+			"description": fields.get("description"),
+			"status": (fields.get("status") or {}).get("name"),
+			"issue_type": (fields.get("issuetype") or {}).get("name"),
+			"assignee": (fields.get("assignee") or {}).get("displayName"),
+			"reporter": (fields.get("reporter") or {}).get("displayName"),
+			"priority": (fields.get("priority") or {}).get("name"),
+			"created": fields.get("created"),
+			"updated": fields.get("updated"),
+			"url": f"{require_credential(SERVICE_NAME, 'base_url').rstrip('/')}/browse/{data.get('key')}",
+		}
+
+		return json.dumps({"success": True, "results": issue_data})
+	except Exception as e:
+		error_msg = f"Jira Get Issue Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_issue(**kwargs) -> str:
+	"""Create a Jira issue."""
+	try:
+		project_key = kwargs.get("project_key")
+		summary = kwargs.get("summary")
+		issue_type = kwargs.get("issue_type") or "Task"
+		if not all([project_key, summary]):
+			return json.dumps(
+				{"success": False, "error": "project_key and summary are required"}, default=str
+			)
+
+		fields = {
+			"project": {"key": project_key},
+			"summary": summary,
+			"issuetype": {"name": issue_type},
+		}
+		description = kwargs.get("description")
+		if description:
+			fields["description"] = _adf_text(description)
+
+		data = _make_jira_request("POST", "issue", json_data={"fields": fields})
+		base_url = require_credential(SERVICE_NAME, "base_url").rstrip("/")
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {
+					"key": data.get("key"),
+					"id": data.get("id"),
+					"url": f"{base_url}/browse/{data.get('key')}",
+				},
+			}
+		)
+	except Exception as e:
+		error_msg = f"Jira Create Issue Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_add_comment(**kwargs) -> str:
+	"""Add a comment to a Jira issue."""
+	try:
+		issue_key = kwargs.get("issue_key")
+		comment = kwargs.get("comment")
+		if not all([issue_key, comment]):
+			return json.dumps({"success": False, "error": "issue_key and comment are required"}, default=str)
+
+		data = _make_jira_request(
+			"POST", f"issue/{issue_key}/comment", json_data={"body": _adf_text(comment)}
+		)
+
+		return json.dumps(
+			{"success": True, "results": {"id": data.get("id"), "created": data.get("created")}}
+		)
+	except Exception as e:
+		error_msg = f"Jira Add Comment Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/jira.py
+++ b/huf/ai/tools/jira.py
@@ -8,7 +8,7 @@ import json
 import frappe
 import requests
 
-from huf.ai.tools.credentials import get_credential, require_credential, update_last_error
+from huf.ai.tools.credentials import require_credential, update_last_error
 
 logger = frappe.logger("huf")
 
@@ -21,6 +21,23 @@ def _get_jira_config():
 	email = require_credential(SERVICE_NAME, "email")
 	api_token = require_credential(SERVICE_NAME, "api_token")
 	return base_url, (email, api_token)
+
+
+def _format_jira_error(response: requests.Response) -> str:
+	try:
+		payload = response.json()
+	except ValueError:
+		return response.text or f"HTTP {response.status_code}"
+
+	if isinstance(payload, dict):
+		messages = payload.get("errorMessages") or []
+		errors = payload.get("errors") or {}
+		parts = [str(message) for message in messages if message]
+		parts.extend(f"{key}: {value}" for key, value in errors.items() if value)
+		if parts:
+			return "; ".join(parts)
+
+	return response.text or f"HTTP {response.status_code}"
 
 
 def _make_jira_request(method: str, path: str, json_data=None, params=None):
@@ -36,7 +53,9 @@ def _make_jira_request(method: str, path: str, json_data=None, params=None):
 		params=params,
 		timeout=30,
 	)
-	response.raise_for_status()
+	if not response.ok:
+		raise ValueError(f"Jira API error ({response.status_code}): {_format_jira_error(response)}")
+
 	return response.json() if response.text else {}
 
 
@@ -49,6 +68,47 @@ def _adf_text(text: str) -> dict:
 	}
 
 
+def _normalize_issue(issue: dict, base_url: str) -> dict:
+	fields = issue.get("fields", {})
+	return {
+		"key": issue.get("key"),
+		"summary": fields.get("summary"),
+		"status": (fields.get("status") or {}).get("name"),
+		"issue_type": (fields.get("issuetype") or {}).get("name"),
+		"assignee": (fields.get("assignee") or {}).get("displayName"),
+		"priority": (fields.get("priority") or {}).get("name"),
+		"url": f"{base_url}/browse/{issue.get('key')}" if issue.get("key") else None,
+	}
+
+
+def handle_list_projects(**kwargs) -> str:
+	"""List Jira projects visible to the configured credentials."""
+	try:
+		max_results = int(kwargs.get("max_results") or 50)
+		data = _make_jira_request(
+			"GET",
+			"project/search",
+			params={"maxResults": max_results},
+		)
+
+		projects = [
+			{
+				"key": project.get("key"),
+				"name": project.get("name"),
+				"project_type": project.get("projectTypeKey"),
+				"style": project.get("style"),
+			}
+			for project in data.get("values", [])
+		]
+
+		return json.dumps({"success": True, "count": len(projects), "results": projects})
+	except Exception as e:
+		error_msg = f"Jira List Projects Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
 def handle_search_issues(**kwargs) -> str:
 	"""Search Jira issues using JQL."""
 	try:
@@ -57,30 +117,18 @@ def handle_search_issues(**kwargs) -> str:
 			return json.dumps({"success": False, "error": "jql is required"}, default=str)
 
 		max_results = int(kwargs.get("max_results") or 20)
+		base_url, _auth = _get_jira_config()
 		data = _make_jira_request(
-			"GET",
-			"search",
-			params={
+			"POST",
+			"search/jql",
+			json_data={
 				"jql": jql,
 				"maxResults": max_results,
-				"fields": "summary,status,issuetype,assignee,priority",
+				"fields": ["summary", "status", "issuetype", "assignee", "priority"],
 			},
 		)
 
-		issues = []
-		for issue in data.get("issues", []):
-			fields = issue.get("fields", {})
-			issues.append(
-				{
-					"key": issue.get("key"),
-					"summary": fields.get("summary"),
-					"status": (fields.get("status") or {}).get("name"),
-					"issue_type": (fields.get("issuetype") or {}).get("name"),
-					"assignee": ((fields.get("assignee") or {}).get("displayName")),
-					"priority": (fields.get("priority") or {}).get("name"),
-					"url": f"{require_credential(SERVICE_NAME, 'base_url').rstrip('/')}/browse/{issue.get('key')}",
-				}
-			)
+		issues = [_normalize_issue(issue, base_url) for issue in data.get("issues", [])]
 
 		return json.dumps({"success": True, "count": len(issues), "results": issues})
 	except Exception as e:

--- a/huf/ai/tools/linear.py
+++ b/huf/ai/tools/linear.py
@@ -37,27 +37,39 @@ def handle_list_issues(**kwargs) -> str:
 	try:
 		team_key = kwargs.get("team_key")
 		limit = int(kwargs.get("limit") or 20)
-
-		filter_clause = ""
 		variables = {}
-		if team_key:
-			filter_clause = ", filter: { team: { key: { eq: $teamKey } } }"
-			variables["teamKey"] = team_key
 
-		query = f"""
-		query Issues($teamKey: String) {{
-			issues(first: {limit}{filter_clause}) {{
-				nodes {{
-					identifier
-					title
-					state {{ name }}
-					assignee {{ name }}
-					priority
-					url
+		if team_key:
+			query = f"""
+			query Issues($teamKey: String!) {{
+				issues(first: {limit}, filter: {{ team: {{ key: {{ eq: $teamKey }} }} }}) {{
+					nodes {{
+						identifier
+						title
+						state {{ name }}
+						assignee {{ name }}
+						priority
+						url
+					}}
 				}}
 			}}
-		}}
-		"""
+			"""
+			variables["teamKey"] = team_key
+		else:
+			query = f"""
+			query Issues {{
+				issues(first: {limit}) {{
+					nodes {{
+						identifier
+						title
+						state {{ name }}
+						assignee {{ name }}
+						priority
+						url
+					}}
+				}}
+			}}
+			"""
 		data = _make_linear_request(query, variables)
 
 		issues = [

--- a/huf/ai/tools/linear.py
+++ b/huf/ai/tools/linear.py
@@ -1,0 +1,177 @@
+"""
+Linear integration tools for issue listing, retrieval, and creation.
+Uses HUF Integration Settings for Linear credentials (api_key). Linear's API is GraphQL-only.
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "linear"
+LINEAR_API_URL = "https://api.linear.app/graphql"
+
+
+def _make_linear_request(query: str, variables: dict | None = None) -> dict:
+	api_key = require_credential(SERVICE_NAME, "api_key")
+
+	response = requests.post(
+		LINEAR_API_URL,
+		headers={"Authorization": api_key, "Content-Type": "application/json"},
+		json={"query": query, "variables": variables or {}},
+		timeout=30,
+	)
+	response.raise_for_status()
+	data = response.json()
+	if data.get("errors"):
+		raise ValueError("; ".join(err.get("message", "unknown error") for err in data["errors"]))
+	return data.get("data", {})
+
+
+def handle_list_issues(**kwargs) -> str:
+	"""List Linear issues, optionally filtered by team key."""
+	try:
+		team_key = kwargs.get("team_key")
+		limit = int(kwargs.get("limit") or 20)
+
+		filter_clause = ""
+		variables = {}
+		if team_key:
+			filter_clause = ", filter: { team: { key: { eq: $teamKey } } }"
+			variables["teamKey"] = team_key
+
+		query = f"""
+		query Issues($teamKey: String) {{
+			issues(first: {limit}{filter_clause}) {{
+				nodes {{
+					identifier
+					title
+					state {{ name }}
+					assignee {{ name }}
+					priority
+					url
+				}}
+			}}
+		}}
+		"""
+		data = _make_linear_request(query, variables)
+
+		issues = [
+			{
+				"identifier": node.get("identifier"),
+				"title": node.get("title"),
+				"status": (node.get("state") or {}).get("name"),
+				"assignee": (node.get("assignee") or {}).get("name"),
+				"priority": node.get("priority"),
+				"url": node.get("url"),
+			}
+			for node in data.get("issues", {}).get("nodes", [])
+		]
+
+		return json.dumps({"success": True, "count": len(issues), "results": issues})
+	except Exception as e:
+		error_msg = f"Linear List Issues Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_issue(**kwargs) -> str:
+	"""Get details of a Linear issue by its human-readable identifier (e.g. 'ENG-123')."""
+	try:
+		issue_id = kwargs.get("issue_id")
+		if not issue_id:
+			return json.dumps({"success": False, "error": "issue_id is required"}, default=str)
+
+		query = """
+		query Issue($id: String!) {
+			issue(id: $id) {
+				identifier
+				title
+				description
+				state { name }
+				assignee { name }
+				priority
+				url
+				createdAt
+				updatedAt
+			}
+		}
+		"""
+		data = _make_linear_request(query, {"id": issue_id})
+		issue = data.get("issue")
+		if not issue:
+			return json.dumps({"success": False, "error": f"Issue '{issue_id}' not found"}, default=str)
+
+		issue_data = {
+			"identifier": issue.get("identifier"),
+			"title": issue.get("title"),
+			"description": issue.get("description"),
+			"status": (issue.get("state") or {}).get("name"),
+			"assignee": (issue.get("assignee") or {}).get("name"),
+			"priority": issue.get("priority"),
+			"url": issue.get("url"),
+			"created_at": issue.get("createdAt"),
+			"updated_at": issue.get("updatedAt"),
+		}
+		return json.dumps({"success": True, "results": issue_data})
+	except Exception as e:
+		error_msg = f"Linear Get Issue Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_issue(**kwargs) -> str:
+	"""Create a Linear issue in a team, given the team's key."""
+	try:
+		team_key = kwargs.get("team_key")
+		title = kwargs.get("title")
+		if not all([team_key, title]):
+			return json.dumps({"success": False, "error": "team_key and title are required"}, default=str)
+
+		team_query = "query Team($key: String!) { teams(filter: { key: { eq: $key } }) { nodes { id } } }"
+		team_data = _make_linear_request(team_query, {"key": team_key})
+		team_nodes = team_data.get("teams", {}).get("nodes", [])
+		if not team_nodes:
+			return json.dumps({"success": False, "error": f"Team '{team_key}' not found"}, default=str)
+		team_id = team_nodes[0]["id"]
+
+		mutation = """
+		mutation CreateIssue($input: IssueCreateInput!) {
+			issueCreate(input: $input) {
+				success
+				issue { identifier title url }
+			}
+		}
+		"""
+		issue_input = {"teamId": team_id, "title": title}
+		description = kwargs.get("description")
+		if description:
+			issue_input["description"] = description
+
+		data = _make_linear_request(mutation, {"input": issue_input})
+		result = data.get("issueCreate", {})
+		if not result.get("success"):
+			return json.dumps({"success": False, "error": "Linear rejected the issue creation"}, default=str)
+
+		issue = result.get("issue", {})
+		return json.dumps(
+			{
+				"success": True,
+				"results": {
+					"identifier": issue.get("identifier"),
+					"title": issue.get("title"),
+					"url": issue.get("url"),
+				},
+			}
+		)
+	except Exception as e:
+		error_msg = f"Linear Create Issue Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/notion.py
+++ b/huf/ai/tools/notion.py
@@ -1,5 +1,5 @@
 """
-Notion integration tools for database queries, page retrieval, and page creation.
+Notion integration tools for search, databases, pages, and blocks.
 Uses HUF Integration Settings for Notion credentials (api_key, database_id).
 """
 
@@ -26,12 +26,43 @@ def _get_notion_headers():
 	}
 
 
-def _make_notion_request(method: str, endpoint: str, json_data=None):
+def _format_notion_error(response: requests.Response) -> str:
+	try:
+		payload = response.json()
+	except ValueError:
+		return response.text or f"HTTP {response.status_code}"
+
+	if isinstance(payload, dict):
+		message = payload.get("message")
+		if message:
+			return str(message)
+
+	return response.text or f"HTTP {response.status_code}"
+
+
+def _make_notion_request(method: str, endpoint: str, json_data=None, params=None):
 	response = requests.request(
-		method, f"{NOTION_API_BASE}/{endpoint}", headers=_get_notion_headers(), json=json_data, timeout=30
+		method,
+		f"{NOTION_API_BASE}/{endpoint}",
+		headers=_get_notion_headers(),
+		json=json_data,
+		params=params,
+		timeout=30,
 	)
-	response.raise_for_status()
+	if not response.ok:
+		raise ValueError(f"Notion API error ({response.status_code}): {_format_notion_error(response)}")
 	return response.json() if response.text else {}
+
+
+def _parse_optional_json(value, field_name: str):
+	if value in (None, ""):
+		return None
+	if isinstance(value, (dict, list)):
+		return value
+	try:
+		return json.loads(value)
+	except (TypeError, json.JSONDecodeError) as exc:
+		raise ValueError(f"{field_name} must be valid JSON") from exc
 
 
 def _resolve_database_id(kwargs: dict) -> str:
@@ -48,6 +79,166 @@ def _extract_title(properties: dict) -> str | None:
 	return None
 
 
+def _extract_database_title(data: dict) -> str | None:
+	title_parts = (data.get("title") or []) if isinstance(data.get("title"), list) else []
+	if title_parts:
+		return "".join(part.get("plain_text", "") for part in title_parts)
+	return _extract_title(data.get("properties", {}))
+
+
+def _summarize_search_result(item: dict) -> dict:
+	object_type = item.get("object")
+	summary = {
+		"id": item.get("id"),
+		"object": object_type,
+		"url": item.get("url"),
+		"archived": item.get("archived"),
+		"last_edited_time": item.get("last_edited_time"),
+	}
+	if object_type == "database":
+		summary["title"] = _extract_database_title(item)
+	elif object_type == "page":
+		summary["title"] = _extract_title(item.get("properties", {}))
+	return summary
+
+
+def _summarize_database_schema(data: dict) -> dict:
+	properties = {}
+	for name, prop in (data.get("properties") or {}).items():
+		prop_type = prop.get("type")
+		entry = {"type": prop_type}
+		if prop_type == "select":
+			entry["options"] = [opt.get("name") for opt in (prop.get("select") or {}).get("options", [])]
+		elif prop_type == "multi_select":
+			entry["options"] = [opt.get("name") for opt in (prop.get("multi_select") or {}).get("options", [])]
+		elif prop_type == "status":
+			status = prop.get("status") or {}
+			entry["options"] = [opt.get("name") for opt in status.get("options", [])]
+		properties[name] = entry
+
+	return {
+		"id": data.get("id"),
+		"title": _extract_database_title(data),
+		"url": data.get("url"),
+		"properties": properties,
+	}
+
+
+def _extract_rich_text(rich_text: list) -> str:
+	return "".join(part.get("plain_text", "") for part in rich_text or [])
+
+
+def _extract_block_text(block: dict) -> str:
+	block_type = block.get("type")
+	if not block_type:
+		return ""
+
+	payload = block.get(block_type) or {}
+	if block_type in {"paragraph", "heading_1", "heading_2", "heading_3", "quote", "callout"}:
+		return _extract_rich_text(payload.get("rich_text", []))
+	if block_type in {"bulleted_list_item", "numbered_list_item", "to_do"}:
+		prefix = "[ ] " if block_type == "to_do" and not payload.get("checked") else ""
+		if block_type == "to_do" and payload.get("checked"):
+			prefix = "[x] "
+		return prefix + _extract_rich_text(payload.get("rich_text", []))
+	if block_type == "code":
+		return _extract_rich_text(payload.get("rich_text", []))
+	if block_type == "divider":
+		return "---"
+	return ""
+
+
+def handle_search(**kwargs) -> str:
+	"""Search Notion pages and databases by title."""
+	try:
+		payload = {"page_size": int(kwargs.get("page_size") or 20)}
+		query = kwargs.get("query")
+		if query:
+			payload["query"] = query
+
+		object_type = kwargs.get("object_type")
+		if object_type:
+			payload["filter"] = {"property": "object", "value": object_type}
+
+		data = _make_notion_request("POST", "search", json_data=payload)
+		results = [_summarize_search_result(item) for item in data.get("results", [])]
+
+		return json.dumps(
+			{
+				"success": True,
+				"count": len(results),
+				"has_more": data.get("has_more", False),
+				"next_cursor": data.get("next_cursor"),
+				"results": results,
+			},
+			default=str,
+		)
+	except Exception as e:
+		error_msg = f"Notion Search Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_list_databases(**kwargs) -> str:
+	"""List Notion databases the integration can access."""
+	try:
+		payload = {
+			"page_size": int(kwargs.get("page_size") or 20),
+			"filter": {"property": "object", "value": "database"},
+		}
+		query = kwargs.get("query")
+		if query:
+			payload["query"] = query
+
+		data = _make_notion_request("POST", "search", json_data=payload)
+		databases = [
+			{
+				"id": item.get("id"),
+				"title": _extract_database_title(item),
+				"url": item.get("url"),
+				"last_edited_time": item.get("last_edited_time"),
+			}
+			for item in data.get("results", [])
+			if item.get("object") == "database"
+		]
+
+		return json.dumps(
+			{
+				"success": True,
+				"count": len(databases),
+				"has_more": data.get("has_more", False),
+				"next_cursor": data.get("next_cursor"),
+				"results": databases,
+			},
+			default=str,
+		)
+	except Exception as e:
+		error_msg = f"Notion List Databases Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_database(**kwargs) -> str:
+	"""Get a Notion database schema and property definitions."""
+	try:
+		database_id = _resolve_database_id(kwargs)
+		if not database_id:
+			return json.dumps(
+				{"success": False, "error": "database_id is required (or set NOTION_DATABASE_ID)"},
+				default=str,
+			)
+
+		data = _make_notion_request("GET", f"databases/{database_id}")
+		return json.dumps({"success": True, "results": _summarize_database_schema(data)}, default=str)
+	except Exception as e:
+		error_msg = f"Notion Get Database Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
 def handle_query_database(**kwargs) -> str:
 	"""Query a Notion database's rows."""
 	try:
@@ -58,10 +249,15 @@ def handle_query_database(**kwargs) -> str:
 				default=str,
 			)
 
-		page_size = int(kwargs.get("page_size") or 20)
-		data = _make_notion_request(
-			"POST", f"databases/{database_id}/query", json_data={"page_size": page_size}
-		)
+		payload = {"page_size": int(kwargs.get("page_size") or 20)}
+		filter_obj = _parse_optional_json(kwargs.get("filter"), "filter")
+		if filter_obj:
+			payload["filter"] = filter_obj
+		sorts = _parse_optional_json(kwargs.get("sorts"), "sorts")
+		if sorts:
+			payload["sorts"] = sorts
+
+		data = _make_notion_request("POST", f"databases/{database_id}/query", json_data=payload)
 
 		pages = []
 		for page in data.get("results", []):
@@ -75,7 +271,16 @@ def handle_query_database(**kwargs) -> str:
 				}
 			)
 
-		return json.dumps({"success": True, "count": len(pages), "results": pages})
+		return json.dumps(
+			{
+				"success": True,
+				"count": len(pages),
+				"has_more": data.get("has_more", False),
+				"next_cursor": data.get("next_cursor"),
+				"results": pages,
+			},
+			default=str,
+		)
 	except Exception as e:
 		error_msg = f"Notion Query Database Error: {e!s}"
 		logger.warning(error_msg)
@@ -99,11 +304,47 @@ def handle_get_page(**kwargs) -> str:
 			"archived": data.get("archived"),
 			"created_time": data.get("created_time"),
 			"last_edited_time": data.get("last_edited_time"),
+			"properties": data.get("properties", {}),
 		}
 
-		return json.dumps({"success": True, "results": page_data})
+		return json.dumps({"success": True, "results": page_data}, default=str)
 	except Exception as e:
 		error_msg = f"Notion Get Page Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_page_content(**kwargs) -> str:
+	"""Get the block content of a Notion page as plain text."""
+	try:
+		page_id = kwargs.get("page_id")
+		if not page_id:
+			return json.dumps({"success": False, "error": "page_id is required"}, default=str)
+
+		page_size = int(kwargs.get("page_size") or 50)
+		data = _make_notion_request(
+			"GET", f"blocks/{page_id}/children", params={"page_size": page_size}
+		)
+
+		lines = []
+		for block in data.get("results", []):
+			text = _extract_block_text(block)
+			if text:
+				lines.append(text)
+
+		return json.dumps(
+			{
+				"success": True,
+				"count": len(lines),
+				"has_more": data.get("has_more", False),
+				"next_cursor": data.get("next_cursor"),
+				"content": "\n".join(lines),
+			},
+			default=str,
+		)
+	except Exception as e:
+		error_msg = f"Notion Get Page Content Error: {e!s}"
 		logger.warning(error_msg)
 		update_last_error(SERVICE_NAME, error_msg)
 		return json.dumps({"success": False, "error": str(e)}, default=str)
@@ -129,11 +370,72 @@ def handle_create_page(**kwargs) -> str:
 			"properties": {title_property: {"title": [{"text": {"content": title}}]}},
 		}
 
+		extra_properties = _parse_optional_json(kwargs.get("properties"), "properties")
+		if extra_properties:
+			payload["properties"].update(extra_properties)
+
 		data = _make_notion_request("POST", "pages", json_data=payload)
 
 		return json.dumps({"success": True, "results": {"id": data.get("id"), "url": data.get("url")}})
 	except Exception as e:
 		error_msg = f"Notion Create Page Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_update_page(**kwargs) -> str:
+	"""Update properties on an existing Notion page."""
+	try:
+		page_id = kwargs.get("page_id")
+		if not page_id:
+			return json.dumps({"success": False, "error": "page_id is required"}, default=str)
+
+		properties = _parse_optional_json(kwargs.get("properties"), "properties")
+		if not properties:
+			return json.dumps(
+				{"success": False, "error": "properties is required (Notion property update JSON)"},
+				default=str,
+			)
+
+		data = _make_notion_request("PATCH", f"pages/{page_id}", json_data={"properties": properties})
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {
+					"id": data.get("id"),
+					"url": data.get("url"),
+					"title": _extract_title(data.get("properties", {})),
+				},
+			},
+			default=str,
+		)
+	except Exception as e:
+		error_msg = f"Notion Update Page Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_archive_page(**kwargs) -> str:
+	"""Archive (soft-delete) a Notion page."""
+	try:
+		page_id = kwargs.get("page_id")
+		if not page_id:
+			return json.dumps({"success": False, "error": "page_id is required"}, default=str)
+
+		data = _make_notion_request("PATCH", f"pages/{page_id}", json_data={"archived": True})
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {"id": data.get("id"), "archived": data.get("archived", True)},
+			},
+			default=str,
+		)
+	except Exception as e:
+		error_msg = f"Notion Archive Page Error: {e!s}"
 		logger.warning(error_msg)
 		update_last_error(SERVICE_NAME, error_msg)
 		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/notion.py
+++ b/huf/ai/tools/notion.py
@@ -1,0 +1,139 @@
+"""
+Notion integration tools for database queries, page retrieval, and page creation.
+Uses HUF Integration Settings for Notion credentials (api_key, database_id).
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import get_credential, require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "notion"
+NOTION_API_BASE = "https://api.notion.com/v1"
+NOTION_VERSION = "2022-06-28"
+
+
+def _get_notion_headers():
+	api_key = require_credential(SERVICE_NAME, "api_key")
+	return {
+		"Authorization": f"Bearer {api_key}",
+		"Notion-Version": NOTION_VERSION,
+		"Content-Type": "application/json",
+	}
+
+
+def _make_notion_request(method: str, endpoint: str, json_data=None):
+	response = requests.request(
+		method, f"{NOTION_API_BASE}/{endpoint}", headers=_get_notion_headers(), json=json_data, timeout=30
+	)
+	response.raise_for_status()
+	return response.json() if response.text else {}
+
+
+def _resolve_database_id(kwargs: dict) -> str:
+	return kwargs.get("database_id") or get_credential(SERVICE_NAME, "database_id")
+
+
+def _extract_title(properties: dict) -> str | None:
+	"""Best-effort extraction of a page's title from its properties dict."""
+	for prop in properties.values():
+		if prop.get("type") == "title":
+			title_parts = prop.get("title", [])
+			if title_parts:
+				return "".join(part.get("plain_text", "") for part in title_parts)
+	return None
+
+
+def handle_query_database(**kwargs) -> str:
+	"""Query a Notion database's rows."""
+	try:
+		database_id = _resolve_database_id(kwargs)
+		if not database_id:
+			return json.dumps(
+				{"success": False, "error": "database_id is required (or set NOTION_DATABASE_ID)"},
+				default=str,
+			)
+
+		page_size = int(kwargs.get("page_size") or 20)
+		data = _make_notion_request(
+			"POST", f"databases/{database_id}/query", json_data={"page_size": page_size}
+		)
+
+		pages = []
+		for page in data.get("results", []):
+			pages.append(
+				{
+					"id": page.get("id"),
+					"title": _extract_title(page.get("properties", {})),
+					"url": page.get("url"),
+					"created_time": page.get("created_time"),
+					"last_edited_time": page.get("last_edited_time"),
+				}
+			)
+
+		return json.dumps({"success": True, "count": len(pages), "results": pages})
+	except Exception as e:
+		error_msg = f"Notion Query Database Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_page(**kwargs) -> str:
+	"""Get a Notion page's properties by ID."""
+	try:
+		page_id = kwargs.get("page_id")
+		if not page_id:
+			return json.dumps({"success": False, "error": "page_id is required"}, default=str)
+
+		data = _make_notion_request("GET", f"pages/{page_id}")
+
+		page_data = {
+			"id": data.get("id"),
+			"title": _extract_title(data.get("properties", {})),
+			"url": data.get("url"),
+			"archived": data.get("archived"),
+			"created_time": data.get("created_time"),
+			"last_edited_time": data.get("last_edited_time"),
+		}
+
+		return json.dumps({"success": True, "results": page_data})
+	except Exception as e:
+		error_msg = f"Notion Get Page Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_page(**kwargs) -> str:
+	"""Create a page (row) in a Notion database with a title property."""
+	try:
+		title = kwargs.get("title")
+		if not title:
+			return json.dumps({"success": False, "error": "title is required"}, default=str)
+
+		database_id = _resolve_database_id(kwargs)
+		if not database_id:
+			return json.dumps(
+				{"success": False, "error": "database_id is required (or set NOTION_DATABASE_ID)"},
+				default=str,
+			)
+
+		title_property = kwargs.get("title_property") or "Name"
+		payload = {
+			"parent": {"database_id": database_id},
+			"properties": {title_property: {"title": [{"text": {"content": title}}]}},
+		}
+
+		data = _make_notion_request("POST", "pages", json_data=payload)
+
+		return json.dumps({"success": True, "results": {"id": data.get("id"), "url": data.get("url")}})
+	except Exception as e:
+		error_msg = f"Notion Create Page Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/trello.py
+++ b/huf/ai/tools/trello.py
@@ -1,0 +1,114 @@
+"""
+Trello integration tools for board/card listing and card creation.
+Uses HUF Integration Settings for Trello credentials (api_key, token).
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "trello"
+TRELLO_API_BASE = "https://api.trello.com/1"
+
+
+def _auth_params():
+	return {
+		"key": require_credential(SERVICE_NAME, "api_key"),
+		"token": require_credential(SERVICE_NAME, "token"),
+	}
+
+
+def _make_trello_request(method: str, endpoint: str, params=None):
+	all_params = _auth_params()
+	all_params.update(params or {})
+
+	response = requests.request(method, f"{TRELLO_API_BASE}/{endpoint}", params=all_params, timeout=30)
+	response.raise_for_status()
+	return response.json() if response.text else {}
+
+
+def handle_list_boards(**kwargs) -> str:
+	"""List Trello boards for the authenticated user."""
+	try:
+		data = _make_trello_request("GET", "members/me/boards", params={"fields": "name,url,closed"})
+
+		boards = [
+			{
+				"id": board.get("id"),
+				"name": board.get("name"),
+				"url": board.get("url"),
+				"closed": board.get("closed"),
+			}
+			for board in data
+		]
+
+		return json.dumps({"success": True, "count": len(boards), "results": boards})
+	except Exception as e:
+		error_msg = f"Trello List Boards Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_list_cards(**kwargs) -> str:
+	"""List cards on a Trello board."""
+	try:
+		board_id = kwargs.get("board_id")
+		if not board_id:
+			return json.dumps({"success": False, "error": "board_id is required"}, default=str)
+
+		data = _make_trello_request(
+			"GET", f"boards/{board_id}/cards", params={"fields": "name,url,due,idList,closed"}
+		)
+
+		cards = [
+			{
+				"id": card.get("id"),
+				"name": card.get("name"),
+				"list_id": card.get("idList"),
+				"due": card.get("due"),
+				"url": card.get("url"),
+				"closed": card.get("closed"),
+			}
+			for card in data
+		]
+
+		return json.dumps({"success": True, "count": len(cards), "results": cards})
+	except Exception as e:
+		error_msg = f"Trello List Cards Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_card(**kwargs) -> str:
+	"""Create a card on a Trello list."""
+	try:
+		list_id = kwargs.get("list_id")
+		name = kwargs.get("name")
+		if not all([list_id, name]):
+			return json.dumps({"success": False, "error": "list_id and name are required"}, default=str)
+
+		params = {"idList": list_id, "name": name}
+		description = kwargs.get("description")
+		if description:
+			params["desc"] = description
+
+		data = _make_trello_request("POST", "cards", params=params)
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {"id": data.get("id"), "name": data.get("name"), "url": data.get("url")},
+			}
+		)
+	except Exception as e:
+		error_msg = f"Trello Create Card Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/zendesk.py
+++ b/huf/ai/tools/zendesk.py
@@ -1,0 +1,127 @@
+"""
+Zendesk integration tools for ticket listing, retrieval, and creation.
+Uses HUF Integration Settings for Zendesk credentials (username=agent email,
+password=API token, company_name=subdomain). Auth follows Zendesk's token
+convention: basic auth with username "<email>/token" and the API token as password.
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "zendesk"
+
+
+def _get_zendesk_config():
+	username = require_credential(SERVICE_NAME, "username")
+	password = require_credential(SERVICE_NAME, "password")
+	company_name = require_credential(SERVICE_NAME, "company_name")
+	base_url = f"https://{company_name}.zendesk.com/api/v2"
+	return base_url, (f"{username}/token", password)
+
+
+def _make_zendesk_request(method: str, endpoint: str, json_data=None, params=None):
+	base_url, auth = _get_zendesk_config()
+
+	response = requests.request(
+		method, f"{base_url}/{endpoint}", auth=auth, json=json_data, params=params, timeout=30
+	)
+	response.raise_for_status()
+	return response.json() if response.text else {}
+
+
+def handle_list_tickets(**kwargs) -> str:
+	"""List Zendesk tickets, optionally filtered by status."""
+	try:
+		data = _make_zendesk_request("GET", "tickets.json")
+
+		status_filter = kwargs.get("status")
+		tickets = []
+		for ticket in data.get("tickets", []):
+			if status_filter and ticket.get("status") != status_filter:
+				continue
+			tickets.append(
+				{
+					"id": ticket.get("id"),
+					"subject": ticket.get("subject"),
+					"status": ticket.get("status"),
+					"priority": ticket.get("priority"),
+					"requester_id": ticket.get("requester_id"),
+					"created_at": ticket.get("created_at"),
+				}
+			)
+
+		return json.dumps({"success": True, "count": len(tickets), "results": tickets})
+	except Exception as e:
+		error_msg = f"Zendesk List Tickets Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_ticket(**kwargs) -> str:
+	"""Get details of a Zendesk ticket by ID."""
+	try:
+		ticket_id = kwargs.get("ticket_id")
+		if not ticket_id:
+			return json.dumps({"success": False, "error": "ticket_id is required"}, default=str)
+
+		data = _make_zendesk_request("GET", f"tickets/{ticket_id}.json")
+		ticket = data.get("ticket", {})
+
+		ticket_data = {
+			"id": ticket.get("id"),
+			"subject": ticket.get("subject"),
+			"description": ticket.get("description"),
+			"status": ticket.get("status"),
+			"priority": ticket.get("priority"),
+			"requester_id": ticket.get("requester_id"),
+			"assignee_id": ticket.get("assignee_id"),
+			"created_at": ticket.get("created_at"),
+			"updated_at": ticket.get("updated_at"),
+		}
+
+		return json.dumps({"success": True, "results": ticket_data})
+	except Exception as e:
+		error_msg = f"Zendesk Get Ticket Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_ticket(**kwargs) -> str:
+	"""Create a Zendesk ticket."""
+	try:
+		subject = kwargs.get("subject")
+		comment = kwargs.get("comment")
+		if not all([subject, comment]):
+			return json.dumps({"success": False, "error": "subject and comment are required"}, default=str)
+
+		ticket_payload = {"subject": subject, "comment": {"body": comment}}
+		priority = kwargs.get("priority")
+		if priority:
+			ticket_payload["priority"] = priority
+
+		data = _make_zendesk_request("POST", "tickets.json", json_data={"ticket": ticket_payload})
+		ticket = data.get("ticket", {})
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {
+					"id": ticket.get("id"),
+					"subject": ticket.get("subject"),
+					"status": ticket.get("status"),
+				},
+			}
+		)
+	except Exception as e:
+		error_msg = f"Zendesk Create Ticket Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/ai/tools/zoom.py
+++ b/huf/ai/tools/zoom.py
@@ -1,0 +1,146 @@
+"""
+Zoom integration tools for meeting listing, retrieval, and creation.
+Uses HUF Integration Settings for Zoom Server-to-Server OAuth credentials
+(account_id, client_id, client_secret). Access tokens are cached in the
+Frappe cache until shortly before they expire.
+"""
+
+import json
+
+import frappe
+import requests
+
+from huf.ai.tools.credentials import require_credential, update_last_error
+
+logger = frappe.logger("huf")
+
+SERVICE_NAME = "zoom"
+ZOOM_OAUTH_URL = "https://zoom.us/oauth/token"
+ZOOM_API_BASE = "https://api.zoom.us/v2"
+_TOKEN_CACHE_KEY = "zoom_s2s_access_token"
+
+
+def _get_access_token() -> str:
+	cached = frappe.cache().get_value(_TOKEN_CACHE_KEY)
+	if cached:
+		return cached
+
+	account_id = require_credential(SERVICE_NAME, "account_id")
+	client_id = require_credential(SERVICE_NAME, "client_id")
+	client_secret = require_credential(SERVICE_NAME, "client_secret")
+
+	response = requests.post(
+		ZOOM_OAUTH_URL,
+		params={"grant_type": "account_credentials", "account_id": account_id},
+		auth=(client_id, client_secret),
+		timeout=30,
+	)
+	response.raise_for_status()
+	data = response.json()
+
+	access_token = data.get("access_token")
+	if not access_token:
+		raise ValueError("Zoom OAuth response did not include an access_token")
+
+	expires_in = int(data.get("expires_in") or 3600)
+	frappe.cache().set_value(_TOKEN_CACHE_KEY, access_token, expires_in_sec=max(expires_in - 60, 60))
+	return access_token
+
+
+def _make_zoom_request(method: str, endpoint: str, json_data=None, params=None):
+	headers = {"Authorization": f"Bearer {_get_access_token()}", "Content-Type": "application/json"}
+
+	response = requests.request(
+		method, f"{ZOOM_API_BASE}/{endpoint}", headers=headers, json=json_data, params=params, timeout=30
+	)
+	response.raise_for_status()
+	return response.json() if response.text else {}
+
+
+def handle_list_meetings(**kwargs) -> str:
+	"""List scheduled Zoom meetings for the authenticated user."""
+	try:
+		data = _make_zoom_request("GET", "users/me/meetings", params={"type": "scheduled"})
+
+		meetings = []
+		for meeting in data.get("meetings", []):
+			meetings.append(
+				{
+					"id": meeting.get("id"),
+					"topic": meeting.get("topic"),
+					"start_time": meeting.get("start_time"),
+					"duration": meeting.get("duration"),
+					"join_url": meeting.get("join_url"),
+				}
+			)
+
+		return json.dumps({"success": True, "count": len(meetings), "results": meetings})
+	except Exception as e:
+		error_msg = f"Zoom List Meetings Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_get_meeting(**kwargs) -> str:
+	"""Get details of a Zoom meeting by ID."""
+	try:
+		meeting_id = kwargs.get("meeting_id")
+		if not meeting_id:
+			return json.dumps({"success": False, "error": "meeting_id is required"}, default=str)
+
+		data = _make_zoom_request("GET", f"meetings/{meeting_id}")
+
+		meeting_data = {
+			"id": data.get("id"),
+			"topic": data.get("topic"),
+			"agenda": data.get("agenda"),
+			"start_time": data.get("start_time"),
+			"duration": data.get("duration"),
+			"timezone": data.get("timezone"),
+			"join_url": data.get("join_url"),
+			"host_email": data.get("host_email"),
+		}
+
+		return json.dumps({"success": True, "results": meeting_data})
+	except Exception as e:
+		error_msg = f"Zoom Get Meeting Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)
+
+
+def handle_create_meeting(**kwargs) -> str:
+	"""Create a scheduled (or instant) Zoom meeting."""
+	try:
+		topic = kwargs.get("topic")
+		if not topic:
+			return json.dumps({"success": False, "error": "topic is required"}, default=str)
+
+		start_time = kwargs.get("start_time")
+		payload = {
+			"topic": topic,
+			"type": 2 if start_time else 1,  # 2 = scheduled, 1 = instant
+			"duration": int(kwargs.get("duration") or 30),
+		}
+		if start_time:
+			payload["start_time"] = start_time
+
+		data = _make_zoom_request("POST", "users/me/meetings", json_data=payload)
+
+		return json.dumps(
+			{
+				"success": True,
+				"results": {
+					"id": data.get("id"),
+					"topic": data.get("topic"),
+					"join_url": data.get("join_url"),
+					"start_url": data.get("start_url"),
+				},
+			}
+		)
+	except Exception as e:
+		error_msg = f"Zoom Create Meeting Error: {e!s}"
+		logger.warning(error_msg)
+		update_last_error(SERVICE_NAME, error_msg)
+		return json.dumps({"success": False, "error": str(e)}, default=str)

--- a/huf/huf/doctype/integration_settings/integration_settings.py
+++ b/huf/huf/doctype/integration_settings/integration_settings.py
@@ -3,6 +3,7 @@
 
 import secrets
 from datetime import datetime, timedelta
+import json
 
 import frappe
 from frappe.model.document import Document
@@ -22,12 +23,51 @@ class IntegrationSettings(Document):
 		"""Validate that credentials are provided when service is set."""
 		if not self.service:
 			frappe.throw("Integration Service is required")
-		
+
+		self._prune_empty_optional_credentials()
+		self._validate_required_credentials()
+
 		# Ensure at least one credential is provided
 		if not self.credentials:
 			frappe.throw("At least one credential is required")
 
 		self._ensure_telegram_webhook_config()
+
+	def _get_service_credential_schema(self) -> list[dict]:
+		raw = frappe.db.get_value("Integration Service", self.service, "required_credentials")
+		if not raw:
+			return []
+		try:
+			return json.loads(raw) if isinstance(raw, str) else raw
+		except (TypeError, json.JSONDecodeError):
+			return []
+
+	@staticmethod
+	def _credential_has_value(cred) -> bool:
+		if cred.value:
+			return True
+		if cred.name:
+			return bool(cred.get_password("value", raise_exception=False))
+		return False
+
+	def _prune_empty_optional_credentials(self):
+		schema = {item.get("key"): item for item in self._get_service_credential_schema() if item.get("key")}
+		pruned = []
+		for cred in self.credentials:
+			required = schema.get(cred.key, {}).get("required", True)
+			if required or self._credential_has_value(cred):
+				pruned.append(cred)
+		self.credentials = pruned
+
+	def _validate_required_credentials(self):
+		present = {cred.key for cred in self.credentials if self._credential_has_value(cred)}
+		missing = [
+			item.get("label") or item["key"]
+			for item in self._get_service_credential_schema()
+			if item.get("key") and item.get("required", True) and item["key"] not in present
+		]
+		if missing:
+			frappe.throw(f"Missing required credentials: {', '.join(missing)}")
 	
 	def on_update(self):
 		"""Optional auto-setup of Telegram webhook after save.

--- a/huf/install.py
+++ b/huf/install.py
@@ -1027,10 +1027,78 @@ def register_integration_services():
 			"category": "Project Management",
 			"description": "Jira issue tracking and project management",
 			"required_credentials": [
-				{"key": "server_url", "label": "Jira Server URL", "required": True},
-				{"key": "username", "label": "Username", "required": True},
-				{"key": "token", "label": "API Token", "required": True}
-			]
+				{"key": "base_url", "label": "Jira Base URL", "required": True},
+				{"key": "email", "label": "Account Email", "required": True},
+				{"key": "api_token", "label": "API Token", "required": True},
+			],
+		},
+		{
+			"service_name": "linear",
+			"category": "Project Management",
+			"description": "Linear issue tracking and project management",
+			"required_credentials": [
+				{"key": "api_key", "label": "Linear API Key", "required": True},
+			],
+		},
+		{
+			"service_name": "clickup",
+			"category": "Project Management",
+			"description": "ClickUp task and project management",
+			"required_credentials": [
+				{"key": "api_key", "label": "ClickUp API Key", "required": True},
+			],
+		},
+		{
+			"service_name": "trello",
+			"category": "Project Management",
+			"description": "Trello boards, lists, and cards",
+			"required_credentials": [
+				{"key": "api_key", "label": "Trello API Key", "required": True},
+				{"key": "token", "label": "Trello Token", "required": True},
+			],
+		},
+		{
+			"service_name": "notion",
+			"category": "Project Management",
+			"description": "Notion pages and database queries",
+			"required_credentials": [
+				{"key": "api_key", "label": "Notion Integration Token", "required": True},
+				{
+					"key": "database_id",
+					"label": "Default Database ID",
+					"required": False,
+					"secret": False,
+					"description": "Optional default database when tools omit database_id",
+				},
+			],
+		},
+		{
+			"service_name": "zendesk",
+			"category": "Other",
+			"description": "Zendesk support ticket management",
+			"required_credentials": [
+				{"key": "username", "label": "Agent Email", "required": True},
+				{"key": "password", "label": "API Token", "required": True},
+				{"key": "company_name", "label": "Zendesk Subdomain", "required": True},
+			],
+		},
+		{
+			"service_name": "calcom",
+			"category": "Other",
+			"description": "Cal.com scheduling and bookings",
+			"required_credentials": [
+				{"key": "api_key", "label": "Cal.com API Key", "required": True},
+			],
+		},
+		{
+			"service_name": "zoom",
+			"category": "Communication",
+			"description": "Zoom meeting management via Server-to-Server OAuth",
+			"required_credentials": [
+				{"key": "account_id", "label": "Zoom Account ID", "required": True},
+				{"key": "client_id", "label": "Zoom Client ID", "required": True},
+				{"key": "client_secret", "label": "Zoom Client Secret", "required": True},
+			],
 		},
 		
 		# Google Workspace Tools

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -17,3 +17,4 @@ huf.patches.v1.fix_agent_message_status
 huf.patches.v1.sync_data_table_permissions
 huf.patches.v1.add_frappe_cloud_service
 huf.patches.v1.backfill_tool_service_links
+huf.patches.v1.add_project_management_integration_services

--- a/huf/patches/v1/add_project_management_integration_services.py
+++ b/huf/patches/v1/add_project_management_integration_services.py
@@ -1,0 +1,11 @@
+def execute():
+	"""Register Linear, ClickUp, Trello, Notion, Zendesk, Cal.com, and Zoom services.
+
+	The integration tool handlers and Agent Tool Function sync shipped in
+	feat/integration-tools-completion, but `register_integration_services()` was
+	not updated at the same time. Existing sites therefore have the tools in the
+	database while the Integration Catalog UI has nothing to connect against.
+	"""
+	from huf.install import register_integration_services
+
+	register_integration_services()


### PR DESCRIPTION
## Summary

Extends the integration tool catalog with eight new services: **Jira, Linear, ClickUp, Trello, Notion, Zendesk, Cal.com, and Zoom**. Each gets a focused set of read/write tools (search or list, get, and create — plus a comment action for Jira) so agents can search issues/tasks/tickets, fetch details, and create new ones through each service's native API.

This is an initial pass, not full API coverage for any of these services — no update/delete/webhook support yet, and some fields (custom Jira fields, Notion property types beyond title, etc.) are intentionally out of scope for now. Follow-ups welcome.

- `huf/ai/tools/{jira,linear,clickup,trello,notion,zendesk,calcom,zoom}.py` — new tool modules, following the existing `github.py`/`google_places.py` pattern (`require_credential`/`update_last_error`, JSON envelope responses, `requests` for HTTP).
- `huf/ai/tools/_registry.py` — registers 25 new tools across `Project Management Tools`, `Scheduling Tools`, `Support Tools`, and `Communication Tools` (Zoom) categories, wired into `ALL_INTEGRATION_TOOLS`.
- `huf/ai/tools/credentials.py` — adds the Jira credential-key pattern (`JIRA_BASE_URL`/`JIRA_EMAIL`/`JIRA_API_TOKEN`); the other seven already had credential schemas defined.
- Docs: `doc/features/tools/builtin-tools.md` catalog updated with the new categories/tools (internal docs repo, not part of this diff).

Zoom uses Server-to-Server OAuth (account_credentials grant) with the access token cached via `frappe.cache()`.

## Test plan

- [x] 71 new unit tests (`huf/ai/tests/test_{jira,linear,clickup,trello,notion,zendesk,calcom,zoom}_tools.py`), all HTTP calls and credential lookups mocked — no live accounts required.
- [x] Ran alongside the existing tool-test suite (`test_google_places_tools.py`, `test_serp_tools.py`, `test_memory_tools.py`, `test_tool_registry_*`) with no regressions.
- [x] `ruff format` applied to match repo style.
- [ ] Not yet exercised against live provider accounts in a running bench — credentials-dependent, mocked coverage only. Would appreciate a real-bench smoke test before merge if a reviewer has test accounts handy.