### PR TITLE
feat(automation): stage 2 — live triggers, agent automations tab, automation UI (stacked on #590)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ const HomePage = lazy(() => import('./pages/HomePage'));
 const AppsPage = lazy(() => import('./pages/AppsPage'));
 const AgentsPage = lazy(() => import('./pages/AgentsPage'));
 const AgentFormPageWrapper = lazy(() => import('./pages/AgentFormPageWrapper'));
+const AutomationFormPageWrapper = lazy(() => import('./pages/AutomationFormPageWrapper'));
 const AgentPromptsPage = lazy(() => import('./pages/AgentPromptsPage'));
 const AgentPromptFormPageWrapper = lazy(() => import('./pages/AgentPromptFormPageWrapper'));
 const AgentSummaryPromptsPage = lazy(() => import('./pages/AgentSummaryPromptsPage'));
@@ -197,6 +198,16 @@ function AppShell() {
               <ProtectedRoute>
                 <Suspense fallback={<PageLoader />}>
                   <AgentFormPageWrapper />
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/automations/:automationId"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<PageLoader />}>
+                  <AutomationFormPageWrapper />
                 </Suspense>
               </ProtectedRoute>
             }

--- a/frontend/src/components/agent/AutomationsTab.tsx
+++ b/frontend/src/components/agent/AutomationsTab.tsx
@@ -1,0 +1,285 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Plus, Play, Pause, Copy, Archive, ExternalLink, Loader2, Workflow } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { EmptyState } from '@/components/dashboard/views/EmptyState';
+import {
+  listAutomations,
+  listTriggers,
+  runAutomationNow,
+  pauseAutomation,
+  resumeAutomation,
+  archiveAutomation,
+} from '@/services/automationApi';
+import type { Automation, AutomationTriggerType } from '@/types/automation.types';
+
+interface AutomationsTabProps {
+  agentId: string;
+}
+
+/** Automation rows shown in the tab, each carrying its resolved trigger types. */
+interface AutomationRow extends Automation {
+  triggerTypes: AutomationTriggerType[];
+}
+
+const MAX_TRIGGER_TYPES_SHOWN = 2;
+
+function formatTimestamp(value?: string): string {
+  if (!value) return '—';
+  const date = new Date(value.includes(' ') ? value.replace(' ', 'T') : value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function statusBadgeVariant(status: Automation['status']): 'default' | 'secondary' | 'destructive' | 'outline' {
+  switch (status) {
+    case 'Active':
+      return 'default';
+    case 'Error':
+      return 'destructive';
+    case 'Archived':
+      return 'outline';
+    default:
+      return 'secondary';
+  }
+}
+
+function triggerTypesLabel(types: AutomationTriggerType[]): string {
+  if (types.length === 0) return 'No triggers';
+  const shown = types.slice(0, MAX_TRIGGER_TYPES_SHOWN);
+  const overflow = types.length - shown.length;
+  return overflow > 0 ? `${shown.join(', ')} +${overflow} more` : shown.join(', ');
+}
+
+export function AutomationsTab({ agentId }: AutomationsTabProps) {
+  const navigate = useNavigate();
+  const [rows, setRows] = useState<AutomationRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+
+  const loadAutomations = useCallback(async () => {
+    setLoading(true);
+    try {
+      const automations = await listAutomations({ agent: agentId });
+      const withTriggers = await Promise.all(
+        automations.map(async (automation) => {
+          const triggers = await listTriggers(automation.name);
+          const triggerTypes = triggers
+            .map((trigger) => trigger.trigger_type)
+            .filter((type): type is AutomationTriggerType => !!type);
+          return { ...automation, triggerTypes };
+        })
+      );
+      setRows(withTriggers);
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    loadAutomations();
+  }, [loadAutomations]);
+
+  const handleAddAutomation = () => {
+    navigate(`/automations/new?agent=${encodeURIComponent(agentId)}`);
+  };
+
+  const handleOpen = (automation: AutomationRow) => {
+    navigate(`/automations/${encodeURIComponent(automation.name)}`);
+  };
+
+  const handleRunNow = async (automation: AutomationRow) => {
+    setPendingAction(`run:${automation.name}`);
+    try {
+      await runAutomationNow(automation.name);
+      toast.success(`${automation.automation_name} started`);
+      await loadAutomations();
+    } catch {
+      // runAutomationNow already surfaces a toast via handleFrappeError.
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const handleTogglePause = async (automation: AutomationRow) => {
+    const isActive = automation.status === 'Active';
+    setPendingAction(`pause:${automation.name}`);
+    try {
+      if (isActive) {
+        await pauseAutomation(automation.name);
+        toast.success(`${automation.automation_name} paused`);
+      } else {
+        await resumeAutomation(automation.name);
+        toast.success(`${automation.automation_name} resumed`);
+      }
+      await loadAutomations();
+    } catch {
+      // pauseAutomation/resumeAutomation already surface a toast on failure.
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const handleDuplicate = (automation: AutomationRow) => {
+    // TODO: duplicating an Automation means cloning it plus every one of its
+    // Automation Trigger child rows (create_automation + create_trigger per
+    // row, since the API has no single "duplicate" endpoint). Deferred --
+    // out of scope for S12/S13; wire this up alongside the Automation form
+    // page (S17) where the trigger editor it needs already lives.
+    toast.info(`Duplicate for "${automation.automation_name}" is not available yet`);
+  };
+
+  const handleArchive = async (automation: AutomationRow) => {
+    setPendingAction(`archive:${automation.name}`);
+    try {
+      await archiveAutomation(automation.name);
+      toast.success(`${automation.automation_name} archived`);
+      await loadAutomations();
+    } catch {
+      // archiveAutomation already surfaces a toast on failure.
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <div className="space-y-1.5">
+          <CardTitle>Automations</CardTitle>
+          <p className="font-body text-[13px] text-steel-soft max-w-[60ch]">
+            Automations run this agent automatically — on a schedule, when a document changes, or from an external event.
+          </p>
+        </div>
+        <Button onClick={handleAddAutomation} size="sm" type="button">
+          <Plus className="w-4 h-4 mr-2" />
+          Add automation
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-steel-soft">
+            <Loader2 className="w-5 h-5 animate-spin" />
+          </div>
+        ) : rows.length === 0 ? (
+          <EmptyState
+            variant="create"
+            icon={Workflow}
+            title="No automations yet"
+            description="Add an automation to run this agent on a schedule, a document change, or an external event."
+            action={{ label: 'Add automation', onClick: handleAddAutomation }}
+          />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Trigger type(s)</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Last Run</TableHead>
+                <TableHead>Next Run</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((automation) => {
+                const isActive = automation.status === 'Active';
+                const busyRun = pendingAction === `run:${automation.name}`;
+                const busyPause = pendingAction === `pause:${automation.name}`;
+                const busyArchive = pendingAction === `archive:${automation.name}`;
+                const rowBusy = busyRun || busyPause || busyArchive;
+                return (
+                  <TableRow key={automation.name}>
+                    <TableCell className="font-medium max-w-xs truncate">
+                      {automation.automation_name}
+                    </TableCell>
+                    <TableCell>{triggerTypesLabel(automation.triggerTypes)}</TableCell>
+                    <TableCell>
+                      <Badge variant={statusBadgeVariant(automation.status)}>{automation.status}</Badge>
+                    </TableCell>
+                    <TableCell>{formatTimestamp(automation.last_execution)}</TableCell>
+                    <TableCell>{formatTimestamp(automation.next_execution)}</TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          title="Open"
+                          onClick={() => handleOpen(automation)}
+                          disabled={rowBusy}
+                        >
+                          <ExternalLink className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          title="Run now"
+                          onClick={() => handleRunNow(automation)}
+                          disabled={rowBusy}
+                        >
+                          {busyRun ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          title={isActive ? 'Pause' : 'Resume'}
+                          onClick={() => handleTogglePause(automation)}
+                          disabled={rowBusy}
+                        >
+                          {busyPause ? (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                          ) : isActive ? (
+                            <Pause className="w-4 h-4" />
+                          ) : (
+                            <Play className="w-4 h-4" />
+                          )}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          title="Duplicate"
+                          onClick={() => handleDuplicate(automation)}
+                          disabled={rowBusy}
+                        >
+                          <Copy className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          title="Archive"
+                          onClick={() => handleArchive(automation)}
+                          disabled={rowBusy || automation.status === 'Archived'}
+                        >
+                          {busyArchive ? <Loader2 className="w-4 h-4 animate-spin" /> : <Archive className="w-4 h-4" />}
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/agent/BehaviorTab.tsx
+++ b/frontend/src/components/agent/BehaviorTab.tsx
@@ -168,10 +168,10 @@ export function BehaviorTab({ form, locked = false }: BehaviorTabProps) {
 							<FormItem className="flex flex-row items-center justify-between rounded-md border p-4">
 								<div className="space-y-0.5">
 									<LabelWithInfo
-										label="Persist per user (doc/schedule)"
-										tooltip="When checked, Doc Event and Scheduled runs create / maintain conversation history per initiating user (or trigger owner). If unchecked, a single shared history is used."
+										label="Persist per user (legacy Doc Event only)"
+										tooltip="Applies only to Doc Event runs on the legacy Agent Trigger model: creates/maintains conversation history per initiating user (or trigger owner) when checked, otherwise a single shared history is used. Scheduled runs never read this field. Automations built on the newer Automation model set conversation identity per-Automation via Conversation Mode instead — this toggle has no effect there."
 									/>
-									<FormDescription>Creates history per initiating user.</FormDescription>
+									<FormDescription>Legacy Doc Event history scoping — does not apply to Scheduled runs or to the newer Automation model.</FormDescription>
 								</div>
 								<FormControl className="ml-1">
 									<Switch checked={field.value} onCheckedChange={field.onChange} />

--- a/frontend/src/components/automation/TriggerDocEventExtras.tsx
+++ b/frontend/src/components/automation/TriggerDocEventExtras.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { getDocTypeMeta } from '@/services/agentApi';
+import type { AutomationTriggerAttachment } from '@/types/automation.types';
+
+const STANDARD_FIELDS = ['name', 'owner', 'creation', 'modified', 'docstatus'];
+
+export interface TriggerDocEventExtrasProps {
+  referenceDoctype?: string;
+  promptField?: string;
+  promptFieldMode?: string;
+  fileAttachments: AutomationTriggerAttachment[];
+  onPromptFieldChange: (value: string) => void;
+  onPromptFieldModeChange: (value: string) => void;
+  onFileAttachmentsChange: (rows: AutomationTriggerAttachment[]) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Doc Event's extra fields: which document field carries the prompt
+ * (plus Supplement/Override mode), and which fields/child tables to pull
+ * file attachments from. Ports the legacy `TriggerDocEventExtras.tsx`'s
+ * field-discovery logic (fetch the chosen DocType's meta, offer its fields
+ * as prompt-field options) onto plain controlled props instead of
+ * `react-hook-form`.
+ */
+export function TriggerDocEventExtras({
+  referenceDoctype,
+  promptField,
+  promptFieldMode,
+  fileAttachments,
+  onPromptFieldChange,
+  onPromptFieldModeChange,
+  onFileAttachmentsChange,
+  disabled,
+}: TriggerDocEventExtrasProps) {
+  const [promptFieldOptions, setPromptFieldOptions] = useState<string[]>([]);
+  const [childTableOptions, setChildTableOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!referenceDoctype) {
+      setPromptFieldOptions([]);
+      setChildTableOptions([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    getDocTypeMeta(referenceDoctype)
+      .then((meta) => {
+        if (cancelled) return;
+        const docFields = (meta?.fields || [])
+          .filter(
+            (df: { fieldtype?: string }) =>
+              !['Section Break', 'Column Break', 'Tab Break', 'Table'].includes(df.fieldtype || '')
+          )
+          .map((df: { fieldname: string }) => df.fieldname);
+        setPromptFieldOptions([...STANDARD_FIELDS, ...docFields]);
+        setChildTableOptions(
+          (meta?.fields || [])
+            .filter((df: { fieldtype?: string }) => df.fieldtype === 'Table')
+            .map((df: { fieldname: string }) => df.fieldname)
+        );
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPromptFieldOptions([]);
+          setChildTableOptions([]);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [referenceDoctype]);
+
+  const promptOptions = useMemo(
+    () => promptFieldOptions.map((fieldname) => ({ value: fieldname, label: fieldname })),
+    [promptFieldOptions]
+  );
+
+  const updateAttachmentRow = (index: number, patch: Partial<AutomationTriggerAttachment>) => {
+    const next = fileAttachments.map((row, i) => (i === index ? { ...row, ...patch } : row));
+    onFileAttachmentsChange(next);
+  };
+
+  const addAttachmentRow = () => {
+    onFileAttachmentsChange([
+      ...fileAttachments,
+      { source_type: 'DocField', field_name: '' } as AutomationTriggerAttachment,
+    ]);
+  };
+
+  const removeAttachmentRow = (index: number) => {
+    onFileAttachmentsChange(fileAttachments.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label>Prompt field</Label>
+        <Select
+          onValueChange={onPromptFieldChange}
+          value={promptField || ''}
+          disabled={!referenceDoctype || disabled}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder={referenceDoctype ? 'Select field' : 'Select DocType first'} />
+          </SelectTrigger>
+          <SelectContent>
+            {promptOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-steel-soft">
+          The field on the Reference DocType that carries the user&apos;s instructions.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>Prompt field mode</Label>
+        <Select
+          onValueChange={onPromptFieldModeChange}
+          value={promptFieldMode || ''}
+          disabled={!promptField || disabled}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Select mode" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Supplement">Supplement</SelectItem>
+            <SelectItem value="Override">Override</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-steel-soft">
+          Supplement adds the field&apos;s value to the automation&apos;s instruction; Override replaces it.
+        </p>
+      </div>
+
+      <div className="space-y-3 rounded-lg border p-4">
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <Label>File attachments</Label>
+            <p className="text-xs text-steel-soft">Fetch files from specific DocFields or Child Tables.</p>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={addAttachmentRow} disabled={disabled}>
+            <Plus className="mr-1 h-4 w-4" />
+            Add
+          </Button>
+        </div>
+
+        {fileAttachments.length === 0 && (
+          <p className="text-sm font-body text-steel-soft">No file attachment mappings configured.</p>
+        )}
+
+        {fileAttachments.map((row, index) => (
+          <div key={row.name ?? index} className="grid gap-3 rounded-md border p-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Source type</Label>
+              <Select
+                onValueChange={(value) => updateAttachmentRow(index, { source_type: value })}
+                value={(row.source_type as string) || 'DocField'}
+                disabled={disabled}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="DocField">DocField</SelectItem>
+                  <SelectItem value="Child Table Field">Child Table Field</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Attach field name</Label>
+              <Input
+                placeholder="e.g. attachment"
+                value={(row.field_name as string) || ''}
+                disabled={disabled}
+                onChange={(event) => updateAttachmentRow(index, { field_name: event.target.value })}
+              />
+            </div>
+
+            {row.source_type === 'Child Table Field' && (
+              <div className="sm:col-span-2 space-y-1.5">
+                <Label>Child table</Label>
+                <Select
+                  onValueChange={(value) => updateAttachmentRow(index, { child_table: value })}
+                  value={(row.child_table as string) || ''}
+                  disabled={disabled}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select child table" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {childTableOptions.map((table) => (
+                      <SelectItem key={table} value={table}>
+                        {table}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <div className="sm:col-span-2 flex justify-end">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => removeAttachmentRow(index)}
+                disabled={disabled}
+              >
+                <Trash2 className="mr-1 h-4 w-4" />
+                Remove
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/automation/TriggerEditor.tsx
+++ b/frontend/src/components/automation/TriggerEditor.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react';
+import { Copy } from 'lucide-react';
+import { toast } from 'sonner';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { getDocTypes } from '@/services/agentApi';
+import { TriggerFieldsRenderer } from './TriggerFieldsRenderer';
+import { TriggerDocEventExtras } from './TriggerDocEventExtras';
+import { AUTOMATION_TRIGGER_TYPES, triggerTypeHelpText } from './TriggerFieldsConfig';
+import type {
+  AutomationTrigger,
+  AutomationTriggerAttachment,
+  AutomationTriggerType,
+} from '@/types/automation.types';
+
+/**
+ * Automation-scoped trigger data as edited in the form: same shape as the
+ * `Automation Trigger` doctype, but `trigger_type` is always present (a row
+ * being edited always has one, even before it's saved) and `webhook_key`
+ * may be populated in-memory right after `create_trigger` returns it -- the
+ * backend never returns it again afterwards (`list_triggers` omits the
+ * field entirely), so once this component is re-mounted from a fresh fetch
+ * the value legitimately disappears. That's the intended "shown once"
+ * behavior, not a bug.
+ */
+export type EditableAutomationTrigger = Partial<AutomationTrigger> & {
+  trigger_type: AutomationTriggerType;
+};
+
+export interface TriggerEditorPermissions {
+  /** False when the user can view but not modify this trigger (e.g. a
+   * locked system agent's automations, or a trigger the user only has
+   * read access to). */
+  canEdit: boolean;
+}
+
+export interface TriggerEditorProps {
+  trigger: EditableAutomationTrigger;
+  onChange: (patch: Partial<EditableAutomationTrigger>) => void;
+  permissions: TriggerEditorPermissions;
+}
+
+const WEBHOOK_ENDPOINT_PATH = '/api/method/huf.ai.automation_webhook.handle_automation_webhook';
+
+/**
+ * Editor for a single Automation Trigger's fields, keyed off `trigger_type`.
+ * Refactored from the legacy Agent-scoped `TriggerModal.tsx` +
+ * `TriggerFieldsRenderer.tsx` + `TriggerDocEventExtras.tsx` trio
+ * (`components/agent/`) -- same field-rendering logic and styling, but this
+ * version has no `agentId` dependency and is meant to be embedded directly
+ * in a page (not a modal), since `AutomationFormPage.tsx` edits 0-N triggers
+ * inline rather than one trigger per dialog.
+ */
+export function TriggerEditor({ trigger, onChange, permissions }: TriggerEditorProps) {
+  const [docTypes, setDocTypes] = useState<Array<{ name: string }>>([]);
+  const [loadingDocTypes, setLoadingDocTypes] = useState(false);
+  const disabled = !permissions.canEdit;
+
+  useEffect(() => {
+    if (trigger.trigger_type !== 'Doc Event') return;
+    let cancelled = false;
+    setLoadingDocTypes(true);
+    getDocTypes()
+      .then((result) => {
+        if (!cancelled) setDocTypes(result || []);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingDocTypes(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [trigger.trigger_type]);
+
+  const handleFieldChange = (field: string, value: string | number | undefined) => {
+    onChange({ [field]: value } as Partial<EditableAutomationTrigger>);
+  };
+
+  const handleCopyWebhookUrl = () => {
+    if (!trigger.webhook_slug) return;
+    const url = `${window.location.origin}${WEBHOOK_ENDPOINT_PATH}?slug=${encodeURIComponent(trigger.webhook_slug)}`;
+    navigator.clipboard
+      .writeText(url)
+      .then(() => toast.success('Webhook URL copied'))
+      .catch(() => toast.error('Could not copy webhook URL'));
+  };
+
+  const handleCopyWebhookKey = () => {
+    if (!trigger.webhook_key) return;
+    navigator.clipboard
+      .writeText(trigger.webhook_key)
+      .then(() => toast.success('Webhook key copied'))
+      .catch(() => toast.error('Could not copy webhook key'));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label>Trigger type</Label>
+        <Select
+          onValueChange={(value) => onChange({ trigger_type: value as AutomationTriggerType })}
+          value={trigger.trigger_type}
+          disabled={disabled}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {AUTOMATION_TRIGGER_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-steel-soft">{triggerTypeHelpText[trigger.trigger_type]}</p>
+      </div>
+
+      <div className="flex flex-row items-center justify-between rounded-md border p-4">
+        <div className="space-y-0.5">
+          <Label className="text-sm">Enabled</Label>
+          <p className="text-xs text-steel-soft">Turn this trigger off without deleting it.</p>
+        </div>
+        <Switch
+          checked={trigger.disabled !== 1}
+          onCheckedChange={(checked) => onChange({ disabled: checked ? 0 : 1 })}
+          disabled={disabled}
+        />
+      </div>
+
+      {(trigger.trigger_type === 'Schedule' ||
+        trigger.trigger_type === 'App Event' ||
+        trigger.trigger_type === 'Doc Event') && (
+        <TriggerFieldsRenderer
+          triggerType={trigger.trigger_type}
+          values={trigger as unknown as Record<string, unknown>}
+          onFieldChange={handleFieldChange}
+          docTypes={docTypes}
+          loadingDocTypes={loadingDocTypes}
+          disabled={disabled}
+        />
+      )}
+
+      {trigger.trigger_type === 'Doc Event' && (
+        <TriggerDocEventExtras
+          referenceDoctype={trigger.reference_doctype}
+          promptField={trigger.prompt_field}
+          promptFieldMode={trigger.prompt_field_mode}
+          fileAttachments={trigger.file_attachments || []}
+          onPromptFieldChange={(value) => onChange({ prompt_field: value })}
+          onPromptFieldModeChange={(value) =>
+            onChange({ prompt_field_mode: value as AutomationTrigger['prompt_field_mode'] })
+          }
+          onFileAttachmentsChange={(rows: AutomationTriggerAttachment[]) => onChange({ file_attachments: rows })}
+          disabled={disabled}
+        />
+      )}
+
+      {trigger.trigger_type === 'Webhook' && (
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Webhook URL</Label>
+            {trigger.webhook_slug ? (
+              <div className="flex items-center gap-2">
+                <Input
+                  readOnly
+                  value={`${WEBHOOK_ENDPOINT_PATH}?slug=${trigger.webhook_slug}`}
+                  className="font-mono text-xs"
+                />
+                <Button type="button" variant="outline" size="icon" onClick={handleCopyWebhookUrl}>
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            ) : (
+              <p className="text-sm text-steel-soft rounded-md border border-dashed p-3">
+                Save this automation to generate a webhook URL and secret key.
+              </p>
+            )}
+            <p className="text-xs text-steel-soft">
+              An external service calls this URL (GET or POST) to run this automation.
+            </p>
+          </div>
+
+          {trigger.webhook_slug && (
+            <div className="space-y-1.5">
+              <Label>Webhook key</Label>
+              {trigger.webhook_key ? (
+                <>
+                  <div className="flex items-center gap-2">
+                    <Input readOnly value={trigger.webhook_key} className="font-mono text-xs" />
+                    <Button type="button" variant="outline" size="icon" onClick={handleCopyWebhookKey}>
+                      <Copy className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-amber-600 dark:text-amber-400">
+                    Copy this now -- it will not be shown again. Send it as an{' '}
+                    <code className="font-mono">X-Webhook-Key</code> header on every call.
+                  </p>
+                </>
+              ) : (
+                <p className="text-sm text-steel-soft rounded-md border border-dashed p-3">
+                  Key generated and stored -- hidden after creation. To rotate it, delete this trigger
+                  and add a new one.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {trigger.trigger_type === 'Manual' && (
+        <p className="text-sm text-steel-soft rounded-lg border p-4">{triggerTypeHelpText.Manual}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/automation/TriggerFieldsConfig.tsx
+++ b/frontend/src/components/automation/TriggerFieldsConfig.tsx
@@ -1,0 +1,128 @@
+import type { AutomationTriggerType } from '@/types/automation.types';
+
+/**
+ * Config-driven field metadata for the automation-scoped trigger editor.
+ *
+ * Mirrors the shape of the legacy Agent Trigger's
+ * `components/agent/TriggerFieldsConfig.tsx`, but this copy is intentionally
+ * NOT shared with it: the legacy file is scoped to the old `Agent Trigger`
+ * doctype's field set (a superset that includes cron/timezone/misfire-policy
+ * fields this pass deliberately does not surface -- see this track's
+ * CONTEXT.md non-goals). Keep the two in sync by hand if a shared field's
+ * label/options change; do not re-merge them.
+ */
+export type TriggerFieldType = 'select' | 'input' | 'textarea' | 'number';
+
+export interface TriggerFieldConfig {
+  field: string;
+  type: TriggerFieldType;
+  label: string;
+  placeholder?: string;
+  options?: string[];
+  description?: string;
+  required?: boolean;
+}
+
+export type TriggerTypeFieldConfig = Record<string, TriggerFieldConfig[]>;
+
+/**
+ * Declarative fields for the trigger types (or the parts of a trigger type)
+ * that don't need bespoke UI. Doc Event's `prompt_field` /
+ * `prompt_field_mode` / `file_attachments` and all of Webhook are rendered
+ * by dedicated components instead (they need data fetched from the chosen
+ * DocType, or server-generated read-only values) -- see
+ * `TriggerDocEventExtras.tsx` and `TriggerEditor.tsx`.
+ */
+export const triggerFieldsConfig: TriggerTypeFieldConfig = {
+  Schedule: [
+    {
+      field: 'scheduled_interval',
+      type: 'select',
+      label: 'Interval',
+      placeholder: 'Select interval',
+      options: ['Hourly', 'Daily', 'Weekly', 'Monthly', 'Yearly'],
+      required: true,
+    },
+    {
+      field: 'interval_count',
+      type: 'number',
+      label: 'Every',
+      placeholder: '1',
+      description: 'Run every N intervals (e.g. every 2 Weeks).',
+      required: true,
+    },
+  ],
+  'Doc Event': [
+    {
+      field: 'reference_doctype',
+      type: 'select',
+      label: 'DocType',
+      placeholder: 'Select DocType',
+      required: true,
+    },
+    {
+      field: 'doc_event',
+      type: 'select',
+      label: 'Doc event',
+      placeholder: 'Select event',
+      options: [
+        'before_insert',
+        'after_insert',
+        'validate',
+        'before_save',
+        'after_save',
+        'before_submit',
+        'on_submit',
+        'on_update',
+        'after_submit',
+        'on_cancel',
+        'before_rename',
+        'after_rename',
+        'on_trash',
+        'after_delete',
+      ],
+      required: true,
+    },
+    {
+      field: 'condition',
+      type: 'textarea',
+      label: 'Condition (Python, optional)',
+      placeholder: "Use 'doc' to reference the document, e.g. doc.status == 'Approved'",
+      description: 'Only run when this expression evaluates truthy. Leave blank to always run.',
+      required: false,
+    },
+  ],
+  'App Event': [
+    {
+      field: 'app_name',
+      type: 'input',
+      label: 'App name',
+      placeholder: 'e.g. Slack',
+      required: true,
+    },
+    {
+      field: 'event_name',
+      type: 'input',
+      label: 'Event name',
+      placeholder: 'e.g. message.posted',
+      required: true,
+    },
+  ],
+};
+
+/** One-line help copy per trigger type, shown under the type selector. */
+export const triggerTypeHelpText: Record<AutomationTriggerType, string> = {
+  Schedule: 'Runs automatically on a repeating schedule.',
+  'Doc Event': 'Runs when a document is created, saved, or changes state.',
+  Webhook: 'Runs when an external service calls a generated URL.',
+  'App Event': 'Runs when another part of the system reports a named event.',
+  Manual: 'This automation only runs when triggered manually (Run now, from chat, or by another automation).',
+};
+
+export const AUTOMATION_TRIGGER_TYPES: AutomationTriggerType[] = [
+  'Schedule',
+  'Doc Event',
+  'Webhook',
+  'App Event',
+  'Manual',
+];

--- a/frontend/src/components/automation/TriggerFieldsRenderer.tsx
+++ b/frontend/src/components/automation/TriggerFieldsRenderer.tsx
@@ -1,0 +1,166 @@
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { triggerFieldsConfig, type TriggerFieldConfig } from './TriggerFieldsConfig';
+
+export interface TriggerFieldsRendererProps {
+  triggerType: string;
+  values: Record<string, unknown>;
+  onFieldChange: (field: string, value: string | number | undefined) => void;
+  docTypes: Array<{ name: string }>;
+  loadingDocTypes: boolean;
+  disabled?: boolean;
+}
+
+/**
+ * Renders the declarative fields for a trigger type (see
+ * `triggerFieldsConfig`). Plain controlled inputs -- this editor is not tied
+ * to a single `react-hook-form` instance because an Automation can hold 0-N
+ * triggers on one page (`AutomationFormPage.tsx`), each with its own
+ * independent field state living in the parent's trigger-rows array.
+ */
+export function TriggerFieldsRenderer({
+  triggerType,
+  values,
+  onFieldChange,
+  docTypes,
+  loadingDocTypes,
+  disabled,
+}: TriggerFieldsRendererProps) {
+  const fields = triggerFieldsConfig[triggerType];
+  if (!fields) return null;
+
+  return (
+    <div className="space-y-4">
+      {fields.map((fieldConfig) => (
+        <TriggerField
+          key={fieldConfig.field}
+          config={fieldConfig}
+          value={values[fieldConfig.field]}
+          onChange={(value) => onFieldChange(fieldConfig.field, value)}
+          docTypes={docTypes}
+          loadingDocTypes={loadingDocTypes}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TriggerField({
+  config,
+  value,
+  onChange,
+  docTypes,
+  loadingDocTypes,
+  disabled,
+}: {
+  config: TriggerFieldConfig;
+  value: unknown;
+  onChange: (value: string | number | undefined) => void;
+  docTypes: Array<{ name: string }>;
+  loadingDocTypes: boolean;
+  disabled?: boolean;
+}) {
+  const stringValue = typeof value === 'string' || typeof value === 'number' ? String(value) : '';
+
+  if (config.type === 'select' && config.field === 'reference_doctype') {
+    const options = docTypes.map((dt) => ({ value: dt.name, label: dt.name }));
+    return (
+      <div className="space-y-1.5">
+        <Label>{config.label}</Label>
+        <Combobox
+          options={options}
+          value={stringValue}
+          onValueChange={onChange}
+          placeholder={loadingDocTypes ? 'Loading...' : config.placeholder || `Select ${config.label}`}
+          disabled={loadingDocTypes || disabled}
+          searchPlaceholder="Search DocType..."
+          emptyText="No DocType found."
+        />
+        {config.description && <p className="text-xs text-steel-soft">{config.description}</p>}
+      </div>
+    );
+  }
+
+  if (config.type === 'select') {
+    const options = config.options ?? [];
+    return (
+      <div className="space-y-1.5">
+        <Label>{config.label}</Label>
+        <Select onValueChange={onChange} value={stringValue} disabled={disabled}>
+          <SelectTrigger>
+            <SelectValue placeholder={config.placeholder || `Select ${config.label}`} />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option} value={option}>
+                {option}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {config.description && <p className="text-xs text-steel-soft">{config.description}</p>}
+      </div>
+    );
+  }
+
+  if (config.type === 'number') {
+    return (
+      <div className="space-y-1.5">
+        <Label>{config.label}</Label>
+        <Input
+          type="number"
+          min={1}
+          inputMode="numeric"
+          placeholder={config.placeholder}
+          value={stringValue}
+          disabled={disabled}
+          onChange={(event) => {
+            const raw = event.target.value;
+            onChange(raw === '' ? undefined : Number(raw));
+          }}
+        />
+        {config.description && <p className="text-xs text-steel-soft">{config.description}</p>}
+      </div>
+    );
+  }
+
+  if (config.type === 'textarea') {
+    return (
+      <div className="space-y-1.5">
+        <Label>{config.label}</Label>
+        <Textarea
+          className="font-mono resize-y min-h-[100px]"
+          placeholder={config.placeholder}
+          value={stringValue}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.value)}
+        />
+        {config.description && <p className="text-xs text-steel-soft">{config.description}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label>{config.label}</Label>
+      <Input
+        type="text"
+        placeholder={config.placeholder}
+        value={stringValue}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {config.description && <p className="text-xs text-steel-soft">{config.description}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -11,7 +11,7 @@ import { usePermissions } from '../contexts/PermissionsContext';
 import { AIProvider, AIModel, AgentToolFunctionRef, type ToolType } from '../types/agent.types';
 import type { AgentSkillRow } from '../types/skill.types';
 import { getSkillOptions } from '../services/skillApi';
-import { getAgent, getAgentSection, updateAgent, updateAgentSection, createAgent, getAgentTriggers, getAgentTrigger, createAgentTrigger, updateAgentTrigger, getDocTypes, getTriggerTypes, type AgentConfigSection, type AgentTriggerListItem, type AgentTriggerDoc, type AgentTriggerAttachmentRow, type TriggerTypeOption, deleteAgentTrigger, runAgentTest, deleteAgent, duplicateAgent } from '../services/agentApi';
+import { getAgent, getAgentSection, updateAgent, updateAgentSection, createAgent, type AgentConfigSection, runAgentTest, deleteAgent, duplicateAgent } from '../services/agentApi';
 import { getAgentPrompt } from '../services/agentPromptApi';
 import { getAgentSummaryPrompt } from '../services/agentSummaryPromptApi';
 import { getProviders, getModels } from '../services/providerApi';
@@ -21,14 +21,13 @@ import type { AgentToolType } from '../types/agent.types';
 import { SelectToolsModal, SelectMCPServersModal } from '../components/tools';
 import { ToolFormModal } from '../components/tools/ToolFormModal';
 import type { ToolFormData } from '../types/toolTemplate.types';
-import { TriggerModal } from '../components/agent/TriggerModal';
 import { getFrappeErrorMessage } from '../lib/frappe-error';
 import { db } from '../lib/frappe-sdk';
 import { AgentHeader } from '../components/agent/AgentHeader';
 import { DeleteAgentDialog } from '../components/agent/DeleteAgentDialog';
 import { GeneralTab } from '../components/agent/GeneralTab';
 import { BehaviorTab } from '../components/agent/BehaviorTab';
-import { TriggersTab } from '../components/agent/TriggersTab';
+import { AutomationsTab } from '../components/agent/AutomationsTab';
 import { ToolsTab } from '../components/agent/ToolsTab';
 import { AdvancedTab, type ExecutionProfileOption, type SSHConnectionOption, type MemoryPolicyOption } from '../components/agent/AdvancedTab';
 import type { AgentPromptOption } from '../components/agent/PromptTemplateSection';
@@ -209,8 +208,8 @@ export function AgentFormPage() {
       disabled: false,
     },
     triggers: {
-      label: 'Triggers',
-      fields: [], // Triggers tab doesn't have form fields
+      label: 'Automations',
+      fields: [], // Automations tab doesn't have form fields
       default: false,
       disabled: false,
     },
@@ -327,7 +326,6 @@ export function AgentFormPage() {
   };
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
-  const [deletingTrigger, setDeletingTrigger] = useState(false);
   const [duplicating, setDuplicating] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -344,11 +342,6 @@ export function AgentFormPage() {
   const [loadingSSHConnections, setLoadingSSHConnections] = useState(false);
   const [memoryPolicyOptions, setMemoryPolicyOptions] = useState<MemoryPolicyOption[]>([]);
   const [loadingMemoryPolicies, setLoadingMemoryPolicies] = useState(false);
-  const [triggers, setTriggers] = useState<AgentTriggerListItem[]>([]);
-  const [showTriggerModal, setShowTriggerModal] = useState(false);
-  const [editingTrigger, setEditingTrigger] = useState<AgentTriggerDoc | null>(null);
-  const [triggerFilter, setTriggerFilter] = useState<string>('all');
-  const [triggerStatusFilter, setTriggerStatusFilter] = useState<string>('all');
   const [optimizingPrompt, setOptimizingPrompt] = useState(false);
   const [showToolsModal, setShowToolsModal] = useState(false);
   const [showToolFormModal, setShowToolFormModal] = useState(false);
@@ -357,10 +350,6 @@ export function AgentFormPage() {
   const [initialTools, setInitialTools] = useState<AgentToolFunctionRef[]>([]); // Track initial tools state
   const [toolTypes, setToolTypes] = useState<AgentToolType[]>([]);
   const [initialDisabled, setInitialDisabled] = useState(false); // Track initial disabled state
-  const [docTypes, setDocTypes] = useState<Array<{ name: string }>>([]);
-  const [loadingDocTypes, setLoadingDocTypes] = useState(false);
-  const [triggerTypes, setTriggerTypes] = useState<TriggerTypeOption[]>([]);
-  const [loadingTriggerTypes, setLoadingTriggerTypes] = useState(false);
   const [showMCPServersModal, setShowMCPServersModal] = useState(false);
   const [mcpServers, setMcpServers] = useState<MCPServerRef[]>([]);
   const [initialMcpServers, setInitialMcpServers] = useState<MCPServerRef[]>([]); // Track initial MCP servers state
@@ -554,47 +543,6 @@ export function AgentFormPage() {
   );
 
   const blocker = useBlocker(shouldBlock);
-
-  // Load trigger types on mount
-  useEffect(() => {
-    if (triggerTypes.length === 0 && !loadingTriggerTypes) {
-      setLoadingTriggerTypes(true);
-      getTriggerTypes()
-        .then((data) => {
-          // Ensure data is an array before setting state
-          if (Array.isArray(data)) {
-            // Filter out any types that don't have a name
-            const triggerTypes = data.filter((type) => (type.name));
-            setTriggerTypes(triggerTypes);
-          } else {
-            console.error('getTriggerTypes returned non-array:', data);
-            setTriggerTypes([]);
-          }
-          setLoadingTriggerTypes(false);
-        })
-        .catch((error) => {
-          console.error('Error loading trigger types:', error);
-          setTriggerTypes([]);
-          setLoadingTriggerTypes(false);
-        });
-    }
-  }, [triggerTypes.length, loadingTriggerTypes]);
-
-  // Load DocTypes when modal opens
-  useEffect(() => {
-    if (showTriggerModal && docTypes.length === 0 && !loadingDocTypes) {
-      setLoadingDocTypes(true);
-      getDocTypes()
-        .then((data) => {
-          setDocTypes(data);
-          setLoadingDocTypes(false);
-        })
-        .catch((error) => {
-          console.error('Error loading DocTypes:', error);
-          setLoadingDocTypes(false);
-        });
-    }
-  }, [showTriggerModal, docTypes.length, loadingDocTypes]);
 
   // Load providers, models, and tool types on mount.
   // Each lookup is independent (a Huf User, for instance, can't list Users/Roles)
@@ -1294,14 +1242,6 @@ export function AgentFormPage() {
           setAgentSkills([]);
           setInitialAgentSkills([]);
         }
-        // Load triggers from Agent Trigger doctype
-        getAgentTriggers(id).then((triggersData) => {
-          setTriggers(triggersData);
-        }).catch((error) => {
-          console.error('Error loading triggers:', error);
-          // Don't show error toast for triggers, just log it
-          setTriggers([]);
-        });
         // Load MCP servers from agent_mcp_server child table (already in agent document)
         if (data.agent_mcp_server && Array.isArray(data.agent_mcp_server) && data.agent_mcp_server.length > 0) {
           // First, map child table data to MCPServerRef format
@@ -2241,118 +2181,13 @@ export function AgentFormPage() {
     }
   };
 
-  const handleAddTrigger = () => {
-    setEditingTrigger(null);
-    setShowTriggerModal(true);
-  };
-
-  const handleEditTrigger = async (trigger: AgentTriggerListItem) => {
-    try {
-      const fullTrigger = await getAgentTrigger(trigger.name);
-      setEditingTrigger(fullTrigger);
-      setShowTriggerModal(true);
-    } catch (error) {
-      console.error('Error loading trigger:', error);
-      const errorMessage = getFrappeErrorMessage(error);
-      toast.error(errorMessage || 'Failed to load trigger details');
-    }
-  };
-
-  const handleDeleteTrigger = async (triggerId: string) => {
-    setDeletingTrigger(true);
-    try {
-      await deleteAgentTrigger(triggerId);
-      setTriggers(triggers.filter(t => t.name !== triggerId));
-      toast.success('Trigger deleted');
-    } catch (error) {
-      const errorMessage = getFrappeErrorMessage(error);
-      toast.error(errorMessage || 'Failed to delete trigger');
-    } finally {
-      setDeletingTrigger(false);
-    }
-  };
-
-  const handleSaveTrigger = async (values: {
-    trigger_name?: string;
-    trigger_type: string;
-    active: boolean;
-    scheduled_interval?: string;
-    interval_count?: string;
-    reference_doctype?: string;
-    doc_event?: string;
-    condition?: string;
-    prompt_field?: string;
-    file_attachments?: AgentTriggerAttachmentRow[];
-    app_name?: string;
-    event_name?: string;
-    webhook_slug?: string;
-    webhook_key?: string;
-  }) => {
-    if (!id || id === 'new') {
-      toast.error('Please save the agent first before adding triggers');
-      return;
-    }
-
-    // Validate trigger_name when creating
-    if (!editingTrigger && !values.trigger_name) {
-      toast.error('Trigger name is required');
-      return;
-    }
-
-    try {
-      const triggerData: Partial<AgentTriggerDoc> = {
-        trigger_name: editingTrigger ? editingTrigger.trigger_name : (values.trigger_name || ''),
-        trigger_type: values.trigger_type,
-        disabled: values.active ? 0 : 1,
-        scheduled_interval: values.scheduled_interval,
-        interval_count: values.interval_count && values.interval_count.trim() !== ''
-          ? parseInt(values.interval_count, 10)
-          : undefined,
-        reference_doctype: values.reference_doctype,
-        doc_event: values.doc_event,
-        condition: values.condition,
-        app_name: values.app_name,
-        event_name: values.event_name,
-        webhook_slug: values.webhook_slug,
-        webhook_key: values.webhook_key,
-      };
-
-      // Doc Event extras: field to read the prompt from + file/audio attachment mappings
-      if (values.trigger_type === 'Doc Event') {
-        triggerData.prompt_field = values.prompt_field || '';
-        triggerData.file_attachments = (values.file_attachments || []).map((row) => ({
-          ...(row.name ? { name: row.name } : {}),
-          source_type: row.source_type,
-          field_name: row.field_name,
-          child_table: row.source_type === 'Child Table Field' ? row.child_table || '' : '',
-        }));
-      }
-
-      if (editingTrigger) {
-        // Update existing trigger
-        await updateAgentTrigger(editingTrigger.name, triggerData);
-        toast.success('Trigger updated successfully');
-      } else {
-        // Create new trigger
-        triggerData.agent = id;
-        await createAgentTrigger(triggerData);
-        toast.success('Trigger created successfully');
-      }
-
-      // Reload triggers list
-      const updatedTriggers = await getAgentTriggers(id);
-      setTriggers(updatedTriggers);
-      setShowTriggerModal(false);
-      setEditingTrigger(null);
-    } catch (error) {
-      console.error('Error saving trigger:', error);
-      const errorMessage = getFrappeErrorMessage(error);
-      toast.error(errorMessage || `Failed to ${editingTrigger ? 'update' : 'create'} trigger`);
-    }
-  };
-
-
-  const activeTriggerCount = triggers.filter(t => t.status === 'active').length;
+  // Agent Trigger CRUD (create/edit/delete of raw Agent Trigger records) used
+  // to live on this page via the handlers this block replaced. Per the plan,
+  // this page must not directly manipulate raw Trigger records anymore --
+  // AutomationsTab below owns automation lifecycle actions (run/pause/
+  // resume/archive) through automationApi, and creating/editing an
+  // Automation's triggers happens in the dedicated Automation editor (S17),
+  // not here.
 
   if (loading) {
     return (
@@ -2391,7 +2226,7 @@ export function AgentFormPage() {
           form={form}
           watchDisabled={watchDisabled}
           models={models}
-          activeTriggerCount={activeTriggerCount}
+          activeTriggerCount={0 /* Agent Trigger tracking removed; see AutomationsTab */}
           isNew={isNew}
           isSystem={isSystemAgent}
           locked={systemLocked || permissionLocked}
@@ -2460,18 +2295,7 @@ export function AgentFormPage() {
               </TabsContent>
 
               <TabsContent value="triggers" className="space-y-4">
-                <TriggersTab
-                  triggers={triggers}
-                  triggerTypes={triggerTypes}
-                  triggerFilter={triggerFilter}
-                  triggerStatusFilter={triggerStatusFilter}
-                  onTriggerFilterChange={setTriggerFilter}
-                  onTriggerStatusFilterChange={setTriggerStatusFilter}
-                  onAddTrigger={handleAddTrigger}
-                  onEditTrigger={handleEditTrigger}
-                  onDeleteTrigger={handleDeleteTrigger}
-                  deletingTrigger={deletingTrigger}
-                />
+                <AutomationsTab agentId={id ?? ''} />
               </TabsContent>
 
               <TabsContent value="tools" className="space-y-4">
@@ -2530,18 +2354,6 @@ export function AgentFormPage() {
           </form>
         </Form>
       </div>
-
-      {/* Trigger Modal */}
-      <TriggerModal
-        open={showTriggerModal}
-        onOpenChange={setShowTriggerModal}
-        editingTrigger={editingTrigger}
-        triggerTypes={triggerTypes}
-        docTypes={docTypes}
-        loadingDocTypes={loadingDocTypes}
-        agentId={id}
-        onSave={handleSaveTrigger}
-      />
 
       {/* Select Tools Modal */}
       <SelectToolsModal

--- a/frontend/src/pages/AutomationFormPageWrapper.tsx
+++ b/frontend/src/pages/AutomationFormPageWrapper.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { UnifiedLayout } from '../layouts/UnifiedLayout';
+import { AutomationFormPage } from './automation/AutomationFormPage';
+import { getAutomation } from '../services/automationApi';
+
+export { AutomationFormPageWrapper };
+export default AutomationFormPageWrapper;
+
+function AutomationFormPageWrapper() {
+  const { automationId } = useParams<{ automationId: string }>();
+  const [automationName, setAutomationName] = useState<string>('New automation');
+  const isNew = !automationId || automationId === 'new';
+
+  useEffect(() => {
+    if (automationId && !isNew) {
+      getAutomation(automationId)
+        .then((automation) => {
+          setAutomationName(automation?.automation_name || automationId);
+        })
+        .catch((error) => {
+          console.error('Error loading automation:', error);
+          setAutomationName('Automation');
+        });
+    } else {
+      setAutomationName('New automation');
+    }
+  }, [automationId, isNew]);
+
+  // No standalone "/automations" registry page exists in this pass (see
+  // this track's CONTEXT.md non-goals) -- there is nowhere useful to link
+  // an "Automations" ancestor crumb back to, so this page's breadcrumb is
+  // just its own name.
+  const breadcrumbs = [{ label: automationName }];
+
+  return (
+    <UnifiedLayout breadcrumbs={breadcrumbs}>
+      <AutomationFormPage />
+    </UnifiedLayout>
+  );
+}

--- a/frontend/src/pages/automation/AutomationFormPage.tsx
+++ b/frontend/src/pages/automation/AutomationFormPage.tsx
@@ -1,0 +1,631 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import { Loader2, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { Combobox } from '@/components/ui/combobox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  TriggerEditor,
+  type EditableAutomationTrigger,
+} from '@/components/automation/TriggerEditor';
+import { AUTOMATION_TRIGGER_TYPES } from '@/components/automation/TriggerFieldsConfig';
+import {
+  createAutomation,
+  createTrigger,
+  deleteTrigger,
+  getAutomation,
+  listTriggers,
+  updateAutomation,
+  updateTrigger,
+} from '@/services/automationApi';
+import { getAgents, getAIModels, type AIModelItem } from '@/services/agentApi';
+import { listProjects } from '@/services/projectApi';
+import { db } from '@/lib/frappe-sdk';
+import { doctype } from '@/data/doctypes';
+import type {
+  Automation,
+  AutomationConversationMode,
+  AutomationStatus,
+  AutomationTrigger as AutomationTriggerDoc,
+} from '@/types/automation.types';
+import type { AgentDoc } from '@/types/agent.types';
+import type { HufProject } from '@/services/projectApi';
+
+const AUTOMATION_STATUSES: AutomationStatus[] = ['Draft', 'Active', 'Paused', 'Error', 'Archived'];
+const CONVERSATION_MODES: AutomationConversationMode[] = ['New', 'Dedicated', 'No-UI'];
+
+let localTriggerCounter = 0;
+function nextLocalId(): string {
+  localTriggerCounter += 1;
+  return `local-${Date.now()}-${localTriggerCounter}`;
+}
+
+/** A trigger row being edited: either an existing Automation Trigger (has
+ * `name`) or one added in this session that hasn't been saved yet (only has
+ * `_localId`). */
+interface TriggerRow extends EditableAutomationTrigger {
+  _localId: string;
+  _isNew: boolean;
+  _isDirty: boolean;
+}
+
+function toTriggerRow(trigger: AutomationTriggerDoc): TriggerRow {
+  return {
+    ...trigger,
+    trigger_type: trigger.trigger_type || 'Schedule',
+    _localId: trigger.name,
+    _isNew: false,
+    _isDirty: false,
+  };
+}
+
+/**
+ * Automation Trigger's autoname is `field:trigger_name` (reqd, unique) --
+ * the UI never surfaces a "trigger name" field to the user (not in this
+ * track's field lists for any trigger type), so generate a stable, unique
+ * one client-side. NOTE: as of this writing `automation_api.create_trigger`
+ * deliberately excludes `trigger_name` from the set of fields it copies out
+ * of `kwargs` (see its `_TRIGGER_FIELDS` docstring -- the exclusion was
+ * meant to stop *renames* going through the generic update path, but
+ * `create_trigger` uses the same tuple and so also drops it on create,
+ * which will make `doc.insert()` fail on the field's `reqd` constraint).
+ * This is a pre-existing backend gap outside this task's file list
+ * (`automation_api.py`) -- sending the value here is still correct so the
+ * frontend contract is right the moment that gap is closed.
+ */
+function generateTriggerName(automationName: string, triggerType: string): string {
+  const slug = `${automationName}-${triggerType}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${slug}-${Date.now().toString(36)}`;
+}
+
+function newTriggerRow(): TriggerRow {
+  return {
+    trigger_type: 'Schedule',
+    disabled: 0,
+    scheduled_interval: 'Daily',
+    interval_count: 1,
+    _localId: nextLocalId(),
+    _isNew: true,
+    _isDirty: false,
+  };
+}
+
+interface UserOption {
+  name: string;
+  full_name?: string;
+}
+
+/**
+ * Standalone create/edit page for an Automation and its Automation Trigger
+ * rows. Reached from `AutomationsTab.tsx`'s "Open" / "+ Add automation"
+ * actions -- routed at `/automations/:automationId` (":automationId" of
+ * "new" is create mode, mirroring `/agents/:id`'s convention).
+ */
+export function AutomationFormPage() {
+  const { automationId } = useParams<{ automationId: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const isNew = !automationId || automationId === 'new';
+  const preselectedAgent = searchParams.get('agent') || undefined;
+
+  const [loading, setLoading] = useState(!isNew);
+  const [saving, setSaving] = useState(false);
+  const [automation, setAutomation] = useState<Automation | null>(null);
+
+  // General
+  const [automationName, setAutomationName] = useState('');
+  const [description, setDescription] = useState('');
+  const [agent, setAgent] = useState(preselectedAgent || '');
+  const [project, setProject] = useState('');
+  const [status, setStatus] = useState<AutomationStatus>('Draft');
+
+  // Task
+  const [instruction, setInstruction] = useState('');
+  const [modelOverride, setModelOverride] = useState('');
+  const [conversationMode, setConversationMode] = useState<AutomationConversationMode>('New');
+
+  // Execution
+  const [runAsUser, setRunAsUser] = useState('');
+  const [notifyUser, setNotifyUser] = useState<0 | 1>(0);
+
+  // Trigger rows
+  const [triggerRows, setTriggerRows] = useState<TriggerRow[]>([]);
+  const [deletedTriggerNames, setDeletedTriggerNames] = useState<string[]>([]);
+
+  // Option lists
+  const [agents, setAgents] = useState<AgentDoc[]>([]);
+  const [projects, setProjects] = useState<HufProject[]>([]);
+  const [models, setModels] = useState<AIModelItem[]>([]);
+  const [users, setUsers] = useState<UserOption[]>([]);
+
+  useEffect(() => {
+    Promise.all([
+      getAgents().then((result) => (Array.isArray(result) ? result : result.items)),
+      listProjects(),
+      getAIModels(),
+      db.getDocList(doctype.User, {
+        fields: ['name', 'full_name'],
+        filters: [['enabled', '=', 1]],
+        limit: 500,
+      }),
+    ]).then(([agentList, projectList, modelList, userList]) => {
+      setAgents(agentList || []);
+      setProjects(projectList || []);
+      setModels(modelList || []);
+      setUsers((userList as UserOption[]) || []);
+    });
+  }, []);
+
+  const loadExisting = useCallback(async (name: string) => {
+    setLoading(true);
+    try {
+      const [automationDoc, triggers] = await Promise.all([getAutomation(name), listTriggers(name)]);
+      if (!automationDoc) {
+        toast.error('Automation not found');
+        navigate('/automations/new', { replace: true });
+        return;
+      }
+      setAutomation(automationDoc);
+      setAutomationName(automationDoc.automation_name);
+      setDescription(automationDoc.description || '');
+      setAgent(automationDoc.agent);
+      setProject(automationDoc.project || '');
+      setStatus(automationDoc.status);
+      setInstruction(automationDoc.instruction || '');
+      setModelOverride(automationDoc.model_override || '');
+      setConversationMode(automationDoc.conversation_mode || 'New');
+      setRunAsUser(automationDoc.run_as_user || '');
+      setNotifyUser(automationDoc.notify_user ? 1 : 0);
+      setTriggerRows((triggers as unknown as AutomationTriggerDoc[]).map(toTriggerRow));
+      setDeletedTriggerNames([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (!isNew && automationId) {
+      loadExisting(automationId);
+    }
+  }, [isNew, automationId, loadExisting]);
+
+  const agentOptions = useMemo(
+    () => agents.map((a) => ({ value: a.name, label: a.agent_name || a.name })),
+    [agents]
+  );
+  const projectOptions = useMemo(
+    () => projects.map((p) => ({ value: p.name, label: p.project_name || p.name })),
+    [projects]
+  );
+  const modelOptions = useMemo(
+    () => models.map((m) => ({ value: m.id, label: `${m.modelName} (${m.providerBrandLabel})` })),
+    [models]
+  );
+  const userOptions = useMemo(
+    () => users.map((u) => ({ value: u.name, label: u.full_name ? `${u.full_name} (${u.name})` : u.name })),
+    [users]
+  );
+
+  const handleAddTrigger = () => {
+    setTriggerRows((rows) => [...rows, newTriggerRow()]);
+  };
+
+  const handleTriggerChange = (localId: string, patch: Partial<TriggerRow>) => {
+    setTriggerRows((rows) =>
+      rows.map((row) => (row._localId === localId ? { ...row, ...patch, _isDirty: true } : row))
+    );
+  };
+
+  const handleRemoveTrigger = (row: TriggerRow) => {
+    if (!row._isNew && row.name) {
+      setDeletedTriggerNames((names) => [...names, row.name as string]);
+    }
+    setTriggerRows((rows) => rows.filter((r) => r._localId !== row._localId));
+  };
+
+  const validate = (): string | null => {
+    if (!automationName.trim()) return 'Name is required.';
+    if (!agent) return 'Select an Agent.';
+    if (!instruction.trim()) return 'Task instruction is required.';
+    for (const row of triggerRows) {
+      if (row.trigger_type === 'Schedule' && (!row.scheduled_interval || !row.interval_count)) {
+        return 'Every Schedule trigger needs an interval and a count.';
+      }
+      if (row.trigger_type === 'Doc Event' && (!row.reference_doctype || !row.doc_event)) {
+        return 'Every Doc Event trigger needs a DocType and a doc event.';
+      }
+      if (row.trigger_type === 'App Event' && (!row.app_name || !row.event_name)) {
+        return 'Every App Event trigger needs an app name and event name.';
+      }
+    }
+    return null;
+  };
+
+  const handleSave = async () => {
+    const error = validate();
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      let automationName_: string;
+
+      if (isNew) {
+        const created = await createAutomation({
+          automation_name: automationName.trim(),
+          agent,
+          instruction: instruction.trim(),
+          description: description.trim() || undefined,
+          project: project || undefined,
+          model_override: modelOverride || undefined,
+          run_as_user: runAsUser || undefined,
+          conversation_mode: conversationMode,
+          notify_user: notifyUser,
+        });
+        automationName_ = created.name;
+        setAutomation(created);
+      } else {
+        const updated = await updateAutomation({
+          automation: automationId as string,
+          automation_name: automationName.trim(),
+          description: description.trim(),
+          agent,
+          project: project || undefined,
+          status,
+          model_override: modelOverride || undefined,
+          run_as_user: runAsUser || undefined,
+          instruction: instruction.trim(),
+          conversation_mode: conversationMode,
+          notify_user: notifyUser,
+        });
+        automationName_ = updated.name;
+        setAutomation(updated);
+      }
+
+      // Delete removed triggers first.
+      await Promise.all(deletedTriggerNames.map((name) => deleteTrigger(name)));
+      setDeletedTriggerNames([]);
+
+      // Create/update trigger rows; capture server-generated fields
+      // (webhook_slug/webhook_key, trigger name) back into local state.
+      const nextRows: TriggerRow[] = [];
+      for (const row of triggerRows) {
+        const { _localId, _isNew, _isDirty, ...fields } = row;
+        if (_isNew) {
+          const created = await createTrigger({
+            automation: automationName_,
+            trigger_type: fields.trigger_type,
+            trigger_name: fields.trigger_name || generateTriggerName(automationName_, fields.trigger_type),
+            disabled: fields.disabled,
+            scheduled_interval: fields.scheduled_interval,
+            interval_count: fields.interval_count,
+            reference_doctype: fields.reference_doctype,
+            doc_event: fields.doc_event,
+            condition: fields.condition,
+            prompt_field: fields.prompt_field,
+            prompt_field_mode: fields.prompt_field_mode,
+            file_attachments: fields.file_attachments,
+            app_name: fields.app_name,
+            event_name: fields.event_name,
+          });
+          nextRows.push(toTriggerRow(created));
+        } else if (_isDirty && row.name) {
+          const updated = await updateTrigger({
+            trigger: row.name,
+            disabled: fields.disabled,
+            scheduled_interval: fields.scheduled_interval,
+            interval_count: fields.interval_count,
+            reference_doctype: fields.reference_doctype,
+            doc_event: fields.doc_event,
+            condition: fields.condition,
+            prompt_field: fields.prompt_field,
+            prompt_field_mode: fields.prompt_field_mode,
+            file_attachments: fields.file_attachments,
+            app_name: fields.app_name,
+            event_name: fields.event_name,
+          });
+          // list_triggers/update_trigger never return webhook_key again
+          // after creation -- preserve whatever this session already has
+          // in memory rather than letting the response's absence blank it.
+          nextRows.push({ ...toTriggerRow(updated), webhook_key: row.webhook_key });
+        } else {
+          nextRows.push({ ...row, _isDirty: false });
+        }
+      }
+      setTriggerRows(nextRows);
+
+      toast.success(isNew ? 'Automation created' : 'Automation saved');
+      if (isNew) {
+        navigate(`/automations/${encodeURIComponent(automationName_)}`, { replace: true });
+      }
+    } catch {
+      // createAutomation/updateAutomation/createTrigger/updateTrigger
+      // already surface a toast via handleFrappeError.
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24 text-steel-soft">
+        <Loader2 className="w-6 h-6 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-heading text-xl">{isNew ? 'New automation' : automationName || 'Automation'}</h1>
+          <p className="font-body text-[13px] text-steel-soft max-w-[60ch]">
+            An automation runs an Agent automatically, outside a normal chat -- on a schedule, when a
+            document changes, or from an external event.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            {isNew ? 'Create automation' : 'Save'}
+          </Button>
+        </div>
+      </div>
+
+      {/* General */}
+      <Card>
+        <CardHeader>
+          <CardTitle>General</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Name</Label>
+            <Input
+              value={automationName}
+              onChange={(e) => setAutomationName(e.target.value)}
+              placeholder="e.g. Weekly usage digest"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Description</Label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What does this automation do? (optional)"
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Agent</Label>
+              <Combobox
+                options={agentOptions}
+                value={agent}
+                onValueChange={setAgent}
+                placeholder="Select agent"
+                searchPlaceholder="Search agents..."
+                emptyText="No agent found."
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Project (optional)</Label>
+              <Combobox
+                options={projectOptions}
+                value={project}
+                onValueChange={setProject}
+                placeholder="No project"
+                searchPlaceholder="Search projects..."
+                emptyText="No project found."
+              />
+            </div>
+          </div>
+          {!isNew && (
+            <div className="space-y-1.5">
+              <Label>Status</Label>
+              <Select onValueChange={(v) => setStatus(v as AutomationStatus)} value={status}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {AUTOMATION_STATUSES.map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {s}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-steel-soft">
+                Prefer the Automations tab&apos;s Pause/Resume actions for normal use -- this is a direct
+                override.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Task */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Task</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Instruction</Label>
+            <Textarea
+              className="min-h-[120px]"
+              value={instruction}
+              onChange={(e) => setInstruction(e.target.value)}
+              placeholder="What should the agent do when this automation runs?"
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label>Model override (optional)</Label>
+              <Combobox
+                options={modelOptions}
+                value={modelOverride}
+                onValueChange={setModelOverride}
+                placeholder="Agent default"
+                searchPlaceholder="Search models..."
+                emptyText="No model found."
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Conversation mode</Label>
+              <Select
+                onValueChange={(v) => setConversationMode(v as AutomationConversationMode)}
+                value={conversationMode}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CONVERSATION_MODES.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {m}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-steel-soft">
+                New starts a fresh conversation each run; Dedicated reuses one conversation across runs;
+                No-UI runs without creating a visible conversation.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Trigger */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle>Trigger</CardTitle>
+            <p className="font-body text-[13px] text-steel-soft max-w-[60ch]">
+              What starts this automation. Add more than one if it should run from several sources.
+            </p>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={handleAddTrigger}>
+            <Plus className="w-4 h-4 mr-2" />
+            Add trigger
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {triggerRows.length === 0 && (
+            <p className="text-sm text-steel-soft rounded-lg border border-dashed p-4">
+              No triggers yet -- this automation can still be run manually (Run now, from chat, or by
+              another automation). Add a trigger above to also run it automatically.
+            </p>
+          )}
+          {triggerRows.map((row) => (
+            <div key={row._localId} className="rounded-lg border p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <Badge variant="secondary">
+                  {AUTOMATION_TRIGGER_TYPES.includes(row.trigger_type) ? row.trigger_type : 'Trigger'}
+                </Badge>
+                <Button type="button" variant="ghost" size="sm" onClick={() => handleRemoveTrigger(row)}>
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  Remove
+                </Button>
+              </div>
+              <TriggerEditor
+                trigger={row}
+                onChange={(patch) => handleTriggerChange(row._localId, patch)}
+                permissions={{ canEdit: true }}
+              />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Execution */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Execution</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Run as (optional)</Label>
+            <Combobox
+              options={userOptions}
+              value={runAsUser}
+              onValueChange={setRunAsUser}
+              placeholder="Runs as this automation's owner"
+              searchPlaceholder="Search users..."
+              emptyText="No user found."
+            />
+            <p className="text-xs text-steel-soft">
+              Only a System Manager may set this to someone other than the automation&apos;s owner.
+            </p>
+          </div>
+          <div className="flex flex-row items-center justify-between rounded-md border p-4">
+            <div className="space-y-0.5">
+              <Label className="text-sm">Notify on completion</Label>
+              <p className="text-xs text-steel-soft">Notify the run-as user when this automation finishes.</p>
+            </div>
+            <Switch checked={notifyUser === 1} onCheckedChange={(checked) => setNotifyUser(checked ? 1 : 0)} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* History */}
+      {!isNew && automation && (
+        <Card>
+          <CardHeader>
+            <CardTitle>History</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid gap-3 sm:grid-cols-2 text-sm">
+              <HistoryField label="Last run" value={automation.last_execution} />
+              <HistoryField label="Last status" value={automation.last_status} />
+              <HistoryField label="Next run" value={automation.next_execution} />
+              <HistoryField label="Total runs" value={automation.total_runs?.toString()} />
+            </div>
+            {automation.last_error && (
+              <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-xs font-mono text-destructive">
+                {automation.last_error}
+              </div>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => navigate(`/executions?agents=${encodeURIComponent(automation.agent)}`)}
+            >
+              View this agent&apos;s runs
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function HistoryField({ label, value }: { label: string; value?: string }) {
+  return (
+    <div>
+      <div className="text-xs text-steel-soft">{label}</div>
+      <div>{value || '—'}</div>
+    </div>
+  );
+}

--- a/frontend/src/services/automationApi.ts
+++ b/frontend/src/services/automationApi.ts
@@ -1,0 +1,325 @@
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+import type {
+  Automation,
+  AutomationTrigger,
+  AutomationTriggerAttachment,
+  AutomationTriggerSummary,
+  DeleteAutomationResponse,
+  DeleteTriggerResponse,
+  RunAutomationNowResponse,
+  ScheduledAutomationSummary,
+} from '@/types/automation.types';
+
+// ---------------------------------------------------------------------------
+// Automation CRUD / lifecycle
+// ---------------------------------------------------------------------------
+
+export interface ListAutomationsParams {
+  agent?: string;
+  status?: string;
+}
+
+/**
+ * List Automations visible to the current user.
+ */
+export async function listAutomations(params: ListAutomationsParams = {}): Promise<Automation[]> {
+  try {
+    const result = await call.get('huf.ai.automation_api.list_automations', {
+      agent: params.agent ?? undefined,
+      status: params.status ?? undefined,
+    });
+    return (result?.message ?? result) as Automation[];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching automations');
+    return [];
+  }
+}
+
+/**
+ * Get a single Automation.
+ */
+export async function getAutomation(automation: string): Promise<Automation | undefined> {
+  try {
+    const result = await call.get('huf.ai.automation_api.get_automation', { automation });
+    return (result?.message ?? result) as Automation;
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching automation');
+  }
+}
+
+export interface CreateAutomationParams {
+  automation_name: string;
+  agent: string;
+  instruction: string;
+  description?: string;
+  project?: string;
+  model_override?: string;
+  run_as_user?: string;
+  input_template?: string;
+  conversation_mode?: string;
+  conversation?: string;
+  notify_user?: 0 | 1;
+  source_system?: string;
+  metadata?: string | Record<string, unknown>;
+}
+
+/**
+ * Create a new Automation (always starts in Draft status).
+ */
+export async function createAutomation(params: CreateAutomationParams): Promise<Automation> {
+  try {
+    const result = await call.post('huf.ai.automation_api.create_automation', {
+      automation_name: params.automation_name,
+      agent: params.agent,
+      instruction: params.instruction,
+      description: params.description ?? undefined,
+      project: params.project ?? undefined,
+      model_override: params.model_override ?? undefined,
+      run_as_user: params.run_as_user ?? undefined,
+      input_template: params.input_template ?? undefined,
+      conversation_mode: params.conversation_mode ?? undefined,
+      conversation: params.conversation ?? undefined,
+      notify_user: params.notify_user ?? undefined,
+      source_system: params.source_system ?? undefined,
+      metadata: params.metadata ?? undefined,
+    });
+    return (result?.message ?? result) as Automation;
+  } catch (error) {
+    handleFrappeError(error, 'Error creating automation');
+    throw error;
+  }
+}
+
+export interface UpdateAutomationParams {
+  automation: string;
+  automation_name?: string;
+  description?: string;
+  status?: string;
+  disabled?: 0 | 1;
+  agent?: string;
+  model_override?: string;
+  project?: string;
+  run_as_user?: string;
+  instruction?: string;
+  input_template?: string;
+  conversation_mode?: string;
+  conversation?: string;
+  notify_user?: 0 | 1;
+  source_system?: string;
+  metadata?: string | Record<string, unknown>;
+}
+
+/**
+ * Update an existing Automation. Only known, explicit fields are accepted
+ * server-side (see huf.ai.automation_service._UPDATABLE_FIELDS).
+ */
+export async function updateAutomation(params: UpdateAutomationParams): Promise<Automation> {
+  try {
+    const { automation, ...fields } = params;
+    const result = await call.post('huf.ai.automation_api.update_automation', {
+      automation,
+      ...fields,
+    });
+    return (result?.message ?? result) as Automation;
+  } catch (error) {
+    handleFrappeError(error, 'Error updating automation');
+    throw error;
+  }
+}
+
+/**
+ * Archive an Automation (status transition, not a destructive delete).
+ */
+export async function archiveAutomation(automation: string): Promise<Automation> {
+  try {
+    const result = await call.post('huf.ai.automation_api.archive_automation', { automation });
+    return (result?.message ?? result) as Automation;
+  } catch (error) {
+    handleFrappeError(error, 'Error archiving automation');
+    throw error;
+  }
+}
+
+/**
+ * Permanently delete an Automation. Only allowed while Draft or Archived.
+ */
+export async function deleteAutomation(automation: string): Promise<DeleteAutomationResponse> {
+  try {
+    const result = await call.post('huf.ai.automation_api.delete_automation', { automation });
+    return (result?.message ?? result) as DeleteAutomationResponse;
+  } catch (error) {
+    handleFrappeError(error, 'Error deleting automation');
+    return { success: false };
+  }
+}
+
+/**
+ * Run an Automation immediately (bypassing any trigger/schedule).
+ */
+export async function runAutomationNow(automation: string): Promise<RunAutomationNowResponse> {
+  try {
+    const result = await call.post('huf.ai.automation_api.run_automation_now', { automation });
+    return (result?.message ?? result) as RunAutomationNowResponse;
+  } catch (error) {
+    handleFrappeError(error, 'Error running automation');
+    throw error;
+  }
+}
+
+/**
+ * Pause an Automation (status -> Paused).
+ */
+export async function pauseAutomation(automation: string): Promise<Automation> {
+  try {
+    const result = await call.post('huf.ai.automation_api.pause_automation', { automation });
+    return (result?.message ?? result) as Automation;
+  } catch (error) {
+    handleFrappeError(error, 'Error pausing automation');
+    throw error;
+  }
+}
+
+/**
+ * Resume a paused (or draft/error) Automation (status -> Active).
+ */
+export async function resumeAutomation(automation: string): Promise<Automation> {
+  try {
+    const result = await call.post('huf.ai.automation_api.resume_automation', { automation });
+    return (result?.message ?? result) as Automation;
+  } catch (error) {
+    handleFrappeError(error, 'Error resuming automation');
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Automation Trigger CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * List Automation Trigger rows for an Automation.
+ */
+export async function listTriggers(automation: string): Promise<AutomationTriggerSummary[]> {
+  try {
+    const result = await call.get('huf.ai.automation_api.list_triggers', { automation });
+    return (result?.message ?? result) as AutomationTriggerSummary[];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching triggers');
+    return [];
+  }
+}
+
+export interface CreateTriggerParams {
+  automation: string;
+  trigger_type: string;
+  trigger_name?: string;
+  disabled?: 0 | 1;
+  // Schedule
+  schedule_type?: string;
+  cron_expression?: string;
+  run_at?: string;
+  scheduled_interval?: string;
+  timezone?: string;
+  start_at?: string;
+  end_at?: string;
+  misfire_policy?: string;
+  interval_count?: number;
+  // Doc Event
+  reference_doctype?: string;
+  doc_event?: string;
+  prompt_field?: string;
+  prompt_field_mode?: string;
+  condition?: string;
+  // Doc Event child table. NOTE: as of this writing,
+  // huf.ai.automation_api's `_TRIGGER_FIELDS` (both create_trigger and
+  // update_trigger use it) does not include `file_attachments`, so this
+  // value is silently dropped server-side today -- included here so the
+  // client contract is correct once that backend gap is closed. Flagged
+  // for a follow-up backend fix; out of scope for this frontend task.
+  file_attachments?: AutomationTriggerAttachment[];
+  // Webhook
+  webhook_slug?: string;
+  webhook_key?: string;
+  allowed_methods?: string;
+  auth_mode?: string;
+  signature_header?: string;
+  secret?: string;
+  response_mode?: string;
+  // App Event
+  app_name?: string;
+  event_name?: string;
+  event_source?: string;
+  payload_mapping?: string;
+  // Shared
+  source_system?: string;
+  metadata?: string | Record<string, unknown>;
+  disabled_reason?: string;
+}
+
+/**
+ * Create an Automation Trigger for an Automation.
+ */
+export async function createTrigger(params: CreateTriggerParams): Promise<AutomationTrigger> {
+  try {
+    const { automation, trigger_type, ...fields } = params;
+    const result = await call.post('huf.ai.automation_api.create_trigger', {
+      automation,
+      trigger_type,
+      ...fields,
+    });
+    return (result?.message ?? result) as AutomationTrigger;
+  } catch (error) {
+    handleFrappeError(error, 'Error creating trigger');
+    throw error;
+  }
+}
+
+export interface UpdateTriggerParams extends Omit<CreateTriggerParams, 'automation' | 'trigger_type'> {
+  trigger: string;
+}
+
+/**
+ * Update an existing Automation Trigger. `automation` cannot be reassigned
+ * through this endpoint (matches huf.ai.automation_api.update_trigger).
+ */
+export async function updateTrigger(params: UpdateTriggerParams): Promise<AutomationTrigger> {
+  try {
+    const { trigger, ...fields } = params;
+    const result = await call.post('huf.ai.automation_api.update_trigger', {
+      trigger,
+      ...fields,
+    });
+    return (result?.message ?? result) as AutomationTrigger;
+  } catch (error) {
+    handleFrappeError(error, 'Error updating trigger');
+    throw error;
+  }
+}
+
+/**
+ * Delete an Automation Trigger.
+ */
+export async function deleteTrigger(trigger: string): Promise<DeleteTriggerResponse> {
+  try {
+    const result = await call.post('huf.ai.automation_api.delete_trigger', { trigger });
+    return (result?.message ?? result) as DeleteTriggerResponse;
+  } catch (error) {
+    handleFrappeError(error, 'Error deleting trigger');
+    return { success: false };
+  }
+}
+
+/**
+ * List Automations that have at least one enabled Schedule-type
+ * Automation Trigger.
+ */
+export async function listScheduledAutomations(): Promise<ScheduledAutomationSummary[]> {
+  try {
+    const result = await call.get('huf.ai.automation_api.list_scheduled_automations');
+    return (result?.message ?? result) as ScheduledAutomationSummary[];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching scheduled automations');
+    return [];
+  }
+}

--- a/frontend/src/types/automation.types.ts
+++ b/frontend/src/types/automation.types.ts
@@ -1,0 +1,202 @@
+/**
+ * TypeScript interfaces mirroring the Automation and Automation Trigger
+ * doctypes (see huf/huf/doctype/automation/automation.json and
+ * huf/huf/doctype/automation_trigger/automation_trigger.json).
+ */
+
+export type AutomationStatus = 'Draft' | 'Active' | 'Paused' | 'Error' | 'Archived';
+
+export type AutomationConversationMode = 'New' | 'Dedicated' | 'No-UI';
+
+export type AutomationTriggerType = 'Schedule' | 'Doc Event' | 'Webhook' | 'App Event' | 'Manual';
+
+export type AutomationTriggerStatus = 'Draft' | 'Active' | 'Disabled' | 'Error';
+
+export type AutomationScheduleType = 'Interval' | 'Cron' | 'Once';
+
+export type AutomationScheduledInterval = 'Hourly' | 'Daily' | 'Weekly' | 'Monthly' | 'Yearly';
+
+export type AutomationMisfirePolicy = 'Skip' | 'Run Immediately' | 'Queue';
+
+export type AutomationDocEvent =
+  | 'before_insert'
+  | 'after_insert'
+  | 'validate'
+  | 'before_save'
+  | 'after_save'
+  | 'before_submit'
+  | 'on_submit'
+  | 'on_update'
+  | 'after_submit'
+  | 'on_cancel'
+  | 'before_rename'
+  | 'after_rename'
+  | 'on_trash'
+  | 'after_delete';
+
+export type AutomationPromptFieldMode = 'Supplement' | 'Override';
+
+export type AutomationAllowedMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'ANY';
+
+export type AutomationAuthMode = 'None' | 'Webhook Key' | 'Signature' | 'Basic Auth' | 'Bearer Token';
+
+export type AutomationResponseMode = 'Sync' | 'Async';
+
+/**
+ * Automation doctype (huf/huf/doctype/automation/automation.json).
+ */
+export interface Automation {
+  name: string;
+  automation_name: string;
+  status: AutomationStatus;
+  disabled?: 0 | 1;
+  description?: string;
+  agent: string;
+  model_override?: string;
+  project?: string;
+  run_as_user?: string;
+  instruction: string;
+  input_template?: string;
+  source_system?: string;
+  is_virtual?: 0 | 1;
+  metadata?: string | Record<string, unknown>;
+  conversation_mode?: AutomationConversationMode;
+  conversation?: string;
+  notify_user?: 0 | 1;
+  last_run?: string;
+  last_execution?: string;
+  last_status?: AutomationStatus | '';
+  next_execution?: string;
+  total_runs?: number;
+  last_error?: string;
+  source_app?: string;
+  source_file?: string;
+  owner?: string;
+  creation?: string;
+  modified?: string;
+}
+
+/**
+ * Automation Trigger doctype
+ * (huf/huf/doctype/automation_trigger/automation_trigger.json).
+ *
+ * Only `schedule_type`/`cron_expression` fields are populated for
+ * Schedule-type triggers, `reference_doctype`/`doc_event`/... for Doc Event
+ * triggers, and so on -- the doctype uses `depends_on` to show/hide field
+ * groups per `trigger_type`, but on the wire every field is just optional.
+ */
+export interface AutomationTrigger {
+  name: string;
+  trigger_name: string;
+  automation: string;
+  status?: AutomationTriggerStatus | '';
+  disabled?: 0 | 1;
+  trigger_type: AutomationTriggerType | '';
+
+  // -- Schedule fields --
+  schedule_type?: AutomationScheduleType | '';
+  cron_expression?: string;
+  run_at?: string;
+  /** Legacy interval field, preserved for migration compatibility. */
+  scheduled_interval?: AutomationScheduledInterval | '';
+  timezone?: string;
+  start_at?: string;
+  end_at?: string;
+  misfire_policy?: AutomationMisfirePolicy | '';
+  /** Legacy interval count field, preserved for migration compatibility. */
+  interval_count?: number;
+  last_execution?: string;
+  next_execution?: string;
+
+  // -- Doc Event fields --
+  reference_doctype?: string;
+  doc_event?: AutomationDocEvent | '';
+  prompt_field?: string;
+  prompt_field_mode?: AutomationPromptFieldMode | '';
+  /** Also used by App Event triggers. */
+  condition?: string;
+  file_attachments?: AutomationTriggerAttachment[];
+
+  // -- Webhook fields --
+  webhook_slug?: string;
+  webhook_key?: string;
+  allowed_methods?: AutomationAllowedMethod | '';
+  auth_mode?: AutomationAuthMode | '';
+  signature_header?: string;
+  secret?: string;
+  response_mode?: AutomationResponseMode | '';
+
+  // -- App Event fields --
+  app_name?: string;
+  event_name?: string;
+  event_source?: string;
+  /** Also used by Webhook triggers. */
+  payload_mapping?: string;
+
+  // -- Shared trailing fields --
+  source_system?: string;
+  metadata?: string | Record<string, unknown>;
+  disabled_reason?: string;
+  is_virtual?: 0 | 1;
+
+  owner?: string;
+  creation?: string;
+  modified?: string;
+}
+
+/** Child table row for Automation Trigger's `file_attachments` field. */
+export interface AutomationTriggerAttachment {
+  name?: string;
+  [key: string]: unknown;
+}
+
+/** Summary row shape returned by list_triggers. */
+export interface AutomationTriggerSummary {
+  name: string;
+  trigger_name: string;
+  automation: string;
+  status?: AutomationTriggerStatus | '';
+  disabled?: 0 | 1;
+  trigger_type: AutomationTriggerType | '';
+  schedule_type?: AutomationScheduleType | '';
+  cron_expression?: string;
+  last_execution?: string;
+  next_execution?: string;
+  modified?: string;
+}
+
+/** Row shape returned by list_scheduled_automations. */
+export interface ScheduledAutomationSummary {
+  name: string;
+  automation_name: string;
+  status: AutomationStatus;
+  disabled?: 0 | 1;
+  agent: string;
+  project?: string;
+  last_execution?: string;
+  last_status?: AutomationStatus | '';
+  next_execution?: string;
+  trigger?: string;
+  schedule_type?: AutomationScheduleType | '';
+  cron_expression?: string;
+  run_at?: string;
+  scheduled_interval?: AutomationScheduledInterval | '';
+  trigger_next_execution?: string;
+}
+
+/** Response shape returned by run_automation_now. */
+export interface RunAutomationNowResponse {
+  success: boolean;
+  status?: string;
+  agent_run_id?: string;
+  conversation_id?: string;
+  [key: string]: unknown;
+}
+
+export interface DeleteAutomationResponse {
+  success: boolean;
+}
+
+export interface DeleteTriggerResponse {
+  success: boolean;
+}

--- a/huf/ai/agent_hooks.py
+++ b/huf/ai/agent_hooks.py
@@ -5,6 +5,7 @@ from frappe.utils.safe_exec import get_safe_globals, safe_eval
 from uuid import uuid4
 from frappe.utils import now_datetime
 import json
+from .automation_runtime_flag import automation_runtime_is_new
 
 CACHE_KEY = "huf:doc_event_agents"
 
@@ -78,6 +79,9 @@ def clear_doc_event_agents_cache(doc=None, method=None):
 
 
 def run_hooked_agents(doc, method=None, *args, **kwargs):
+    if automation_runtime_is_new():
+        return
+
     if not method:
         return
 

--- a/huf/ai/agent_scheduler.py
+++ b/huf/ai/agent_scheduler.py
@@ -2,9 +2,12 @@ import frappe
 from frappe import _
 from frappe.utils import now_datetime, add_to_date
 from .agent_integration import run_agent_sync
+from .automation_runtime_flag import automation_runtime_is_new
 
 @frappe.whitelist()
 def run_scheduled_agents():
+    if automation_runtime_is_new():
+        return
     now = now_datetime().replace(microsecond=0)
     
     if frappe.session.user != "Administrator" and not frappe.has_permission("Agent Trigger", "write"):

--- a/huf/ai/automation_api.py
+++ b/huf/ai/automation_api.py
@@ -374,10 +374,19 @@ def create_trigger(automation: str, trigger_type: str, **kwargs) -> dict:
     if not frappe.has_permission("Automation Trigger", "create"):
         frappe.throw(_("Not permitted"), frappe.PermissionError)
 
+    # trigger_name is deliberately excluded from _TRIGGER_FIELDS (see the
+    # comment on that tuple) so update_trigger can never silently desync
+    # doc.name from it. But it is Automation Trigger's autoname source
+    # (field:trigger_name) -- Frappe requires it be set at insert time, so
+    # create_trigger (unlike update_trigger) still accepts it explicitly,
+    # generating a reasonable default if the caller did not supply one.
+    trigger_name = kwargs.get("trigger_name") or f"{automation}-{trigger_type}-{frappe.generate_hash(length=6)}"
+
     doc_fields = {
         "doctype": "Automation Trigger",
         "automation": automation,
         "trigger_type": trigger_type,
+        "trigger_name": trigger_name,
     }
     for fieldname in _TRIGGER_FIELDS:
         if fieldname in kwargs and kwargs[fieldname] is not None:

--- a/huf/ai/automation_api.py
+++ b/huf/ai/automation_api.py
@@ -21,6 +21,41 @@ from frappe import _
 
 from huf.ai import automation_service
 
+
+def _ensure_agent_automations_editable(agent_name):
+	"""Block non-admins from creating/editing/deleting Automations or
+	Automation Triggers that target a locked system agent.
+
+	This is the Automation-model analog of
+	``Agent._validate_system_agent_immutability()``'s ``protected_fields``
+	check (huf/huf/doctype/agent/agent.py). Since Automation is a separate
+	doctype rather than an Agent child table, that check can't cover it --
+	Automations pointing at a system agent need their own guard here, or a
+	non-admin could freely create/edit/delete automations (this track's
+	replacement for the old Triggers tab) on an agent whose own identity
+	fields are otherwise locked. Mirrors the same bypass conditions
+	(seeding/install/migrate, System Manager role).
+	"""
+	if not agent_name:
+		return
+	if (
+		frappe.flags.in_seeding
+		or frappe.flags.in_install
+		or frappe.flags.in_migrate
+		or "System Manager" in frappe.get_roles()
+	):
+		return
+	is_system = frappe.db.get_value("Agent", agent_name, "is_system")
+	if is_system:
+		frappe.throw(
+			_(
+				"Only System Managers can create or modify automations for the "
+				"system agent '{0}'."
+			).format(agent_name),
+			frappe.PermissionError,
+			title=_("System Agent Protected"),
+		)
+
 # Fields a client may set when creating/updating an Automation Trigger.
 # ``automation`` and ``trigger_type`` are handled explicitly by
 # create_trigger; everything else here is passed straight through.
@@ -122,6 +157,8 @@ def create_automation(automation_name: str, agent: str, instruction: str, **kwar
     if not frappe.has_permission("Automation", "create"):
         frappe.throw(_("Not permitted"), frappe.PermissionError)
 
+    _ensure_agent_automations_editable(agent)
+
     doc = automation_service.create_automation(automation_name, agent, instruction, **kwargs)
 
     return doc.as_dict()
@@ -144,6 +181,8 @@ def update_automation(automation: str, **kwargs) -> dict:
     doc = automation_service.resolve_automation(automation)
     if not doc.has_permission("write"):
         frappe.throw(_("You do not have permission to edit this automation."), frappe.PermissionError)
+
+    _ensure_agent_automations_editable(doc.agent)
 
     doc = automation_service.update_automation(doc, **kwargs)
 
@@ -188,6 +227,8 @@ def delete_automation(automation: str) -> dict:
     doc = automation_service.resolve_automation(automation)
     if not doc.has_permission("delete"):
         frappe.throw(_("You do not have permission to delete this automation."), frappe.PermissionError)
+
+    _ensure_agent_automations_editable(doc.agent)
 
     if doc.status not in ("Draft", "Archived"):
         frappe.throw(
@@ -325,6 +366,8 @@ def create_trigger(automation: str, trigger_type: str, **kwargs) -> dict:
     if not automation_doc.has_permission("write"):
         frappe.throw(_("You do not have permission to modify this automation."), frappe.PermissionError)
 
+    _ensure_agent_automations_editable(automation_doc.agent)
+
     if not trigger_type or not trigger_type.strip():
         frappe.throw(_("Trigger Type is required"))
 
@@ -364,6 +407,8 @@ def update_trigger(trigger: str, **kwargs) -> dict:
     if not doc.has_permission("write"):
         frappe.throw(_("You do not have permission to edit this trigger."), frappe.PermissionError)
 
+    _ensure_agent_automations_editable(frappe.db.get_value("Automation", doc.automation, "agent"))
+
     changed = False
     for fieldname in _TRIGGER_FIELDS:
         if fieldname not in kwargs:
@@ -394,6 +439,8 @@ def delete_trigger(trigger: str) -> dict:
     doc = frappe.get_doc("Automation Trigger", trigger)
     if not doc.has_permission("delete"):
         frappe.throw(_("You do not have permission to delete this trigger."), frappe.PermissionError)
+
+    _ensure_agent_automations_editable(frappe.db.get_value("Automation", doc.automation, "agent"))
 
     frappe.delete_doc("Automation Trigger", trigger)
 

--- a/huf/ai/automation_api.py
+++ b/huf/ai/automation_api.py
@@ -25,7 +25,11 @@ from huf.ai import automation_service
 # ``automation`` and ``trigger_type`` are handled explicitly by
 # create_trigger; everything else here is passed straight through.
 _TRIGGER_FIELDS = (
-    "trigger_name",
+    # NOTE: trigger_name deliberately excluded — Automation Trigger's
+    # autoname is field:trigger_name, so a plain doc.set()+doc.save() would
+    # silently desync doc.name from doc.trigger_name instead of renaming.
+    # Renaming (if ever needed) must go through frappe.rename_doc()
+    # explicitly, not this generic field-update path.
     "disabled",
     "schedule_type",
     "cron_expression",

--- a/huf/ai/automation_app_event.py
+++ b/huf/ai/automation_app_event.py
@@ -1,0 +1,60 @@
+import frappe
+from frappe import _
+
+from .automation_runner import run_automation
+from .automation_runtime_flag import automation_runtime_is_new
+
+
+@frappe.whitelist()
+def trigger_app_event(app_name: str, event_name: str, payload: dict | None = None) -> dict:
+	"""Fire every enabled App Event Automation Trigger matching (app_name, event_name).
+
+	Net-new: the legacy "App Event" Agent Trigger type has no runtime
+	implementation anywhere in this codebase (schema field only) — there is
+	no legacy behavior to preserve or fall back to. Intended for internal
+	callers (other huf modules, external apps with a real Frappe session)
+	that want to fan out an app-level event to any matching Automations —
+	not for untrusted/unauthenticated callers (no allow_guest, unlike the
+	Webhook trigger type which is specifically for that).
+	"""
+	if not automation_runtime_is_new():
+		return {"triggered": 0, "skipped": "legacy_runtime"}
+
+	if not frappe.has_permission("Automation", "read"):
+		frappe.throw(_("You do not have permission to trigger app events."), frappe.PermissionError)
+
+	if not app_name or not event_name:
+		frappe.throw(_("app_name and event_name are required."))
+
+	triggers = frappe.get_all(
+		"Automation Trigger",
+		filters={
+			"trigger_type": "App Event",
+			"app_name": app_name,
+			"event_name": event_name,
+			"disabled": 0,
+		},
+		fields=["name", "automation"],
+	)
+
+	triggered_automations = []
+	for t in triggers:
+		try:
+			run_automation(
+				t["automation"],
+				trigger_name=t["name"],
+				trigger_context={
+					"type": "app_event",
+					"app_name": app_name,
+					"event_name": event_name,
+					"payload": payload or {},
+				},
+			)
+			triggered_automations.append(t["automation"])
+		except Exception:
+			frappe.log_error(
+				title=f"App Event Automation Error: {t['name']}",
+				message=frappe.get_traceback(),
+			)
+
+	return {"triggered": len(triggered_automations), "automation_names": triggered_automations}

--- a/huf/ai/automation_hooks.py
+++ b/huf/ai/automation_hooks.py
@@ -1,0 +1,362 @@
+import json
+from uuid import uuid4
+
+import frappe
+from frappe.utils import now_datetime
+from frappe.utils.background_jobs import enqueue
+from frappe.utils.safe_exec import get_safe_globals, safe_eval
+
+from .automation_runtime_flag import automation_runtime_is_new
+
+CACHE_KEY = "huf:doc_event_automation_triggers"
+
+# Doc Event names Automation Trigger's own Select field supports (see
+# huf/huf/doctype/automation_trigger/automation_trigger.json). Deliberately
+# NOT identical to Agent Trigger's list (that one has "before_cancel", this
+# one has "on_cancel" instead) — hooks.py registers exactly this set.
+SUPPORTED_DOC_EVENTS = [
+	"before_insert",
+	"after_insert",
+	"validate",
+	"before_save",
+	"after_save",
+	"before_submit",
+	"on_submit",
+	"on_update",
+	"on_cancel",
+	"before_rename",
+	"after_rename",
+	"on_trash",
+	"after_delete",
+]
+
+
+def get_doc_event_automation_triggers(event: str):
+	"""Fetch & cache Doc Event Automation Triggers for a given doc_event.
+
+	Cache holds ONLY routing/condition metadata — not resolved agent/model
+	config — so a change to the Automation's agent/instructions takes effect
+	on the very next fire without a cache-clear. Config resolution happens
+	fresh inside run_automation() every time. This is the key behavioral
+	difference from the legacy huf.ai.agent_hooks cache, which baked in
+	provider/model/instructions at cache time.
+	"""
+	if not frappe.db.exists("DocType", "Automation Trigger"):
+		return []
+
+	if not frappe.has_permission("Automation Trigger", "read"):
+		return []
+
+	cached = frappe.cache().hget(CACHE_KEY, f"doc_event:{event}")
+	if cached:
+		return frappe.parse_json(cached)
+
+	triggers = frappe.get_all(
+		"Automation Trigger",
+		filters={
+			"trigger_type": "Doc Event",
+			"disabled": 0,
+			"doc_event": event,
+		},
+		fields=[
+			"name",
+			"automation",
+			"reference_doctype",
+			"doc_event",
+			"condition",
+			"prompt_field",
+			"prompt_field_mode",
+		],
+	)
+
+	result = []
+	for t in triggers:
+		try:
+			trigger_doc = frappe.get_doc("Automation Trigger", t["name"])
+			result.append(
+				{
+					"name": t["name"],
+					"automation": t["automation"],
+					"reference_doctype": t.get("reference_doctype"),
+					"doc_event": t.get("doc_event"),
+					"condition": t.get("condition"),
+					"prompt_field": t.get("prompt_field"),
+					"prompt_field_mode": t.get("prompt_field_mode") or "Supplement",
+					"file_attachments": [
+						{
+							"source_type": a.source_type,
+							"child_table": a.child_table,
+							"field_name": a.field_name,
+						}
+						for a in (trigger_doc.get("file_attachments") or [])
+					],
+				}
+			)
+		except Exception as e:
+			frappe.logger("huf").error(f"Automation Trigger load failed: {t.get('name')} - {str(e)}")
+
+	frappe.cache().hset(CACHE_KEY, f"doc_event:{event}", frappe.as_json(result))
+	return result
+
+
+def clear_doc_event_automation_cache(doc=None, method=None):
+	"""Clear cache when an Automation Trigger changes."""
+	try:
+		frappe.cache().delete_key(CACHE_KEY)
+	except Exception:
+		pass
+
+
+def run_hooked_automations(doc, method=None, *args, **kwargs):
+	"""hooks.py doc_events entrypoint — the Automation-side counterpart of
+	huf.ai.agent_hooks.run_hooked_agents. Registered alongside (not
+	replacing) the legacy function; both check automation_runtime_is_new()
+	so exactly one runtime actually queues work for a given fire.
+	"""
+	if not automation_runtime_is_new():
+		return
+
+	if not method:
+		return
+
+	# Do not fire during site install, migrations, or bulk imports — mirrors
+	# the legacy guard in agent_hooks.run_hooked_agents.
+	if frappe.flags.in_import or frappe.flags.in_patch or frappe.flags.in_install:
+		return
+
+	if method not in SUPPORTED_DOC_EVENTS:
+		return
+
+	triggers = get_doc_event_automation_triggers(method)
+	matching = [
+		t for t in triggers
+		if t.get("reference_doctype") == doc.doctype and t.get("doc_event") == method
+	]
+	if not matching:
+		return
+
+	for trigger in matching:
+		condition = trigger.get("condition")
+		if condition:
+			try:
+				if not safe_eval(condition, get_safe_globals(), {"doc": doc}):
+					continue
+			except Exception as e:
+				frappe.log_error(
+					title="Automation Hooks Condition Error",
+					message=f"Condition error in Automation Trigger {trigger.get('name')}: {e}",
+				)
+				continue
+
+		# Queue AFTER the triggering document's own transaction commits, and
+		# run the automation in a background worker — mirrors
+		# agent_hooks.run_hooked_agents' after_commit + enqueue pattern.
+		# This means run_automation() always executes in its own fresh
+		# transaction (never inside the doc's still-open one), so the
+		# default commit=True is correct here — no commit=False needed,
+		# unlike a hypothetical synchronous-inline call site.
+		def _queue_after_commit(t=trigger, d=doc, m=method, u=frappe.session.user):
+			safe_name = d.name or str(id(d))
+			lock_key = f"huf:lock:automation:{t['automation']}:{d.doctype}:{safe_name}:{m}"
+			cache = frappe.cache()
+			if cache.get_value(lock_key):
+				return
+			cache.set_value(lock_key, now_datetime().isoformat(), expires_in_sec=30)
+
+			enqueue(
+				run_automation_for_doc,
+				queue="long",
+				job_id=f"run-automation-{t['automation']}-{d.doctype}-{safe_name}-{m}-{uuid4()}",
+				trigger=t,
+				doc=d.as_dict(),
+				event_name=m,
+				initiating_user=u,
+			)
+
+		frappe.db.after_commit.add(_queue_after_commit)
+
+
+def run_automation_for_doc(trigger, doc, event_name, initiating_user=None):
+	"""Background worker: resolve trigger_context for a fired Doc Event
+	Automation Trigger and hand off to the canonical run_automation().
+
+	Runs in its own background-job transaction (enqueued via
+	run_hooked_automations above), so commit=True (run_automation's
+	default) is correct and safe here.
+	"""
+	from .automation_runner import run_automation
+
+	original_user = frappe.session.user
+	try:
+		if initiating_user and frappe.session.user != initiating_user:
+			try:
+				frappe.set_user(initiating_user)
+			except frappe.DoesNotExistError:
+				pass
+
+		doc_dict = doc if isinstance(doc, dict) else doc.as_dict()
+
+		prompt_field = trigger.get("prompt_field")
+		prompt_field_mode = trigger.get("prompt_field_mode") or "Supplement"
+		custom_instruction = doc_dict.get(prompt_field) if prompt_field else None
+
+		# Files: extract from configured attachment fields, run OCR on
+		# non-image/non-audio files, transcribe audio files. Reuses the same
+		# helpers as the legacy agent_hooks.run_agent_for_doc.
+		files = []
+		file_attachments = trigger.get("file_attachments") or []
+		if file_attachments:
+			import mimetypes
+
+			from huf.ai.audio_service import is_audio_file
+
+			file_urls = []
+			for attachment in file_attachments:
+				fetch_from = attachment.get("source_type")
+				field_name = attachment.get("field_name")
+				table_name = attachment.get("child_table")
+				if fetch_from == "DocField":
+					if field_name and doc_dict.get(field_name):
+						file_urls.append(doc_dict.get(field_name))
+				elif fetch_from == "Child Table Field":
+					if table_name and field_name and doc_dict.get(table_name):
+						for row in doc_dict.get(table_name):
+							f_url = row.get(field_name) if isinstance(row, dict) else None
+							if f_url:
+								file_urls.append(f_url)
+
+			for f_url in file_urls:
+				if any(f["file_url"] == f_url for f in files):
+					continue
+				filename = f_url.split("/")[-1]
+				mime_type, _mt = mimetypes.guess_type(filename)
+				is_image = bool(mime_type and mime_type.startswith("image/"))
+				is_audio = 0 if is_image else (1 if is_audio_file(filename, mime_type) else 0)
+				file_id = frappe.db.get_value("File", {"file_url": f_url}, "name")
+				files.append(
+					{
+						"file_id": file_id,
+						"filename": filename,
+						"file_url": f_url,
+						"is_image": is_image,
+						"is_audio": is_audio,
+					}
+				)
+
+		extracted_content = []
+		if any(not f.get("is_image") and not f.get("is_audio") for f in files):
+			from huf.ai.sdk_tools import handle_ocr_document
+			import asyncio
+
+			loop = asyncio.new_event_loop()
+			asyncio.set_event_loop(loop)
+			try:
+				for file in files:
+					if not file.get("is_image") and not file.get("is_audio"):
+						ocr_result = loop.run_until_complete(
+							handle_ocr_document(
+								file_id=file.get("file_id"),
+								file_url=file["file_url"],
+								agent_name=None,
+							)
+						)
+						if ocr_result and ocr_result.get("success"):
+							extracted_content.append(
+								f"--- File: {file['filename']} ---\n{ocr_result.get('text')}\n"
+							)
+			except Exception:
+				frappe.log_error(
+					title="Automation Hooks OCR Error",
+					message=frappe.get_traceback(),
+				)
+			finally:
+				loop.close()
+
+		transcribed_content = []
+		if any(f.get("is_audio") for f in files):
+			from huf.ai import audio_service
+
+			for file in files:
+				if not file.get("is_audio"):
+					continue
+				try:
+					stt_result = audio_service.transcribe_audio_file(
+						file_id=file.get("file_id"),
+						file_url=file["file_url"],
+						agent_name=None,
+					)
+					if stt_result and stt_result.get("success"):
+						transcribed_content.append(
+							f"--- File: {file['filename']} ---\n"
+							f"{stt_result.get('transcript') or stt_result.get('text')}\n"
+						)
+				except Exception:
+					frappe.log_error(
+						title="Automation Hooks Audio Error",
+						message=frappe.get_traceback(),
+					)
+
+		# Clean + truncate the document JSON for context, same convention as
+		# legacy agent_hooks.run_agent_for_doc.
+		clean_doc = dict(doc_dict)
+		for key in ["_user_tags", "_comments", "_assign", "_liked_by", "docstatus", "password"]:
+			clean_doc.pop(key, None)
+		MAX_FIELD_LENGTH = 10000
+		for k, v in list(clean_doc.items()):
+			if isinstance(v, str) and len(v) > MAX_FIELD_LENGTH:
+				clean_doc[k] = v[:MAX_FIELD_LENGTH] + f"\n... [truncated, full length {len(v)} chars]"
+		try:
+			doc_json = json.dumps(clean_doc, indent=2, default=str)
+		except (TypeError, ValueError):
+			doc_json = "{}"
+
+		# Compose the event-specific supplement. Precedence is explicit and
+		# not hidden: Automation.instruction (the task's own base
+		# instruction) always runs first; this supplement is appended after
+		# it by automation_runner._resolve_instruction whenever
+		# trigger_context carries "_doc_event_supplement" AND
+		# automation.input_template is not set (input_template, when set,
+		# is a full override of the default composition — see that
+		# function's docstring). See prompt_field_mode below for how a
+		# trigger's own prompt_field content participates in that supplement
+		# rather than silently replacing the Automation's instruction.
+		supplement_parts = [f"Document event: {event_name}", f"Doctype: {doc_dict.get('doctype')}", f"Document name: {doc_dict.get('name')}"]
+
+		if custom_instruction and prompt_field_mode == "Override":
+			# Caller-visible override: still appended, never silently
+			# replaces automation.instruction at this layer — the plan's
+			# "do not hide this precedence in code" rule means the override
+			# happens by explicit labeling, not by dropping the base
+			# instruction. If a true full override is needed later, that's
+			# a product decision for the Automation form UI, not this hook.
+			supplement_parts.append(f"Document-specific request (overrides general instruction below):\n{custom_instruction}")
+		elif custom_instruction:
+			supplement_parts.append(f"Document-specific note:\n{custom_instruction}")
+
+		supplement_parts.append(f"Document data:\n```json\n{doc_json}\n```")
+
+		if extracted_content:
+			supplement_parts.append("Attached file content (OCR extracted):\n" + "".join(extracted_content))
+		if transcribed_content:
+			supplement_parts.append("Attached audio transcript(s):\n" + "".join(transcribed_content))
+
+		trigger_context = {
+			"type": "doc_event",
+			"event_name": event_name,
+			"reference_doctype": doc_dict.get("doctype"),
+			"reference_name": doc_dict.get("name"),
+			"_doc_event_supplement": "\n\n".join(supplement_parts),
+		}
+
+		run_automation(
+			trigger["automation"],
+			trigger_name=trigger.get("name"),
+			trigger_context=trigger_context,
+			initiating_user=initiating_user,
+		)
+	finally:
+		if frappe.session.user != original_user:
+			try:
+				frappe.set_user(original_user)
+			except Exception:
+				pass

--- a/huf/ai/automation_runner.py
+++ b/huf/ai/automation_runner.py
@@ -29,6 +29,7 @@ def run_automation(
 	trigger_context=None,
 	initiating_user=None,
 	now=False,
+	commit=True,
 ):
 	"""Execute an Automation by name.
 
@@ -43,8 +44,29 @@ def run_automation(
 		initiating_user: the user on whose behalf this run should execute.
 			Falls back to ``automation.run_as_user``, then the current
 			session user (mirrors the pattern in ``agent_hooks.run_agent_for_doc``).
+			When no ``initiating_user`` is supplied and ``automation.run_as_user``
+			would switch identity away from the Automation's own owner, the
+			owner must hold the System Manager role — see
+			``_check_run_as_user_permission`` — otherwise a
+			``frappe.PermissionError`` is raised rather than silently running
+			as the configured user.
 		now: if truthy, forces immediate (non-queued) execution — passed
 			straight through to ``run_agent_sync``.
+		commit: if truthy (the default), ``_execute`` commits the current
+			database transaction once bookkeeping is written. Top-level
+			callers that own their own request/job transaction (scheduler
+			ticks, webhook requests, app-event API calls, manual "Run now"
+			calls) should keep the default so this run's writes are durable
+			right away. Callers invoking this synchronously from inside
+			another doctype's ``on_update``/``after_insert``/etc hook chain
+			(the doc-event automation path) MUST pass ``commit=False`` — an
+			explicit commit mid-hook would also commit the *caller's* still
+			in-flight document save, which is not this function's
+			transaction to commit and can leave the caller's document
+			partially/inconsistently persisted if a later step in its own
+			hook chain fails afterward. Frappe's own request/job-dispatch
+			machinery commits at the end of the request/job regardless, so
+			skipping the commit here is safe, not merely deferred.
 
 	Returns:
 		The dict returned by ``run_agent_sync`` (``success``, ``status``,
@@ -73,6 +95,9 @@ def run_automation(
 
 	trigger_context = dict(trigger_context or {})
 
+	if not initiating_user and automation.run_as_user:
+		_check_run_as_user_permission(automation)
+
 	original_user = frappe.session.user
 	run_user = initiating_user or automation.run_as_user
 	switched_user = False
@@ -86,13 +111,53 @@ def run_automation(
 			pass
 
 	try:
-		return _execute(automation, trigger_name, trigger_context, now)
+		return _execute(automation, trigger_name, trigger_context, now, commit)
 	finally:
 		if switched_user:
 			frappe.set_user(original_user)
 
 
-def _execute(automation, trigger_name, trigger_context, now):
+def _check_run_as_user_permission(automation):
+	"""Guard against unchecked identity impersonation via ``run_as_user``.
+
+	Only exercised when a trigger resolves the run identity purely from
+	``automation.run_as_user`` — i.e. no caller-supplied ``initiating_user``
+	took precedence (that's the case for Schedule/Doc Event/Webhook/App
+	Event triggers per Stage 2; ``run_automation_now`` always passes
+	``initiating_user=frappe.session.user`` and never reaches this check).
+
+	Without this, an Automation's owner could type any user — including
+	Administrator — into ``run_as_user`` and have every scheduled/webhook
+	fire execute with that identity's permissions, with nothing verifying
+	the owner is actually allowed to impersonate it.
+
+	Mirrors this codebase's existing privileged-impersonation convention:
+	only a System Manager may act as an identity other than their own (see
+	``huf/huf/doctype/agent/agent.py``'s system-agent guards and
+	``huf/ai/tools/builder.py``'s ``_require_builder_capability``, both of
+	which gate privileged operations on ``"System Manager" in
+	frappe.get_roles(...)``).
+	"""
+	run_as_user = automation.run_as_user
+	owner = automation.owner
+
+	if not run_as_user or run_as_user == owner:
+		return
+
+	if "System Manager" in frappe.get_roles(owner):
+		return
+
+	frappe.throw(
+		_(
+			"Automation '{0}' is configured to run as '{1}', but its owner "
+			"'{2}' does not have the System Manager role required to run "
+			"automations as another user."
+		).format(automation.name, run_as_user, owner),
+		frappe.PermissionError,
+	)
+
+
+def _execute(automation, trigger_name, trigger_context, now, commit=True):
 	instruction = _resolve_instruction(automation, trigger_context)
 
 	conversation_id, channel_id, external_id, skip_user_message = _resolve_conversation_routing(
@@ -153,7 +218,12 @@ def _execute(automation, trigger_name, trigger_context, now):
 	if trigger_name:
 		_update_trigger_bookkeeping(trigger_name, error_message)
 
-	frappe.db.commit()
+	if commit:
+		# Only for top-level callers (scheduler/webhook/app-event/manual
+		# "Run now") that own the current request/job transaction. Doc-event
+		# callers run inside another doctype's hook chain and pass
+		# commit=False — see run_automation()'s docstring for why.
+		frappe.db.commit()
 
 	return result
 
@@ -190,6 +260,17 @@ def _resolve_instruction(automation, trigger_context):
 		else:
 			if rendered and rendered.strip():
 				instruction = rendered
+	elif trigger_context.get("_doc_event_supplement"):
+		# Doc Event triggers (huf/ai/automation_hooks.py) compose an
+		# event-specific supplement (event name, doc data, prompt_field
+		# content, OCR/audio-transcribed attachment text) and pass it here
+		# via this reserved trigger_context key. Per the plan's explicit
+		# rule that prompt_field must not silently replace the Automation's
+		# own instruction, the supplement is always APPENDED after
+		# automation.instruction, never substituted for it — an
+		# input_template (handled above) remains the only way to fully
+		# override the default composition.
+		instruction = (instruction + chr(10) + chr(10) + trigger_context["_doc_event_supplement"]).strip()
 
 	if not instruction or not instruction.strip():
 		frappe.throw(_("Automation '{0}' has no instruction to execute.").format(automation.name))

--- a/huf/ai/automation_runtime_flag.py
+++ b/huf/ai/automation_runtime_flag.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""Shared site-config flag gating live Automation runtime code paths.
+
+Stage 2 hard-cuts ``hooks.py``'s scheduler/doc-event registrations onto the
+new ``automation_scheduler.py`` / ``automation_hooks.py`` entrypoints, but
+keeps a one-line rollback available without a code revert: setting
+``automation_trigger_runtime`` to ``"legacy"`` in ``site_config.json`` makes
+every new entrypoint that checks this flag act as disabled, while the
+untouched legacy ``agent_scheduler.py`` / ``agent_hooks.py`` files keep
+working unconditionally (they never check this flag).
+
+Webhook and App Event trigger types have no legacy counterpart (confirmed
+by grep across the whole ``huf/`` tree -- see
+``Tracks/safwan-erooth.ChatSidebarTriggerStage2/CONTEXT.md``), so for those
+two "legacy" simply means "disabled" rather than "fall back to an old path".
+"""
+
+from __future__ import annotations
+
+import frappe
+
+_SITE_CONFIG_KEY = "automation_trigger_runtime"
+_VALID_VALUES = ("legacy", "new")
+
+
+def automation_runtime_mode() -> str:
+	"""Return the configured mode: "legacy" or "new" (default "new" if unset or invalid)."""
+	value = frappe.conf.get(_SITE_CONFIG_KEY)
+	if value not in _VALID_VALUES:
+		return "new"
+	return value
+
+
+def automation_runtime_is_new() -> bool:
+	"""True unless site config explicitly opts into "legacy" mode."""
+	return automation_runtime_mode() == "new"

--- a/huf/ai/automation_scheduler.py
+++ b/huf/ai/automation_scheduler.py
@@ -1,0 +1,114 @@
+import frappe
+from frappe import _
+from frappe.utils import now_datetime, add_to_date
+from .automation_runtime_flag import automation_runtime_is_new
+from .automation_runner import run_automation
+
+# Short-lived per-trigger lock so an overlapping scheduler tick (or a manual
+# invocation racing a real tick) can't double-fire the same due trigger.
+# Mirrors the lock pattern in huf/ai/agent_hooks.py's run_hooked_agents.
+_LOCK_PREFIX = "huf:automation_scheduler:lock:"
+_LOCK_TTL_SEC = 60
+
+
+@frappe.whitelist()
+def run_due_automations():
+	"""Fire every due Schedule-type Automation Trigger.
+
+	Registered in hooks.py's ``scheduler_events["all"]`` alongside (not
+	replacing) the legacy ``huf.ai.agent_scheduler.run_scheduled_agents`` —
+	each checks ``automation_runtime_is_new()`` and no-ops when the other
+	runtime is active, so exactly one of the two ever actually executes.
+	"""
+	if not automation_runtime_is_new():
+		return
+
+	now = now_datetime().replace(microsecond=0)
+
+	if not frappe.db.exists("DocType", "Automation Trigger"):
+		return
+
+	triggers = frappe.get_all(
+		"Automation Trigger",
+		filters={
+			"trigger_type": "Schedule",
+			"disabled": 0,
+			"next_execution": ("<=", now),
+		},
+		fields=[
+			"name",
+			"automation",
+			"scheduled_interval",
+			"interval_count",
+			"next_execution",
+			"last_execution",
+		],
+	)
+
+	for t in triggers:
+		try:
+			_fire_due_trigger(t, now)
+		except Exception:
+			frappe.log_error(
+				title=f"Automation Scheduler Error: {t.get('name')}",
+				message=frappe.get_traceback(),
+			)
+
+
+def _fire_due_trigger(t, now):
+	trigger_name = t["name"]
+
+	# Re-check next_execution against a fresh read under the lock — the
+	# batch query above may be stale by the time we get here.
+	lock_key = f"{_LOCK_PREFIX}{trigger_name}"
+	cache = frappe.cache()
+	if cache.get_value(lock_key):
+		return
+	cache.set_value(lock_key, now.isoformat(), expires_in_sec=_LOCK_TTL_SEC)
+
+	current_next = frappe.db.get_value("Automation Trigger", trigger_name, "next_execution")
+	if not current_next or current_next > now:
+		return
+
+	# Claim immediately by advancing next_execution BEFORE executing, so a
+	# second overlapping tick (or a slow run) can't re-select this trigger
+	# while the first run is still in flight.
+	interval = t.get("interval_count") or 1
+	si = (t.get("scheduled_interval") or "").lower()
+	provisional_next = add_to_date(
+		now,
+		hours=interval if si == "hourly" else 0,
+		days=interval if si == "daily" else 0,
+		weeks=interval if si == "weekly" else 0,
+		months=interval if si == "monthly" else 0,
+		years=interval if si == "yearly" else 0,
+	)
+	frappe.db.set_value(
+		"Automation Trigger",
+		trigger_name,
+		{"next_execution": provisional_next},
+		update_modified=False,
+	)
+	frappe.db.commit()
+
+	automation_name = t.get("automation")
+	if not automation_name:
+		return
+
+	run_automation(
+		automation_name,
+		trigger_name=trigger_name,
+		trigger_context={"type": "schedule", "fired_at": now.isoformat()},
+		now=True,
+	)
+
+	# run_automation()'s own bookkeeping (_update_trigger_bookkeeping) only
+	# touches last_execution/status, not next_execution — set last_execution
+	# here explicitly for symmetry with the legacy scheduler's behavior.
+	frappe.db.set_value(
+		"Automation Trigger",
+		trigger_name,
+		{"last_execution": now},
+		update_modified=False,
+	)
+	frappe.db.commit()

--- a/huf/ai/automation_webhook.py
+++ b/huf/ai/automation_webhook.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""HTTP route firing an Automation Trigger of type "Webhook".
+
+Net-new runtime: a grep across the whole ``huf/`` tree found no live HTTP
+route resolving the legacy "Agent Trigger" doctype's Webhook type either --
+``webhook_slug`` was schema-only before this file. There is therefore no
+legacy behavior to preserve or fall back to; the
+``automation_trigger_runtime`` flag (see ``automation_runtime_flag.py``)
+being ``"legacy"`` just means this endpoint is disabled.
+
+Follows the same allow_guest whitelisted-webhook convention already used by
+``huf.ai.gateway_webhook.handle_gateway_webhook``: the routing key (here,
+the Automation Trigger's ``webhook_slug``) is read directly off the query
+string via ``frappe.request.args`` rather than taken as a function kwarg,
+because ``frappe.app.make_form_dict`` replaces ``frappe.form_dict`` wholesale
+with the parsed JSON body whenever ``Content-Type`` is ``application/json``
+-- every real webhook caller posts JSON, so a query-string kwarg named
+``slug`` would never actually reach this function on a live call. The
+response shape (``{"success": bool, "error": str}`` on failure) also mirrors
+``gateway_webhook.py``.
+
+Auth follows the plan's explicit V1 scope ("preserve existing key/slug and
+migrate later" -- advanced ``auth_mode``/``signature_header``/
+``payload_mapping`` fields are out of scope): the secret stored on the
+trigger's ``webhook_key`` field must be supplied via an ``X-Webhook-Key``
+request header. Headers, not the query string or body, are the convention
+here specifically so the secret never lands in access logs or inside the
+``trigger_context`` payload handed to the automation.
+
+Routing safety: the URL's ``slug`` is the *only* input that selects which
+Automation Trigger (and therefore which Automation) runs. The request body
+is parsed only after routing + auth have both succeeded, and is passed to
+``run_automation`` purely as inert ``trigger_context`` data -- nothing in
+the payload is ever read to choose a doctype, trigger, or automation name.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+
+import frappe
+from frappe import _
+
+# Headers never forwarded into trigger_context: credentials that must not be
+# echoed back into automation prompts, logs, or (eventually) chat history.
+_EXCLUDED_HEADERS = frozenset({"authorization", "cookie", "x-webhook-key"})
+
+# Generic messages for the two failure modes that must not leak details:
+# unknown/disabled/wrong-type slugs, and slugs that resolve but whose key
+# check fails. Neither message names the automation, the trigger, or why a
+# slug didn't resolve (unknown vs. disabled vs. wrong trigger_type all look
+# identical from the outside).
+_NOT_FOUND = {"success": False, "error": "Not found."}
+_INVALID_KEY = {"success": False, "error": "Invalid webhook key."}
+
+
+@frappe.whitelist(allow_guest=True, methods=["GET", "POST"])
+def handle_automation_webhook():
+	"""Resolve `?slug=...` to an Automation Trigger and run its Automation."""
+	from huf.ai.automation_runner import run_automation
+	from huf.ai.automation_runtime_flag import automation_runtime_is_new
+
+	if not automation_runtime_is_new():
+		frappe.local.response["http_status_code"] = 503
+		return {"success": False, "error": "Automation webhooks are disabled."}
+
+	slug = frappe.request.args.get("slug") if frappe.request is not None else None
+	if not slug:
+		frappe.local.response["http_status_code"] = 404
+		return dict(_NOT_FOUND)
+
+	trigger_name = frappe.db.get_value(
+		"Automation Trigger",
+		{"trigger_type": "Webhook", "webhook_slug": slug, "disabled": 0},
+		"name",
+	)
+	if not trigger_name:
+		frappe.local.response["http_status_code"] = 404
+		return dict(_NOT_FOUND)
+
+	trigger = frappe.get_doc("Automation Trigger", trigger_name)
+
+	supplied_key = frappe.get_request_header("X-Webhook-Key") or ""
+	expected_key = trigger.webhook_key or ""
+	if not expected_key or not hmac.compare_digest(supplied_key, expected_key):
+		frappe.local.response["http_status_code"] = 401
+		return dict(_INVALID_KEY)
+
+	if not trigger.automation:
+		# Configured but incomplete (no Automation linked yet) -- same
+		# externally-observable outcome as a slug that never resolved.
+		frappe.local.response["http_status_code"] = 404
+		return dict(_NOT_FOUND)
+
+	raw_body = frappe.request.get_data(as_text=False) if frappe.request is not None else b""
+	trigger_context = {
+		"type": "webhook",
+		"payload": _parse_payload(raw_body),
+		"headers": _safe_headers(frappe.request.headers if frappe.request is not None else {}),
+	}
+
+	try:
+		result = run_automation(trigger.automation, trigger.name, trigger_context=trigger_context)
+	except Exception:
+		frappe.log_error(
+			title=f"Automation webhook run failed: {trigger.automation}",
+			message=frappe.get_traceback(),
+		)
+		frappe.local.response["http_status_code"] = 500
+		return {"success": False, "error": _("Automation run failed.")}
+
+	return {"success": True, "result": result}
+
+
+def _safe_headers(headers) -> dict:
+	"""Drop credential-bearing headers before they become trigger_context data."""
+	return {
+		key: value
+		for key, value in dict(headers or {}).items()
+		if key.lower() not in _EXCLUDED_HEADERS
+	}
+
+
+def _parse_payload(raw_body: bytes):
+	"""Best-effort JSON decode of the request body; never raises."""
+	if not raw_body:
+		return {}
+	try:
+		return json.loads(raw_body.decode("utf-8"))
+	except (UnicodeDecodeError, json.JSONDecodeError):
+		return {"raw": raw_body.decode("utf-8", errors="replace")}

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -184,25 +184,25 @@ permission_query_conditions = {
 
 doc_events = {
     "*": {
-        "validate": "huf.ai.agent_hooks.run_hooked_agents",
-        "before_insert": "huf.ai.agent_hooks.run_hooked_agents",
-        "after_insert": "huf.ai.agent_hooks.run_hooked_agents",
-        "before_save": "huf.ai.agent_hooks.run_hooked_agents",
-        "after_save": "huf.ai.agent_hooks.run_hooked_agents",
-        "before_submit": "huf.ai.agent_hooks.run_hooked_agents",
-        "after_submit": "huf.ai.agent_hooks.run_hooked_agents",
-        "before_cancel": "huf.ai.agent_hooks.run_hooked_agents",
-        "on_submit": "huf.ai.agent_hooks.run_hooked_agents",
-        "on_update": "huf.ai.agent_hooks.run_hooked_agents",
-        "before_rename": "huf.ai.agent_hooks.run_hooked_agents",
-        "after_rename": "huf.ai.agent_hooks.run_hooked_agents",
-        "on_trash": "huf.ai.agent_hooks.run_hooked_agents",
-        "after_delete": "huf.ai.agent_hooks.run_hooked_agents",
+        "validate": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "before_insert": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "after_insert": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "before_save": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "after_save": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "before_submit": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "after_submit": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "before_cancel": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "on_submit": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "on_update": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "before_rename": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "after_rename": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "on_trash": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
+        "after_delete": ["huf.ai.agent_hooks.run_hooked_agents", "huf.ai.automation_hooks.run_hooked_automations"],
     },
     "Agent Trigger": {
-        "after_insert": "huf.ai.agent_hooks.clear_doc_event_agents_cache",
-        "on_update": "huf.ai.agent_hooks.clear_doc_event_agents_cache",
-        "on_trash": "huf.ai.agent_hooks.clear_doc_event_agents_cache",
+        "after_insert": ["huf.ai.agent_hooks.clear_doc_event_agents_cache", "huf.ai.automation_hooks.clear_doc_event_automation_cache"],
+        "on_update": ["huf.ai.agent_hooks.clear_doc_event_agents_cache", "huf.ai.automation_hooks.clear_doc_event_automation_cache"],
+        "on_trash": ["huf.ai.agent_hooks.clear_doc_event_agents_cache", "huf.ai.automation_hooks.clear_doc_event_automation_cache"],
     },
     "AI Provider": {
         "on_update": "huf.ai.app_seeding.hub_orchestrator.on_ai_provider_update",
@@ -246,7 +246,8 @@ doc_events = {
 # }
 scheduler_events = {
     "all": [
-        "huf.ai.agent_scheduler.run_scheduled_agents"
+        "huf.ai.agent_scheduler.run_scheduled_agents",
+        "huf.ai.automation_scheduler.run_due_automations"
     ],
     "daily": [
         "huf.ai.knowledge.maintenance.cleanup_orphaned_files",

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -556,7 +556,7 @@
   },
   {
    "default": "1",
-   "description": "When checked, Doc Event and Scheduled runs create / maintain conversation history per initiating user (or trigger owner). If unchecked, a single shared history is used.",
+   "description": "Applies only to Doc Event runs on the legacy Agent Trigger model: creates/maintains conversation history per initiating user (or trigger owner) when checked, otherwise a single shared history is used. Scheduled runs never read this field. Automations built on the newer Automation model (Schedule, Doc Event, Webhook, App Event) do not read this field either — they set conversation identity per-Automation via Conversation Mode instead.",
    "fieldname": "persist_user_history",
    "fieldtype": "Check",
    "label": "Persist per User (Doc/Schedule)"

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -189,6 +189,19 @@ class Agent(Document):
             "model",
             "disabled",
             "allow_chat",
+            # The remaining Behavior-tab fields: BehaviorTab.tsx already locks
+            # the whole tab (all four switches) on the frontend via the same
+            # `systemLocked` prop that gates allow_chat, so a locked system
+            # agent's persist/multi-run behavior reads as protected in the
+            # UI. Before this fix, only allow_chat was actually enforced here
+            # server-side -- a non-admin could still PATCH persist_conversation,
+            # persist_user_history, or enable_multi_run directly via the API on
+            # a "locked" system agent, bypassing the frontend-only lock on the
+            # other three. Listed explicitly so backend enforcement matches
+            # what the frontend already implies is locked.
+            "persist_conversation",
+            "persist_user_history",
+            "enable_multi_run",
         )
         changed = [field for field in protected_fields if self.has_value_changed(field)]
 
@@ -198,6 +211,15 @@ class Agent(Document):
             previous_tools = [row.as_dict() for row in before.get("agent_tool") or []]
             if frappe.as_json(current_tools) != frappe.as_json(previous_tools):
                 changed.append("agent_tool")
+
+            # default_plan is the Behavior tab's other locked-when-system field
+            # (only shown/editable when enable_multi_run is on) -- diff it the
+            # same way agent_tool is diffed, since has_value_changed() does not
+            # cover child tables.
+            current_plan = [row.as_dict() for row in self.get("default_plan") or []]
+            previous_plan = [row.as_dict() for row in before.get("default_plan") or []]
+            if frappe.as_json(current_plan) != frappe.as_json(previous_plan):
+                changed.append("default_plan")
 
         if changed:
             frappe.throw(

--- a/huf/huf/doctype/automation/automation.py
+++ b/huf/huf/doctype/automation/automation.py
@@ -1,9 +1,47 @@
 # Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class Automation(Document):
-	pass
+	def validate(self):
+		self._validate_system_agent_lock()
+
+	def _validate_system_agent_lock(self):
+		"""Block non-admins from creating/editing an Automation that targets
+		a locked system agent.
+
+		Lives here, not only in huf/ai/automation_api.py's whitelisted
+		wrappers, because a generic Frappe REST/RPC call (e.g. a direct
+		POST/PUT to /api/resource/Automation, or any other caller with plain
+		doctype "write"/"create" permission on Automation -- Huf Manager has
+		both by default) bypasses those wrappers entirely and goes straight
+		through this controller. automation_api.py's guard is real defense
+		in depth for the whitelisted path, but this is the one that actually
+		closes the gap for every path, mirroring how
+		Agent._validate_system_agent_immutability() itself lives in the
+		Agent doctype controller rather than only in an API layer.
+		"""
+		if not self.agent:
+			return
+		if (
+			frappe.flags.in_seeding
+			or frappe.flags.in_install
+			or frappe.flags.in_migrate
+			or frappe.flags.in_patch
+			or "System Manager" in frappe.get_roles()
+		):
+			return
+		is_system = frappe.db.get_value("Agent", self.agent, "is_system")
+		if is_system:
+			frappe.throw(
+				_(
+					"Only System Managers can create or modify automations for the "
+					"system agent '{0}'."
+				).format(self.agent),
+				frappe.PermissionError,
+				title=_("System Agent Protected"),
+			)

--- a/huf/huf/doctype/automation_trigger/automation_trigger.py
+++ b/huf/huf/doctype/automation_trigger/automation_trigger.py
@@ -1,8 +1,42 @@
 # Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
 # For license information, please see license.txt
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
 class AutomationTrigger(Document):
-	pass
+	def validate(self):
+		self._validate_system_agent_lock()
+
+	def _validate_system_agent_lock(self):
+		"""Same guard as Automation._validate_system_agent_lock(), applied
+		here too since an Automation Trigger can be created/edited directly
+		(generic REST, or any caller with doctype permission on Automation
+		Trigger) without ever touching the parent Automation's own
+		validate(). See Automation.py's docstring for the full rationale.
+		"""
+		if not self.automation:
+			return
+		if (
+			frappe.flags.in_seeding
+			or frappe.flags.in_install
+			or frappe.flags.in_migrate
+			or frappe.flags.in_patch
+			or "System Manager" in frappe.get_roles()
+		):
+			return
+		agent_name = frappe.db.get_value("Automation", self.automation, "agent")
+		if not agent_name:
+			return
+		is_system = frappe.db.get_value("Agent", agent_name, "is_system")
+		if is_system:
+			frappe.throw(
+				_(
+					"Only System Managers can create or modify triggers for automations "
+					"belonging to the system agent '{0}'."
+				).format(agent_name),
+				frappe.PermissionError,
+				title=_("System Agent Protected"),
+			)


### PR DESCRIPTION
## Stacked PR — depends on #590

This PR targets `feat/chat-sidebar-trigger` (#590), **not `pre-dev`**, because it builds directly on top of #590's Automation/Trigger schema, canonical runner, and CRUD API. Neither #588 nor #590 is merged yet.

```
pre-dev
  └─ feat/chat-shell-v3            (#588, draft)
       └─ feat/chat-sidebar-trigger        (#590, draft — Projects+Pins done; Automation schema+runner only)
            └─ feat/chat-sidebar-trigger-stage2  ← this PR
```

If #590 changes before merging, this branch gets rebased on top and re-verified. If #590 merges into `pre-dev` first, this branch rebases onto `pre-dev` and the PR base moves there — the diff should collapse to just this PR's own work at that point. Review/merge order: this should land after (or be squash-merged together with) #590, not independently.

## What this PR does

**Phase S1 — backend Stage 2: switch live trigger execution onto the canonical runner**
`automation_runner.run_automation()` (built in #590) could previously only be invoked manually. This wires it to actually fire:
- `automation_scheduler.py` (`run_due_automations`) and `automation_hooks.py` (`run_hooked_automations`) replace the legacy `agent_scheduler.py`/`agent_hooks.py` as the live execution path for Schedule and Doc Event triggers — ported condition/prompt_field/attachment/OCR/audio-transcription handling from the legacy code, async via `frappe.db.after_commit` + `enqueue` so automations always run in their own transaction.
- `automation_webhook.py` and `automation_app_event.py` — net-new runtime for Webhook and App Event trigger types (confirmed via grep the legacy `Agent Trigger` model never had live wiring for either, schema fields only).
- Cutover is behind a site-config rollback flag (`automation_trigger_runtime: legacy|new`, default `new`) checked in both old and new entrypoints, so a revert is one `bench set-config` away without a code revert.
- Two should-fix items from #590's final review, closed here: `automation_runner`'s unconditional commit is now conditional (`commit` param), and `run_as_user` impersonation now requires the Automation owner to hold System Manager.
- Live-verified end to end: Schedule, Doc Event, and App Event automations all fire through the new path with correct `Agent Run` linkage; legacy path confirmed inert; rollback flag confirmed working both directions.

**Phase S2/S3 — Agent Automations tab + standalone Automation UI**
- Agent form's "Triggers" tab → "Automations" tab, backed by a new `AutomationsTab.tsx` (list, run-now/pause-resume/archive, `+ Add automation`). Legacy `TriggersTab.tsx` left on disk, unreferenced, per the compatibility window.
- New `AutomationFormPage.tsx` (General/Task/Trigger/Execution/History) with a refactored `TriggerEditor` supporting 0-N triggers per automation, decoupled from any single Agent.
- Found and fixed a real bug via live smoke test (not caught by typecheck): `create_trigger` was throwing `417 Trigger Name is required` because a rename-desync fix elsewhere had also stripped `trigger_name` from trigger creation. Re-verified the full create→list round trip after the fix.

**Cross-cutting: AgentBehaviourSettingsAudit follow-up**
A separate audit doc flagged two issues worth re-checking now that this PR changes the trigger/scheduling model:
- `persist_user_history`'s description falsely claimed Scheduled runs honor it (never true) and is now *also* false for anything on the new Automation model (`Automation.conversation_mode` supersedes it). Corrected the doctype description and UI copy.
- The system-agent lock (`protected_fields`) doesn't cover Automations, since Automation is a separate doctype the Agent-side check can never reach. Added `_ensure_agent_automations_editable()` guards — moved into both doctypes' own `validate()` after confirming the API-only version was bypassable via a direct REST call, mirroring how `Agent`'s own lock avoids the same bypass. Also extended `protected_fields` to cover the rest of the Behavior tab (`persist_conversation`, `persist_user_history`, `enable_multi_run`, `default_plan`), which the frontend already implied was locked but the backend didn't enforce.
- The rest of that audit's punch list (allow_chat enforcement, Permissions/Advanced/Knowledge/Skills tab protection, orchestration step caps) is broader than this PR's scope and was spawned as a separate follow-up task rather than mixed in here.

## Known gaps / follow-ups (not blockers)
- `AutomationFormPage.tsx` doesn't yet proactively disable fields for a locked system agent's automation — the backend guard still correctly rejects the save, so this is a UX rough edge, not a security gap.
- Phase S4 (Scheduled sidebar page), Phase S5 (Stage 3 Project↔Automation filter), and remaining should-fix items are not yet in this PR — full breakdown in `Tracks/safwan-erooth.ChatSidebarTriggerStage2/CONTEXT.md` (workspace repo, not part of this diff).
- `bench run-tests` (backend Python suite) is still blocked repo-wide by a pre-existing Frappe-version mismatch, same as noted in #590 — unrelated to this PR, has its own follow-up task.

## Test plan
- [x] `tsc -b` clean
- [x] 131/131 frontend vitest passing (no regression)
- [x] Live bench verification: Schedule/Doc Event/App Event automations fire through the new runtime with correct `Agent Run` linkage; rollback flag works both directions; Agent form Automations tab renders and lists correctly; New Automation form renders, accepts input, and its Schedule-trigger row works; full `create_automation`→`create_trigger`→`list_triggers` API round trip succeeds
- [x] System-agent lock: non-admin blocked (both via the whitelisted API and a direct doctype-level bypass attempt), non-system-agent automations unaffected, Administrator unaffected
- [ ] `bench run-tests` — blocked, see above