### PR TITLE
feat(ai): env-var fallback for AI Provider api_key (all providers)

### DIFF
--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -414,28 +414,62 @@ def _normalize_model_name(model: str, provider: str, brand: str = None) -> str:
     return f"{prefix}/{model}"
 
 
+# Providers that need environment variables (LiteLLM requirement)
+_ENV_VAR_PROVIDERS = {
+    "openrouter": "OPENROUTER_API_KEY",
+    "xai": "XAI_API_KEY",  # Grok
+    "deepseek": "DEEPSEEK_API_KEY",
+    "mistral": "MISTRAL_API_KEY",
+    "dashscope": "DASHSCOPE_API_KEY",  # Alibaba
+    "google": "GEMINI_API_KEY",  # Alternative to api_key param
+    "cohere": "COHERE_API_KEY",
+    "perplexity": "PERPLEXITY_API_KEY",
+    "moonshot": "MOONSHOT_API_KEY",
+}
+
+
+# Some AI Provider `provider_brand` values don't match the LiteLLM-routing
+# prefix _normalize_model_name() derives from them (see its own
+# brand_prefix_map/provider_prefix_map) — e.g. brand "alibaba" routes through
+# the "dashscope" prefix, brand "grok" through "xai". Without this alias step,
+# _resolve_api_key() and _setup_api_key() would resolve DIFFERENT env var
+# names for the same provider (one via raw brand, one via the routed
+# prefix), so a real key sitting in the "correct" env var would never be
+# found. Keep in sync with _normalize_model_name()'s own brand mappings.
+_BRAND_TO_ENV_LOOKUP_KEY = {
+    "alibaba": "dashscope",
+    "grok": "xai",
+}
+
+
+def _env_var_name_for_provider(provider_brand: str) -> str:
+    """Resolve the conventional environment variable name for a provider.
+
+    Known providers (LiteLLM's own env var requirements) use the explicit
+    mapping in `_ENV_VAR_PROVIDERS`, after normalizing any brand alias that
+    routes to a differently-named prefix (see `_BRAND_TO_ENV_LOOKUP_KEY`).
+    Unknown/new providers fall back to the heuristic `PROVIDER_API_KEY`
+    shape, which already happens to match the standard env var names for
+    OpenAI/Anthropic (OPENAI_API_KEY, ANTHROPIC_API_KEY). Handles an
+    empty/None input gracefully, producing a harmless placeholder name that
+    won't match anything real.
+    """
+    provider_brand = provider_brand or ""
+    lookup_key = _BRAND_TO_ENV_LOOKUP_KEY.get(provider_brand, provider_brand)
+    if lookup_key in _ENV_VAR_PROVIDERS:
+        return _ENV_VAR_PROVIDERS[lookup_key]
+    return f"{provider_brand.upper().replace('-', '_')}_API_KEY"
+
+
 def _setup_api_key(provider_name: str, api_key: str, completion_kwargs: dict):
     """
     Setup API key for LiteLLM based on provider requirements.
 
     Some providers need environment variables, others accept api_key parameter.
     """
-    # Providers that need environment variables (LiteLLM requirement)
-    env_var_providers = {
-        "openrouter": "OPENROUTER_API_KEY",
-        "xai": "XAI_API_KEY",  # Grok
-        "deepseek": "DEEPSEEK_API_KEY",
-        "mistral": "MISTRAL_API_KEY",
-        "dashscope": "DASHSCOPE_API_KEY",  # Alibaba
-        "google": "GEMINI_API_KEY",  # Alternative to api_key param
-        "cohere": "COHERE_API_KEY",
-        "perplexity": "PERPLEXITY_API_KEY",
-        "moonshot": "MOONSHOT_API_KEY",
-    }
-
-    if provider_name in env_var_providers:
+    if provider_name in _ENV_VAR_PROVIDERS:
         # Set environment variable for this request
-        os.environ[env_var_providers[provider_name]] = api_key
+        os.environ[_ENV_VAR_PROVIDERS[provider_name]] = api_key
         return
 
     # For known providers that accept an api_key parameter directly, prefer that.
@@ -445,8 +479,48 @@ def _setup_api_key(provider_name: str, api_key: str, completion_kwargs: dict):
     # Set a heuristic env var as well so users don't have to wait for a code
     # change to try a new LiteLLM provider; the api_key param remains the primary
     # mechanism for providers that support it.
-    env_name = f"{provider_name.upper().replace('-', '_')}_API_KEY"
-    os.environ[env_name] = api_key
+    os.environ[_env_var_name_for_provider(provider_name)] = api_key
+
+
+# _setup_api_key() writes resolved DB keys into os.environ as a side effect
+# (LiteLLM/some provider SDKs only accept certain providers' keys via env
+# var, not a kwarg) and never clears them afterward. Reading live os.environ
+# in _resolve_api_key() would mean an AI Provider record WITH a stored key
+# could leave that key sitting in the process env, where a DIFFERENT AI
+# Provider record of the same brand but a genuinely blank key would then
+# silently "succeed" using the first record's key on a later call in the
+# same worker process — a real cross-record/cross-request leak, and worse
+# than the pre-fallback behavior (which correctly errored in that case).
+# Snapshotting the environment once at import time — before any request has
+# had a chance to run _setup_api_key() — means the fallback only ever sees
+# keys that were genuinely present in the process environment from the
+# start (e.g. an operator-set GEMINI_API_KEY), never ones this module wrote
+# itself.
+_BOOT_ENV = dict(os.environ)
+
+
+def _resolve_api_key(provider_doc) -> str:
+    """Resolve the API key for a provider, falling back to the environment.
+
+    Reads the stored `api_key` from the AI Provider doc first. If that's
+    blank, mirrors the DB-then-env fallback pattern used elsewhere in this
+    codebase (see `huf/ai/tools/credentials.py::require_credential`) by
+    checking the environment variable LiteLLM/the provider SDK would
+    conventionally use for this provider's brand — read from a boot-time
+    snapshot (see `_BOOT_ENV`), not live `os.environ`, so this can never
+    pick up a key `_setup_api_key()` wrote for a different request.
+    """
+    api_key = provider_doc.get_password("api_key")
+    if api_key:
+        return api_key
+
+    provider_brand = (provider_doc.get("provider_brand") or "").lower()
+    if not provider_brand:
+        # No brand to key an env var name off of — don't guess at a bare
+        # "_API_KEY" placeholder that could coincidentally exist.
+        return ""
+    env_var_name = _env_var_name_for_provider(provider_brand)
+    return _BOOT_ENV.get(env_var_name, "")
 
 
 def _resolve_api_base(provider_doc) -> str | None:
@@ -524,7 +598,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
 		# Get API key from AI Provider doc (same as current implementation)
         provider_doc = frappe.get_doc("AI Provider", provider)
-        api_key = provider_doc.get_password("api_key")
+        api_key = _resolve_api_key(provider_doc)
 
         if not api_key:
             frappe.throw("API key not configured in AI Provider.")
@@ -1124,7 +1198,7 @@ async def get_simple_completion(model: str, messages: list, provider: str) -> st
         litellm.drop_params = True
         
         provider_doc = frappe.get_doc("AI Provider", provider)
-        api_key = provider_doc.get_password("api_key")
+        api_key = _resolve_api_key(provider_doc)
         
         normalized_model = _normalize_model_name(model, provider, brand=provider_doc.get("provider_brand"))
         provider_name = normalized_model.split("/")[0]
@@ -1176,7 +1250,7 @@ async def get_simple_completion_with_usage(
         litellm.drop_params = True
 
         provider_doc = frappe.get_doc("AI Provider", provider)
-        api_key = provider_doc.get_password("api_key")
+        api_key = _resolve_api_key(provider_doc)
 
         normalized_model = _normalize_model_name(model, provider, brand=provider_doc.get("provider_brand"))
         provider_name = normalized_model.split("/")[0]
@@ -1269,7 +1343,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
 
         # Get API key
         provider_doc = frappe.get_doc("AI Provider", provider)
-        api_key = provider_doc.get_password("api_key")
+        api_key = _resolve_api_key(provider_doc)
 
         if not api_key:
             yield {"type": "error", "error": "API key not configured in AI Provider."}

--- a/huf/ai/tests/test_provider_error_contract.py
+++ b/huf/ai/tests/test_provider_error_contract.py
@@ -32,6 +32,7 @@ from huf.ai.providers.litellm import (
     _is_transient_litellm_error,
     _normalize_model_name,
     _resolve_api_base,
+    _resolve_api_key,
     _setup_api_key,
     run,
 )
@@ -186,6 +187,62 @@ class TestGenericProviderSupport(IntegrationTestCase):
             _setup_api_key("foo-bar", "secret-key", kwargs)
             self.assertEqual(kwargs.get("api_key"), "secret-key")
             self.assertEqual(os.environ.get(env_key), "secret-key")
+
+
+class TestResolveApiKeyEnvFallback(IntegrationTestCase):
+    """_resolve_api_key should fall back to the environment when the AI
+    Provider's stored api_key is blank, using the same env var name
+    _setup_api_key would use for that provider brand.
+
+    _resolve_api_key reads from litellm_module._BOOT_ENV (a snapshot taken at
+    import time), NOT live os.environ — that's deliberate, so a key
+    _setup_api_key() writes into os.environ for one request can never leak
+    into a different, genuinely-blank-keyed AI Provider record later in the
+    same worker process. Tests patch _BOOT_ENV directly to match.
+    """
+
+    def test_uses_db_key_when_present(self):
+        doc = _FakeDoc(api_key="db-secret", provider_brand="google")
+        with patch.object(litellm_module, "_BOOT_ENV", {"GEMINI_API_KEY": "env-secret"}):
+            self.assertEqual(_resolve_api_key(doc), "db-secret")
+
+    def test_falls_back_to_known_provider_env_var_when_db_key_blank(self):
+        doc = _FakeDoc(api_key="", provider_brand="google")
+        with patch.object(litellm_module, "_BOOT_ENV", {"GEMINI_API_KEY": "from-env"}):
+            self.assertEqual(_resolve_api_key(doc), "from-env")
+
+    def test_falls_back_to_heuristic_env_var_for_unlisted_provider_brand(self):
+        doc = _FakeDoc(api_key=None, provider_brand="some-new-provider")
+        with patch.object(litellm_module, "_BOOT_ENV", {"SOME_NEW_PROVIDER_API_KEY": "from-env"}):
+            self.assertEqual(_resolve_api_key(doc), "from-env")
+
+    def test_returns_empty_string_when_neither_db_nor_env_has_a_key(self):
+        doc = _FakeDoc(api_key="", provider_brand="google")
+        with patch.object(litellm_module, "_BOOT_ENV", {}):
+            self.assertEqual(_resolve_api_key(doc), "")
+
+    def test_aliased_brand_resolves_to_the_prefix_its_write_path_actually_uses(self):
+        # provider_brand "alibaba" routes through the "dashscope" LiteLLM
+        # prefix (see _normalize_model_name's provider_prefix_map), so
+        # _setup_api_key("dashscope", ...) is what actually runs for it —
+        # the read side must resolve the same DASHSCOPE_API_KEY, not a
+        # naive ALIBABA_API_KEY guess.
+        doc = _FakeDoc(api_key="", provider_brand="alibaba")
+        with patch.object(litellm_module, "_BOOT_ENV", {"DASHSCOPE_API_KEY": "from-env"}):
+            self.assertEqual(_resolve_api_key(doc), "from-env")
+
+    def test_does_not_leak_a_key_setup_api_key_wrote_for_a_different_request(self):
+        # _setup_api_key's write into os.environ must never be visible to a
+        # later _resolve_api_key call for a different, genuinely blank-keyed
+        # provider record — that would be a real cross-request key leak.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GEMINI_API_KEY", None)
+            _setup_api_key("google", "leaked-from-another-request", {})
+            self.assertEqual(os.environ.get("GEMINI_API_KEY"), "leaked-from-another-request")
+
+            other_doc = _FakeDoc(api_key="", provider_brand="google")
+            with patch.object(litellm_module, "_BOOT_ENV", {}):
+                self.assertEqual(_resolve_api_key(other_doc), "")
 
 
 class TestNormalizeModelName(IntegrationTestCase):


### PR DESCRIPTION
## Summary

Every LLM call path in `huf/ai/providers/litellm.py` threw/errored immediately when an `AI Provider`'s stored `api_key` was blank, even though this same file already knows the conventional environment variable name for most providers (`GEMINI_API_KEY` for Google, etc.) and an identical DB-then-env fallback pattern already exists elsewhere in this codebase (`huf/ai/tools/credentials.py::require_credential`).

- Added `_resolve_api_key(provider_doc)`: DB key if present, else the matching env var, else empty string. All 4 call sites updated; existing throw/yield-error checks unchanged.
- Hoisted the provider→env-var mapping into a shared `_env_var_name_for_provider()` helper (was duplicated inline in `_setup_api_key`).
- Added `_BRAND_TO_ENV_LOOKUP_KEY` for the two provider brands whose LiteLLM-routing prefix diverges from the brand name (`alibaba`→`dashscope`, `grok`→`xai`), so read and write paths resolve the same env var for the same provider.
- **Caught in review, fixed before push**: reads from a `_BOOT_ENV` snapshot taken at import time, not live `os.environ` — `_setup_api_key()` writes resolved keys into `os.environ` as a side effect and never clears them, so reading live `os.environ` would have let one `AI Provider` record's key silently leak into a different, genuinely blank-keyed record of the same brand later in the same worker process.
- 6 new unit tests covering DB-key precedence, env fallback (known + heuristic), empty-when-neither, the brand-alias case, and an explicit anti-leak regression test.

## Where this came from

Investigated as part of a workspace question: "all multihand disposable benches default to a keyless Demo Assistant — can this read from a server env var the way Google's own SDKs do?" Answer was yes, and the mapping already half-existed in this file.

## Test plan

- [x] `py_compile` clean
- [x] New tests added, closely matching this file's existing `IntegrationTestCase` pattern
- [ ] `bench run-tests` — not run; no live bench available in this bare worktree. Please run `bench --site <site> run-tests --app huf --module huf.ai.tests.test_provider_error_contract` before merge.