### PR TITLE
feat(lifecycle): conversation hide/archive/trash/delete with agent-level retention policy

### DIFF
--- a/huf/ai/agent_chat.py
+++ b/huf/ai/agent_chat.py
@@ -1119,6 +1119,48 @@ def _policy_permits(policy: str, required: str) -> bool:
     return _RETENTION_POLICY_ORDER.index(policy) >= _RETENTION_POLICY_ORDER.index(required)
 
 
+def _assert_owns_conversation(conv_owner: str):
+    """Only the conversation's owner or a System Manager may change its lifecycle state."""
+    if conv_owner != frappe.session.user and "System Manager" not in frappe.get_roles():
+        raise frappe.PermissionError(_("You do not have permission to manage this conversation."))
+
+
+def _effective_policy(policy: str | None) -> str:
+    """Doctype Select default only applies to new docs — rows created before this policy
+    field existed have no value in the DB. Treat missing/unrecognized policy as the same
+    'allow_trash' default declared on the Agent doctype, rather than silently denying every
+    lifecycle action for pre-existing agents."""
+    if policy in _RETENTION_POLICY_ORDER:
+        return policy
+    return "allow_trash"
+
+
+def _orphan_conversation_links(conversation: str):
+    """Clear every Link field across the schema that points at this Agent Conversation,
+    instead of deleting the referencing records — preserves Agent Message/Agent Run/etc.
+    as an audit trail and avoids frappe.exceptions.LinkExistsError on delete_doc."""
+    link_fields = frappe.get_all(
+        "DocField",
+        filters={"fieldtype": "Link", "options": "Agent Conversation"},
+        fields=["parent as doctype", "fieldname"],
+    )
+    link_fields += frappe.get_all(
+        "Custom Field",
+        filters={"fieldtype": "Link", "options": "Agent Conversation"},
+        fields=["dt as doctype", "fieldname"],
+    )
+    for link in link_fields:
+        if link.doctype == "Agent Conversation":
+            continue
+        meta = frappe.get_meta(link.doctype)
+        if meta.istable:
+            # Child tables are deleted along with their parent document; nothing to orphan.
+            continue
+        record_names = frappe.get_all(link.doctype, filters={link.fieldname: conversation}, pluck="name")
+        for record_name in record_names:
+            frappe.db.set_value(link.doctype, record_name, link.fieldname, None, update_modified=False)
+
+
 @frappe.whitelist()
 def set_conversation_status(conversation: str, status: str):
     """Transition an Agent Conversation's status, gated by the agent's retention policy."""
@@ -1126,10 +1168,13 @@ def set_conversation_status(conversation: str, status: str):
         frappe.throw(_("Invalid status: {0}").format(status))
 
     doc = frappe.get_doc("Agent Conversation", conversation)
+    _assert_owns_conversation(doc.owner)
 
     required_policy = _STATUS_REQUIRED_POLICY.get(status)
     if required_policy:
-        agent_policy = frappe.db.get_value("Agent", doc.agent, "conversation_retention_policy")
+        agent_policy = _effective_policy(
+            frappe.db.get_value("Agent", doc.agent, "conversation_retention_policy")
+        )
         if not _policy_permits(agent_policy, required_policy):
             raise frappe.PermissionError(
                 _("This agent's retention policy does not allow moving conversations to {0}.").format(status)
@@ -1145,22 +1190,21 @@ def set_conversation_status(conversation: str, status: str):
 
 @frappe.whitelist()
 def hard_delete_conversation(conversation: str):
-    """Permanently delete an Agent Conversation while preserving its Agent Message/Agent Run audit trail."""
-    agent = frappe.db.get_value("Agent Conversation", conversation, "agent")
-    agent_policy = frappe.db.get_value("Agent", agent, "conversation_retention_policy") if agent else None
+    """Permanently delete an Agent Conversation while preserving its Agent Message/Agent Run
+    (and every other linked doctype's) audit trail — only the links to this conversation are
+    cleared, never the records themselves."""
+    conv = frappe.get_doc("Agent Conversation", conversation)
+    _assert_owns_conversation(conv.owner)
 
+    agent_policy = _effective_policy(
+        frappe.db.get_value("Agent", conv.agent, "conversation_retention_policy") if conv.agent else None
+    )
     if agent_policy != "allow_delete":
         raise frappe.PermissionError(
             _("This agent's retention policy does not allow permanently deleting conversations.")
         )
 
-    # Audit-log requirement: Agent Message / Agent Run records are never deleted,
-    # only orphaned from the conversation being removed.
-    message_names = frappe.get_all(
-        "Agent Message", filters={"conversation": conversation}, pluck="name"
-    )
-    for message_name in message_names:
-        frappe.db.set_value("Agent Message", message_name, "conversation", None, update_modified=False)
+    _orphan_conversation_links(conversation)
 
     frappe.delete_doc("Agent Conversation", conversation, ignore_permissions=True)
     frappe.db.commit()

--- a/huf/ai/agent_chat.py
+++ b/huf/ai/agent_chat.py
@@ -1097,3 +1097,113 @@ def add_message(
         # API boundary: log unexpected failure with traceback, then re-raise.
         frappe.log_error(message=f"add_message API error: {frappe.get_traceback()}", title="Huf API")
         raise
+
+
+VALID_CONVERSATION_STATUSES = ("Active", "Hidden", "Archived", "Trashed")
+
+# Ordered escalation of destructive actions a retention policy may permit.
+_RETENTION_POLICY_ORDER = ("allow_hide", "allow_archive", "allow_trash", "allow_delete")
+
+# Minimum retention policy required to move a conversation into each status.
+_STATUS_REQUIRED_POLICY = {
+    "Hidden": "allow_hide",
+    "Archived": "allow_archive",
+    "Trashed": "allow_trash",
+}
+
+
+def _policy_permits(policy: str, required: str) -> bool:
+    """Check whether `policy` is at least as permissive as `required` on the escalation ladder."""
+    if not policy or policy not in _RETENTION_POLICY_ORDER:
+        return False
+    return _RETENTION_POLICY_ORDER.index(policy) >= _RETENTION_POLICY_ORDER.index(required)
+
+
+@frappe.whitelist()
+def set_conversation_status(conversation: str, status: str):
+    """Transition an Agent Conversation's status, gated by the agent's retention policy."""
+    if status not in VALID_CONVERSATION_STATUSES:
+        frappe.throw(_("Invalid status: {0}").format(status))
+
+    doc = frappe.get_doc("Agent Conversation", conversation)
+
+    required_policy = _STATUS_REQUIRED_POLICY.get(status)
+    if required_policy:
+        agent_policy = frappe.db.get_value("Agent", doc.agent, "conversation_retention_policy")
+        if not _policy_permits(agent_policy, required_policy):
+            raise frappe.PermissionError(
+                _("This agent's retention policy does not allow moving conversations to {0}.").format(status)
+            )
+
+    doc.status = status
+    doc.trashed_at = frappe.utils.now_datetime() if status == "Trashed" else None
+    doc.archived_at = frappe.utils.now_datetime() if status == "Archived" else None
+    doc.save(ignore_permissions=False)
+
+    return {"status": "ok", "conversation": conversation, "new_status": status}
+
+
+@frappe.whitelist()
+def hard_delete_conversation(conversation: str):
+    """Permanently delete an Agent Conversation while preserving its Agent Message/Agent Run audit trail."""
+    agent = frappe.db.get_value("Agent Conversation", conversation, "agent")
+    agent_policy = frappe.db.get_value("Agent", agent, "conversation_retention_policy") if agent else None
+
+    if agent_policy != "allow_delete":
+        raise frappe.PermissionError(
+            _("This agent's retention policy does not allow permanently deleting conversations.")
+        )
+
+    # Audit-log requirement: Agent Message / Agent Run records are never deleted,
+    # only orphaned from the conversation being removed.
+    message_names = frappe.get_all(
+        "Agent Message", filters={"conversation": conversation}, pluck="name"
+    )
+    for message_name in message_names:
+        frappe.db.set_value("Agent Message", message_name, "conversation", None, update_modified=False)
+
+    frappe.delete_doc("Agent Conversation", conversation, ignore_permissions=True)
+    frappe.db.commit()
+
+    return {"status": "ok", "deleted": conversation}
+
+
+def purge_trashed_conversations():
+    """Scheduler entry point: hard-delete Trashed conversations past their agent's retention window."""
+    trashed_conversations = frappe.get_all(
+        "Agent Conversation",
+        filters={"status": "Trashed"},
+        fields=["name", "agent", "trashed_at"],
+    )
+
+    for conv in trashed_conversations:
+        try:
+            if not conv.trashed_at:
+                continue
+
+            trash_retention_days = frappe.db.get_value("Agent", conv.agent, "trash_retention_days")
+            if trash_retention_days is None or trash_retention_days == -1:
+                continue
+
+            age_days = (frappe.utils.now_datetime() - conv.trashed_at).days
+            if age_days >= trash_retention_days:
+                hard_delete_conversation(conv.name)
+        except Exception:  # boundary exception handler: scheduler job
+            frappe.log_error(
+                message=f"purge_trashed_conversations error for {conv.name}: {frappe.get_traceback()}",
+                title="Huf Scheduler",
+            )
+            continue
+
+
+@frappe.whitelist()
+def list_orphaned_messages(limit=100):
+    """Admin-only: list Agent Message records whose conversation link was cleared by a hard-deleted conversation (audit-log retention)."""
+    frappe.only_for("System Manager")
+    return frappe.get_all(
+        "Agent Message",
+        filters={"conversation": ["in", ["", None]]},
+        fields=["name", "content", "kind", "role", "creation", "agent"],
+        order_by="creation desc",
+        limit_page_length=limit,
+    )

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -253,6 +253,7 @@ scheduler_events = {
         "huf.ai.knowledge.maintenance.optimize_indexes",
         # P2-10: Proactively mark expired Memory Records (past effective_until) as Expired
         "huf.ai.memory_tools.expire_stale_memory_records",
+        "huf.ai.agent_chat.purge_trashed_conversations",
     ],
     "cron": {
         "*/1 * * * *": [

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -84,6 +84,12 @@
   "autonaming_of_conversation_title",
   "enable_conversation_data",
   "column_break_fl05",
+  "conversation_lifecycle_section",
+  "conversation_retention_policy",
+  "trash_retention_days",
+  "column_break_lifecycle",
+  "message_retention_days",
+  "auto_archive_after_days",
   "inject_conversation_data",
   "conversation_data_api_permission",
   "memory_section",
@@ -575,7 +581,6 @@
    "fieldtype": "Check",
    "label": "Enable Multi Run"
   },
-
   {
    "depends_on": "eval:!doc.disabled",
    "description": "Configure prompt caching to reduce costs by caching repeated prompt content",

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -932,6 +932,44 @@
   {
    "fieldname": "column_break_fl05",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "conversation_lifecycle_section",
+   "fieldtype": "Section Break",
+   "label": "Conversation Lifecycle Policy"
+  },
+  {
+   "fieldname": "conversation_retention_policy",
+   "fieldtype": "Select",
+   "options": "allow_hide\nallow_archive\nallow_trash\nallow_delete",
+   "default": "allow_trash",
+   "label": "Conversation Retention Policy",
+   "description": "Maximum destructive action a user may take on their own conversations with this agent."
+  },
+  {
+   "fieldname": "trash_retention_days",
+   "fieldtype": "Int",
+   "default": "30",
+   "label": "Trash Retention (days)",
+   "description": "Days before trashed conversations are auto-purged. 0 = purge immediately, -1 = never auto-purge."
+  },
+  {
+   "fieldname": "column_break_lifecycle",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "message_retention_days",
+   "fieldtype": "Int",
+   "default": "-1",
+   "label": "Message Retention (days)",
+   "description": "-1 = retain forever."
+  },
+  {
+   "fieldname": "auto_archive_after_days",
+   "fieldtype": "Int",
+   "default": "0",
+   "label": "Auto-Archive After (days)",
+   "description": "0 = disabled."
   }
  ],
  "grid_page_length": 50,

--- a/huf/huf/doctype/agent_conversation/agent_conversation.json
+++ b/huf/huf/doctype/agent_conversation/agent_conversation.json
@@ -6,6 +6,10 @@
  "field_order": [
   "overview_tab",
   "title",
+  "status",
+  "pinned",
+  "trashed_at",
+  "archived_at",
   "agent",
   "model",
   "column_break_9v4t",

--- a/huf/huf/doctype/agent_conversation/agent_conversation.json
+++ b/huf/huf/doctype/agent_conversation/agent_conversation.json
@@ -38,6 +38,33 @@
    "read_only": 1
   },
   {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "options": "Active\nHidden\nArchived\nTrashed\nDeleted",
+   "default": "Active",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status"
+  },
+  {
+   "fieldname": "pinned",
+   "fieldtype": "Check",
+   "default": "0",
+   "label": "Pinned"
+  },
+  {
+   "fieldname": "trashed_at",
+   "fieldtype": "Datetime",
+   "label": "Trashed At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "archived_at",
+   "fieldtype": "Datetime",
+   "label": "Archived At",
+   "read_only": 1
+  },
+  {
    "description": "Rolling summary of the conversation context, used when the history limit is exceeded.",
    "fieldname": "summary",
    "fieldtype": "Long Text",

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -17,3 +17,4 @@ huf.patches.v1.fix_agent_message_status
 huf.patches.v1.sync_data_table_permissions
 huf.patches.v1.add_frappe_cloud_service
 huf.patches.v1.backfill_tool_service_links
+huf.patches.v1.backfill_conversation_lifecycle_defaults

--- a/huf/patches/v1/backfill_conversation_lifecycle_defaults.py
+++ b/huf/patches/v1/backfill_conversation_lifecycle_defaults.py
@@ -1,0 +1,37 @@
+import frappe
+
+
+def execute():
+	"""Backfill conversation_retention_policy / trash_retention_days on Agent rows created
+	before the conversation-lifecycle fields existed, and status on pre-existing Agent
+	Conversation rows. Select-field defaults only apply to new docs, so without this,
+	every lifecycle action (hide/archive/trash/delete) would be denied for existing agents."""
+	frappe.db.sql(
+		"""
+		UPDATE `tabAgent`
+		SET conversation_retention_policy = 'allow_trash'
+		WHERE conversation_retention_policy IS NULL OR conversation_retention_policy = ''
+		"""
+	)
+	frappe.db.sql(
+		"""
+		UPDATE `tabAgent`
+		SET trash_retention_days = 30
+		WHERE trash_retention_days IS NULL
+		"""
+	)
+	frappe.db.sql(
+		"""
+		UPDATE `tabAgent`
+		SET message_retention_days = -1
+		WHERE message_retention_days IS NULL
+		"""
+	)
+	frappe.db.sql(
+		"""
+		UPDATE `tabAgent Conversation`
+		SET status = 'Active'
+		WHERE status IS NULL OR status = ''
+		"""
+	)
+	frappe.db.commit()


### PR DESCRIPTION
## Summary
- Adds `status` / `pinned` / `trashed_at` / `archived_at` to **Agent Conversation**
- Adds `conversation_retention_policy` / `trash_retention_days` / `message_retention_days` / `auto_archive_after_days` to **Agent**
- New whitelisted methods in `huf/ai/agent_chat.py`: `set_conversation_status`, `hard_delete_conversation`, `list_orphaned_messages`
- New daily scheduler job `purge_trashed_conversations` (`huf/hooks.py`)
- **Audit-log guarantee**: `hard_delete_conversation` never deletes `Agent Message` / `Agent Run` records — it only clears their `conversation` link (orphans them) before deleting the conversation shell. Retention policy is enforced with an ordered escalation (`allow_hide < allow_archive < allow_trash < allow_delete`).

Companion frontend PR: https://github.com/tridz-dev/huf_pwa/pull/1

Full design doc: `workspace/Tracks/ConversationLifecycle/CONTEXT.md`

## Test plan
- [x] `python3 -m py_compile huf/ai/agent_chat.py huf/hooks.py`
- [x] Doctype JSON validated with `json.load`
- [ ] `bench migrate` on a live site to confirm new fields land cleanly
- [ ] Manual: create conversation → trash → verify `set_conversation_status` respects agent policy → verify `hard_delete_conversation` orphans messages, not deletes them
- [ ] Manual: verify `purge_trashed_conversations` respects `trash_retention_days` (including `-1` = never purge)