### PR TITLE
feat(knowledge): S3 integration + bulk ingestion (Upload/Directory/S3/SFTP)

### DIFF
--- a/HUF_BULK_INGESTION_EXECUTION_PLAN.md
+++ b/HUF_BULK_INGESTION_EXECUTION_PLAN.md
@@ -1,0 +1,189 @@
+# Bulk Ingestion — Detailed Execution Plan (V1: Upload/Directory/SFTP + S3-as-Integration)
+
+Companion to [`HUF_BULK_INGESTION_PLAN.md`](HUF_BULK_INGESTION_PLAN.md) (the high-level architecture). This document is the file-by-file build order. It covers three things end to end:
+
+1. **S3 as a first-class HUF Integration** — so any agent can call `s3_list_objects` / `s3_get_object` / `s3_search_objects` as a tool, exactly like `google_drive.py`, `jira.py`, etc. This is built first because bulk-ingestion's S3 source reuses its credentials and client code — one S3 setup powers both.
+2. **Bulk Ingestion** itself (new `Ingestion Job` machinery + Upload/Directory/S3/SFTP sources), built on top of the existing single-document pipeline (`process_knowledge_input()`).
+3. **SFTP as a bulk source** (Part D) — reusing the existing `SSH Connection` credential doctype, via a dedicated `paramiko` SFTP channel rather than the existing `run_ssh_command` exec tool (which caps output at 64-128KB and is unsuitable for file transfer — see Part D for why).
+
+Every HUF integration already follows one fixed pattern (confirmed against `google_drive.py` and the Jira/Notion/ClickUp/Linear/Zendesk/Cal.com/Zoom tools added in `e253a2f9`): an `Integration Service` DocType record (seeded in `huf/install.py`) declares required credentials → a module in `huf/ai/tools/` reads them via `require_credential()` → functions are registered in `huf/ai/tools/_registry.py` → `ALL_INTEGRATION_TOOLS` is synced into `Agent Tool Function` records that agents can attach. The frontend's credential UI (`CredentialsTab.tsx`) is entirely schema-driven off `Integration Service.required_credentials`, so it needs **no new frontend code** for the integration itself.
+
+---
+
+## Part A — S3 as an Integration (agent tool)
+
+### A1. Add the dependency
+**File: `pyproject.toml`** (same section as the existing `llama-index-vector-stores-*` pins, line ~21-32)
+- Add `boto3>=1.34.0`.
+- No other backend depends on this yet — grep confirmed `boto3` doesn't currently appear anywhere in the repo.
+
+### A2. Seed the Integration Service record
+**File: `huf/install.py`** — function `register_integration_services()` (starts at line 1004; `services` list starts at line 1012, right after the existing `serpapi` entry at line 1112-1119)
+- Add a new dict:
+  ```python
+  {
+      "service_name": "aws_s3",
+      "category": "Cloud",   # matches the existing enum on Integration Service (line ~10-19 of integration_service.json)
+      "description": "Amazon S3 object storage — list, read, and search objects in a bucket",
+      "required_credentials": [
+          {"key": "access_key_id", "label": "AWS Access Key ID", "required": True},
+          {"key": "secret_access_key", "label": "AWS Secret Access Key", "required": True},
+          {"key": "region", "label": "AWS Region", "required": True},
+      ],
+  }
+  ```
+- Dependency: none (pure data, this function already runs idempotently on `after_install`/`after_migrate`).
+- No DocType schema change needed — `Integration Service`, `Integration Settings`, `Integration Credential` are all generic already.
+
+### A3. Write the tool module
+**New file: `huf/ai/tools/s3.py`** — mirror `huf/ai/tools/google_drive.py`'s shape exactly (imports `json`, `frappe`, `require_credential`/`update_last_error` from `huf/ai/tools/credentials.py`), but use `boto3` instead of raw `requests`:
+- `_get_client()` — builds a `boto3.client("s3", aws_access_key_id=..., aws_secret_access_key=..., region_name=...)` using `require_credential("aws_s3", "access_key_id")` etc. (same three-line pattern as `google_drive.py:11-16`).
+- `handle_list_buckets(**kwargs)` — `client.list_buckets()`, return `{"success": True, "results": [...]}`.
+- `handle_list_objects(**kwargs)` — params: `bucket` (required), `prefix`, `limit` (default 50); calls `client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=limit)`; returns key/size/last_modified/etag per object. **This same call, with pagination, becomes the bulk-ingestion scanner in Part B — do not duplicate the listing logic, factor it into a shared `list_objects_page(client, bucket, prefix, continuation_token, page_size)` helper in this file that both the agent tool and the bulk scanner import.**
+- `handle_get_object_metadata(**kwargs)` — params: `bucket`, `key`; `client.head_object(...)`.
+- `handle_search_objects(**kwargs)` — params: `bucket`, `query`; client-side substring filter over `list_objects_v2` pages (S3 has no server-side full-text search) — same shape as `google_drive.py`'s `handle_search_files`.
+- Every handler wrapped in try/except calling `update_last_error("aws_s3", str(e))` on failure, matching the existing pattern.
+- Dependency: A1 (boto3), A2 (credential lookups will raise `ValueError` until the service exists, same as any other tool before it's configured — acceptable, matches existing behavior).
+
+### A4. Register the tools
+**File: `huf/ai/tools/_registry.py`**
+- Add near the other tool-list constants (pattern at line 705-730 for `GOOGLE_DRIVE_TOOLS`):
+  ```python
+  S3_TOOLS = [
+      {"tool_name": "s3_list_buckets", "description": "List S3 buckets accessible with the configured AWS credentials.", "function_path": "huf.ai.tools.s3.handle_list_buckets", "category": "Cloud", "parameters": []},
+      {"tool_name": "s3_list_objects", "description": "List objects in an S3 bucket, optionally filtered by prefix.", "function_path": "huf.ai.tools.s3.handle_list_objects", "category": "Cloud", "parameters": [_p("bucket", required=True), _p("prefix"), _p("limit", type="integer", description="Max objects (default 50)")]},
+      {"tool_name": "s3_get_object_metadata", "description": "Get metadata (size, type, last modified) of an S3 object.", "function_path": "huf.ai.tools.s3.handle_get_object_metadata", "category": "Cloud", "parameters": [_p("bucket", required=True), _p("key", required=True)]},
+      {"tool_name": "s3_search_objects", "description": "Search for objects in an S3 bucket by key/name substring.", "function_path": "huf.ai.tools.s3.handle_search_objects", "category": "Cloud", "parameters": [_p("bucket", required=True), _p("query", required=True)]},
+  ]
+  ```
+- Append `+ _with_service(S3_TOOLS, "aws_s3")` to the `ALL_INTEGRATION_TOOLS` tuple (currently ends at line 1854-1860, alongside `GOOGLE_DRIVE_TOOLS`/`GOOGLE_MEET_TOOLS`).
+- Dependency: A3 (function paths must resolve via `importlib` when `sync_discovered_tools()` validates them — see `huf/ai/tool_registry.py:413-430`).
+
+### A5. Sync + verify
+- On next `bench migrate` (or manually via `bench execute huf.ai.tool_registry.sync_discovered_tools`), the four `s3_*` tools become `Agent Tool Function` records under category "Cloud", attachable to any agent from the existing tool picker UI — **no frontend work required** for this part.
+- Manual verification: attach `s3_list_objects` to a test agent, configure an `Integration Settings` record for `aws_s3` via the existing Integration Settings UI, ask the agent to list a bucket.
+
+---
+
+## Part B — Bulk Ingestion (Upload / Directory / S3 sources)
+
+Builds on Part A only for the S3 source specifically; Upload and Directory sources have no integration dependency and can ship independently/first if you want to sequence V1 without S3.
+
+### B1. New DocTypes (backend data model)
+**New: `huf/huf/doctype/ingestion_job/ingestion_job.json` + `ingestion_job.py`**
+- Fields: `knowledge_source` (Link), `source_kind` (Select: `Upload`/`Directory`/`S3`/`SFTP`/`Google Drive`), `status` (Select: `Queued`/`Scanning`/`Processing`/`Completed`/`Completed with Errors`/`Failed` — same enum style as `Flow Run`/`Agent Run`), `total_discovered`, `pending`, `processing`, `succeeded`, `failed`, `skipped` (all Int), `started_at`, `finished_at` (Datetime), `error_message` (Small Text), `sync_cursor` (Data — S3 continuation token / Drive pageToken / SFTP directory-queue snapshot, for resumable scans), plus source-kind-specific config fields (`s3_bucket`, `s3_prefix`, `directory_path`, `sftp_connection` (Link to `SSH Connection`), `sftp_root_path`) shown/hidden via `depends_on` like `Knowledge Source`'s existing `chroma_*`/`pgvector_*` sections do.
+- `ingestion_job.py`: whitelisted methods `start()` (enqueues `scan_bulk_source`, see B3) and a `@frappe.whitelist()` `get_progress(name)` reader.
+
+**New: `huf/huf/doctype/ingestion_job_item/ingestion_job_item.json` + `.py`** (child table, `istable: 1`)
+- Fields: `external_path` (Data), `external_checksum` (Data), `size_bytes` (Int), `status` (Select: `Pending`/`Processing`/`Succeeded`/`Failed`/`Skipped`), `knowledge_input` (Link, set once created), `error_message` (Small Text).
+- Dependency: none (new, independent DocTypes). Follows the exact status-enum convention already used by `Flow Run`/`Agent Run`/`Gateway Event`.
+
+### B2. Extend existing DocTypes
+**File: `huf/huf/doctype/knowledge_input/knowledge_input.json`** (+ `.py`)
+- Add fields: `external_source_path` (Data), `external_checksum` (Data), `ingestion_job` (Link, optional — back-reference for traceability).
+- **Do not reuse `source_hash`/`check_duplicate()` for bulk dedup** — that mechanism (`knowledge_input.py:30-56`) hashes the Frappe file URL/text/url string and hard-`frappe.throw()`s on collision, which is correct for the single-input create UI but wrong for bulk sync (re-scanning an unchanged S3 prefix must silently *skip*, not raise). The bulk scanner (B3) checks `external_checksum` against existing `Knowledge Input` rows for the same `knowledge_source` **before** calling `frappe.get_doc().insert()`, so `check_duplicate()` never even fires for legitimately-skipped items.
+- Dependency: none.
+
+**File: `huf/huf/doctype/knowledge_source/knowledge_source.json`**
+- Add `source_kind` Select field (`Manual`/`Upload`/`Directory`/`S3`/`Google Drive`, default `Manual`) next to the existing `configuration_section` fields (line ~1-10 of the field list) — purely descriptive/filtering, the actual per-job config lives on `Ingestion Job` from B1.
+- Dependency: none.
+
+### B3. Bulk ingestion backend package
+**New directory: `huf/ai/knowledge/bulk/`**
+- `huf/ai/knowledge/bulk/__init__.py`
+- `huf/ai/knowledge/bulk/scanners.py`
+  - `scan_upload(job_name)` — reads an already-extracted temp directory (populated by B4's upload handler), walks it with `os.walk`, writes `Ingestion Job Item` rows in batches of ~200 (avoid one giant `.save()`).
+  - `scan_directory(job_name)` — same walk, but rooted at `Ingestion Job.directory_path` on the bench filesystem (admin-only; validate path is under an allow-listed root to avoid path traversal).
+  - `scan_s3(job_name)` — **imports `list_objects_page` from `huf/ai/tools/s3.py`** (the shared helper from A3) and `require_credential` from `credentials.py`, paginating via `continuation_token`, writing `sync_cursor` back onto the `Ingestion Job` after each page so a crashed scan resumes instead of restarting. This is the concrete reuse point requested: **the S3 credentials and boto3 client set up in Part A are the same ones used here** — no separate S3 credential UI for bulk ingestion.
+  - `scan_sftp(job_name)` — see **Part D** below for the full spec; listed here only for placement (same file, same `Ingestion Job.status` lifecycle).
+  - Each scanner sets `Ingestion Job.status = "Scanning"` → updates `total_discovered` incrementally → on completion enqueues `process_ingestion_batches(job_name)`.
+- `huf/ai/knowledge/bulk/orchestrator.py`
+  - `process_ingestion_batches(job_name)` — reads all `Pending` `Ingestion Job Item` rows for the job, splits into chunks of 20-100 (configurable), and for each chunk calls `frappe.enqueue(process_batch, queue="default", items=[...], job_id=f"bulk_batch_{job_name}_{i}")`.
+  - `process_batch(job_name, item_names)` — for each item: skip if `external_checksum` matches an existing `Knowledge Input.external_checksum` under the same source; otherwise create/update a `Knowledge Input` doc (bypassing its `after_insert` auto-enqueue — call **`process_knowledge_input()` directly, in-process**, since we're already inside a worker) and update the `Ingestion Job Item` + `Ingestion Job` counters. On the last batch, set `Ingestion Job.status` to `Completed` or `Completed with Errors`.
+  - Dependency: B1 (doctypes must exist), B2 (new fields), A3 (S3 scanner only).
+
+### B4. Whitelisted API endpoints
+**New file: `huf/ai/knowledge/bulk/api.py`** (all `@frappe.whitelist()`)
+- `start_upload_import(knowledge_source, files)` — receives already-uploaded Frappe `File` docnames (frontend uploads via Frappe's standard multi-file upload first, same as any other Attach field), extracts any `.zip` among them to a private temp dir under `frappe.get_site_path("private", "files", "bulk_import", job_name)`, creates the `Ingestion Job` (`source_kind="Upload"`), enqueues `scan_upload`.
+- `start_directory_import(knowledge_source, directory_path)` — creates `Ingestion Job` (`source_kind="Directory"`), enqueues `scan_directory`.
+- `start_s3_import(knowledge_source, bucket, prefix)` — creates `Ingestion Job` (`source_kind="S3"`), enqueues `scan_s3`.
+- `start_sftp_import(knowledge_source, sftp_connection, root_path)` — creates `Ingestion Job` (`source_kind="SFTP"`), enqueues `scan_sftp`. `sftp_connection` is an existing `SSH Connection` docname — no new credential form.
+- `get_job_progress(job_name)` — thin wrapper returning the `Ingestion Job` counters + a page of `Ingestion Job Item` rows (for the error list in the UI).
+- Dependency: B1, B3.
+
+### B5. Backend tests
+**New: `huf/ai/knowledge/tests/test_bulk_ingestion.py`** — mirrors existing test style in `huf/ai/knowledge/tests/`. Cover: scanner pagination/cursor resume, checksum skip logic, batch counter updates, S3 scanner using a mocked `boto3` client (same mocking style as `huf/ai/tests/test_*_tools.py` from the Jira/Notion commit).
+
+---
+
+## Part C — Frontend
+
+### C1. API layer
+**New file: `frontend/src/services/bulkIngestionApi.ts`** (sibling to `knowledgeApi.ts`, same fetch/error-handling conventions)
+- `startUploadImport(knowledgeSource, fileUrls)`, `startDirectoryImport(knowledgeSource, path)`, `startS3Import(knowledgeSource, bucket, prefix)`, `getJobProgress(jobName)` — thin wrappers over B4's whitelisted methods.
+- Dependency: B4 must exist (or stub during parallel FE/BE work).
+
+**Edit: `frontend/src/types/integration.types.ts`** — no changes needed (S3 credentials are generic `Integration Credential` rows, already typed).
+**New types file (or extend `frontend/src/types/knowledge.types.ts` if it exists, else add to `knowledgeApi.ts`)**: `IngestionJobDoc`, `IngestionJobItemDoc` matching B1's fields.
+
+### C2. Bulk import UI
+**New file: `frontend/src/components/knowledge/KnowledgeBulkImportModal.tsx`** — built directly on the existing template `frontend/src/components/data-table/BulkImportModal.tsx` (drag-drop, upload progress, 2s-interval polling with a `TERMINAL_STATUSES` set, error summary list). Differences from the CSV template:
+- A source-kind picker (Upload / Directory / S3 / SFTP) as a first step — Directory, S3, and SFTP show a small config form instead of a dropzone (path input; bucket+prefix inputs; SFTP connection dropdown + root path input — the SFTP dropdown lists existing `SSH Connection` records via a simple Link-field-style fetch, no new credential form). Google Drive is out of scope for V1 per the phasing in the high-level plan, so the picker only offers Upload/Directory/S3/SFTP for now, with the component structured so a fifth option is a one-line addition later.
+- On submit, calls the matching `bulkIngestionApi.ts` function instead of the CSV import endpoint, then polls `getJobProgress` and renders counts (`succeeded/failed/skipped/pending`) using the existing `frontend/src/components/ui/progress.tsx` bar plus a scrollable error list sourced from `Ingestion Job Item` rows with `status="Failed"`.
+- Dependency: C1.
+
+### C3. Wire the entry point
+**Edit: `frontend/src/pages/KnowledgeSourcesPage.tsx`** — add a "Bulk Import" button next to the existing per-source actions, opening `KnowledgeBulkImportModal` scoped to that `Knowledge Source`.
+**Edit: `frontend/src/pages/KnowledgeSourceFormPage.tsx`** — optionally surface the same entry point from within a source's detail/status tab (`StatusTab.tsx`) so users can bulk-import into a source they're already configuring, without leaving the page.
+- Dependency: C2.
+
+### C4. S3 credential UI
+No new frontend code — once A2 seeds the `aws_s3` Integration Service, it appears automatically in `ServiceCatalogModal.tsx` and gets a generic credential form via `CredentialsTab.tsx` (schema-driven off `required_credentials`), exactly like every other integration. Verify this renders correctly (3 fields: access key id / secret access key / region) as a manual QA step, not a code change.
+
+---
+
+## Part D — SFTP as a bulk source
+
+**Why not reuse the existing SSH tool as-is:** `huf/ai/tools/ssh_execution.py`'s `run_ssh_command` is a one-shot remote **exec** tool — no PTY, per-call human-approval workflow, and output hard-capped at `DEFAULT_STDOUT_MAX_BYTES = 65536` / `DEFAULT_COMBINED_OUTPUT_MAX_BYTES = 131072` (`ssh_execution.py:33-38`). Piping `scp`/`cat` through it would silently truncate almost any real document and would fire an approval prompt per file, which doesn't work for a job touching thousands of files. It is out of scope to change.
+
+**What *is* reusable:** the `SSH Connection` DocType (`huf/huf/doctype/ssh_connection/ssh_connection.json`) already stores `host`, `port`, `username`, `auth_method` (`Password`/`Private Key`), `password`/`private_key`/`private_key_passphrase`, and strict pinned host-key verification (`host_key_fingerprint`, `host_key_type`) — solid, already-encrypted credential storage. And `paramiko` is already a dependency (used by `ssh_execution.py`). `paramiko.SSHClient.open_sftp()` opens a **separate channel** from the exec/output-capture path — no output cap, streams file bytes directly.
+
+### D1. SFTP client helper
+**New file: `huf/ai/knowledge/bulk/sftp_client.py`**
+- `_connect(ssh_connection_name)` — loads the `SSH Connection` doc, builds a `paramiko.SSHClient()`, and reuses the **exact same host-key verification and private-key-loading logic already written** in `ssh_execution.py` (`_load_private_key()` at line ~93-106, `_fingerprint_for_key()` at line ~89-91) — import and call those functions directly rather than re-implementing key parsing or host-key pinning. Connects with `password` or the loaded private key per `auth_method`. Returns an open `SFTPClient` (`ssh_client.open_sftp()`).
+- `list_dir_recursive(sftp, root_path, dir_queue)` — one page of work: pops one directory off `dir_queue` (a plain list), calls `sftp.listdir_attr(path)`, splits entries into subdirectories (pushed back onto `dir_queue`) and files (returned, each as `{path, size, mtime}` — `mtime` + `size` stand in for a checksum since SFTP/SSH has no native content hash equivalent to S3's ETag). Caller persists the returned `dir_queue` as JSON into `Ingestion Job.sync_cursor` after each page, so a crashed/paused scan resumes from the same directory frontier instead of restarting.
+- `read_file(sftp, path, local_tmp_path)` — `sftp.get(path, local_tmp_path)`, used by the batch worker to stream a remote file to a local temp path before handing it to the existing extractors (which expect a local file, same as the Upload/Directory sources).
+- Dependency: none new (paramiko already installed); imports from `ssh_execution.py` only the two helper functions named above, not the whole exec/approval flow.
+
+### D2. Scanner
+**Add to `huf/ai/knowledge/bulk/scanners.py`: `scan_sftp(job_name)`**
+- Reads `Ingestion Job.sftp_connection` and `sftp_root_path`; if `sync_cursor` is already set (resume case), parses it back into the starting `dir_queue`, otherwise starts with `[sftp_root_path]`.
+- Calls `sftp_client._connect()`, then loops `list_dir_recursive()` popping one directory per iteration, writing `Ingestion Job Item` rows in batches of ~200 (`external_path` = remote path, `external_checksum` = `f"{size}:{mtime}"`), updating `total_discovered` and persisting `sync_cursor` after each batch — same shape as `scan_s3`'s pagination loop.
+- On an empty `dir_queue`, closes the SFTP session, clears `sync_cursor`, and enqueues `process_ingestion_batches(job_name)` exactly like the other scanners.
+
+### D3. Batch processing
+**`process_batch()` in `huf/ai/knowledge/bulk/orchestrator.py`** needs one branch for `source_kind == "SFTP"`: instead of reading a local path directly (Upload/Directory) or calling boto3 (S3), it opens one SFTP session per batch (not per file — reuse the connection across the batch for throughput), calls `sftp_client.read_file()` into a private temp path per item, then hands off to the same `process_knowledge_input()` call used by every other source. This is the one place SFTP needs orchestrator-level branching; everything downstream (extraction, chunking, embedding, backend write) is identical across all four source kinds.
+
+### D4. DocType/API/UI touch points
+Already covered inline above — `source_kind` enum (B1) includes `SFTP`, `Ingestion Job` carries `sftp_connection`/`sftp_root_path` (B1), `bulk/api.py` gets `start_sftp_import` (B4), and the frontend picker (C2) gets a fourth option that reuses the existing `SSH Connection` list rather than a new credential form (no `Integration Service` needed for SFTP — it rides entirely on `SSH Connection`, which predates this feature).
+
+### D5. Tests
+**Add to `huf/ai/knowledge/tests/test_bulk_ingestion.py`**: mock `paramiko.SSHClient`/`SFTPClient` (same mocking approach as D1's dependency-free design makes this straightforward) to cover `list_dir_recursive` pagination/cursor resume and the size+mtime checksum-skip path.
+
+---
+
+## Build order (dependency-ordered)
+
+1. **A1 → A2 → A3 → A4 → A5** (S3 integration, fully independent of bulk ingestion; ships and is useful on its own — agents can already use S3 as a tool once this lands).
+2. **B1** (new DocTypes, now including `SFTP` in `source_kind` + `sftp_connection`/`sftp_root_path` fields) — no dependency on Part A.
+3. **B2** (field additions to `Knowledge Input`/`Knowledge Source`) — depends on B1 existing so migrations apply cleanly together.
+4. **D1** (`sftp_client.py`) — no dependency on A/B; only imports two helper functions from the existing `ssh_execution.py`.
+5. **B3** `scanners.py` (Upload/Directory/S3/`scan_sftp` per D2) and `orchestrator.py` (per D3) — depends on B1, B2. `scan_s3` also depends on A3 (imports `list_objects_page`). `scan_sftp` also depends on D1.
+6. **B4** (API endpoints, including `start_sftp_import`) — depends on B3.
+7. **B5**/**D5** (backend tests) — depends on B3, B4, D1.
+8. **C1** (frontend API layer) — can start in parallel with B3/B4 against a stubbed contract, wired for real once B4 lands.
+9. **C2** (bulk import modal, 4-way source picker) — depends on C1.
+10. **C3** (entry points in existing pages) — depends on C2.
+11. **C4** (manual QA of auto-generated S3 credential UI) — depends on A2 only, can happen right after step 1.
+
+**Suggested shipping slice for V1**: steps 1, 2, 3, 5 (Upload + Directory scanners only, skip `scan_s3`/`scan_sftp` internals), 6, 8, 9, 10 — i.e. ship Upload/Directory bulk import first, then land S3-as-integration and SFTP as fast-follows that slot into the same `Ingestion Job` machinery with zero changes to B1/B2/C2/C3.

--- a/HUF_BULK_INGESTION_PLAN.md
+++ b/HUF_BULK_INGESTION_PLAN.md
@@ -1,0 +1,99 @@
+# Bulk Ingestion — High-Level Plan
+
+## Why this matters
+
+Today, HUF's knowledge system (`huf/ai/knowledge/`) only ingests one document at a time: a user creates a `Knowledge Input` (File / Text / URL), which enqueues `process_knowledge_input()`. There is no way to point HUF at a folder, a ZIP, an S3 prefix, or a Google Drive folder and have it ingest hundreds or thousands of documents. Without this, no real business with an existing document corpus (SharePoint exports, S3 buckets, Drive folders, HR/legal archives) can onboard onto HUF — they'd have to upload files one by one through a modal.
+
+## Guiding principle: don't build a new ingestion engine
+
+`process_knowledge_input()` (`huf/ai/knowledge/indexer.py:45`) is already a complete, correct, atomic ingestion worker: extract → chunk (LlamaIndex `SentenceSplitter`) → embed → write to the configured vector backend (Chroma / pgvector / Weaviate / Pinecone / FAISS / sqlite). It already runs behind Frappe's Redis-backed job queue (`frappe.enqueue`, `queue="default"`, `deduplicate=True`, `enqueue_after_commit=True`).
+
+**Bulk ingestion is purely an orchestration layer on top of this existing worker.** We are not replacing it, not building a second ingestion path, and not hand-rolling document loading — LlamaIndex already ships the readers/connectors we'd need if we ever want them (`llama-index-readers-s3`, `llama-index-readers-google-drive`, `SimpleDirectoryReader`, etc.); `llama-index-core` is already pinned in `pyproject.toml`, so adding a reader is a dependency bump, not new infrastructure.
+
+```
+Bulk source (ZIP / folder / S3 prefix / Drive folder)
+        │
+        ▼
+  Source scanner (lists files, one per row)
+        │
+        ▼
+  Create N × Knowledge Input docs (Pending)
+        │
+        ▼
+  Batch enqueue, 20-100 at a time
+        │
+        ▼
+  Existing process_knowledge_input() worker  ◄── reused unchanged
+        │
+        ▼
+  Vector backend (Chroma / pgvector / Weaviate / Pinecone / FAISS)
+```
+
+## What already exists in HUF that this can be built on
+
+| Need | Existing building block | Reuse as-is? |
+|---|---|---|
+| Per-document ingestion | `process_knowledge_input()` — `huf/ai/knowledge/indexer.py:45` | Yes, unchanged |
+| Per-document status | `Knowledge Input` doctype: `Pending → Processing → Indexed / Error` | Yes |
+| Source-level status/stats | `Knowledge Source` doctype: `total_chunks`, `total_inputs`, `index_size_bytes` | Extend |
+| Background job pattern | `frappe.enqueue(..., queue="default"/"long", deduplicate=True, job_id=..., enqueue_after_commit=True)` | Yes — same pattern |
+| Job-with-progress DocType precedent | `Flow Run`, `Agent Run`, `Gateway Event` doctypes (`Queued/Running/Success/Failed` style status) | Copy the pattern for a new `Ingestion Job` doctype |
+| File extraction (PDF/DOCX/XLSX/PPTX/HTML/MD/URL) | `huf/ai/knowledge/extractors/` | Yes, unchanged |
+| Chunking | `chunkers/sentence.py` (LlamaIndex `SentenceSplitter`) | Yes, unchanged |
+| Vector write | `backends/*.py` (`add_chunks`, `delete_chunks`, `get_stats`) | Yes, unchanged |
+| Google Drive OAuth + file listing | `huf/ai/tools/google_drive.py` (already used by agent tools) | Reuse the auth/listing code as the Drive scanner |
+| S3 | Nothing yet | New — but LlamaIndex has `llama-index-readers-s3` / plain `boto3` is fine too, listing is trivial |
+| Multi-file upload UI + progress polling | `frontend/src/components/data-table/BulkImportModal.tsx` (CSV bulk import: drag-drop, upload progress, 2s polling, terminal-status detection, error summary) | **Direct template** — this is almost exactly the UX we need, just repointed at a new bulk-ingestion endpoint |
+| Progress bar component | `frontend/src/components/ui/progress.tsx` (Radix) | Yes |
+| Realtime job updates | `frontend/src/contexts/SocketContext.tsx`, `useChatSocket.tsx`, `frappe.publish_realtime` (used elsewhere, not yet for knowledge) | Reuse pattern |
+| Existing single-input upload UI | `frontend/src/components/knowledge/KnowledgeInputsModal.tsx` | Keep for single-file case; bulk is a new sibling entry point |
+
+**Gaps to fill (genuinely new code):**
+1. No content-hash/checksum dedup — reprocessing today just deletes-and-reinserts by `input_id`. Incremental sync needs a real checksum (path + mtime/etag/hash) per external source.
+2. No generic "bulk job" DocType — status today lives only on `Knowledge Input`/`Knowledge Source`, which is fine per-document but has no place to track "5,000 discovered, 3,200 succeeded, 40 failed, 1,760 pending."
+3. No S3 or ZIP/folder scanning code exists at all.
+4. No incremental/cursor-based listing for very large sources (millions of objects).
+
+## Proposed data model (new)
+
+1. **`Bulk Ingestion Source`** (or extend `Knowledge Source` with a `source_kind` field: `Manual | Upload | Directory | S3 | Google Drive`)
+   - Connection config: bucket/prefix, folder path, Drive folder ID, credentials link (reuse `AI Provider`-style credential doc, or Drive's existing OAuth doc)
+   - `sync_cursor` — resume point for incremental scans (S3 continuation token, Drive `pageToken`, or `last_synced_at` for directories)
+
+2. **`Ingestion Job`** — modeled directly on `Flow Run` / `Agent Run`'s status pattern
+   - `status`: `Queued → Scanning → Processing → Completed / Completed with Errors / Failed`
+   - `total_discovered`, `pending`, `processing`, `succeeded`, `failed`, `skipped`
+   - `knowledge_source` (link), `started_at`, `finished_at`
+   - Child table `Ingestion Job Item`: one row per discovered file — `external_path`, `checksum`/`etag`, `knowledge_input` (link, created lazily), `status`, `error_message`
+
+3. **`Knowledge Input`** gets two new fields: `external_source_path`, `content_checksum` — this is the whole incremental-sync mechanism: on re-scan, skip any item whose checksum matches what's already indexed.
+
+## Processing flow
+
+1. User configures a `Bulk Ingestion Source` (upload ZIP, pick a server directory, enter an S3 prefix, or authorize + pick a Drive folder) and hits "Import."
+2. `frappe.enqueue(scan_bulk_source, queue="long", job_id=f"bulk_scan_{job}")` — scanner lists objects (streaming/paginated for S3 and Drive, not loading everything into memory), writes `Ingestion Job Item` rows in batches, updates `total_discovered` as it goes so the UI shows a live count even before processing starts.
+3. Scanner enqueues processing batches of 20-100 items each (`queue="default"`, several jobs in parallel — Frappe's own worker pool handles concurrency, no new scheduler needed).
+4. Each batch worker, for each item: skip if checksum unchanged; otherwise create/update a `Knowledge Input` doc and call `process_knowledge_input()` **directly in-process** (not re-enqueued) since we're already inside a background worker — avoids double-queueing overhead for bulk runs.
+5. Batch worker updates the `Ingestion Job` counters (succeeded/failed/skipped) and, on the last batch, sets the job to a terminal status.
+6. Frontend polls `Ingestion Job` status every ~2s (same pattern as `BulkImportModal.tsx`) or subscribes via `frappe.publish_realtime` (same pattern as chat's `SocketContext`) for live progress; on completion shows a summary with per-item errors pulled from `Ingestion Job Item`.
+
+## Source-type specifics
+
+- **Upload (ZIP / multi-file)**: simplest V1. Browser multi-file or ZIP upload → server extracts to a temp private-files location → each file becomes a `Knowledge Input` → straight into the existing pipeline. No external credentials needed. Ship this first.
+- **Server directory**: admin-only, points at a path the bench process can read; walk it with a generator, don't load the full listing into memory for huge trees.
+- **S3**: list via `boto3` `list_objects_v2` (paginated) or `llama-index-readers-s3`; store a continuation token as the sync cursor; stream each object to a worker rather than downloading the whole bucket up front. Credentials stored the same way other secrets are (existing credential-storage convention, not a new one).
+- **Google Drive**: reuse `huf/ai/tools/google_drive.py`'s OAuth + listing entirely; add folder-level recursive listing and a `pageToken` cursor.
+
+## Phasing
+
+1. **V1 — Upload/ZIP + directory sources.** New `Ingestion Job` + `Ingestion Job Item` doctypes, batch orchestration, reuse `BulkImportModal.tsx` as the frontend template, reuse `process_knowledge_input()` untouched. This alone unblocks most business onboarding (people already have files, not necessarily live S3/Drive feeds).
+2. **V2 — Checksum-based incremental sync** for whatever source types exist so far (re-running an import only touches changed/new files).
+3. **V3 — S3 connector** (paginated listing + cursor, streamed processing, no full-bucket download).
+4. **V4 — Google Drive connector** (extend existing OAuth integration with recursive folder listing + cursor).
+5. **V5 (optional)** — scheduled/periodic re-sync per source using Frappe's existing scheduler hooks, for sources that should stay continuously in sync.
+
+## Explicitly out of scope for V1
+
+- Downloading entire buckets/folders before processing (always stream/paginate).
+- A generic "connector framework" beyond what's needed for these four source kinds — don't build a pluggable-connector abstraction speculatively; add the next source type's scanner function when it's actually needed.
+- Real content-hash dedup for the manual-upload path (checksums matter most for repeat S3/Drive syncs, less for one-off uploads).

--- a/frontend/src/components/knowledge/KnowledgeBulkImportModal.tsx
+++ b/frontend/src/components/knowledge/KnowledgeBulkImportModal.tsx
@@ -1,0 +1,585 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import {
+	Upload,
+	FolderOpen,
+	Cloud,
+	Server,
+	FileText,
+	Loader2,
+	CheckCircle2,
+	XCircle,
+} from 'lucide-react';
+import {
+	Dialog,
+	DialogDescription,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import {
+	DialogScrollBody,
+	DialogScrollContent,
+	DialogScrollFooter,
+	DialogScrollHeader,
+} from '@/components/ui/dialog-scroll';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { file as frappeFile } from '@/lib/frappe-sdk';
+import { db } from '@/lib/frappe-sdk';
+import {
+	startUploadImport,
+	startDirectoryImport,
+	startS3Import,
+	startSftpImport,
+	getJobProgress,
+	type IngestionJobProgress,
+} from '../../services/bulkIngestionApi';
+
+const TERMINAL_STATUSES = new Set(['Completed', 'Completed with Errors', 'Failed']);
+const POLL_INTERVAL_MS = 2000;
+
+type SourceKind = 'Upload' | 'Directory' | 'S3' | 'SFTP';
+
+interface SourceKindOption {
+	value: SourceKind;
+	label: string;
+	icon: typeof Upload;
+}
+
+const SOURCE_KIND_OPTIONS: SourceKindOption[] = [
+	{ value: 'Upload', label: 'Upload', icon: Upload },
+	{ value: 'Directory', label: 'Directory', icon: FolderOpen },
+	{ value: 'S3', label: 'S3', icon: Cloud },
+	{ value: 'SFTP', label: 'SFTP', icon: Server },
+];
+
+interface SSHConnectionOption {
+	value: string;
+	label: string;
+	description?: string;
+}
+
+interface KnowledgeBulkImportModalProps {
+	knowledgeSource: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function KnowledgeBulkImportModal({
+	knowledgeSource,
+	open,
+	onOpenChange,
+}: KnowledgeBulkImportModalProps) {
+	const [sourceKind, setSourceKind] = useState<SourceKind>('Upload');
+
+	// Upload step state
+	const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+	const [uploadedFileUrls, setUploadedFileUrls] = useState<string[]>([]);
+	const [uploading, setUploading] = useState(false);
+	const [uploadProgress, setUploadProgress] = useState(0);
+	const [dragOver, setDragOver] = useState(false);
+
+	// Directory step state
+	const [directoryPath, setDirectoryPath] = useState('');
+
+	// S3 step state
+	const [s3Bucket, setS3Bucket] = useState('');
+	const [s3Prefix, setS3Prefix] = useState('');
+
+	// SFTP step state
+	const [sshConnections, setSSHConnections] = useState<SSHConnectionOption[]>([]);
+	const [loadingSSHConnections, setLoadingSSHConnections] = useState(false);
+	const [sshConnection, setSSHConnection] = useState('');
+	const [sftpRootPath, setSftpRootPath] = useState('');
+
+	// Job / progress state
+	const [starting, setStarting] = useState(false);
+	const [jobName, setJobName] = useState<string | null>(null);
+	const [jobProgress, setJobProgress] = useState<IngestionJobProgress | null>(null);
+
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const stopPolling = useCallback(() => {
+		if (pollTimerRef.current) {
+			clearTimeout(pollTimerRef.current);
+			pollTimerRef.current = null;
+		}
+	}, []);
+
+	const isTerminal = (progress: IngestionJobProgress | null) =>
+		progress !== null && TERMINAL_STATUSES.has(progress.status);
+
+	const resetState = useCallback(() => {
+		stopPolling();
+		setSourceKind('Upload');
+		setSelectedFiles([]);
+		setUploadedFileUrls([]);
+		setUploading(false);
+		setUploadProgress(0);
+		setDragOver(false);
+		setDirectoryPath('');
+		setS3Bucket('');
+		setS3Prefix('');
+		setSSHConnection('');
+		setSftpRootPath('');
+		setStarting(false);
+		setJobName(null);
+		setJobProgress(null);
+		if (fileInputRef.current) fileInputRef.current.value = '';
+	}, [stopPolling]);
+
+	// Reset whenever the modal is closed; stop polling on unmount.
+	useEffect(() => {
+		if (!open) resetState();
+	}, [open, resetState]);
+
+	useEffect(() => stopPolling, [stopPolling]);
+
+	// Load SSH Connection options when the SFTP step is selected, mirroring
+	// KnowledgeSourceFormPage's Link-field option fetching approach.
+	useEffect(() => {
+		if (!open || sourceKind !== 'SFTP') return;
+		let cancelled = false;
+
+		const loadSSHConnections = async () => {
+			setLoadingSSHConnections(true);
+			try {
+				const rows = (await db.getDocList('SSH Connection', {
+					fields: ['name', 'display_name', 'host', 'username'],
+					filters: [['enabled', '=', 1]],
+					limit: 500,
+					orderBy: { field: 'modified', order: 'desc' },
+				})) as Array<{
+					name: string;
+					display_name?: string | null;
+					host?: string | null;
+					username?: string | null;
+				}>;
+				if (cancelled) return;
+				setSSHConnections(
+					rows.map((row) => ({
+						value: row.name,
+						label: row.display_name || row.name,
+						description: [row.username, row.host].filter(Boolean).join('@') || undefined,
+					}))
+				);
+			} catch {
+				if (!cancelled) {
+					setSSHConnections([]);
+					toast.error('Failed to load SSH Connections');
+				}
+			} finally {
+				if (!cancelled) setLoadingSSHConnections(false);
+			}
+		};
+
+		loadSSHConnections();
+		return () => {
+			cancelled = true;
+		};
+	}, [open, sourceKind]);
+
+	const handleOpenChange = (next: boolean) => {
+		// Don't allow closing mid-import poll; the user can close after it finishes.
+		if (jobName && !isTerminal(jobProgress)) return;
+		onOpenChange(next);
+	};
+
+	const uploadSelectedFiles = async (files: File[]) => {
+		setUploading(true);
+		setUploadProgress(0);
+		const urls: string[] = [];
+		try {
+			for (let i = 0; i < files.length; i++) {
+				const response = await frappeFile.uploadFile(
+					files[i],
+					{ isPrivate: true },
+					(completed, total) => {
+						if (total) {
+							const fileFraction = completed / total;
+							setUploadProgress(Math.round(((i + fileFraction) / files.length) * 100));
+						}
+					}
+				);
+				const res = response as any;
+				const fileUrl = res?.data?.message?.file_url;
+				if (fileUrl) urls.push(fileUrl);
+			}
+			if (urls.length === 0) {
+				toast.error('Upload succeeded but no file URLs returned');
+				setSelectedFiles([]);
+			} else {
+				setUploadedFileUrls(urls);
+				if (urls.length < files.length) {
+					toast.warning(`Only ${urls.length} of ${files.length} file(s) uploaded successfully`);
+				}
+			}
+		} catch {
+			toast.error('Failed to upload file(s)');
+			setSelectedFiles([]);
+		} finally {
+			setUploading(false);
+		}
+	};
+
+	const acceptFiles = (files: FileList | File[] | undefined | null) => {
+		if (!files || files.length === 0) return;
+		const fileArray = Array.from(files);
+		setSelectedFiles(fileArray);
+		setUploadedFileUrls([]);
+		uploadSelectedFiles(fileArray);
+	};
+
+	const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+		acceptFiles(e.target.files);
+	};
+
+	const handleDrop = (e: React.DragEvent) => {
+		e.preventDefault();
+		setDragOver(false);
+		if (uploading || starting || jobName) return;
+		acceptFiles(e.dataTransfer.files);
+	};
+
+	const pollProgress = useCallback(async (name: string) => {
+		try {
+			const progress = await getJobProgress(name);
+			setJobProgress(progress);
+			if (TERMINAL_STATUSES.has(progress.status)) {
+				if (progress.status === 'Completed') {
+					toast.success(`Import complete: ${progress.succeeded} item(s) imported`);
+				} else if (progress.status === 'Completed with Errors') {
+					toast.warning(
+						`Import completed with errors: ${progress.succeeded} succeeded, ${progress.failed} failed`
+					);
+				} else {
+					toast.error('Import failed', { description: `${progress.failed} item(s) failed` });
+				}
+				return;
+			}
+		} catch (err: any) {
+			toast.error('Failed to check import progress', { description: err.message });
+			return;
+		}
+		pollTimerRef.current = setTimeout(() => pollProgress(name), POLL_INTERVAL_MS);
+	}, []);
+
+	const beginPolling = (name: string) => {
+		setJobName(name);
+		setJobProgress(null);
+		pollTimerRef.current = setTimeout(() => pollProgress(name), POLL_INTERVAL_MS);
+	};
+
+	const canStart = (() => {
+		switch (sourceKind) {
+			case 'Upload':
+				return uploadedFileUrls.length > 0 && !uploading;
+			case 'Directory':
+				return directoryPath.trim().length > 0;
+			case 'S3':
+				return s3Bucket.trim().length > 0;
+			case 'SFTP':
+				return sshConnection.length > 0 && sftpRootPath.trim().length > 0;
+			default:
+				return false;
+		}
+	})();
+
+	const handleStartImport = async () => {
+		if (!canStart) return;
+		setStarting(true);
+		try {
+			let result: { ingestion_job: string };
+			switch (sourceKind) {
+				case 'Upload':
+					result = await startUploadImport(knowledgeSource, uploadedFileUrls);
+					break;
+				case 'Directory':
+					result = await startDirectoryImport(knowledgeSource, directoryPath.trim());
+					break;
+				case 'S3':
+					result = await startS3Import(knowledgeSource, s3Bucket.trim(), s3Prefix.trim() || undefined);
+					break;
+				case 'SFTP':
+					result = await startSftpImport(knowledgeSource, sshConnection, sftpRootPath.trim());
+					break;
+			}
+			beginPolling(result.ingestion_job);
+		} catch (err: any) {
+			toast.error('Failed to start import', { description: err.message });
+		} finally {
+			setStarting(false);
+		}
+	};
+
+	const jobFinished = isTerminal(jobProgress);
+	const showProgressView = jobName !== null;
+
+	const renderSourceKindPicker = () => (
+		<div className="grid grid-cols-4 gap-2">
+			{SOURCE_KIND_OPTIONS.map(({ value, label, icon: Icon }) => (
+				<button
+					key={value}
+					type="button"
+					onClick={() => setSourceKind(value)}
+					className={`flex flex-col items-center justify-center gap-1.5 rounded-none border p-3 text-xs transition-colors ${
+						sourceKind === value
+							? 'border-primary bg-primary/5 text-foreground'
+							: 'border-input text-steel hover:bg-muted/40'
+					}`}
+				>
+					<Icon className="w-4 h-4" />
+					{label}
+				</button>
+			))}
+		</div>
+	);
+
+	const renderUploadStep = () => (
+		<div className="space-y-1.5">
+			<div
+				className={`flex flex-col items-center justify-center gap-2 rounded-md border border-dashed p-6 text-center transition-colors ${
+					dragOver ? 'border-primary bg-primary/5' : 'border-input'
+				} ${uploading ? 'opacity-60 pointer-events-none' : 'cursor-pointer'}`}
+				onClick={() => fileInputRef.current?.click()}
+				onDragOver={(e) => {
+					e.preventDefault();
+					if (!uploading) setDragOver(true);
+				}}
+				onDragLeave={() => setDragOver(false)}
+				onDrop={handleDrop}
+			>
+				{uploading ? (
+					<>
+						<Loader2 className="w-6 h-6 animate-spin text-steel-soft" />
+						<p className="text-xs text-steel">Uploading... {uploadProgress}%</p>
+						<Progress value={uploadProgress} className="w-full h-1.5" />
+					</>
+				) : selectedFiles.length > 0 ? (
+					<>
+						<FileText className="w-6 h-6 text-steel-soft" />
+						<p className="text-sm">
+							{selectedFiles.length} file{selectedFiles.length === 1 ? '' : 's'} selected
+						</p>
+						{uploadedFileUrls.length > 0 ? (
+							<p className="text-xs text-green-600 flex items-center gap-1">
+								<CheckCircle2 className="w-3.5 h-3.5" />
+								{uploadedFileUrls.length} uploaded, ready to import
+							</p>
+						) : (
+							<p className="text-xs text-destructive">Upload failed — pick another file</p>
+						)}
+					</>
+				) : (
+					<>
+						<Upload className="w-6 h-6 text-steel-soft" />
+						<p className="text-sm text-steel">
+							Drag &amp; drop files or a .zip archive here, or click to browse
+						</p>
+					</>
+				)}
+			</div>
+			<input
+				ref={fileInputRef}
+				type="file"
+				multiple
+				accept=".zip,*"
+				className="hidden"
+				onChange={handleFileSelect}
+			/>
+		</div>
+	);
+
+	const renderDirectoryStep = () => (
+		<div className="space-y-1.5">
+			<Label htmlFor="bulk-import-directory">Server path</Label>
+			<Input
+				id="bulk-import-directory"
+				placeholder="/data/shared/docs"
+				value={directoryPath}
+				onChange={(e) => setDirectoryPath(e.target.value)}
+			/>
+			<p className="text-xs text-steel-soft">
+				This is an absolute path on the server filesystem. Admin use only.
+			</p>
+		</div>
+	);
+
+	const renderS3Step = () => (
+		<div className="space-y-3">
+			<div className="space-y-1.5">
+				<Label htmlFor="bulk-import-s3-bucket">Bucket name</Label>
+				<Input
+					id="bulk-import-s3-bucket"
+					placeholder="my-bucket"
+					value={s3Bucket}
+					onChange={(e) => setS3Bucket(e.target.value)}
+				/>
+			</div>
+			<div className="space-y-1.5">
+				<Label htmlFor="bulk-import-s3-prefix">Prefix (optional)</Label>
+				<Input
+					id="bulk-import-s3-prefix"
+					placeholder="docs/2024/"
+					value={s3Prefix}
+					onChange={(e) => setS3Prefix(e.target.value)}
+				/>
+			</div>
+		</div>
+	);
+
+	const renderSftpStep = () => (
+		<div className="space-y-3">
+			<div className="space-y-1.5">
+				<Label>SSH Connection</Label>
+				<Select value={sshConnection} onValueChange={setSSHConnection}>
+					<SelectTrigger>
+						<SelectValue
+							placeholder={loadingSSHConnections ? 'Loading connections...' : 'Select a connection'}
+						/>
+					</SelectTrigger>
+					<SelectContent>
+						{sshConnections.map((conn) => (
+							<SelectItem key={conn.value} value={conn.value}>
+								{conn.label}
+								{conn.description ? ` (${conn.description})` : ''}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+			<div className="space-y-1.5">
+				<Label htmlFor="bulk-import-sftp-path">Root path to scan</Label>
+				<Input
+					id="bulk-import-sftp-path"
+					placeholder="/home/user/docs"
+					value={sftpRootPath}
+					onChange={(e) => setSftpRootPath(e.target.value)}
+				/>
+			</div>
+		</div>
+	);
+
+	const renderSourceStep = () => {
+		switch (sourceKind) {
+			case 'Upload':
+				return renderUploadStep();
+			case 'Directory':
+				return renderDirectoryStep();
+			case 'S3':
+				return renderS3Step();
+			case 'SFTP':
+				return renderSftpStep();
+			default:
+				return null;
+		}
+	};
+
+	const renderProgressView = () => {
+		const totalDiscovered = jobProgress?.total_discovered ?? 0;
+		const processed = jobProgress
+			? jobProgress.succeeded + jobProgress.failed + jobProgress.skipped
+			: 0;
+		const progressValue = totalDiscovered > 0 ? Math.round((processed / totalDiscovered) * 100) : 0;
+		const failedItems = jobProgress?.items?.filter((item) => item.status === 'Failed') ?? [];
+
+		return (
+			<div className="space-y-4">
+				<div className="flex items-center gap-2 text-sm text-steel">
+					{!jobFinished && <Loader2 className="w-4 h-4 animate-spin" />}
+					{jobProgress?.status || 'Starting...'}
+				</div>
+
+				<div className="space-y-1.5">
+					<Progress value={progressValue} className="w-full h-1.5" />
+					<p className="text-xs text-steel-soft">
+						{processed} / {totalDiscovered || '?'} processed
+					</p>
+				</div>
+
+				<div className="grid grid-cols-4 gap-2 text-center text-xs">
+					<div className="rounded-none border p-2">
+						<p className="text-green-600 font-medium">{jobProgress?.succeeded ?? 0}</p>
+						<p className="text-steel-soft">Succeeded</p>
+					</div>
+					<div className="rounded-none border p-2">
+						<p className="text-destructive font-medium">{jobProgress?.failed ?? 0}</p>
+						<p className="text-steel-soft">Failed</p>
+					</div>
+					<div className="rounded-none border p-2">
+						<p className="text-amber-600 font-medium">{jobProgress?.skipped ?? 0}</p>
+						<p className="text-steel-soft">Skipped</p>
+					</div>
+					<div className="rounded-none border p-2">
+						<p className="font-medium">
+							{Math.max(totalDiscovered - processed, 0)}
+						</p>
+						<p className="text-steel-soft">Pending</p>
+					</div>
+				</div>
+
+				{failedItems.length > 0 && (
+					<div className="space-y-1.5">
+						<p className="text-sm font-medium flex items-center gap-1.5">
+							<XCircle className="w-3.5 h-3.5 text-destructive" />
+							Failed items
+						</p>
+						<div className="max-h-40 overflow-auto rounded bg-muted/50 p-2 space-y-1.5">
+							{failedItems.map((item, i) => (
+								<div key={i} className="text-xs font-mono">
+									<p className="text-foreground truncate">{item.external_path}</p>
+									<p className="text-destructive">{item.error_message}</p>
+								</div>
+							))}
+						</div>
+					</div>
+				)}
+			</div>
+		);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogScrollContent className="max-w-lg">
+				<DialogScrollHeader>
+					<DialogTitle>Bulk Import</DialogTitle>
+					<DialogDescription>
+						Import many documents into this knowledge source at once.
+					</DialogDescription>
+				</DialogScrollHeader>
+
+				<DialogScrollBody className="space-y-4 py-2">
+					{showProgressView ? (
+						renderProgressView()
+					) : (
+						<>
+							<div className="space-y-1.5">
+								<p className="text-sm font-medium">1. Choose a source</p>
+								{renderSourceKindPicker()}
+							</div>
+							<div className="space-y-1.5">
+								<p className="text-sm font-medium">2. Configure</p>
+								{renderSourceStep()}
+							</div>
+						</>
+					)}
+				</DialogScrollBody>
+
+				<DialogScrollFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						{jobFinished || !showProgressView ? 'Close' : 'Cancel'}
+					</Button>
+					{!showProgressView && (
+						<Button onClick={handleStartImport} disabled={!canStart || starting}>
+							{starting && <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />}
+							Start Import
+						</Button>
+					)}
+				</DialogScrollFooter>
+			</DialogScrollContent>
+		</Dialog>
+	);
+}

--- a/frontend/src/pages/KnowledgeSourcesPage.tsx
+++ b/frontend/src/pages/KnowledgeSourcesPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { Calendar, Settings, Database, BookOpen } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Calendar, Settings, Database, BookOpen, Upload } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { PageFrame } from '@/layouts/PageFrame';
@@ -9,6 +9,7 @@ import { getKnowledgeSources } from '../services/knowledgeApi';
 import { formatTimeAgo } from '../utils/time';
 import { knowledgeSourceFilterStatuses, knowledgeTypeLabels } from '../data/knowledge';
 import type { KnowledgeSourceDoc } from '../types/knowledge.types';
+import { KnowledgeBulkImportModal } from '../components/knowledge/KnowledgeBulkImportModal';
 
 function getStatusVariant(source: KnowledgeSourceDoc): 'default' | 'secondary' | 'destructive' | 'success' | 'outline' {
   if (source.disabled === 1) return 'secondary';
@@ -35,6 +36,8 @@ export default KnowledgeSourcesPage;
 
 function KnowledgeSourcesPage() {
   const navigate = useNavigate();
+  const [bulkImportTarget, setBulkImportTarget] = useState<string | null>(null);
+  const [bulkImportOpen, setBulkImportOpen] = useState(false);
 
   const {
     items: sources,
@@ -101,6 +104,11 @@ function KnowledgeSourcesPage() {
         />
       }
     >
+      <KnowledgeBulkImportModal
+        knowledgeSource={bulkImportTarget ?? ''}
+        open={bulkImportOpen}
+        onOpenChange={setBulkImportOpen}
+      />
       {error && !initialLoading && (
         <div className="text-center py-12">
           <p className="text-destructive mb-4">Failed to load knowledge sources</p>
@@ -145,6 +153,14 @@ function KnowledgeSourcesPage() {
                   icon: Settings,
                   label: 'Configure',
                   onClick: () => navigate(`/knowledge/${source.name}`),
+                },
+                {
+                  icon: Upload,
+                  label: 'Bulk Import',
+                  onClick: () => {
+                    setBulkImportTarget(source.name);
+                    setBulkImportOpen(true);
+                  },
                 },
               ]}
               onClick={() => navigate(`/knowledge/${source.name}`)}

--- a/frontend/src/services/bulkIngestionApi.ts
+++ b/frontend/src/services/bulkIngestionApi.ts
@@ -1,0 +1,115 @@
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+
+// ---------------------------------------------------------------------------
+// Bulk Ingestion
+// ---------------------------------------------------------------------------
+
+export interface IngestionJobItemSummary {
+  external_path: string;
+  status: string;
+  error_message?: string;
+}
+
+export interface IngestionJobProgress {
+  status: string;
+  total_discovered: number;
+  pending: number;
+  processing: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  error_message?: string;
+  items: IngestionJobItemSummary[];
+}
+
+export async function startUploadImport(
+  knowledgeSource: string,
+  fileUrls: string[],
+): Promise<{ ingestion_job: string }> {
+  try {
+    const result = await call.post(
+      'huf.ai.knowledge.bulk.api.start_upload_import',
+      { knowledge_source: knowledgeSource, files: JSON.stringify(fileUrls) },
+    );
+    const response = result as { message?: { ingestion_job: string } } & {
+      ingestion_job: string;
+    };
+    return response.message ?? response;
+  } catch (error) {
+    handleFrappeError(error, 'Error starting upload import');
+  }
+}
+
+export async function startDirectoryImport(
+  knowledgeSource: string,
+  directoryPath: string,
+): Promise<{ ingestion_job: string }> {
+  try {
+    const result = await call.post(
+      'huf.ai.knowledge.bulk.api.start_directory_import',
+      { knowledge_source: knowledgeSource, directory_path: directoryPath },
+    );
+    const response = result as { message?: { ingestion_job: string } } & {
+      ingestion_job: string;
+    };
+    return response.message ?? response;
+  } catch (error) {
+    handleFrappeError(error, 'Error starting directory import');
+  }
+}
+
+export async function startS3Import(
+  knowledgeSource: string,
+  bucket: string,
+  prefix?: string,
+): Promise<{ ingestion_job: string }> {
+  try {
+    const result = await call.post(
+      'huf.ai.knowledge.bulk.api.start_s3_import',
+      { knowledge_source: knowledgeSource, bucket, prefix: prefix ?? '' },
+    );
+    const response = result as { message?: { ingestion_job: string } } & {
+      ingestion_job: string;
+    };
+    return response.message ?? response;
+  } catch (error) {
+    handleFrappeError(error, 'Error starting S3 import');
+  }
+}
+
+export async function startSftpImport(
+  knowledgeSource: string,
+  sftpConnection: string,
+  rootPath: string,
+): Promise<{ ingestion_job: string }> {
+  try {
+    const result = await call.post(
+      'huf.ai.knowledge.bulk.api.start_sftp_import',
+      {
+        knowledge_source: knowledgeSource,
+        sftp_connection: sftpConnection,
+        root_path: rootPath,
+      },
+    );
+    const response = result as { message?: { ingestion_job: string } } & {
+      ingestion_job: string;
+    };
+    return response.message ?? response;
+  } catch (error) {
+    handleFrappeError(error, 'Error starting SFTP import');
+  }
+}
+
+export async function getJobProgress(jobName: string): Promise<IngestionJobProgress> {
+  try {
+    const result = await call.get(
+      'huf.ai.knowledge.bulk.api.get_job_progress',
+      { ingestion_job: jobName },
+    );
+    const response = result as { message?: IngestionJobProgress } | undefined;
+    return (response?.message ?? response) as IngestionJobProgress;
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching ingestion job progress');
+  }
+}

--- a/huf/ai/knowledge/bulk/__init__.py
+++ b/huf/ai/knowledge/bulk/__init__.py
@@ -1,0 +1,1 @@
+"""Bulk ingestion orchestration: scan external sources (upload, directory, S3, SFTP) and batch-process discovered documents through the existing single-document knowledge ingestion pipeline (huf.ai.knowledge.indexer.process_knowledge_input)."""

--- a/huf/ai/knowledge/bulk/api.py
+++ b/huf/ai/knowledge/bulk/api.py
@@ -9,9 +9,21 @@ import zipfile
 import frappe
 
 
+def _check_write_access(knowledge_source: str):
+	"""Bulk-importing into a Knowledge Source should require the same
+	permission as editing it directly -- Ingestion Job itself is inserted
+	with ignore_permissions=True throughout this module (it's a
+	system-managed job record, not something users create directly), so this
+	is the actual permission gate for these endpoints.
+	"""
+	frappe.has_permission("Knowledge Source", doc=knowledge_source, ptype="write", throw=True)
+
+
 @frappe.whitelist()
 def start_upload_import(knowledge_source: str, files: str):
 	"""Start an ingestion job from files already uploaded via Frappe's file upload."""
+	_check_write_access(knowledge_source)
+
 	if isinstance(files, str):
 		files = json.loads(files)
 
@@ -44,6 +56,8 @@ def start_upload_import(knowledge_source: str, files: str):
 @frappe.whitelist()
 def start_directory_import(knowledge_source: str, directory_path: str):
 	"""Start an ingestion job from a directory already reachable on the server."""
+	_check_write_access(knowledge_source)
+
 	job = frappe.new_doc("Ingestion Job")
 	job.knowledge_source = knowledge_source
 	job.source_kind = "Directory"
@@ -57,6 +71,8 @@ def start_directory_import(knowledge_source: str, directory_path: str):
 @frappe.whitelist()
 def start_s3_import(knowledge_source: str, bucket: str, prefix: str = ""):
 	"""Start an ingestion job from an S3 bucket/prefix."""
+	_check_write_access(knowledge_source)
+
 	job = frappe.new_doc("Ingestion Job")
 	job.knowledge_source = knowledge_source
 	job.source_kind = "S3"
@@ -71,6 +87,8 @@ def start_s3_import(knowledge_source: str, bucket: str, prefix: str = ""):
 @frappe.whitelist()
 def start_sftp_import(knowledge_source: str, sftp_connection: str, root_path: str):
 	"""Start an ingestion job from an SFTP connection."""
+	_check_write_access(knowledge_source)
+
 	job = frappe.new_doc("Ingestion Job")
 	job.knowledge_source = knowledge_source
 	job.source_kind = "SFTP"
@@ -88,6 +106,7 @@ def get_job_progress(ingestion_job: str):
 	from huf.huf.doctype.ingestion_job.ingestion_job import get_progress as _get_progress
 
 	doc = frappe.get_doc("Ingestion Job", ingestion_job)
+	frappe.has_permission("Knowledge Source", doc=doc.knowledge_source, ptype="read", throw=True)
 	progress = _get_progress(ingestion_job)
 
 	failed_items = [row for row in doc.items if row.status == "Failed"][:50]

--- a/huf/ai/knowledge/bulk/api.py
+++ b/huf/ai/knowledge/bulk/api.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+import json
+import os
+import shutil
+import zipfile
+
+import frappe
+
+
+@frappe.whitelist()
+def start_upload_import(knowledge_source: str, files: str):
+	"""Start an ingestion job from files already uploaded via Frappe's file upload."""
+	if isinstance(files, str):
+		files = json.loads(files)
+
+	job = frappe.new_doc("Ingestion Job")
+	job.knowledge_source = knowledge_source
+	job.source_kind = "Upload"
+	job.insert(ignore_permissions=True)
+
+	temp_dir = frappe.get_site_path("private", "files", "bulk_import", job.name)
+	os.makedirs(temp_dir, exist_ok=True)
+
+	for file_url in files:
+		file_doc = frappe.get_doc("File", {"file_url": file_url})
+		src_path = file_doc.get_full_path()
+		dest_path = os.path.join(temp_dir, file_doc.file_name)
+		shutil.copy(src_path, dest_path)
+
+		if dest_path.lower().endswith(".zip"):
+			with zipfile.ZipFile(dest_path) as zf:
+				zf.extractall(temp_dir)
+			os.remove(dest_path)
+
+	job.db_set("directory_path", temp_dir)
+	job.reload()
+	job.start()
+
+	return {"ingestion_job": job.name}
+
+
+@frappe.whitelist()
+def start_directory_import(knowledge_source: str, directory_path: str):
+	"""Start an ingestion job from a directory already reachable on the server."""
+	job = frappe.new_doc("Ingestion Job")
+	job.knowledge_source = knowledge_source
+	job.source_kind = "Directory"
+	job.directory_path = directory_path
+	job.insert(ignore_permissions=True)
+	job.start()
+
+	return {"ingestion_job": job.name}
+
+
+@frappe.whitelist()
+def start_s3_import(knowledge_source: str, bucket: str, prefix: str = ""):
+	"""Start an ingestion job from an S3 bucket/prefix."""
+	job = frappe.new_doc("Ingestion Job")
+	job.knowledge_source = knowledge_source
+	job.source_kind = "S3"
+	job.s3_bucket = bucket
+	job.s3_prefix = prefix
+	job.insert(ignore_permissions=True)
+	job.start()
+
+	return {"ingestion_job": job.name}
+
+
+@frappe.whitelist()
+def start_sftp_import(knowledge_source: str, sftp_connection: str, root_path: str):
+	"""Start an ingestion job from an SFTP connection."""
+	job = frappe.new_doc("Ingestion Job")
+	job.knowledge_source = knowledge_source
+	job.source_kind = "SFTP"
+	job.sftp_connection = sftp_connection
+	job.sftp_root_path = root_path
+	job.insert(ignore_permissions=True)
+	job.start()
+
+	return {"ingestion_job": job.name}
+
+
+@frappe.whitelist()
+def get_job_progress(ingestion_job: str):
+	"""Return progress counters plus the most relevant failed items for an Ingestion Job."""
+	from huf.huf.doctype.ingestion_job.ingestion_job import get_progress as _get_progress
+
+	doc = frappe.get_doc("Ingestion Job", ingestion_job)
+	progress = _get_progress(ingestion_job)
+
+	failed_items = [row for row in doc.items if row.status == "Failed"][:50]
+	progress["items"] = [
+		{
+			"external_path": row.external_path,
+			"status": row.status,
+			"error_message": row.error_message,
+		}
+		for row in failed_items
+	]
+
+	return progress

--- a/huf/ai/knowledge/bulk/orchestrator.py
+++ b/huf/ai/knowledge/bulk/orchestrator.py
@@ -1,0 +1,248 @@
+"""Bulk ingestion orchestrator.
+
+Splits an Ingestion Job's pending items into batches, fans them out to the
+background queue, and lets each batch report back into the job's counters
+and, once the last batch lands, finalize the job's status.
+"""
+
+import os
+import tempfile
+import time
+
+import frappe
+from frappe.utils import now_datetime
+
+from huf.ai.knowledge.indexer import process_knowledge_input
+from huf.ai.tools.credentials import require_credential
+
+BATCH_SIZE = 50
+
+
+def process_ingestion_batches(ingestion_job: str) -> None:
+	"""Split an Ingestion Job's pending items into batches and enqueue them.
+
+	Each batch is processed by ``process_batch`` in its own background job.
+	Because multiple batches for the same job run concurrently, we can't
+	tell "was this the last batch?" from inside a single batch just by
+	looking at the job doc (it could be stale). Instead we stash the total
+	batch count in cache up front, and each batch atomically decrements it
+	when it finishes; whichever batch drives the counter to zero is -- by
+	construction -- the one that finalizes the job.
+	"""
+	job = frappe.get_doc("Ingestion Job", ingestion_job)
+
+	pending_item_names = [item.name for item in job.items if item.status == "Pending"]
+
+	if not pending_item_names:
+		_finalize_ingestion_job(ingestion_job)
+		return
+
+	chunks = [
+		pending_item_names[i : i + BATCH_SIZE] for i in range(0, len(pending_item_names), BATCH_SIZE)
+	]
+
+	frappe.cache().set_value(_remaining_batches_key(ingestion_job), len(chunks))
+
+	for i, item_names in enumerate(chunks):
+		frappe.enqueue(
+			"huf.ai.knowledge.bulk.orchestrator.process_batch",
+			queue="default",
+			ingestion_job=ingestion_job,
+			item_names=item_names,
+			job_id=f"bulk_batch_{ingestion_job}_{i}",
+			enqueue_after_commit=True,
+		)
+
+
+def process_batch(ingestion_job: str, item_names: list) -> None:
+	"""Process one batch of Ingestion Job Item rows.
+
+	Runs as its own background job, so this is where a chunk of raw
+	source files (Upload/Directory paths, S3 keys, or SFTP paths) actually
+	get pulled down, registered as Knowledge Inputs, and indexed.
+	"""
+	job = frappe.get_doc("Ingestion Job", ingestion_job)
+	items_by_name = {item.name: item for item in job.items}
+	items = [items_by_name[name] for name in item_names if name in items_by_name]
+
+	succeeded = failed = skipped = 0
+	tmpdir = tempfile.mkdtemp(prefix=f"bulk_ingest_{ingestion_job}_")
+	sftp = ssh_client = None
+
+	try:
+		if job.source_kind == "SFTP":
+			# One SFTP session for the whole batch, not per-file, so we
+			# don't pay a fresh handshake per item.
+			from huf.ai.knowledge.bulk.sftp_client import _connect
+
+			ssh_client, sftp = _connect(job.sftp_connection)
+
+		for item in items:
+			try:
+				item.db_set("status", "Processing", update_modified=False)
+
+				if frappe.db.exists(
+					"Knowledge Input",
+					{
+						"knowledge_source": job.knowledge_source,
+						"external_checksum": item.external_checksum,
+					},
+				):
+					item.db_set("status", "Skipped", update_modified=False)
+					skipped += 1
+					continue
+
+				local_path = _fetch_local_file(job, item, tmpdir, sftp)
+
+				with open(local_path, "rb") as f:
+					content = f.read()
+
+				file_doc = frappe.get_doc(
+					{
+						"doctype": "File",
+						"file_name": os.path.basename(item.external_path),
+						"content": content,
+						"is_private": 1,
+					}
+				).insert(ignore_permissions=True)
+
+				knowledge_input = frappe.get_doc(
+					{
+						"doctype": "Knowledge Input",
+						"knowledge_source": job.knowledge_source,
+						"input_type": "File",
+						"file": file_doc.file_url,
+						"external_source_path": item.external_path,
+						"external_checksum": item.external_checksum,
+						"ingestion_job": ingestion_job,
+					}
+				).insert(ignore_permissions=True)
+
+				process_knowledge_input(knowledge_input.name, skip_lock=False)
+
+				item.db_set("status", "Succeeded", update_modified=False)
+				item.db_set("knowledge_input", knowledge_input.name, update_modified=False)
+				succeeded += 1
+
+			except Exception as e:
+				frappe.db.rollback()
+				item.db_set("status", "Failed", update_modified=False)
+				item.db_set("error_message", str(e)[:500], update_modified=False)
+				failed += 1
+				frappe.log_error(f"Bulk Ingestion Item Error: {item.name}", frappe.get_traceback())
+
+	finally:
+		if ssh_client is not None:
+			ssh_client.close()
+		_cleanup_tmpdir(tmpdir)
+
+	# Counters are shared across concurrent batches of the same job, so we
+	# fold this batch's deltas in with a single atomic SQL update rather
+	# than loading/mutating/saving the whole job doc (which would race
+	# with the other batches running in parallel).
+	if succeeded or failed or skipped:
+		frappe.db.sql(
+			"""
+			UPDATE `tabIngestion Job`
+			SET succeeded = succeeded + %(succeeded)s,
+				failed = failed + %(failed)s,
+				skipped = skipped + %(skipped)s,
+				pending = pending - %(processed)s
+			WHERE name = %(name)s
+			""",
+			{
+				"succeeded": succeeded,
+				"failed": failed,
+				"skipped": skipped,
+				"processed": succeeded + failed + skipped,
+				"name": ingestion_job,
+			},
+		)
+	frappe.db.commit()
+
+	if _decrement_remaining_batches(ingestion_job) <= 0:
+		_finalize_ingestion_job(ingestion_job)
+
+
+def _fetch_local_file(job, item, tmpdir: str, sftp) -> str:
+	"""Get a local filesystem path for an item's content.
+
+	Upload/Directory items already point at a local path. S3/SFTP items
+	need to be downloaded into the batch's temp directory first.
+	"""
+	if job.source_kind in ("Upload", "Directory"):
+		return item.external_path
+
+	if job.source_kind == "S3":
+		local_path = os.path.join(tmpdir, os.path.basename(item.external_path))
+		client = _get_s3_client()
+		client.download_file(job.s3_bucket, item.external_path, local_path)
+		return local_path
+
+	if job.source_kind == "SFTP":
+		from huf.ai.knowledge.bulk.sftp_client import read_file
+
+		local_path = os.path.join(tmpdir, os.path.basename(item.external_path))
+		read_file(sftp, item.external_path, local_path)
+		return local_path
+
+	frappe.throw(f"Unsupported source_kind for bulk ingestion: {job.source_kind}")
+
+
+def _get_s3_client():
+	"""Build a boto3 S3 client the same way huf.ai.tools.s3._get_client() does."""
+	import boto3
+
+	access_key_id = require_credential("aws_s3", "access_key_id")
+	secret_access_key = require_credential("aws_s3", "secret_access_key")
+	region = require_credential("aws_s3", "region")
+
+	return boto3.client(
+		"s3",
+		aws_access_key_id=access_key_id,
+		aws_secret_access_key=secret_access_key,
+		region_name=region,
+	)
+
+
+def _cleanup_tmpdir(tmpdir: str) -> None:
+	import shutil
+
+	shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _remaining_batches_key(ingestion_job: str) -> str:
+	return f"bulk_ingestion_batches_remaining_{ingestion_job}"
+
+
+def _decrement_remaining_batches(ingestion_job: str) -> int:
+	"""Atomically decrement the remaining-batch counter for this job.
+
+	Mirrors the per-source Redis lock pattern in
+	huf.ai.knowledge.indexer.process_knowledge_input: a short-lived nx
+	lock guards the read-modify-write of the counter so concurrent
+	process_batch workers can't both read the same value and step on
+	each other's decrement.
+	"""
+	counter_key = _remaining_batches_key(ingestion_job)
+	lock_key = f"{counter_key}_lock"
+
+	while not frappe.cache().set(lock_key, 1, ex=30, nx=True):
+		time.sleep(0.05)
+
+	try:
+		remaining = frappe.cache().get_value(counter_key) or 0
+		remaining = int(remaining) - 1
+		frappe.cache().set_value(counter_key, remaining)
+		return remaining
+	finally:
+		frappe.cache().delete(lock_key)
+
+
+def _finalize_ingestion_job(ingestion_job: str) -> None:
+	"""Mark the job Completed / Completed with Errors once all batches are done."""
+	job = frappe.get_doc("Ingestion Job", ingestion_job)
+	job.status = "Completed" if not job.failed else "Completed with Errors"
+	job.finished_at = now_datetime()
+	job.save(ignore_permissions=True)
+	frappe.db.commit()

--- a/huf/ai/knowledge/bulk/orchestrator.py
+++ b/huf/ai/knowledge/bulk/orchestrator.py
@@ -13,7 +13,7 @@ import frappe
 from frappe.utils import now_datetime
 
 from huf.ai.knowledge.indexer import process_knowledge_input
-from huf.ai.tools.credentials import require_credential
+from huf.ai.tools.s3 import _get_client as _get_s3_client
 
 BATCH_SIZE = 50
 
@@ -116,7 +116,13 @@ def process_batch(ingestion_job: str, item_names: list) -> None:
 						"external_checksum": item.external_checksum,
 						"ingestion_job": ingestion_job,
 					}
-				).insert(ignore_permissions=True)
+				)
+				# Bulk ingestion calls process_knowledge_input() directly below
+				# (we're already inside a background worker); skip_auto_index
+				# stops Knowledge Input's own after_insert hook from also
+				# enqueuing it, which would otherwise index every document twice.
+				knowledge_input.flags.skip_auto_index = True
+				knowledge_input.insert(ignore_permissions=True)
 
 				process_knowledge_input(knowledge_input.name, skip_lock=False)
 
@@ -124,12 +130,20 @@ def process_batch(ingestion_job: str, item_names: list) -> None:
 				item.db_set("knowledge_input", knowledge_input.name, update_modified=False)
 				succeeded += 1
 
+				# Commit this item's work now. Batches share one long-lived
+				# transaction otherwise, so a later item's rollback (below)
+				# would silently discard every earlier item's File/Knowledge
+				# Input inserts in the same batch even though they'd already
+				# been reported as Succeeded.
+				frappe.db.commit()
+
 			except Exception as e:
 				frappe.db.rollback()
 				item.db_set("status", "Failed", update_modified=False)
 				item.db_set("error_message", str(e)[:500], update_modified=False)
 				failed += 1
 				frappe.log_error(f"Bulk Ingestion Item Error: {item.name}", frappe.get_traceback())
+				frappe.db.commit()
 
 	finally:
 		if ssh_client is not None:
@@ -187,22 +201,6 @@ def _fetch_local_file(job, item, tmpdir: str, sftp) -> str:
 		return local_path
 
 	frappe.throw(f"Unsupported source_kind for bulk ingestion: {job.source_kind}")
-
-
-def _get_s3_client():
-	"""Build a boto3 S3 client the same way huf.ai.tools.s3._get_client() does."""
-	import boto3
-
-	access_key_id = require_credential("aws_s3", "access_key_id")
-	secret_access_key = require_credential("aws_s3", "secret_access_key")
-	region = require_credential("aws_s3", "region")
-
-	return boto3.client(
-		"s3",
-		aws_access_key_id=access_key_id,
-		aws_secret_access_key=secret_access_key,
-		region_name=region,
-	)
 
 
 def _cleanup_tmpdir(tmpdir: str) -> None:

--- a/huf/ai/knowledge/bulk/scanners.py
+++ b/huf/ai/knowledge/bulk/scanners.py
@@ -22,16 +22,14 @@ def scan_upload(ingestion_job):
 	doc = frappe.get_doc("Ingestion Job", ingestion_job)
 
 	try:
-		doc.status = "Scanning"
-		doc.save(ignore_permissions=True)
-		frappe.db.commit()
+		_set_fields(ingestion_job, status="Scanning")
 
-		_scan_local_directory(doc, doc.directory_path)
+		_scan_local_directory(ingestion_job, doc.directory_path)
 
-		_enqueue_processing(doc)
+		_enqueue_processing(ingestion_job)
 
 	except Exception as e:
-		_mark_failed(doc, e)
+		_mark_failed(ingestion_job, e)
 		raise
 
 
@@ -40,21 +38,52 @@ def scan_directory(ingestion_job):
 	doc = frappe.get_doc("Ingestion Job", ingestion_job)
 
 	try:
-		doc.status = "Scanning"
-		doc.save(ignore_permissions=True)
-		frappe.db.commit()
+		_set_fields(ingestion_job, status="Scanning")
 
-		directory_path = doc.directory_path
-		if not directory_path or not os.path.isabs(directory_path) or not os.path.exists(directory_path):
-			frappe.throw(_("Ingestion Job directory_path must be an absolute path that exists: {0}").format(directory_path))
+		directory_path = _validate_directory_path(doc.directory_path)
 
-		_scan_local_directory(doc, directory_path)
+		_scan_local_directory(ingestion_job, directory_path)
 
-		_enqueue_processing(doc)
+		_enqueue_processing(ingestion_job)
 
 	except Exception as e:
-		_mark_failed(doc, e)
+		_mark_failed(ingestion_job, e)
 		raise
+
+
+def _validate_directory_path(directory_path):
+	"""Resolve and validate a user-supplied Directory-source path.
+
+	Directory imports are admin-triggered but the path itself travels through
+	a whitelisted API (huf.ai.knowledge.bulk.api.start_directory_import), so
+	it's untrusted input. Require it to resolve (after following symlinks) to
+	somewhere under one of the site's configured allow-listed roots, rather
+	than just checking it's an absolute path that exists -- otherwise any
+	caller of that endpoint could point a job at /etc or the bench's own
+	config directory and have it ingested into a knowledge base agents query.
+	"""
+	if not directory_path or not os.path.isabs(directory_path):
+		frappe.throw(_("Ingestion Job directory_path must be an absolute path: {0}").format(directory_path))
+
+	resolved = os.path.realpath(directory_path)
+	if not os.path.exists(resolved):
+		frappe.throw(_("Ingestion Job directory_path does not exist: {0}").format(directory_path))
+
+	allowed_roots = frappe.conf.get("bulk_ingestion_allowed_directories") or []
+	if not allowed_roots:
+		frappe.throw(
+			_(
+				"Directory-source bulk ingestion is disabled: no bulk_ingestion_allowed_directories "
+				"are configured in site_config.json. Add the server paths that are safe to ingest from."
+			)
+		)
+
+	for root in allowed_roots:
+		allowed_root = os.path.realpath(root)
+		if resolved == allowed_root or resolved.startswith(allowed_root + os.sep):
+			return resolved
+
+	frappe.throw(_("Ingestion Job directory_path is not under an allow-listed root: {0}").format(directory_path))
 
 
 def scan_s3(ingestion_job):
@@ -62,9 +91,7 @@ def scan_s3(ingestion_job):
 	doc = frappe.get_doc("Ingestion Job", ingestion_job)
 
 	try:
-		doc.status = "Scanning"
-		doc.save(ignore_permissions=True)
-		frappe.db.commit()
+		_set_fields(ingestion_job, status="Scanning")
 
 		access_key_id = require_credential("aws_s3", "access_key_id")
 		secret_access_key = require_credential("aws_s3", "secret_access_key")
@@ -99,8 +126,7 @@ def scan_s3(ingestion_job):
 				)
 
 			next_token = page["next_token"]
-			doc.sync_cursor = next_token or ""
-			_flush_batch(doc, batch)
+			_flush_batch(ingestion_job, batch, sync_cursor=next_token or "")
 			batch = []
 
 			if not next_token:
@@ -108,14 +134,10 @@ def scan_s3(ingestion_job):
 
 			continuation_token = next_token
 
-		doc.sync_cursor = ""
-		doc.save(ignore_permissions=True)
-		frappe.db.commit()
-
-		_enqueue_processing(doc)
+		_enqueue_processing(ingestion_job)
 
 	except Exception as e:
-		_mark_failed(doc, e)
+		_mark_failed(ingestion_job, e)
 		raise
 
 
@@ -124,9 +146,7 @@ def scan_sftp(ingestion_job):
 	doc = frappe.get_doc("Ingestion Job", ingestion_job)
 
 	try:
-		doc.status = "Scanning"
-		doc.save(ignore_permissions=True)
-		frappe.db.commit()
+		_set_fields(ingestion_job, status="Scanning")
 
 		if doc.sync_cursor:
 			dir_queue = json.loads(doc.sync_cursor)
@@ -150,12 +170,7 @@ def scan_sftp(ingestion_job):
 						}
 					)
 
-				doc.sync_cursor = json.dumps(dir_queue)
-				_flush_batch(doc, batch)
-
-			doc.sync_cursor = ""
-			doc.save(ignore_permissions=True)
-			frappe.db.commit()
+				_flush_batch(ingestion_job, batch, sync_cursor=json.dumps(dir_queue))
 
 		finally:
 			try:
@@ -163,14 +178,14 @@ def scan_sftp(ingestion_job):
 			finally:
 				ssh_client.close()
 
-		_enqueue_processing(doc)
+		_enqueue_processing(ingestion_job)
 
 	except Exception as e:
-		_mark_failed(doc, e)
+		_mark_failed(ingestion_job, e)
 		raise
 
 
-def _scan_local_directory(doc, root_path):
+def _scan_local_directory(ingestion_job, root_path):
 	"""Walk `root_path` and append discovered files as Ingestion Job Items, in batches."""
 	batch = []
 
@@ -189,55 +204,88 @@ def _scan_local_directory(doc, root_path):
 			)
 
 			if len(batch) >= BATCH_SIZE:
-				_flush_batch(doc, batch)
+				_flush_batch(ingestion_job, batch)
 				batch = []
 
-	_flush_batch(doc, batch)
+	_flush_batch(ingestion_job, batch)
 
 
-def _flush_batch(doc, batch):
-	"""Append `batch` rows to doc.items and save, updating discovery/pending counters."""
-	if not batch:
-		doc.save(ignore_permissions=True)
-		frappe.db.commit()
-		return
+def _flush_batch(ingestion_job, batch, sync_cursor=None):
+	"""Insert `batch` as Ingestion Job Item rows and bump discovery/pending counters.
 
-	for row in batch:
-		doc.append("items", row)
+	Deliberately does NOT load the parent Ingestion Job doc, append to its
+	in-memory child table, and doc.save() it -- across a scan with many pages
+	that would re-serialize the whole, ever-growing child table on every
+	single flush (O(n^2) over the full scan). Instead each row is inserted
+	directly via Document.db_insert() (Frappe's low-level bulk-child-insert
+	API, which doesn't touch the parent's other children) and the counters
+	are bumped with one atomic SQL update, mirroring the pattern
+	huf.ai.knowledge.bulk.orchestrator already uses for its batch counters.
 
-	doc.total_discovered = (doc.total_discovered or 0) + len(batch)
-	doc.pending = (doc.pending or 0) + len(batch)
+	Because this bypasses the ORM's child-table sync, nothing else in this
+	module may call doc.save() on an Ingestion Job doc once items exist for
+	it -- Frappe's save() reconciles child tables against whatever is in the
+	in-memory doc, and would delete any rows inserted this way that aren't
+	also present there. Status/cursor fields are updated separately via
+	frappe.db.set_value(), which only touches the named scalar columns.
+	"""
+	if batch:
+		next_idx = frappe.db.count("Ingestion Job Item", {"parent": ingestion_job}) + 1
+		for i, row in enumerate(batch):
+			child = frappe.get_doc(
+				{
+					"doctype": "Ingestion Job Item",
+					"parent": ingestion_job,
+					"parenttype": "Ingestion Job",
+					"parentfield": "items",
+					"idx": next_idx + i,
+					**row,
+				}
+			)
+			child.db_insert()
 
-	doc.save(ignore_permissions=True)
+		frappe.db.sql(
+			"""
+			UPDATE `tabIngestion Job`
+			SET total_discovered = total_discovered + %(count)s,
+				pending = pending + %(count)s
+			WHERE name = %(name)s
+			""",
+			{"count": len(batch), "name": ingestion_job},
+		)
+
+	if sync_cursor is not None:
+		frappe.db.set_value("Ingestion Job", ingestion_job, "sync_cursor", sync_cursor, update_modified=False)
+
 	frappe.db.commit()
 
 
-def _enqueue_processing(doc):
+def _set_fields(ingestion_job, **fields):
+	"""Update scalar fields on an Ingestion Job without touching its child table."""
+	frappe.db.set_value("Ingestion Job", ingestion_job, fields, update_modified=False)
+	frappe.db.commit()
+
+
+def _enqueue_processing(ingestion_job):
 	"""Kick off the batch processor now that scanning has produced pending items."""
 	frappe.enqueue(
 		"huf.ai.knowledge.bulk.orchestrator.process_ingestion_batches",
 		queue="default",
-		ingestion_job=doc.name,
-		job_id=f"bulk_process_{doc.name}",
+		ingestion_job=ingestion_job,
+		job_id=f"bulk_process_{ingestion_job}",
 		enqueue_after_commit=True,
 	)
 
-	doc.status = "Processing"
-	doc.save(ignore_permissions=True)
-	frappe.db.commit()
+	_set_fields(ingestion_job, status="Processing")
 
 
-def _mark_failed(doc, error):
+def _mark_failed(ingestion_job, error):
 	"""Record a scan failure on the Ingestion Job. Caller re-raises after this."""
 	frappe.db.rollback()
 
-	doc.reload()
-	doc.status = "Failed"
-	doc.error_message = str(error)[:500]
-	doc.save(ignore_permissions=True)
-	frappe.db.commit()
+	_set_fields(ingestion_job, status="Failed", error_message=str(error)[:500])
 
-	frappe.log_error(f"Ingestion Job Scan Error: {doc.name}", frappe.get_traceback())
+	frappe.log_error(f"Ingestion Job Scan Error: {ingestion_job}", frappe.get_traceback())
 
 
 SCANNER_BY_SOURCE_KIND = {

--- a/huf/ai/knowledge/bulk/scanners.py
+++ b/huf/ai/knowledge/bulk/scanners.py
@@ -1,0 +1,248 @@
+"""Scanners that discover source files/objects for an Ingestion Job and
+
+populate its "items" child table, before handing off to the batch processor.
+"""
+
+import json
+import os
+
+import boto3
+import frappe
+from frappe import _
+
+from huf.ai.knowledge.bulk.sftp_client import _connect, list_dir_recursive
+from huf.ai.tools.credentials import require_credential
+from huf.ai.tools.s3 import list_objects_page
+
+BATCH_SIZE = 200
+
+
+def scan_upload(ingestion_job):
+	"""Scan a directory populated by the API layer from an uploaded zip/files."""
+	doc = frappe.get_doc("Ingestion Job", ingestion_job)
+
+	try:
+		doc.status = "Scanning"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		_scan_local_directory(doc, doc.directory_path)
+
+		_enqueue_processing(doc)
+
+	except Exception as e:
+		_mark_failed(doc, e)
+		raise
+
+
+def scan_directory(ingestion_job):
+	"""Scan a directory path directly (no upload extraction step)."""
+	doc = frappe.get_doc("Ingestion Job", ingestion_job)
+
+	try:
+		doc.status = "Scanning"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		directory_path = doc.directory_path
+		if not directory_path or not os.path.isabs(directory_path) or not os.path.exists(directory_path):
+			frappe.throw(_("Ingestion Job directory_path must be an absolute path that exists: {0}").format(directory_path))
+
+		_scan_local_directory(doc, directory_path)
+
+		_enqueue_processing(doc)
+
+	except Exception as e:
+		_mark_failed(doc, e)
+		raise
+
+
+def scan_s3(ingestion_job):
+	"""Scan an S3 bucket/prefix, resuming from doc.sync_cursor if set."""
+	doc = frappe.get_doc("Ingestion Job", ingestion_job)
+
+	try:
+		doc.status = "Scanning"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		access_key_id = require_credential("aws_s3", "access_key_id")
+		secret_access_key = require_credential("aws_s3", "secret_access_key")
+		region = require_credential("aws_s3", "region")
+
+		client = boto3.client(
+			"s3",
+			aws_access_key_id=access_key_id,
+			aws_secret_access_key=secret_access_key,
+			region_name=region,
+		)
+
+		continuation_token = doc.sync_cursor or None
+		batch = []
+
+		while True:
+			page = list_objects_page(
+				client,
+				doc.s3_bucket,
+				doc.s3_prefix or "",
+				continuation_token=continuation_token,
+			)
+
+			for obj in page["objects"]:
+				batch.append(
+					{
+						"external_path": obj["key"],
+						"external_checksum": obj["etag"],
+						"size_bytes": obj["size"],
+						"status": "Pending",
+					}
+				)
+
+			next_token = page["next_token"]
+			doc.sync_cursor = next_token or ""
+			_flush_batch(doc, batch)
+			batch = []
+
+			if not next_token:
+				break
+
+			continuation_token = next_token
+
+		doc.sync_cursor = ""
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		_enqueue_processing(doc)
+
+	except Exception as e:
+		_mark_failed(doc, e)
+		raise
+
+
+def scan_sftp(ingestion_job):
+	"""Scan an SFTP tree, resuming from doc.sync_cursor (a JSON directory queue)."""
+	doc = frappe.get_doc("Ingestion Job", ingestion_job)
+
+	try:
+		doc.status = "Scanning"
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+
+		if doc.sync_cursor:
+			dir_queue = json.loads(doc.sync_cursor)
+		else:
+			dir_queue = [doc.sftp_root_path]
+
+		ssh_client, sftp_client = _connect(doc.sftp_connection)
+
+		try:
+			while dir_queue:
+				files, dir_queue = list_dir_recursive(sftp_client, dir_queue)
+
+				batch = []
+				for entry in files:
+					batch.append(
+						{
+							"external_path": entry["path"],
+							"external_checksum": f"{entry['size']}:{entry['mtime']}",
+							"size_bytes": entry["size"],
+							"status": "Pending",
+						}
+					)
+
+				doc.sync_cursor = json.dumps(dir_queue)
+				_flush_batch(doc, batch)
+
+			doc.sync_cursor = ""
+			doc.save(ignore_permissions=True)
+			frappe.db.commit()
+
+		finally:
+			try:
+				sftp_client.close()
+			finally:
+				ssh_client.close()
+
+		_enqueue_processing(doc)
+
+	except Exception as e:
+		_mark_failed(doc, e)
+		raise
+
+
+def _scan_local_directory(doc, root_path):
+	"""Walk `root_path` and append discovered files as Ingestion Job Items, in batches."""
+	batch = []
+
+	for dirpath, _dirnames, filenames in os.walk(root_path):
+		for filename in filenames:
+			file_path = os.path.abspath(os.path.join(dirpath, filename))
+			stat = os.stat(file_path)
+
+			batch.append(
+				{
+					"external_path": file_path,
+					"external_checksum": f"{stat.st_size}:{stat.st_mtime}",
+					"size_bytes": stat.st_size,
+					"status": "Pending",
+				}
+			)
+
+			if len(batch) >= BATCH_SIZE:
+				_flush_batch(doc, batch)
+				batch = []
+
+	_flush_batch(doc, batch)
+
+
+def _flush_batch(doc, batch):
+	"""Append `batch` rows to doc.items and save, updating discovery/pending counters."""
+	if not batch:
+		doc.save(ignore_permissions=True)
+		frappe.db.commit()
+		return
+
+	for row in batch:
+		doc.append("items", row)
+
+	doc.total_discovered = (doc.total_discovered or 0) + len(batch)
+	doc.pending = (doc.pending or 0) + len(batch)
+
+	doc.save(ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _enqueue_processing(doc):
+	"""Kick off the batch processor now that scanning has produced pending items."""
+	frappe.enqueue(
+		"huf.ai.knowledge.bulk.orchestrator.process_ingestion_batches",
+		queue="default",
+		ingestion_job=doc.name,
+		job_id=f"bulk_process_{doc.name}",
+		enqueue_after_commit=True,
+	)
+
+	doc.status = "Processing"
+	doc.save(ignore_permissions=True)
+	frappe.db.commit()
+
+
+def _mark_failed(doc, error):
+	"""Record a scan failure on the Ingestion Job. Caller re-raises after this."""
+	frappe.db.rollback()
+
+	doc.reload()
+	doc.status = "Failed"
+	doc.error_message = str(error)[:500]
+	doc.save(ignore_permissions=True)
+	frappe.db.commit()
+
+	frappe.log_error(f"Ingestion Job Scan Error: {doc.name}", frappe.get_traceback())
+
+
+SCANNER_BY_SOURCE_KIND = {
+	"Upload": scan_upload,
+	"Directory": scan_directory,
+	"S3": scan_s3,
+	"SFTP": scan_sftp,
+}

--- a/huf/ai/knowledge/bulk/sftp_client.py
+++ b/huf/ai/knowledge/bulk/sftp_client.py
@@ -1,0 +1,130 @@
+"""SFTP-based bulk-source client for Ingestion Job scanning.
+
+Distinct from ``huf.ai.tools.ssh_execution``, which is a one-shot
+command-execution tool with a human-approval workflow and a capped
+output size -- the wrong fit for bulk file listing/transfer. This
+module opens a dedicated paramiko SFTP channel instead, reusing the
+same private-key loading and strict pinned host-key verification
+logic as ``ssh_execution.py`` so authentication and host-key pinning
+behavior stay identical across both tools.
+"""
+
+from __future__ import annotations
+
+import stat
+
+import frappe
+import paramiko
+
+from huf.ai.tools.ssh_execution import _fingerprint_for_key, _load_private_key
+
+DEFAULT_PAGE_LIMIT = 200
+
+
+class _PinnedHostKeyPolicy(paramiko.MissingHostKeyPolicy):
+	"""Accept the server key only if it matches the SSH Connection's pinned fingerprint."""
+
+	def __init__(self, connection_doc):
+		self.connection_doc = connection_doc
+
+	def missing_host_key(self, client, hostname, key):
+		fingerprint = _fingerprint_for_key(key)
+		expected = (self.connection_doc.host_key_fingerprint or "").strip()
+		if fingerprint != expected:
+			frappe.throw(
+				f"SSH host key mismatch for {self.connection_doc.name}. Expected {expected}, got {fingerprint}.",
+				frappe.ValidationError,
+			)
+		if (self.connection_doc.host_key_type or "").strip() and key.get_name() != self.connection_doc.host_key_type:
+			frappe.throw(
+				f"SSH host key type mismatch for {self.connection_doc.name}. "
+				f"Expected {self.connection_doc.host_key_type}, got {key.get_name()}.",
+				frappe.ValidationError,
+			)
+
+
+def _connect(ssh_connection_name: str):
+	"""Authenticate to the SSH Connection and open an SFTP channel.
+
+	Reuses the same key-loading and password/private-key branching as
+	``ssh_execution.py``, and enforces the same strict pinned host-key
+	verification when ``host_key_verification`` is "Strict (Pinned)".
+	Returns (ssh_client, sftp_client) -- the caller closes both when done.
+	"""
+	connection_doc = frappe.get_doc("SSH Connection", ssh_connection_name)
+
+	if connection_doc.host_key_verification == "Strict (Pinned)" and not (
+		connection_doc.host_key_fingerprint or ""
+	).strip():
+		frappe.throw(
+			f"SSH Connection '{connection_doc.name}' requires strict pinned host-key verification "
+			"but has no enrolled host key fingerprint.",
+			frappe.ValidationError,
+		)
+
+	ssh_client = paramiko.SSHClient()
+	if connection_doc.host_key_verification == "Strict (Pinned)":
+		ssh_client.set_missing_host_key_policy(_PinnedHostKeyPolicy(connection_doc))
+	else:
+		ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+	connect_kwargs = {
+		"hostname": connection_doc.host,
+		"port": int(connection_doc.port or 22),
+		"username": connection_doc.username,
+	}
+
+	if connection_doc.auth_method == "Password":
+		connect_kwargs["password"] = connection_doc.get_password("password")
+	else:
+		pkey = _load_private_key(
+			connection_doc.get_password("private_key"),
+			connection_doc.get_password("private_key_passphrase", raise_exception=False),
+		)
+		connect_kwargs["pkey"] = pkey
+
+	ssh_client.connect(**connect_kwargs)
+
+	sftp_client = ssh_client.open_sftp()
+	return ssh_client, sftp_client
+
+
+def list_dir_recursive(sftp, dir_queue, page_limit=DEFAULT_PAGE_LIMIT):
+	"""Pop directories off the front of `dir_queue`, listing files and enqueueing subdirectories.
+
+	`dir_queue` is a plain list of remote directory path strings acting as a
+	resumable cursor. Directories are popped from the front and visited one
+	at a time; any subdirectories discovered are appended to the end of
+	`dir_queue` so a crashed/paused scan can resume from the same frontier.
+	Stops once `page_limit` files have been collected or `dir_queue` is empty.
+	Returns (files_collected, remaining_dir_queue).
+	"""
+	files_collected = []
+
+	while dir_queue and len(files_collected) < page_limit:
+		current_dir = dir_queue.pop(0)
+
+		for entry in sftp.listdir_attr(current_dir):
+			full_path = f"{current_dir.rstrip('/')}/{entry.filename}"
+
+			if stat.S_ISDIR(entry.st_mode):
+				dir_queue.append(full_path)
+			else:
+				files_collected.append(
+					{
+						"path": full_path,
+						"size": entry.st_size,
+						"mtime": entry.st_mtime,
+					}
+				)
+
+				if len(files_collected) >= page_limit:
+					break
+
+	return files_collected, dir_queue
+
+
+def read_file(sftp, remote_path, local_tmp_path):
+	"""Stream `remote_path` down to `local_tmp_path` via SFTP. Returns `local_tmp_path`."""
+	sftp.get(remote_path, local_tmp_path)
+	return local_tmp_path

--- a/huf/ai/knowledge/tests/test_bulk_ingestion.py
+++ b/huf/ai/knowledge/tests/test_bulk_ingestion.py
@@ -1,0 +1,233 @@
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from unittest.mock import patch, MagicMock
+
+
+class TestBulkIngestionChecksumSkip(IntegrationTestCase):
+	"""huf.ai.knowledge.bulk.orchestrator.process_batch — checksum-based skip logic."""
+
+	def setUp(self):
+		self.source_name = "Test Bulk Source Checksum"
+		if not frappe.db.exists("Knowledge Source", self.source_name):
+			frappe.get_doc({
+				"doctype": "Knowledge Source",
+				"source_name": self.source_name,
+				"scope": "Global",
+				"storage_mode": "Frappe File",
+				"knowledge_type": "sqlite_fts",
+				"status": "Ready",
+				"chunk_size": 512,
+				"chunk_overlap": 50,
+			}).insert(ignore_permissions=True)
+
+		self.existing_checksum = "checksum-abc-123"
+
+		# An existing Knowledge Input already ingested under this checksum.
+		self.existing_input = frappe.get_doc({
+			"doctype": "Knowledge Input",
+			"knowledge_source": self.source_name,
+			"input_type": "Text",
+			"text": "already ingested content",
+			"external_checksum": self.existing_checksum,
+			"status": "Indexed",
+		}).insert(ignore_permissions=True)
+
+		# An Ingestion Job with one Pending item whose checksum matches the
+		# already-ingested Knowledge Input above.
+		self.job = frappe.get_doc({
+			"doctype": "Ingestion Job",
+			"knowledge_source": self.source_name,
+			"source_kind": "Directory",
+			"status": "Processing",
+			"directory_path": "/tmp/bulk-test",
+			"items": [
+				{
+					"external_path": "/tmp/bulk-test/dup.txt",
+					"external_checksum": self.existing_checksum,
+					"size_bytes": 42,
+					"status": "Pending",
+				}
+			],
+		}).insert(ignore_permissions=True)
+		self.item_name = self.job.items[0].name
+
+	def tearDown(self):
+		frappe.delete_doc("Ingestion Job", self.job.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Knowledge Input", self.existing_input.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Knowledge Source", self.source_name, force=True, ignore_permissions=True)
+
+	def test_checksum_skip_logic(self):
+		with patch("huf.ai.knowledge.indexer.process_knowledge_input") as mock_process:
+			from huf.ai.knowledge.bulk import orchestrator
+
+			orchestrator.process_batch(self.job.name, [self.item_name])
+
+			# The real indexing/vector-backend pipeline must never be touched
+			# for a checksum that already exists in this source.
+			mock_process.assert_not_called()
+
+		self.job.reload()
+		item = self.job.items[0]
+		self.assertEqual(item.status, "Skipped")
+
+		# No second Knowledge Input should have been created for this checksum.
+		count = frappe.db.count("Knowledge Input", {
+			"knowledge_source": self.source_name,
+			"external_checksum": self.existing_checksum,
+		})
+		self.assertEqual(count, 1)
+
+
+class TestScanS3PaginationAndCursor(IntegrationTestCase):
+	"""huf.ai.knowledge.bulk.scanners.scan_s3 — pagination + sync_cursor handling."""
+
+	def setUp(self):
+		self.source_name = "Test Bulk Source S3"
+		if not frappe.db.exists("Knowledge Source", self.source_name):
+			frappe.get_doc({
+				"doctype": "Knowledge Source",
+				"source_name": self.source_name,
+				"scope": "Global",
+				"storage_mode": "Frappe File",
+				"knowledge_type": "sqlite_fts",
+				"status": "Ready",
+				"chunk_size": 512,
+				"chunk_overlap": 50,
+			}).insert(ignore_permissions=True)
+
+		self.job = frappe.get_doc({
+			"doctype": "Ingestion Job",
+			"knowledge_source": self.source_name,
+			"source_kind": "S3",
+			"status": "Queued",
+			"s3_bucket": "test-bucket",
+			"s3_prefix": "docs/",
+		}).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.delete_doc("Ingestion Job", self.job.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Knowledge Source", self.source_name, force=True, ignore_permissions=True)
+
+	def test_scan_s3_pagination_and_cursor(self):
+		page_1 = {
+			"objects": [
+				{"key": "docs/a.txt", "size": 10, "last_modified": "2024-01-01T00:00:00", "etag": "etag-a"},
+				{"key": "docs/b.txt", "size": 20, "last_modified": "2024-01-02T00:00:00", "etag": "etag-b"},
+			],
+			"next_token": "page2",
+		}
+		page_2 = {
+			"objects": [
+				{"key": "docs/c.txt", "size": 30, "last_modified": "2024-01-03T00:00:00", "etag": "etag-c"},
+			],
+			"next_token": None,
+		}
+
+		def fake_list_objects_page(client, bucket, prefix="", continuation_token=None, page_size=100):
+			if continuation_token is None:
+				return page_1
+			self.assertEqual(continuation_token, "page2")
+			return page_2
+
+		with patch("huf.ai.knowledge.bulk.scanners.list_objects_page", side_effect=fake_list_objects_page), \
+				patch("huf.ai.knowledge.bulk.scanners.require_credential", return_value="dummy"), \
+				patch("huf.ai.knowledge.bulk.scanners.boto3") as mock_boto3, \
+				patch("huf.ai.knowledge.bulk.scanners.frappe.enqueue"):
+			mock_boto3.client.return_value = MagicMock()
+
+			from huf.ai.knowledge.bulk import scanners
+			scanners.scan_s3(self.job.name)
+			# Note: list_objects_page, require_credential, and boto3 are imported at
+			# module level in huf.ai.knowledge.bulk.scanners specifically so they can
+			# be patched here -- scan_s3() does not re-import them locally.
+
+		self.job.reload()
+
+		# Items from BOTH pages must have been written.
+		created_paths = {row.external_path for row in self.job.items}
+		self.assertEqual(
+			created_paths,
+			{"docs/a.txt", "docs/b.txt", "docs/c.txt"},
+		)
+		self.assertEqual(len(self.job.items), 3)
+
+		# sync_cursor must be cleared once the scan is fully complete.
+		self.assertIn(self.job.sync_cursor, (None, "", "null"))
+
+
+class TestScanSftpPaginationAndCursor(IntegrationTestCase):
+	"""huf.ai.knowledge.bulk.scanners.scan_sftp — pagination + sync_cursor handling."""
+
+	def setUp(self):
+		self.source_name = "Test Bulk Source SFTP"
+		if not frappe.db.exists("Knowledge Source", self.source_name):
+			frappe.get_doc({
+				"doctype": "Knowledge Source",
+				"source_name": self.source_name,
+				"scope": "Global",
+				"storage_mode": "Frappe File",
+				"knowledge_type": "sqlite_fts",
+				"status": "Ready",
+				"chunk_size": 512,
+				"chunk_overlap": 50,
+			}).insert(ignore_permissions=True)
+
+		self.job = frappe.get_doc({
+			"doctype": "Ingestion Job",
+			"knowledge_source": self.source_name,
+			"source_kind": "SFTP",
+			"status": "Queued",
+			"sftp_root_path": "/remote/root",
+		}).insert(ignore_permissions=True)
+
+	def tearDown(self):
+		frappe.delete_doc("Ingestion Job", self.job.name, force=True, ignore_permissions=True)
+		frappe.delete_doc("Knowledge Source", self.source_name, force=True, ignore_permissions=True)
+
+	def test_scan_sftp_pagination_and_cursor(self):
+		files_page_1 = [
+			{"path": "/remote/root/a.txt", "size": 10, "mtime": 1700000000},
+			{"path": "/remote/root/b.txt", "size": 20, "mtime": 1700000001},
+		]
+		files_page_2 = [
+			{"path": "/remote/root/sub/c.txt", "size": 30, "mtime": 1700000002},
+		]
+
+		call_log = []
+
+		def fake_list_dir_recursive(sftp, dir_queue):
+			call_log.append(list(dir_queue))
+			if len(call_log) == 1:
+				self.assertEqual(dir_queue, ["/remote/root"])
+				return files_page_1, ["/remote/root/sub"]
+			self.assertEqual(dir_queue, ["/remote/root/sub"])
+			return files_page_2, []
+
+		fake_ssh_client = MagicMock()
+		fake_sftp_session = MagicMock()
+
+		with patch("huf.ai.knowledge.bulk.scanners._connect", return_value=(fake_ssh_client, fake_sftp_session)), \
+				patch("huf.ai.knowledge.bulk.scanners.list_dir_recursive", side_effect=fake_list_dir_recursive), \
+				patch("huf.ai.knowledge.bulk.scanners.frappe.enqueue"):
+			# _connect and list_dir_recursive are imported by name at module level
+			# in huf.ai.knowledge.bulk.scanners specifically so they can be patched
+			# here -- scan_sftp() does not re-import them locally. _connect's real
+			# return order is (ssh_client, sftp_client).
+
+			from huf.ai.knowledge.bulk import scanners
+			scanners.scan_sftp(self.job.name)
+
+		self.assertEqual(len(call_log), 2)
+
+		self.job.reload()
+
+		created_paths = {row.external_path for row in self.job.items}
+		self.assertEqual(
+			created_paths,
+			{"/remote/root/a.txt", "/remote/root/b.txt", "/remote/root/sub/c.txt"},
+		)
+		self.assertEqual(len(self.job.items), 3)
+
+		# sync_cursor must be cleared once the directory queue is exhausted.
+		self.assertIn(self.job.sync_cursor, (None, "", "null"))

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -730,6 +730,48 @@ GOOGLE_DRIVE_TOOLS = [
 ]
 
 
+S3_TOOLS = [
+	{
+		"tool_name": "s3_list_buckets",
+		"description": "List S3 buckets accessible with the configured AWS credentials.",
+		"function_path": "huf.ai.tools.s3.handle_list_buckets",
+		"category": "Cloud",
+		"parameters": [],
+	},
+	{
+		"tool_name": "s3_list_objects",
+		"description": "List objects in an S3 bucket, optionally filtered by prefix.",
+		"function_path": "huf.ai.tools.s3.handle_list_objects",
+		"category": "Cloud",
+		"parameters": [
+			_p("bucket", required=True, description="S3 bucket name"),
+			_p("prefix", description="Optional key prefix to filter by"),
+			_p("limit", type="integer", description="Max objects (default 50)"),
+		],
+	},
+	{
+		"tool_name": "s3_get_object_metadata",
+		"description": "Get metadata (size, type, last modified) of an S3 object.",
+		"function_path": "huf.ai.tools.s3.handle_get_object_metadata",
+		"category": "Cloud",
+		"parameters": [
+			_p("bucket", required=True, description="S3 bucket name"),
+			_p("key", required=True, description="Object key"),
+		],
+	},
+	{
+		"tool_name": "s3_search_objects",
+		"description": "Search for objects in an S3 bucket by key/name substring.",
+		"function_path": "huf.ai.tools.s3.handle_search_objects",
+		"category": "Cloud",
+		"parameters": [
+			_p("bucket", required=True, description="S3 bucket name"),
+			_p("query", required=True, description="Substring to search for in object keys"),
+		],
+	},
+]
+
+
 GOOGLE_MEET_TOOLS = [
 	{
 		"tool_name": "google_meet_create_space",
@@ -1852,6 +1894,7 @@ ALL_INTEGRATION_TOOLS = (
 	# `google_places.py` sets SERVICE_NAME = "google_maps".
 	+ _with_service(GOOGLE_PLACES_TOOLS, "google_maps")
 	+ _with_service(GOOGLE_DRIVE_TOOLS, "google_drive")
+	+ _with_service(S3_TOOLS, "aws_s3")
 	+ _with_service(GOOGLE_MEET_TOOLS, "google_meet")
 	+ _with_service(SERP_HOTEL_TOOLS, "serpapi")
 	+ _with_service(SERP_REVIEW_TOOLS, "serpapi")

--- a/huf/ai/tools/s3.py
+++ b/huf/ai/tools/s3.py
@@ -1,0 +1,160 @@
+import json
+import frappe
+logger = frappe.logger("huf")
+from huf.ai.tools.credentials import require_credential, update_last_error
+import boto3
+
+
+def _get_client():
+	service_name = "aws_s3"
+	access_key_id = require_credential(service_name, "access_key_id")
+	secret_access_key = require_credential(service_name, "secret_access_key")
+	region = require_credential(service_name, "region")
+
+	return boto3.client(
+		"s3",
+		aws_access_key_id=access_key_id,
+		aws_secret_access_key=secret_access_key,
+		region_name=region,
+	)
+
+
+def list_objects_page(client, bucket, prefix="", continuation_token=None, page_size=100):
+	kwargs = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": page_size}
+	if continuation_token:
+		kwargs["ContinuationToken"] = continuation_token
+
+	resp = client.list_objects_v2(**kwargs)
+
+	objects = []
+	for obj in resp.get("Contents", []):
+		objects.append({
+			"key": obj.get("Key"),
+			"size": obj.get("Size"),
+			"last_modified": obj.get("LastModified").isoformat() if obj.get("LastModified") else None,
+			"etag": obj.get("ETag"),
+		})
+
+	next_token = resp.get("NextContinuationToken") if resp.get("IsTruncated") else None
+
+	return {"objects": objects, "next_token": next_token}
+
+
+def handle_list_buckets(**kwargs):
+	"""List S3 buckets."""
+	service_name = "aws_s3"
+	try:
+		client = _get_client()
+		resp = client.list_buckets()
+		buckets = [
+			{"name": b.get("Name"), "creation_date": b.get("CreationDate").isoformat() if b.get("CreationDate") else None}
+			for b in resp.get("Buckets", [])
+		]
+		return json.dumps({
+			"success": True,
+			"count": len(buckets),
+			"results": buckets
+		})
+	except Exception as e:
+		logger.warning(f"S3 Error (List Buckets): {str(e)}")
+		update_last_error(service_name, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def handle_list_objects(**kwargs):
+	"""List objects in an S3 bucket."""
+	service_name = "aws_s3"
+	try:
+		bucket = kwargs.get("bucket")
+		if not bucket:
+			return json.dumps({"success": False, "error": "bucket is required"})
+
+		prefix = kwargs.get("prefix", "")
+		limit = int(kwargs.get("limit", 50))
+
+		client = _get_client()
+		page = list_objects_page(client, bucket, prefix, page_size=limit)
+		objects = page["objects"]
+
+		return json.dumps({
+			"success": True,
+			"count": len(objects),
+			"results": objects
+		})
+	except Exception as e:
+		logger.warning(f"S3 Error (List Objects): {str(e)}")
+		update_last_error(service_name, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def handle_get_object_metadata(**kwargs):
+	"""Get metadata of an S3 object."""
+	service_name = "aws_s3"
+	try:
+		bucket = kwargs.get("bucket")
+		if not bucket:
+			return json.dumps({"success": False, "error": "bucket is required"})
+
+		key = kwargs.get("key")
+		if not key:
+			return json.dumps({"success": False, "error": "key is required"})
+
+		client = _get_client()
+		resp = client.head_object(Bucket=bucket, Key=key)
+
+		data = {
+			"content_length": resp.get("ContentLength"),
+			"content_type": resp.get("ContentType"),
+			"last_modified": resp.get("LastModified").isoformat() if resp.get("LastModified") else None,
+			"etag": resp.get("ETag"),
+		}
+
+		return json.dumps({
+			"success": True,
+			"results": data
+		})
+	except Exception as e:
+		logger.warning(f"S3 Error (Get Object Metadata): {str(e)}")
+		update_last_error(service_name, str(e))
+		return json.dumps({"success": False, "error": str(e)})
+
+
+def handle_search_objects(**kwargs):
+	"""Search for objects in an S3 bucket by key substring."""
+	service_name = "aws_s3"
+	try:
+		bucket = kwargs.get("bucket")
+		if not bucket:
+			return json.dumps({"success": False, "error": "bucket is required"})
+
+		query = kwargs.get("query")
+		if not query:
+			return json.dumps({"success": False, "error": "query is required"})
+
+		client = _get_client()
+		query_lower = query.lower()
+
+		matches = []
+		token = None
+		for _ in range(5):
+			page = list_objects_page(client, bucket, continuation_token=token)
+			for obj in page["objects"]:
+				if query_lower in obj["key"].lower():
+					matches.append(obj)
+					if len(matches) >= 200:
+						break
+			if len(matches) >= 200:
+				break
+			token = page["next_token"]
+			if not token:
+				break
+
+		return json.dumps({
+			"success": True,
+			"count": len(matches),
+			"results": matches
+		})
+	except Exception as e:
+		logger.warning(f"S3 Error (Search Objects): {str(e)}")
+		update_last_error(service_name, str(e))
+		return json.dumps({"success": False, "error": str(e)})

--- a/huf/huf/doctype/ingestion_job/ingestion_job.json
+++ b/huf/huf/doctype/ingestion_job/ingestion_job.json
@@ -1,0 +1,222 @@
+{
+	"actions": [],
+	"allow_rename": 1,
+	"autoname": "hash",
+	"creation": "2026-08-07 00:00:00.000000",
+	"doctype": "DocType",
+	"engine": "InnoDB",
+	"field_order": [
+		"knowledge_source",
+		"source_kind",
+		"status",
+		"column_break_1",
+		"total_discovered",
+		"pending",
+		"processing",
+		"succeeded",
+		"failed",
+		"skipped",
+		"timing_section",
+		"started_at",
+		"finished_at",
+		"error_message",
+		"sync_cursor",
+		"source_config_section",
+		"s3_bucket",
+		"s3_prefix",
+		"directory_path",
+		"sftp_connection",
+		"sftp_root_path",
+		"items"
+	],
+	"fields": [
+		{
+			"fieldname": "knowledge_source",
+			"fieldtype": "Link",
+			"label": "Knowledge Source",
+			"options": "Knowledge Source",
+			"reqd": 1
+		},
+		{
+			"fieldname": "source_kind",
+			"fieldtype": "Select",
+			"label": "Source Kind",
+			"options": "Upload\nDirectory\nS3\nSFTP\nGoogle Drive",
+			"reqd": 1
+		},
+		{
+			"default": "Queued",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"label": "Status",
+			"options": "Queued\nScanning\nProcessing\nCompleted\nCompleted with Errors\nFailed",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_1",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "0",
+			"fieldname": "total_discovered",
+			"fieldtype": "Int",
+			"label": "Total Discovered",
+			"read_only": 1
+		},
+		{
+			"default": "0",
+			"fieldname": "pending",
+			"fieldtype": "Int",
+			"label": "Pending",
+			"read_only": 1
+		},
+		{
+			"default": "0",
+			"fieldname": "processing",
+			"fieldtype": "Int",
+			"label": "Processing",
+			"read_only": 1
+		},
+		{
+			"default": "0",
+			"fieldname": "succeeded",
+			"fieldtype": "Int",
+			"label": "Succeeded",
+			"read_only": 1
+		},
+		{
+			"default": "0",
+			"fieldname": "failed",
+			"fieldtype": "Int",
+			"label": "Failed",
+			"read_only": 1
+		},
+		{
+			"default": "0",
+			"fieldname": "skipped",
+			"fieldtype": "Int",
+			"label": "Skipped",
+			"read_only": 1
+		},
+		{
+			"fieldname": "timing_section",
+			"fieldtype": "Section Break",
+			"label": "Timing"
+		},
+		{
+			"fieldname": "started_at",
+			"fieldtype": "Datetime",
+			"label": "Started At",
+			"read_only": 1
+		},
+		{
+			"fieldname": "finished_at",
+			"fieldtype": "Datetime",
+			"label": "Finished At",
+			"read_only": 1
+		},
+		{
+			"fieldname": "error_message",
+			"fieldtype": "Small Text",
+			"label": "Error Message",
+			"read_only": 1
+		},
+		{
+			"fieldname": "sync_cursor",
+			"fieldtype": "Long Text",
+			"label": "Sync Cursor",
+			"read_only": 1,
+			"hidden": 1
+		},
+		{
+			"fieldname": "source_config_section",
+			"fieldtype": "Section Break",
+			"label": "Source Configuration"
+		},
+		{
+			"fieldname": "s3_bucket",
+			"fieldtype": "Data",
+			"label": "S3 Bucket",
+			"depends_on": "eval:doc.source_kind=='S3'"
+		},
+		{
+			"fieldname": "s3_prefix",
+			"fieldtype": "Data",
+			"label": "S3 Prefix",
+			"depends_on": "eval:doc.source_kind=='S3'"
+		},
+		{
+			"fieldname": "directory_path",
+			"fieldtype": "Data",
+			"label": "Directory Path",
+			"depends_on": "eval:doc.source_kind=='Directory'"
+		},
+		{
+			"fieldname": "sftp_connection",
+			"fieldtype": "Link",
+			"label": "SFTP Connection",
+			"options": "SSH Connection",
+			"depends_on": "eval:doc.source_kind=='SFTP'"
+		},
+		{
+			"fieldname": "sftp_root_path",
+			"fieldtype": "Data",
+			"label": "SFTP Root Path",
+			"depends_on": "eval:doc.source_kind=='SFTP'"
+		},
+		{
+			"fieldname": "items",
+			"fieldtype": "Table",
+			"label": "Items",
+			"options": "Ingestion Job Item"
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-08-07 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "Huf",
+	"name": "Ingestion Job",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "System Manager",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Huf Manager",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Huf User",
+			"share": 1,
+			"write": 1
+		}
+	],
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": []
+}

--- a/huf/huf/doctype/ingestion_job/ingestion_job.py
+++ b/huf/huf/doctype/ingestion_job/ingestion_job.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+from frappe import _
+
+from huf.ai.knowledge.bulk.scanners import SCANNER_BY_SOURCE_KIND
+
+
+class IngestionJob(Document):
+	def start(self):
+		"""Resolve the scanner for this source kind and enqueue it."""
+		scanner = SCANNER_BY_SOURCE_KIND.get(self.source_kind)
+		if not scanner:
+			frappe.throw(_("No scanner registered for source kind: {0}").format(self.source_kind))
+
+		self.status = "Queued"
+		self.started_at = frappe.utils.now_datetime()
+		self.save()
+
+		frappe.enqueue(
+			scanner,
+			queue="long",
+			job_id=f"bulk_scan_{self.name}",
+			ingestion_job=self.name,
+			enqueue_after_commit=True,
+		)
+
+
+@frappe.whitelist()
+def get_progress(ingestion_job: str):
+	"""Return progress counters for an Ingestion Job."""
+	doc = frappe.get_doc("Ingestion Job", ingestion_job)
+
+	return {
+		"status": doc.status,
+		"total_discovered": doc.total_discovered,
+		"pending": doc.pending,
+		"processing": doc.processing,
+		"succeeded": doc.succeeded,
+		"failed": doc.failed,
+		"skipped": doc.skipped,
+		"error_message": doc.error_message,
+	}

--- a/huf/huf/doctype/ingestion_job_item/ingestion_job_item.json
+++ b/huf/huf/doctype/ingestion_job_item/ingestion_job_item.json
@@ -1,0 +1,68 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-08-07 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "external_path",
+  "external_checksum",
+  "size_bytes",
+  "status",
+  "knowledge_input",
+  "error_message"
+ ],
+ "fields": [
+  {
+   "fieldname": "external_path",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Path"
+  },
+  {
+   "fieldname": "external_checksum",
+   "fieldtype": "Data",
+   "label": "Checksum"
+  },
+  {
+   "fieldname": "size_bytes",
+   "fieldtype": "Int",
+   "label": "Size (bytes)"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Pending\nProcessing\nSucceeded\nFailed\nSkipped"
+  },
+  {
+   "fieldname": "knowledge_input",
+   "fieldtype": "Link",
+   "label": "Knowledge Input",
+   "options": "Knowledge Input"
+  },
+  {
+   "fieldname": "error_message",
+   "fieldtype": "Small Text",
+   "label": "Error Message"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-07 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Ingestion Job Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/huf/huf/doctype/ingestion_job_item/ingestion_job_item.py
+++ b/huf/huf/doctype/ingestion_job_item/ingestion_job_item.py
@@ -1,0 +1,6 @@
+import frappe
+from frappe.model.document import Document
+
+
+class IngestionJobItem(Document):
+	pass

--- a/huf/huf/doctype/knowledge_input/knowledge_input.json
+++ b/huf/huf/doctype/knowledge_input/knowledge_input.json
@@ -15,6 +15,9 @@
   "status_section",
   "status",
   "source_hash",
+  "external_source_path",
+  "external_checksum",
+  "ingestion_job",
   "chunks_created",
   "character_count",
   "processed_at",
@@ -77,6 +80,25 @@
    "fieldname": "source_hash",
    "fieldtype": "Data",
    "label": "Source Hash",
+   "read_only": 1
+  },
+  {
+   "fieldname": "external_source_path",
+   "fieldtype": "Data",
+   "label": "External Source Path",
+   "read_only": 1
+  },
+  {
+   "fieldname": "external_checksum",
+   "fieldtype": "Data",
+   "label": "External Checksum",
+   "read_only": 1
+  },
+  {
+   "fieldname": "ingestion_job",
+   "fieldtype": "Link",
+   "options": "Ingestion Job",
+   "label": "Ingestion Job",
    "read_only": 1
   },
   {

--- a/huf/huf/doctype/knowledge_input/knowledge_input.py
+++ b/huf/huf/doctype/knowledge_input/knowledge_input.py
@@ -85,7 +85,17 @@ class KnowledgeInput(Document):
 		return ext_map.get(ext, "application/octet-stream")
 	
 	def after_insert(self):
-		"""Queue processing after insert."""
+		"""Queue processing after insert.
+
+		Skipped when flags.skip_auto_index is set -- bulk ingestion
+		(huf.ai.knowledge.bulk.orchestrator) creates its Knowledge Input docs
+		with that flag and calls process_knowledge_input() directly and
+		synchronously right after insert, since it's already running inside a
+		background worker. Without this guard both paths would fire and every
+		bulk-ingested document would be indexed twice.
+		"""
+		if self.flags.get("skip_auto_index"):
+			return
 		self.queue_processing()
 	
 	def queue_processing(self):

--- a/huf/huf/doctype/knowledge_source/knowledge_source.json
+++ b/huf/huf/doctype/knowledge_source/knowledge_source.json
@@ -9,6 +9,7 @@
 		"configuration_section",
 		"source_name",
 		"description",
+		"source_kind",
 		"column_break_1",
 		"knowledge_type",
 		"scope",
@@ -76,6 +77,13 @@
 			"fieldname": "description",
 			"fieldtype": "Small Text",
 			"label": "Description"
+		},
+		{
+			"default": "Manual",
+			"fieldtype": "Select",
+			"label": "Source Kind",
+			"options": "Manual\nUpload\nDirectory\nS3\nSFTP\nGoogle Drive",
+			"fieldname": "source_kind"
 		},
 		{
 			"fieldname": "column_break_1",

--- a/huf/install.py
+++ b/huf/install.py
@@ -1100,6 +1100,16 @@ def register_integration_services():
 				{"key": "api_key", "label": "SerpApi API Key", "required": True}
 			]
 		},
+		{
+			"service_name": "aws_s3",
+			"category": "Cloud",
+			"description": "Amazon S3 object storage -- list, read, and search objects in a bucket",
+			"required_credentials": [
+				{"key": "access_key_id", "label": "AWS Access Key ID", "required": True},
+				{"key": "secret_access_key", "label": "AWS Secret Access Key", "required": True},
+				{"key": "region", "label": "AWS Region", "required": True}
+			]
+		},
 	]
 	
 	# Create or update each service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "tinycss2>=1.5.0",
     # PDF export for document artifacts (huf.ai.artifacts.render.pdf/safety).
     "weasyprint>=68.0",
+    "boto3>=1.34.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

Adds bulk document ingestion to HUF's knowledge/RAG system, built as an orchestration layer on top of the existing single-document pipeline (`process_knowledge_input`) rather than a new ingestion engine — per [HUF_BULK_INGESTION_PLAN.md](HUF_BULK_INGESTION_PLAN.md) and the file-by-file build order in [HUF_BULK_INGESTION_EXECUTION_PLAN.md](HUF_BULK_INGESTION_EXECUTION_PLAN.md).

- **S3 as a first-class Integration** (`huf/ai/tools/s3.py`, registered in `_registry.py`, seeded in `install.py`) — any agent can call `s3_list_buckets` / `s3_list_objects` / `s3_get_object_metadata` / `s3_search_objects`, following the exact same `Integration Service` → tool module → `_registry.py` pattern as `google_drive.py`, Jira, Notion, etc. The credential UI needs no new frontend code — it's schema-driven off `Integration Service.required_credentials`.
- **`Ingestion Job` / `Ingestion Job Item`** — new DocTypes (modeled on `Flow Run`/`Agent Run`'s status pattern) that track a bulk import's discovery/processing progress: `total_discovered / pending / processing / succeeded / failed / skipped`.
- **Four bulk sources**, all funneling through `huf/ai/knowledge/bulk/scanners.py` → `orchestrator.py` → the existing `process_knowledge_input()`:
  - **Upload** — browser multi-file/ZIP upload, extracted server-side.
  - **Directory** — a server-side path, admin use.
  - **S3** — paginated `list_objects_v2` with a resumable `sync_cursor` continuation token, reusing the exact same boto3 client/credentials as the S3 agent tool above.
  - **SFTP** (`huf/ai/knowledge/bulk/sftp_client.py`) — reuses the existing `SSH Connection` credential doctype and its host-key pinning (imported from `ssh_execution.py`), but opens a dedicated `paramiko` SFTP channel rather than routing through the exec-only, output-capped `run_ssh_command` tool.
- **Dedup**: a new `external_checksum` field on `Knowledge Input` is checked before creating a duplicate, so re-syncing an unchanged source is a no-op. This is deliberately separate from the existing `source_hash`/`check_duplicate()` mechanism, which hard-throws on collision and is left untouched.
- **Frontend**: `KnowledgeBulkImportModal.tsx` (built on the existing CSV `BulkImportModal.tsx` template — 4-way source picker, 2s-interval progress polling, failed-item list) wired into `KnowledgeSourcesPage.tsx` via a new "Bulk Import" action, backed by `frontend/src/services/bulkIngestionApi.ts`.

## Test plan

- [ ] `bench migrate` to apply the two new DocTypes and the new fields on `Knowledge Input`/`Knowledge Source`
- [ ] `bench execute huf.ai.tool_registry.sync_discovered_tools` and confirm the four `s3_*` tools appear under an agent's tool picker (category "Cloud")
- [ ] Configure an `aws_s3` Integration Settings record and attach `s3_list_objects` to a test agent; confirm it lists a real bucket
- [ ] Run `huf/ai/knowledge/tests/test_bulk_ingestion.py` (checksum-skip, S3 pagination/cursor, SFTP pagination/cursor)
- [ ] Manually run each of the four bulk sources against a small test set (a handful of files) and confirm the modal's progress view reaches a terminal status with correct succeeded/failed/skipped counts
- [ ] Confirm re-running an S3/SFTP import over unchanged files skips them via checksum instead of re-indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)