### PR TITLE
fix(tests): backport IntegrationTestCase/UnitTestCase compat shim for v15

### DIFF
--- a/huf/__init__.py
+++ b/huf/__init__.py
@@ -19,3 +19,15 @@ try:
 	sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
 except ImportError:
 	pass  # Fall back to stdlib; sqlite_vec will fail with clear error
+
+# v16-only test classes backported for v15 compat
+try:
+	import frappe.tests as _frappe_tests
+	from frappe.tests.utils import FrappeTestCase
+
+	if not hasattr(_frappe_tests, "IntegrationTestCase"):
+		_frappe_tests.IntegrationTestCase = FrappeTestCase
+	if not hasattr(_frappe_tests, "UnitTestCase"):
+		_frappe_tests.UnitTestCase = FrappeTestCase
+except ImportError:
+	pass  # frappe.tests.utils.FrappeTestCase unavailable; leave frappe.tests as-is


### PR DESCRIPTION
## Problem

`bench --site <site>.local run-tests --app huf` fails immediately at import-collection time on any Frappe **version-15** bench:

```
File "apps/huf/huf/ai/knowledge/tests/test_chroma_backend.py", line 12, in <module>
    from frappe.tests import IntegrationTestCase
ImportError: cannot import name 'IntegrationTestCase' from 'frappe.tests'
```

40+ huf test files import `IntegrationTestCase` (and 2 files import `UnitTestCase`) from `frappe.tests`, expecting them to exist as the modern `FrappeTestCase` replacement. They don't — on version-15.

## Root cause

`IntegrationTestCase`/`UnitTestCase` are **v16/`develop`-only** additions to Frappe, introduced in [frappe PR #27992](https://github.com/frappe/frappe/pull/27992) (merged Oct 2024) — a rename+split of the old `FrappeTestCase` into a new leaner `UnitTestCase` base, with `IntegrationTestCase` subclassing it to carry the original DB/site-setup behavior. This was **never backported to `version-15`**, confirmed directly against `raw.githubusercontent.com/frappe/frappe/version-15/frappe/tests/__init__.py`, which only exports `update_system_settings`, `get_system_setting`, `global_test_dependencies`. `FrappeTestCase` still lives at `frappe/tests/utils.py` on v15 and is functionally a superset of both v16 classes.

Since huf pins to `frappe~=15.0.0`, updating the bench's frappe checkout doesn't help — this bench was already at the tip of `version-15` (15.117.0).

## Fix

A small, forward-compatible shim at the end of `huf/__init__.py` (runs at app-init time, before frappe's test runner imports any huf test module):

```python
# v16-only test classes backported for v15 compat
try:
	import frappe.tests as _frappe_tests
	from frappe.tests.utils import FrappeTestCase

	if not hasattr(_frappe_tests, "IntegrationTestCase"):
		_frappe_tests.IntegrationTestCase = FrappeTestCase
	if not hasattr(_frappe_tests, "UnitTestCase"):
		_frappe_tests.UnitTestCase = FrappeTestCase
except ImportError:
	pass  # frappe.tests.utils.FrappeTestCase unavailable; leave frappe.tests as-is
```

- Guarded with `hasattr` so it's a no-op once/if Frappe backports the real classes to v15, or on a future v16 bench — no shadowing.
- Wrapped in `try/except ImportError` to match the two existing init-time side-effect blocks already in this file (boot logger setup, pysqlite3 swap) — if `FrappeTestCase` itself ever disappears, app import fails soft instead of breaking every web/worker process.
- Both v16 names are aliased to the same `FrappeTestCase` class. `FrappeTestCase` is a behavioral superset of the leaner v16 `UnitTestCase`, so the 2 files using `UnitTestCase` (`huf/ai/tests/test_agent_run_analytics.py`, `huf/ai/tests/test_cache_metrics.py`) get DB/site setup they don't strictly need — negligible cost since `bench run-tests` already has a live site connection.

## Verification

Before: `bench --site chat-sidebar-trigger.local run-tests --app huf` crashed at import, **0 tests ran**.

After: **744 tests ran** in ~11s. Zero `frappe.tests` import errors. Remaining failures/errors are pre-existing and unrelated (a fixture `AttributeError` on `frappe.flags.currently_saving`, an unrelated "Agent Starter Prompt" doctype module-import issue, one Ollama-URL assertion) — none are related to this shim.

Discovered while working on an unrelated track (chat sidebar trigger); none of the affected test files were touched by that work — this is a pre-existing, repo-wide bench/environment gap.