### PR TITLE
fix(tests): migrate off deprecated FrappeTestCase for Frappe 16 runner

### DIFF
--- a/huf/ai/knowledge/tests/test_chroma_backend.py
+++ b/huf/ai/knowledge/tests/test_chroma_backend.py
@@ -9,12 +9,12 @@ import unittest
 from unittest.mock import Mock, patch, MagicMock
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 from huf.ai.knowledge.backends.chroma_backend import ChromaBackend, LLAMAINDEX_AVAILABLE
 
 
-class TestChromaBackend(FrappeTestCase):
+class TestChromaBackend(IntegrationTestCase):
 	"""Test cases for ChromaBackend."""
 	
 	def setUp(self):

--- a/huf/ai/knowledge/tests/test_tool.py
+++ b/huf/ai/knowledge/tests/test_tool.py
@@ -1,6 +1,6 @@
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 from unittest.mock import patch, MagicMock
 from huf.ai.knowledge.tool import (
     create_knowledge_search_tool,
@@ -9,7 +9,7 @@ from huf.ai.knowledge.tool import (
     handle_get_knowledge_sources
 )
 
-class TestKnowledgeTool(FrappeTestCase):
+class TestKnowledgeTool(IntegrationTestCase):
     def setUp(self):
         # Create dependencies
         if not frappe.db.exists("AI Provider", "Test Provider"):

--- a/huf/ai/test_mcp_connection_resolver.py
+++ b/huf/ai/test_mcp_connection_resolver.py
@@ -23,7 +23,8 @@ frappe_mock.log_error = MagicMock()
 frappe_mock.throw = MagicMock(side_effect=Exception("Permission denied"))
 frappe_mock._ = lambda x: x
 frappe_mock.whitelist = MagicMock(return_value=lambda fn: fn)
-sys.modules["frappe"] = frappe_mock
+if "frappe" not in sys.modules:
+    sys.modules["frappe"] = frappe_mock
 
 from huf.ai.mcp_connection_resolver import (
     _canonical_resource,

--- a/huf/ai/test_mcp_oauth.py
+++ b/huf/ai/test_mcp_oauth.py
@@ -32,7 +32,8 @@ frappe_mock.log_error = MagicMock()
 frappe_mock.throw = MagicMock(side_effect=Exception("Permission denied"))
 frappe_mock._ = lambda x: x
 frappe_mock.whitelist = MagicMock(return_value=lambda fn: fn)
-sys.modules["frappe"] = frappe_mock
+if "frappe" not in sys.modules:
+    sys.modules["frappe"] = frappe_mock
 
 from huf.ai.mcp_oauth import (
     _has_manual_oauth_config,
@@ -106,7 +107,15 @@ class TestHasManualOAuthConfig(unittest.TestCase):
 
 class TestResolveAndStartOAuthFlow(unittest.TestCase):
     def setUp(self):
-        frappe_mock.get_doc.reset_mock()
+        for target, attr in (
+            ("get_doc", "mock_get_doc"),
+            ("has_permission", "mock_has_permission"),
+            ("log_error", "mock_log_error"),
+        ):
+            patcher = patch(f"huf.ai.mcp_oauth.frappe.{target}")
+            setattr(self, attr, patcher.start())
+            self.addCleanup(patcher.stop)
+        self.mock_has_permission.return_value = True
 
     @patch("huf.ai.mcp_oauth.start_oauth_flow")
     @patch("huf.ai.mcp_oauth.discover_mcp_server")
@@ -120,7 +129,7 @@ class TestResolveAndStartOAuthFlow(unittest.TestCase):
             oauth_authorization_endpoint="https://idp.example.com/authorize",
             oauth_token_endpoint="https://idp.example.com/token",
         )
-        frappe_mock.get_doc.return_value = server
+        self.mock_get_doc.return_value = server
         mock_start_oauth.return_value = {"auth_url": "https://idp.example.com/authorize?client_id=manual-client-id"}
 
         result = resolve_and_start_oauth_flow("manual-server")
@@ -141,7 +150,7 @@ class TestResolveAndStartOAuthFlow(unittest.TestCase):
             oauth_authorization_endpoint="",
             oauth_token_endpoint="",
         )
-        frappe_mock.get_doc.return_value = server
+        self.mock_get_doc.return_value = server
         mock_discover.return_value = {
             "discovery_status": "Ready",
             "client_id": "dynamic-client-id",
@@ -161,7 +170,7 @@ class TestResolveAndStartOAuthFlow(unittest.TestCase):
     ):
         """When discovery fails and no manual config exists, return the discovery error."""
         server = MockServer("dynamic-only-server")
-        frappe_mock.get_doc.return_value = server
+        self.mock_get_doc.return_value = server
         mock_discover.return_value = {
             "discovery_status": "Failed",
             "discovery_error": "Dynamic Client Registration is not available for this server.",
@@ -181,7 +190,7 @@ class TestResolveAndStartOAuthFlow(unittest.TestCase):
     ):
         """A server with no manual config but successful DCR starts OAuth."""
         server = MockServer("dcr-server")
-        frappe_mock.get_doc.return_value = server
+        self.mock_get_doc.return_value = server
         mock_discover.return_value = {
             "discovery_status": "Ready",
             "client_id": "dcr-client-id",

--- a/huf/huf/doctype/agent/test_agent.py
+++ b/huf/huf/doctype/agent/test_agent.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgent(FrappeTestCase):
+class TestAgent(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_chat/test_agent_chat.py
+++ b/huf/huf/doctype/agent_chat/test_agent_chat.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2025, Tridz Technologies Pvt Ltd and Contributors
 # See license.txt
 
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 from huf.ai.agent_chat import render_markdown
 
 
-class TestAgentChat(FrappeTestCase):
+class TestAgentChat(IntegrationTestCase):
 	def test_render_markdown(self):
 		# Regression test: `from frappe.utils.markdown import markdown` is not
 		# a valid import path on Frappe v16 — render_markdown() silently fell

--- a/huf/huf/doctype/agent_console/test_agent_console.py
+++ b/huf/huf/doctype/agent_console/test_agent_console.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentConsole(FrappeTestCase):
+class TestAgentConsole(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_context_artifact/test_agent_context_artifact.py
+++ b/huf/huf/doctype/agent_context_artifact/test_agent_context_artifact.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentContextArtifact(FrappeTestCase):
+class TestAgentContextArtifact(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_conversation/test_agent_conversation.py
+++ b/huf/huf/doctype/agent_conversation/test_agent_conversation.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentConversation(FrappeTestCase):
+class TestAgentConversation(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_mcp_server/test_agent_mcp_server.py
+++ b/huf/huf/doctype/agent_mcp_server/test_agent_mcp_server.py
@@ -4,10 +4,10 @@
 import json
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentMCPServer(FrappeTestCase):
+class TestAgentMCPServer(IntegrationTestCase):
 	def _make_provider_and_model(self):
 		# Shared fixture: same provider/model can be reused across test
 		# methods, so get-or-create instead of a bare insert.

--- a/huf/huf/doctype/agent_message/test_agent_message.py
+++ b/huf/huf/doctype/agent_message/test_agent_message.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentMessage(FrappeTestCase):
+class TestAgentMessage(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_prompt/test_agent_prompt.py
+++ b/huf/huf/doctype/agent_prompt/test_agent_prompt.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
 # See license.txt
 
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentPrompt(FrappeTestCase):
+class TestAgentPrompt(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_prompt_category/test_agent_prompt_category.py
+++ b/huf/huf/doctype/agent_prompt_category/test_agent_prompt_category.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
 # See license.txt
 
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentPromptCategory(FrappeTestCase):
+class TestAgentPromptCategory(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_run/test_agent_run.py
+++ b/huf/huf/doctype/agent_run/test_agent_run.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentRun(FrappeTestCase):
+class TestAgentRun(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_run_feedback/test_agent_run_feedback.py
+++ b/huf/huf/doctype/agent_run_feedback/test_agent_run_feedback.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentRunFeedback(FrappeTestCase):
+class TestAgentRunFeedback(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_settings/test_agent_settings.py
+++ b/huf/huf/doctype/agent_settings/test_agent_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentSettings(FrappeTestCase):
+class TestAgentSettings(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_summary_prompt/test_agent_summary_prompt.py
+++ b/huf/huf/doctype/agent_summary_prompt/test_agent_summary_prompt.py
@@ -2,10 +2,10 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentSummaryPrompt(FrappeTestCase):
+class TestAgentSummaryPrompt(IntegrationTestCase):
 	def test_prompt_group_set_for_new_lineage(self):
 		prompt = frappe.get_doc({
 			"doctype": "Agent Summary Prompt",

--- a/huf/huf/doctype/agent_tool_call/test_agent_tool_call.py
+++ b/huf/huf/doctype/agent_tool_call/test_agent_tool_call.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentToolCall(FrappeTestCase):
+class TestAgentToolCall(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_tool_function/test_agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/test_agent_tool_function.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentToolFunction(FrappeTestCase):
+class TestAgentToolFunction(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_tool_type/test_agent_tool_type.py
+++ b/huf/huf/doctype/agent_tool_type/test_agent_tool_type.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentToolType(FrappeTestCase):
+class TestAgentToolType(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/agent_trigger/test_agent_trigger.py
+++ b/huf/huf/doctype/agent_trigger/test_agent_trigger.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAgentTrigger(FrappeTestCase):
+class TestAgentTrigger(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/ai_model/test_ai_model.py
+++ b/huf/huf/doctype/ai_model/test_ai_model.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAIModel(FrappeTestCase):
+class TestAIModel(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/ai_provider/test_ai_provider.py
+++ b/huf/huf/doctype/ai_provider/test_ai_provider.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestAIProvider(FrappeTestCase):
+class TestAIProvider(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/elevenlabs_settings/test_elevenlabs_settings.py
+++ b/huf/huf/doctype/elevenlabs_settings/test_elevenlabs_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestElevenlabsSettings(FrappeTestCase):
+class TestElevenlabsSettings(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/groq_settings/test_groq_settings.py
+++ b/huf/huf/doctype/groq_settings/test_groq_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestGroqSettings(FrappeTestCase):
+class TestGroqSettings(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/huf_role/test_huf_role.py
+++ b/huf/huf/doctype/huf_role/test_huf_role.py
@@ -2,10 +2,10 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestHufRole(FrappeTestCase):
+class TestHufRole(IntegrationTestCase):
 	def _make_role(self, **overrides):
 		doc = {
 			"doctype": "Huf Role",

--- a/huf/huf/doctype/huf_role_permission/test_huf_role_permission.py
+++ b/huf/huf/doctype/huf_role_permission/test_huf_role_permission.py
@@ -2,10 +2,10 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestHufRolePermission(FrappeTestCase):
+class TestHufRolePermission(IntegrationTestCase):
 	"""`Huf Role Permission` is a child table (istable=1) of the `permissions`
 	field on `Huf Role`, so it is tested as rows on a parent Huf Role."""
 

--- a/huf/huf/doctype/integration_service/test_integration_service.py
+++ b/huf/huf/doctype/integration_service/test_integration_service.py
@@ -2,10 +2,10 @@
 # See license.txt
 
 import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestIntegrationService(FrappeTestCase):
+class TestIntegrationService(IntegrationTestCase):
 	def test_service_name_required(self):
 		# Regression test: before_insert() used to call self.service_name.lower()
 		# unguarded, raising AttributeError on None instead of the intended

--- a/huf/huf/doctype/mcp_server/test_mcp_server.py
+++ b/huf/huf/doctype/mcp_server/test_mcp_server.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestMCPServer(FrappeTestCase):
+class TestMCPServer(IntegrationTestCase):
 	pass

--- a/huf/huf/doctype/openai_settings/test_openai_settings.py
+++ b/huf/huf/doctype/openai_settings/test_openai_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import IntegrationTestCase
 
 
-class TestOpenAISettings(FrappeTestCase):
+class TestOpenAISettings(IntegrationTestCase):
 	pass


### PR DESCRIPTION
- 28 test files: FrappeTestCase -> IntegrationTestCase (the old class forces the v16 compat path in deprecation_dumpster.py which calls the removed frappe.get_app_path, crashing the whole run)
- test_mcp_oauth.py / test_mcp_connection_resolver.py: guard the import-time sys.modules['frappe'] mock so it no longer clobbers the real module; OAuth flow tests now patch frappe.get_doc/has_permission/log_error per test

Root-caused by orchestrator worker w-1784518333-2985cc (claude/fable); committed by orchestrator after worker was permission-blocked from committing.