### PR TITLE
refactor(settings): merge AI Providers and Models into tabbed pair

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Plug, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -147,7 +147,7 @@ const settingsNavGroups: Array<{ label?: string; items: Array<{ title: string; u
   {
     items: [
       { title: "General", url: "/settings/general", icon: SlidersHorizontal, capability: null },
-      { title: "AI Providers & Models", url: "/providers", icon: Plug, capability: "system.providers.manage" },
+      { title: "AI Providers & Models", url: "/providers", icon: Layers, capability: "system.providers.manage" },
       { title: "MCP Servers", url: "/mcp", icon: Server, capability: "system.mcp.manage" },
       { title: "Gateways", url: "/gateways", icon: GlobeLock, capability: "system.integrations.manage" },
       { title: "Integrations", url: "/integrations", icon: Link2, capability: "system.integrations.manage" },

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Plug, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, Layers, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Plug, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -147,8 +147,7 @@ const settingsNavGroups: Array<{ label?: string; items: Array<{ title: string; u
   {
     items: [
       { title: "General", url: "/settings/general", icon: SlidersHorizontal, capability: null },
-      { title: "AI Providers", url: "/providers", icon: Plug, capability: "system.providers.manage" },
-      { title: "Models", url: "/models", icon: Layers, capability: "system.providers.manage" },
+      { title: "AI Providers & Models", url: "/providers", icon: Plug, capability: "system.providers.manage" },
       { title: "MCP Servers", url: "/mcp", icon: Server, capability: "system.mcp.manage" },
       { title: "Gateways", url: "/gateways", icon: GlobeLock, capability: "system.integrations.manage" },
       { title: "Integrations", url: "/integrations", icon: Link2, capability: "system.integrations.manage" },

--- a/frontend/src/components/settings/ProviderModelTabs.tsx
+++ b/frontend/src/components/settings/ProviderModelTabs.tsx
@@ -1,0 +1,29 @@
+import { NavLink } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+
+const providerModelSections = [
+  { label: 'Providers', to: '/providers' },
+  { label: 'Models', to: '/models' },
+];
+
+export function ProviderModelTabs() {
+  return (
+    <nav aria-label="Provider and model sections" className="mb-5 flex border-b border-ink">
+      {providerModelSections.map((section) => (
+        <NavLink
+          key={section.to}
+          to={section.to}
+          end
+          className={({ isActive }) =>
+            cn(
+              'border-b-2 border-transparent px-4 pb-2 font-mono text-[11.5px] uppercase tracking-wide text-steel transition-colors hover:text-ink',
+              isActive && '-mb-px border-signal text-ink',
+            )
+          }
+        >
+          {section.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/layouts/UnifiedHeader.tsx
+++ b/frontend/src/layouts/UnifiedHeader.tsx
@@ -25,7 +25,7 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
     if (path.startsWith('/agents')) return 'Agent';
     if (path.startsWith('/flows')) return 'Flows';
     if (path.startsWith('/data')) return 'Data';
-    if (path.startsWith('/providers')) return 'AI Providers';
+    if (path.startsWith('/providers')) return 'AI Providers & Models';
     if (path.startsWith('/integration-services')) return 'Integration Catalog';
     if (path.startsWith('/integrations')) return 'Integrations';
     if (path.startsWith('/gateways')) return 'Gateways';
@@ -42,7 +42,7 @@ export function UnifiedHeader({ actions, breadcrumbs }: UnifiedHeaderProps) {
     if (path.startsWith('/members')) return 'Members';
     if (path.startsWith('/users')) return 'Users';
     if (path.startsWith('/roles')) return 'Roles';
-    if (path.startsWith('/models')) return 'Models';
+    if (path.startsWith('/models')) return 'AI Providers & Models';
     if (path.startsWith('/execution-profiles')) return 'Code Execution';
     if (path.startsWith('/ssh-connections')) return 'SSH Connections';
     if (path.startsWith('/apps')) return 'Apps';

--- a/frontend/src/pages/AiProvidersPage.tsx
+++ b/frontend/src/pages/AiProvidersPage.tsx
@@ -13,6 +13,7 @@ import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Checkbox } from '../components/ui/checkbox';
 import { PageFrame } from '@/layouts/PageFrame';
+import { ProviderModelTabs } from '@/components/settings/ProviderModelTabs';
 import { FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import {
@@ -417,6 +418,7 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
         />
       }
     >
+      <ProviderModelTabs />
       <div className="border border-line bg-panel p-4 space-y-3">
         <div className="flex items-start gap-3">
           <Sparkles className="h-4 w-4 mt-0.5 text-signal shrink-0" />

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '../components/ui/select';
 import { PageFrame } from '@/layouts/PageFrame';
+import { ProviderModelTabs } from '@/components/settings/ProviderModelTabs';
 import { FilterBar, GridView, ItemCard, LoadMoreButton, EmptyState } from '../components/dashboard';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import {
@@ -319,6 +320,7 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         />
       }
     >
+      <ProviderModelTabs />
       {error && !initialLoading && (
         <div className="text-center py-12">
           <p className="text-destructive mb-4">Failed to load models</p>


### PR DESCRIPTION
## Summary

Follow-up to #582 (`workspace/HUF_IA_AUDIT.md` §4.1 flagged this as a deferred item — the two were left as separate Settings nav entries because a real merge needs page-level changes, not just a nav relabel).

Providers and Models are virtually always configured as a pair (add a provider, then its models) but lived as two disconnected Settings list items. This mirrors the exact same pattern already shipped for Agent Prompts / Summary Prompts (`PromptLibraryTabs`) — a shared tab bar, two still-independent routes.

- New `frontend/src/components/settings/ProviderModelTabs.tsx`, rendered inside both `AiProvidersPage` and `ModelsPage` (same injection point pattern as `PromptLibraryTabs`).
- Sidebar: the two Settings entries ("AI Providers", "Models") collapse into one — **"AI Providers & Models"** → `/providers`. Removed the now-unused `Layers` icon import.
- `UnifiedHeader` breadcrumb: both `/providers` and `/models` now resolve to the same `"AI Providers & Models"` title, matching how `/prompts`/`/summary-prompts` already share one breadcrumb label.

## Explicitly NOT changed

- **No route/URL changes.** `/providers` and `/models` remain independently working routes, including the `?configure=<id>` deep-link contract (`lib/link-routes.ts`'s `aiProvider()`/`aiModel()` helpers) and the `?starter=openrouter|google` onboarding flow from `HomePage.tsx`. Verified these call sites still target the same URLs.
- No changes to the underlying page logic/data-fetching/modals — each page keeps its own `*Wrapper` + Context (`AiProvidersProvider`/`ModelsProvider`), only a tab bar was added.

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` — 0 errors (checked against `tsconfig.app.json` directly, not the root solution tsconfig, per the lesson from #582's review)
- [x] Manually verified live in a disposable bench (`frappe-multihand`, isolated from the shared `huf.localhost` bench): confirmed sidebar shows one merged entry, breadcrumb reads "AI Providers & Models" on both `/providers` and `/models`, tab bar correctly highlights the active tab, header action button correctly switches between "+ Add Provider" / "+ Add Model", and both pages still load real provider/model data with their existing cards/grids intact.
- [x] Confirmed `?configure=<id>` deep link (e.g. `/providers?configure=OpenAI`) still opens the correct edit modal on top of the correctly-active Providers tab — screenshot verified in the same bench.