### PR TITLE
refactor(sidebar): regroup nav into Build/Library/Monitor, flatten Settings

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -70,45 +70,14 @@ const buildNavItems = [
     capability: "agent.use",
   },
   {
-    title: "Prompts",
-    url: "/prompts",
-    icon: FileText,
-    capability: "agent.use",
-  },
-  {
     title: "Flows",
     url: "/flows",
     icon: Workflow,
     capability: "flows.use",
     badge: "Experimental",
   },
-]
-
-/**
- * Knowledge surfaces live in a flat "Know" label group, matching Build and
- * Operate: Tables for structured/relational data, Sources for retrieval
- * knowledge stores backed by any vector/FTS backend (RAG). Future source
- * types (Files, Repos, Drives) nest here as additional items.
- */
-const knowNavItems = [
   {
-    title: "Tables",
-    url: "/data",
-    icon: Database,
-    capability: [
-      "data.tables.manage",
-      "data.records.view_own",
-      "data.records.view_all",
-    ],
-  },
-  {
-    title: "Sources",
-    url: "/knowledge",
-    icon: BookOpen,
-    capability: "agent.use",
-  },
-  {
-    title: "Memory",
+    title: "Intelligence",
     url: "/memory",
     icon: Brain,
     capability: "agent.use",
@@ -120,6 +89,36 @@ const knowNavItems = [
     icon: Sparkles,
     capability: "agent.use",
     badge: "Experimental",
+  },
+]
+
+/**
+ * Library surfaces live in a flat "Library" label group: Prompts for reusable
+ * prompt templates, Sources for retrieval knowledge stores backed by any
+ * vector/FTS backend (RAG), Tables for structured/relational data.
+ */
+const libraryNavItems = [
+  {
+    title: "Prompts",
+    url: "/prompts",
+    icon: FileText,
+    capability: "agent.use",
+  },
+  {
+    title: "Sources",
+    url: "/knowledge",
+    icon: BookOpen,
+    capability: "agent.use",
+  },
+  {
+    title: "Tables",
+    url: "/data",
+    icon: Database,
+    capability: [
+      "data.tables.manage",
+      "data.records.view_own",
+      "data.records.view_all",
+    ],
   },
 ]
 
@@ -146,36 +145,15 @@ const operateNavItems = [
  */
 const settingsNavGroups = [
   {
-    label: "General",
     items: [
       { title: "General", url: "/settings/general", icon: SlidersHorizontal, capability: null },
-    ],
-  },
-  {
-    label: "Intelligence",
-    items: [
       { title: "AI Providers", url: "/providers", icon: Plug, capability: "system.providers.manage" },
       { title: "Models", url: "/models", icon: Layers, capability: "system.providers.manage" },
-    ],
-  },
-  {
-    label: "Runtime",
-    items: [
-      { title: "Code Execution", url: "/execution-profiles", icon: SquareChevronRight, capability: "agent.use" },
-      { title: "SSH Connections", url: "/ssh-connections", icon: ChevronsLeftRightEllipsis, capability: "agent.use" },
-    ],
-  },
-  {
-    label: "Connectivity",
-    items: [
+      { title: "MCP Servers", url: "/mcp", icon: Server, capability: "system.mcp.manage" },
       { title: "Gateways", url: "/gateways", icon: GlobeLock, capability: "system.integrations.manage" },
       { title: "Integrations", url: "/integrations", icon: Link2, capability: "system.integrations.manage" },
-      { title: "MCP Servers", url: "/mcp", icon: Server, capability: "system.mcp.manage" },
-    ],
-  },
-  {
-    label: "Access",
-    items: [
+      { title: "Code Execution", url: "/execution-profiles", icon: SquareChevronRight, capability: "agent.use" },
+      { title: "SSH Connections", url: "/ssh-connections", icon: ChevronsLeftRightEllipsis, capability: "agent.use" },
       {
         title: "Members",
         url: "/members",
@@ -228,7 +206,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	const buildItems = filterItemsByCapability(buildNavItems).map((item) =>
 		item.title === "Agents" ? { ...item, count: agentCount } : item
 	)
-	const knowledgeItems = filterItemsByCapability(knowNavItems)
+	const libraryItems = filterItemsByCapability(libraryNavItems)
 	const operateItems = filterItemsByCapability(operateNavItems)
   const settingsGroups = settingsNavGroups
     .map((group) => ({
@@ -269,7 +247,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               </SidebarMenuItem>
             </SidebarMenu>
             {settingsGroups.map((group) => (
-              <NavMain key={group.label} items={group.items} label={group.label} />
+              <NavMain key={group.label ?? "settings"} items={group.items} label={group.label} />
             ))}
           </>
         ) : (
@@ -277,8 +255,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             {dashboardItems.length > 0 && <NavMain items={dashboardItems} />}
             {useItems.length > 0 && <NavMain items={useItems} label="Use" />}
             {buildItems.length > 0 && <NavMain items={buildItems} label="Build" />}
-            {knowledgeItems.length > 0 && <NavMain items={knowledgeItems} label="Know" />}
-            {operateItems.length > 0 && <NavMain items={operateItems} label="Operate" />}
+            {libraryItems.length > 0 && <NavMain items={libraryItems} label="Library" />}
+            {operateItems.length > 0 && <NavMain items={operateItems} label="Monitor" />}
           </>
         )}
       </SidebarContent>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Plug, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, Layers, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Plug, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, Layers, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -44,7 +44,7 @@ const dashboardNavItems = [
 
 /**
  * The "Use" side of the platform: end-user HUF Apps discovered from
- * installed provider apps. Build/Operate/People remain the manage side.
+ * installed provider apps. Build/Library/Monitor remain the manage side.
  */
 const useNavItems = [
   {
@@ -143,7 +143,7 @@ const operateNavItems = [
  * primary navigation so the longer administration list never pushes the main
  * destinations off-screen.
  */
-const settingsNavGroups = [
+const settingsNavGroups: Array<{ label?: string; items: Array<{ title: string; url: string; icon: LucideIcon; capability: string | string[] | null }> }> = [
   {
     items: [
       { title: "General", url: "/settings/general", icon: SlidersHorizontal, capability: null },

--- a/frontend/src/layouts/UnifiedHeader.tsx
+++ b/frontend/src/layouts/UnifiedHeader.tsx
@@ -46,7 +46,7 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
     if (path.startsWith('/execution-profiles')) return 'Code Execution';
     if (path.startsWith('/ssh-connections')) return 'SSH Connections';
     if (path.startsWith('/apps')) return 'Apps';
-    if (path.startsWith('/memory')) return 'Memory';
+    if (path.startsWith('/memory')) return 'Intelligence';
     if (path.startsWith('/skills')) return 'Skills';
     if (path.startsWith('/ssh')) return 'SSH Execution';
     return 'HufAI';

--- a/frontend/src/pages/MemoryPage.tsx
+++ b/frontend/src/pages/MemoryPage.tsx
@@ -34,7 +34,7 @@ export default function MemoryPage() {
 
   return (
     <PageFrame
-      title="Memory"
+      title="Intelligence"
       badge={<ExperimentalBadge />}
       subtitle="Facts, preferences, and context your AI agents have learned from conversations."
     >

--- a/frontend/src/pages/MemoryPolicyFormPageWrapper.tsx
+++ b/frontend/src/pages/MemoryPolicyFormPageWrapper.tsx
@@ -28,7 +28,7 @@ function MemoryPolicyFormPageWrapper() {
   }, [id, isNew]);
 
   const breadcrumbs = [
-    { label: 'Memory', href: '/memory' },
+    { label: 'Intelligence', href: '/memory' },
     { label: 'Policies', href: '/memory#policies' },
     { label: policyLabel },
   ];


### PR DESCRIPTION
## Summary

First low-risk slice of a broader sidebar IA cleanup (full audit in `workspace/HUF_IA_AUDIT.md`, sections 4–7). This PR only touches nav labels and grouping in `app-sidebar.tsx` — **no routes/URLs change**, so it ships with zero redirect risk.

- **New "Library" group** — Prompts, Sources (Knowledge), and Tables move here from "Build"/"Know". These are org-wide content libraries (dept/category/purpose taxonomy), not per-agent build inputs, so they shouldn't live under "Build" or be implied to be agent-owned.
- **Memory → "Intelligence"**, moved into "Build" — it's agent learning/context behavior, and the name is now consistent across the sidebar, breadcrumbs (`MemoryPolicyFormPageWrapper.tsx`), header title (`UnifiedHeader.tsx`), and page title (`MemoryPage.tsx`).
- **"Operate" → "Monitor"** — Executions and Playground are observational surfaces, not action/control surfaces; the old name implied more agency than they have.
- **Settings flattened** — 5 labeled sub-groups (General/Intelligence/Runtime/Connectivity/Access) collapse into one flat list. Sub-groups of 1–2 items were adding a header line without helping scanning; MCP Servers also moves earlier in the list, ahead of Gateways/Integrations.

## Not in this PR (tracked separately in the audit doc)

- Orphan route cleanup/redirects (`/users`, `/roles`, `/integration-services`, `/ssh` vs `/ssh-connections`, `/settings` vs `/settings/general`)
- Dead code removal (`pages/SettingsPage.tsx`)
- Members/Users/Roles access-page merge (deferred — needs permission-model documentation first per Opus review)
- In-agent-editor pickers for MCP Servers / Knowledge Sources attachment
- Any decision on the 3 parallel chat implementations
- Top-block reorder (Hub/Chat/Apps/Dashboard) suggested in the audit's §7 sketch — current PR keeps Hub/Dashboard, then a separate "Use" group (Apps/Chat), unchanged from today; flagged as an open item, not silently dropped
- **AI Providers + Models merge** — the audit (§4.1) proposed merging these into one settings destination since they're virtually always configured as a pair. That did NOT make it into this PR; Settings still lists them as two separate flat items. This was dropped without being flagged when the implementation-ready spec was compiled — caught during manual testing, not a deliberate call. A real merge is a page-level change (combining `AiProvidersPage.tsx`/`ModelsPage.tsx` or nesting Models under a provider), which doesn't fit this PR's "labels/grouping only, zero route risk" scope — treat as a genuine follow-up, not something silently completed or abandoned

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` passes clean (verified via symlinked `node_modules` from a sibling checkout — note: `tsc --noEmit -p .` against the root solution tsconfig falsely reports clean regardless of errors since it has no `--build` and an empty `files: []`; always check against `tsconfig.app.json` directly for this repo)
- [ ] Manual smoke test in a running bench: confirm sidebar renders Build/Library/Monitor groups correctly, Settings renders as one flat list, capability-based filtering still hides items correctly for a non-admin role
- [ ] Confirm breadcrumb/header title on `/memory` and `/memory/policies/:id` reads "Intelligence" everywhere

## Review history

An Opus-model plan-vs-implementation review (before the fix commit) caught a real bug this description's earlier "typecheck passes" claim had missed: the flattened `settingsNavGroups` literal had no `label` key, so `group.label` in the render map was a genuine TS2339 compile error. Root cause of the false-clean check: `tsc --noEmit -p .` was being run against the root solution-style tsconfig (`files: []`, only `references`), which no-ops without `--build` instead of actually type-checking anything. Fixed by explicitly typing `settingsNavGroups` and re-verifying against `tsconfig.app.json`, which now reports 0 errors. Also fixed a stale comment referencing the retired "Operate"/"People" group names.
