### PR TITLE
feat(tools): per-group selection and lazy tool counts for integration attach

### DIFF
--- a/frontend/src/components/agent/ToolsTab.tsx
+++ b/frontend/src/components/agent/ToolsTab.tsx
@@ -150,7 +150,7 @@ export function ToolsTab({
           ) : (
             <div className="grid gap-3 sm:grid-cols-2">
               {selectedTools.map((tool) => {
-                const ToolIcon = getToolIconForType(tool.types);
+                const ToolIcon = getToolIconForType(tool.types, tool.service, tool.tool_type);
                 const usedByAgents = toolUsageMap.get(tool.name) || [];
                 const isShared = usedByAgents.length > 0;
                 

--- a/frontend/src/components/integrations/AddIntegrationToAgentModal.tsx
+++ b/frontend/src/components/integrations/AddIntegrationToAgentModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Bot, Check, Loader2, Search, Wrench } from 'lucide-react';
+import { Bot, Loader2, Search, Wrench } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -36,6 +36,7 @@ export function AddIntegrationToAgentModal({
 }: AddIntegrationToAgentModalProps) {
   const [tools, setTools] = useState<ServiceTool[]>([]);
   const [toolsLoading, setToolsLoading] = useState(false);
+  const [selectedToolNames, setSelectedToolNames] = useState<Set<string>>(new Set());
   const [agents, setAgents] = useState<AgentDoc[]>([]);
   const [agentsLoading, setAgentsLoading] = useState(false);
   const [selectedAgentNames, setSelectedAgentNames] = useState<Set<string>>(new Set());
@@ -45,6 +46,7 @@ export function AddIntegrationToAgentModal({
   useEffect(() => {
     if (!open) {
       setSelectedAgentNames(new Set());
+      setSelectedToolNames(new Set());
       setAgentSearch('');
       return;
     }
@@ -53,7 +55,12 @@ export function AddIntegrationToAgentModal({
     setAgentsLoading(true);
 
     getServiceTools(service)
-      .then((items) => setTools(items || []))
+      .then((items) => {
+        setTools(items || []);
+        // Every tool is selected by default — most users want the full set,
+        // but can now deselect the ones they don't need for this agent.
+        setSelectedToolNames(new Set((items || []).map((t) => t.tool_name)));
+      })
       .catch((error) => {
         toast.error(getFrappeErrorMessage(error) || 'Failed to load tools');
       })
@@ -80,6 +87,26 @@ export function AddIntegrationToAgentModal({
     );
   }, [agents, agentSearch]);
 
+  const toggleTool = (name: string) => {
+    setSelectedToolNames((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  };
+
+  const handleSelectAllTools = () => {
+    if (selectedToolNames.size === tools.length) {
+      setSelectedToolNames(new Set());
+    } else {
+      setSelectedToolNames(new Set(tools.map((t) => t.tool_name)));
+    }
+  };
+
   const toggleAgent = (name: string) => {
     setSelectedAgentNames((prev) => {
       const next = new Set(prev);
@@ -105,8 +132,8 @@ export function AddIntegrationToAgentModal({
       toast.error('Select at least one agent');
       return;
     }
-    if (tools.length === 0) {
-      toast.error('No tools available for this integration');
+    if (selectedToolNames.size === 0) {
+      toast.error('Select at least one tool');
       return;
     }
 
@@ -114,7 +141,7 @@ export function AddIntegrationToAgentModal({
     try {
       const result = await attachServiceTools({
         service,
-        tool_names: tools.map((t) => t.tool_name),
+        tool_names: Array.from(selectedToolNames),
         agents: Array.from(selectedAgentNames),
       });
 
@@ -126,7 +153,7 @@ export function AddIntegrationToAgentModal({
         });
       } else {
         toast.success(
-          `Added ${tools.length} tool${tools.length > 1 ? 's' : ''} to ${selectedAgentNames.size} agent${
+          `Added ${selectedToolNames.size} tool${selectedToolNames.size > 1 ? 's' : ''} to ${selectedAgentNames.size} agent${
             selectedAgentNames.size > 1 ? 's' : ''
           }${skipped > 0 ? ` (${skipped} already present)` : ''}`,
         );
@@ -155,14 +182,21 @@ export function AddIntegrationToAgentModal({
         </DialogScrollHeader>
 
         <div className="space-y-6 px-6 py-2">
-          {/* Tools summary */}
+          {/* Tools selection */}
           <div className="space-y-2">
-            <div className="flex items-center gap-2 text-sm font-medium text-steel">
-              <Wrench className="w-4 h-4" />
-              Tools to attach
-              <Badge variant="outline" className="ml-1">
-                {tools.length}
-              </Badge>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm font-medium text-steel">
+                <Wrench className="w-4 h-4" />
+                Tools to attach
+                <Badge variant="outline" className="ml-1">
+                  {selectedToolNames.size}/{tools.length}
+                </Badge>
+              </div>
+              {tools.length > 0 && (
+                <Button variant="ghost" size="sm" onClick={handleSelectAllTools}>
+                  {selectedToolNames.size === tools.length ? 'Deselect all' : 'Select all'}
+                </Button>
+              )}
             </div>
             {toolsLoading ? (
               <div className="flex items-center gap-2 text-sm text-steel-soft">
@@ -172,16 +206,28 @@ export function AddIntegrationToAgentModal({
             ) : tools.length === 0 ? (
               <div className="text-sm text-steel-soft">No tools found for this service.</div>
             ) : (
-              <div className="rounded-md border border-border bg-muted/30 p-3 space-y-1 max-h-40 overflow-y-auto">
-                {tools.map((tool) => (
-                  <div key={tool.tool_name} className="flex items-start gap-2 text-sm">
-                    <Check className="w-4 h-4 text-primary mt-0.5 shrink-0" />
-                    <div>
-                      <div className="font-medium">{tool.tool_name}</div>
-                      <div className="text-xs text-steel-soft">{tool.description}</div>
-                    </div>
-                  </div>
-                ))}
+              <div className="rounded-md border border-border divide-y divide-border max-h-52 overflow-y-auto">
+                {tools.map((tool) => {
+                  const selected = selectedToolNames.has(tool.tool_name);
+                  return (
+                    <label
+                      key={tool.tool_name}
+                      className={`flex items-start gap-3 p-3 cursor-pointer hover:bg-muted/50 transition-colors ${
+                        selected ? 'bg-muted/50' : ''
+                      }`}
+                    >
+                      <Checkbox
+                        checked={selected}
+                        onCheckedChange={() => toggleTool(tool.tool_name)}
+                        className="mt-0.5"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="font-medium text-sm truncate">{tool.tool_name}</div>
+                        <div className="text-xs text-steel-soft">{tool.description}</div>
+                      </div>
+                    </label>
+                  );
+                })}
               </div>
             )}
           </div>
@@ -268,7 +314,7 @@ export function AddIntegrationToAgentModal({
             </Button>
             <Button
               onClick={handleSubmit}
-              disabled={selectedAgentNames.size === 0 || tools.length === 0 || submitting}
+              disabled={selectedAgentNames.size === 0 || selectedToolNames.size === 0 || submitting}
             >
               {submitting && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
               Add to {selectedAgentNames.size > 0 ? `${selectedAgentNames.size} Agent${selectedAgentNames.size > 1 ? 's' : ''}` : 'Agent'}

--- a/frontend/src/components/integrations/AddIntegrationToAgentModal.tsx
+++ b/frontend/src/components/integrations/AddIntegrationToAgentModal.tsx
@@ -16,7 +16,8 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { getAgents } from '@/services/agentApi';
-import { attachServiceTools, getServiceTools } from '@/services/integrationApi';
+import { attachServiceTools } from '@/services/integrationApi';
+import { getServiceToolsCached } from '@/services/serviceToolsCache';
 import type { AgentDoc } from '@/types/agent.types';
 import type { ServiceTool } from '@/types/integration.types';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
@@ -54,7 +55,7 @@ export function AddIntegrationToAgentModal({
     setToolsLoading(true);
     setAgentsLoading(true);
 
-    getServiceTools(service)
+    getServiceToolsCached(service)
       .then((items) => {
         setTools(items || []);
         // Every tool is selected by default — most users want the full set,

--- a/frontend/src/components/integrations/ServiceToolCount.tsx
+++ b/frontend/src/components/integrations/ServiceToolCount.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { getServiceToolsCached, getCachedServiceToolCount } from '@/services/serviceToolsCache';
+
+interface ServiceToolCountProps {
+  service: string;
+}
+
+/**
+ * Renders "N tools" for an Integration Service card, lazily. Reads a
+ * synchronous cache hit immediately (no flicker on re-render); otherwise
+ * shows a placeholder until the count resolves.
+ */
+export function ServiceToolCount({ service }: ServiceToolCountProps) {
+  const [count, setCount] = useState<number | undefined>(() => getCachedServiceToolCount(service));
+
+  useEffect(() => {
+    if (count !== undefined) return;
+    let cancelled = false;
+    getServiceToolsCached(service)
+      .then((tools) => {
+        if (!cancelled) setCount(tools.length);
+      })
+      .catch(() => {
+        if (!cancelled) setCount(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [service, count]);
+
+  if (count === undefined) return <span className="text-steel-soft">…</span>;
+  return <span>{count} tool{count !== 1 ? 's' : ''}</span>;
+}

--- a/frontend/src/components/tools/SelectToolsModal.tsx
+++ b/frontend/src/components/tools/SelectToolsModal.tsx
@@ -283,6 +283,17 @@ export function SelectToolsModal({
     });
   };
 
+  const handleSelectAllInGroup = (tools: AgentToolFunctionRef[], allSelected: boolean) => {
+    setSelectedToolIds((prev) => {
+      const next = new Set(prev);
+      tools.forEach((tool) => {
+        if (allSelected) next.delete(tool.name);
+        else next.add(tool.name);
+      });
+      return next;
+    });
+  };
+
   const renderGroup = ({
     key,
     label,
@@ -297,40 +308,60 @@ export function SelectToolsModal({
     const Icon = getCategoryIcon(label);
     const expanded = isSearching || expandedGroups.has(key);
     const selectedHere = tools.filter((t) => selectedToolIds.has(t.name)).length;
+    const allSelected = selectedHere === tools.length && tools.length > 0;
     const isService = key.startsWith('service:');
 
     return (
       <div key={key} className="mb-2 last:mb-0">
-        <button
-          type="button"
-          onClick={() => toggleGroup(key)}
-          aria-expanded={expanded}
+        <div
           className={cn(
-            'flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors',
-            'hover:bg-paper-deep focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+            'flex w-full items-center gap-2 rounded-lg px-2 py-2 transition-colors',
+            'hover:bg-paper-deep'
           )}
         >
-          <ChevronRight
+          <button
+            type="button"
+            onClick={() => toggleGroup(key)}
+            aria-expanded={expanded}
             className={cn(
-              'h-4 w-4 shrink-0 text-steel-soft transition-transform',
-              expanded && 'rotate-90'
+              'flex flex-1 items-center gap-2 text-left min-w-0',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-md'
             )}
-            aria-hidden="true"
-          />
-          <Icon className="h-4 w-4 shrink-0 text-steel-soft" aria-hidden="true" />
-          <span className="text-sm font-medium text-foreground">{label}</span>
-          <span className="text-xs text-steel-soft">{tools.length}</span>
-          {isService && !connected && (
-            <Badge variant="outline" className="shrink-0 text-[10px] font-normal">
-              Needs setup
-            </Badge>
-          )}
-          {selectedHere > 0 && (
-            <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
-              {selectedHere} selected
-            </Badge>
-          )}
-        </button>
+          >
+            <ChevronRight
+              className={cn(
+                'h-4 w-4 shrink-0 text-steel-soft transition-transform',
+                expanded && 'rotate-90'
+              )}
+              aria-hidden="true"
+            />
+            <Icon className="h-4 w-4 shrink-0 text-steel-soft" aria-hidden="true" />
+            <span className="truncate text-sm font-medium text-foreground">{label}</span>
+            <span className="shrink-0 text-xs text-steel-soft">{tools.length}</span>
+            {isService && !connected && (
+              <Badge variant="outline" className="shrink-0 text-[10px] font-normal">
+                Needs setup
+              </Badge>
+            )}
+            {selectedHere > 0 && (
+              <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
+                {selectedHere} selected
+              </Badge>
+            )}
+          </button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 shrink-0 px-2 text-xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleSelectAllInGroup(tools, allSelected);
+            }}
+          >
+            {allSelected ? 'Deselect all' : 'Select all'}
+          </Button>
+        </div>
         {expanded && (
           <div className="mt-1 space-y-2 pl-6">
             {isService && !connected && (

--- a/frontend/src/components/tools/toolCategoryIcon.ts
+++ b/frontend/src/components/tools/toolCategoryIcon.ts
@@ -16,14 +16,30 @@ import {
   LifeBuoy,
   Users,
   Globe,
+  Slack,
+  Github,
+  Mail,
+  Calendar,
+  Table,
+  FolderOpen,
+  Video,
+  MessageCircle,
+  Terminal,
+  KeyRound,
+  UserPlus,
+  Send,
+  Gamepad2,
+  Rss,
   type LucideIcon,
 } from 'lucide-react';
 
 /**
- * Icon for an Agent Tool Type (the curated, product-facing category such as
- * "Frappe Cloud" or "Communication Tools"). Matched on keywords rather than
- * exact names so categories added later still get a sensible icon instead of
- * falling back to the generic one.
+ * Icon for a tool group (an Agent Tool Type such as "Frappe Cloud", or a
+ * connected-app service name such as "Slack" / "Gmail"). Matched on keywords
+ * rather than exact names so groups added later still get a sensible icon
+ * instead of falling back to the generic one. More specific patterns are
+ * listed before broader ones so e.g. "Google Calendar" hits Calendar, not
+ * the generic Google fallback.
  */
 const KEYWORD_ICONS: Array<[RegExp, LucideIcon]> = [
   [/frappe cloud/i, Cloud],
@@ -31,10 +47,24 @@ const KEYWORD_ICONS: Array<[RegExp, LucideIcon]> = [
   [/audio/i, AudioLines],
   [/ocr/i, ScanText],
   [/generation/i, Sparkles],
-  [/serp|search/i, Search],
+  [/serp|perplexity|web search/i, Search],
   [/places|maps/i, MapPin],
+  [/calendar/i, Calendar],
+  [/sheets?/i, Table],
+  [/drive|storage/i, FolderOpen],
+  [/meet|zoom/i, Video],
+  [/gmail|email|mail/i, Mail],
+  [/slack/i, Slack],
+  [/github/i, Github],
+  [/discord/i, Gamepad2],
+  [/telegram/i, Send],
+  [/whatsapp|messenger/i, MessageCircle],
+  [/rss|feed/i, Rss],
   [/google/i, Globe],
   [/communication|raven|chat/i, MessageSquare],
+  [/ssh|docker|sandbox|execution|terminal|script/i, Terminal],
+  [/credential|secret|auth/i, KeyRound],
+  [/recipient|contact/i, UserPlus],
   [/builder/i, Wrench],
   [/developer/i, Code],
   [/memory/i, Brain],

--- a/frontend/src/components/tools/toolIconMap.ts
+++ b/frontend/src/components/tools/toolIconMap.ts
@@ -1,6 +1,13 @@
 import { Bot, Code2, Globe, type LucideIcon } from 'lucide-react';
+import { getCategoryIcon } from './toolCategoryIcon';
 
-export function getToolIconForType(types?: string): LucideIcon {
+/**
+ * Icon for an individual tool card. Prefers the tool's connected-app service
+ * or curated tool type (via getCategoryIcon) so e.g. a Slack tool shows the
+ * Slack icon; falls back to a coarse icon based on the raw operation type.
+ */
+export function getToolIconForType(types?: string, service?: string, toolType?: string): LucideIcon {
+  if (service || toolType) return getCategoryIcon(service || toolType);
   if (types === 'GET' || types === 'POST') return Globe;
   if (types === 'Run Agent') return Bot;
   return Code2;

--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -598,7 +598,6 @@ export default function GatewaysPage() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="Open">Open — allow anyone to message</SelectItem>
                     <SelectItem value="Allow list">Allow list — Require approved Gateway Access Entry</SelectItem>
                     <SelectItem value="Pairing">Pairing — require pairing request approval</SelectItem>
                     <SelectItem value="Disabled">Disabled — reject direct messages</SelectItem>

--- a/frontend/src/pages/IntegrationSettingsListingPage.tsx
+++ b/frontend/src/pages/IntegrationSettingsListingPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/services/integrationApi';
 import { AddIntegrationToAgentModal } from '@/components/integrations/AddIntegrationToAgentModal';
 import { ServiceCatalogModal } from '@/components/integrations/ServiceCatalogModal';
+import { ServiceToolCount } from '@/components/integrations/ServiceToolCount';
 import type { IntegrationSettingsDoc, IntegrationServiceDoc } from '@/types/integration.types';
 import { formatTimeAgo } from '@/utils/time';
 import { getServiceIdentity, messagingServiceNames } from '@/data/serviceIdentity';
@@ -183,6 +184,7 @@ export function IntegrationSettingsListingPage({
           const identity = getServiceIdentity(setting.service);
           const metadata = [
             ...(category ? [{ label: 'Category', value: category }] : []),
+            { label: 'Tools', value: <ServiceToolCount service={setting.service} /> },
             ...(setting.is_default ? [{ label: 'Default', value: 'Yes', icon: Star }] : []),
             ...(setting.last_used
               ? [{ label: 'Last used', value: formatTimeAgo(setting.last_used) }]

--- a/frontend/src/services/serviceToolsCache.ts
+++ b/frontend/src/services/serviceToolsCache.ts
@@ -1,0 +1,55 @@
+/**
+ * Lazy-loaded, in-memory cache for "which tools does this Integration Service
+ * expose" lookups (huf.ai.tools.integration_utils.get_service_tools).
+ *
+ * The list rarely changes — only when a tool doc is created or edited — so a
+ * per-session cache avoids re-fetching it every time a card, badge, or modal
+ * wants the count. Call invalidateServiceTools() (or invalidateAllServiceTools())
+ * whenever a tool mutation could affect it; toolApi's create/update calls do
+ * this already.
+ */
+
+import { getServiceTools } from './integrationApi';
+import type { ServiceTool } from '@/types/integration.types';
+
+const cache = new Map<string, ServiceTool[]>();
+const inFlight = new Map<string, Promise<ServiceTool[]>>();
+
+/** Fetch a service's tools, serving from cache when available. */
+export function getServiceToolsCached(service: string): Promise<ServiceTool[]> {
+  const cached = cache.get(service);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = inFlight.get(service);
+  if (pending) return pending;
+
+  const promise = getServiceTools(service)
+    .then((tools) => {
+      cache.set(service, tools);
+      inFlight.delete(service);
+      return tools;
+    })
+    .catch((error) => {
+      inFlight.delete(service);
+      throw error;
+    });
+
+  inFlight.set(service, promise);
+  return promise;
+}
+
+/** Synchronously read a cached count without triggering a fetch, or undefined if not yet loaded. */
+export function getCachedServiceToolCount(service: string): number | undefined {
+  return cache.get(service)?.length;
+}
+
+/** Clear the cached tool list for one service (or every service when omitted). */
+export function invalidateServiceTools(service?: string): void {
+  if (service) {
+    cache.delete(service);
+    inFlight.delete(service);
+  } else {
+    cache.clear();
+    inFlight.clear();
+  }
+}

--- a/frontend/src/services/toolApi.ts
+++ b/frontend/src/services/toolApi.ts
@@ -6,6 +6,7 @@ import type { ParameterData } from '@/components/tools/ParameterCard';
 import type { HttpHeaderData } from '@/components/tools/HttpHeaderCard';
 import type { ToolFormData } from '@/types/toolTemplate.types';
 import { handleFrappeError } from '@/lib/frappe-error';
+import { invalidateServiceTools } from './serviceToolsCache';
 
 /** Tool parameter row after ID enrichment (returned by getToolFunction) */
 export type ToolFunctionParameter = ParameterData & { id: string };
@@ -226,6 +227,9 @@ export async function updateToolFunction(name: string, data: {
     }
 
     const updatedTool = await db.updateDoc(doctype['Agent Tool Function'], name, toolData);
+    // A tool's name/description/service association may have changed —
+    // invalidate rather than try to patch every cached service's list.
+    invalidateServiceTools();
     return {
       name: updatedTool.name,
       tool_name: updatedTool.tool_name as string,
@@ -314,6 +318,9 @@ export async function createToolFunction(data: {
     }
 
     const newTool = await db.createDoc(doctype['Agent Tool Function'], toolData);
+    // A brand-new tool could belong to any service's group — invalidate so
+    // the next "Add to Agent" / tool-count lookup picks it up.
+    invalidateServiceTools();
     return {
       name: newTool.name,
       tool_name: newTool.tool_name as string,


### PR DESCRIPTION
## Summary
- Consolidate tool group icons and fix a dead-end option in gateway policy selection
- Add per-group select all/none plus individual tool-level selection when attaching integration tools
- Add lazy-cached tool count display on integration cards

## Test plan
- [ ] Open an Agent's Tools tab, attach an Integration Service, verify per-group select all/none and individual tool checkboxes work
- [ ] Verify gateway policy selector no longer has a dead-end/unreachable option
- [ ] Verify integration cards show a tool count that loads lazily without blocking the listing