### PR TITLE
Fix agent config, knowledge embeddings, and code-execution bugs from live QA sweep

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -890,6 +890,29 @@ def run_background_summarization(conversation_name, agent_name):
             "Agent Background Summarization Error"
         )
 
+
+
+def _set_conversation_title_with_retry(conversation_name, title, max_retries=2):
+    """Set conversation title, retrying on transient MariaDB deadlocks.
+
+    The title generation runs in a background job that may race with the
+    main request thread updating the same Agent Conversation row. A single
+    short retry is usually enough to land the title without surfacing a
+    non-critical error to the user.
+    """
+    import time
+
+    for attempt in range(max_retries):
+        try:
+            frappe.db.set_value("Agent Conversation", conversation_name, "title", title)
+            return
+        except frappe.QueryDeadlockError:
+            if attempt < max_retries - 1:
+                time.sleep(0.2 * (attempt + 1))
+                continue
+            raise
+
+
 @frappe.whitelist()
 def generate_conversation_title(conversation_name, agent_name):
     """
@@ -928,7 +951,7 @@ def generate_conversation_title(conversation_name, agent_name):
         )
         if title:
             title = title.strip().strip('"').strip("'")
-            frappe.db.set_value("Agent Conversation", conversation_name, "title", title)
+            _set_conversation_title_with_retry(conversation_name, title)
             frappe.db.commit()  # nosemgrep: justified background-job commit
             _emit_conversation_title_updated(conversation_name, title)
     except Exception as e:

--- a/huf/ai/agent_run_analytics_api.py
+++ b/huf/ai/agent_run_analytics_api.py
@@ -28,6 +28,14 @@ def get_execution_analytics(from_date: str | None = None, to_date: str | None = 
         frappe.throw("granularity must be 'hour' or 'day'")
     end = get_datetime(to_date) if to_date else now_datetime()
     start = get_datetime(from_date) if from_date else add_to_date(end, days=-7)
+    # from_date/to_date arrive as ISO strings (often UTC with a Z/offset suffix) from the
+    # frontend, which get_datetime parses as timezone-aware, while now_datetime()/add_to_date()
+    # return naive local datetimes. Mixing the two raises
+    # "can't compare offset-naive and offset-aware datetimes" on the next line.
+    if start.tzinfo is not None:
+        start = start.replace(tzinfo=None)
+    if end.tzinfo is not None:
+        end = end.replace(tzinfo=None)
     if start > end or (end - start).days > MAX_WINDOW_DAYS:
         frappe.throw(f"Date range must be between zero and {MAX_WINDOW_DAYS} days")
     if not frappe.db.exists("DocType", ROLLUP_DOCTYPE):

--- a/huf/ai/flow_tool_executor.py
+++ b/huf/ai/flow_tool_executor.py
@@ -183,6 +183,7 @@ def _resolve_function_path(tool_doc: dict) -> str | None:
 		"Set Conversation Data": "huf.ai.sdk_tools.handle_set_conversation_data",
 		"Load Conversation Data": "huf.ai.sdk_tools.handle_load_conversation_data",
 		"Perplexity Search": "huf.ai.tools.perplexity.handle_perplexity_search",
+		"Code Execution": "huf.ai.tools.code_execution.run_python",
 	}
 
 	return type_to_handler.get(tool_type)

--- a/huf/ai/knowledge/embedding.py
+++ b/huf/ai/knowledge/embedding.py
@@ -123,8 +123,8 @@ def resolve_embedding_config(knowledge_source: str) -> dict[str, Any]:
 	Resolve embedding configuration from a Knowledge Source document.
 
 	Reads the embedding_model, vector_dimension, and embedding_provider fields
-	from the Knowledge Source DocType and resolves the API key from the linked
-	AI Provider.
+	from the Knowledge Source DocType and resolves the API key and API base from
+	the linked AI Provider.
 
 	Args:
 		knowledge_source: Name of the Knowledge Source document.
@@ -143,17 +143,25 @@ def resolve_embedding_config(knowledge_source: str) -> dict[str, Any]:
 	if source.embedding_provider:
 		provider = frappe.get_doc("AI Provider", source.embedding_provider)
 		api_key = provider.get_password("api_key") if provider.api_key else None
-		api_base = getattr(provider, "api_base", None) or None
-		# Fallback: local LLM providers use url+port instead of api_base
+		# Precedence: api_base_url field > url+port (local LLM) > site_config fallback
+		api_base = (getattr(provider, "api_base_url", None) or "").strip() or None
 		if not api_base and getattr(provider, "is_local_llm", False):
-			url = getattr(provider, "url", None)
-			port = getattr(provider, "port", None)
+			url = (getattr(provider, "url", None) or "").strip() or None
+			port = str(getattr(provider, "port", None) or "").strip() or None
 			if url:
-				api_base = f"{url}:{port}" if port else url
+				url = url.rstrip("/")
+				api_base = f"{url}:{port}" if port and not url.endswith(f":{port}") else url
 
 	# Fallback to site_config for Ollama
 	if not api_base:
 		api_base = frappe.conf.get("ollama_api_base") or None
+
+	# LiteLLM requires a provider-prefixed model identifier (e.g. "ollama/nomic-embed-text").
+	# If the stored model name is not already prefixed, prepend the linked provider's brand.
+	if model and "/" not in model and source.embedding_provider:
+		provider_brand = frappe.db.get_value("AI Provider", source.embedding_provider, "provider_brand")
+		if provider_brand:
+			model = f"{provider_brand}/{model}"
 
 	return {
 		"model": model,

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -192,6 +192,8 @@ def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
                     function_path = "huf.ai.memory_tools.handle_archive_memory_record"
                 elif function_doc.types == "Promote Memory to Knowledge":
                     function_path = "huf.ai.memory_tools.handle_promote_memory_to_knowledge"
+                elif function_doc.types == "Code Execution":
+                    function_path = "huf.ai.tools.code_execution.run_python"
 
                 else:
                     continue

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -107,15 +107,21 @@ class PermissionAwareToolRegistry:
 
     @classmethod
     def _allows_code_execution(cls, tool_doc, agent_doc, user: str) -> bool:
-        """Additional gate for tools of type 'Code Execution'.
+        """Additional gate for the Python code execution tool.
 
-        A Code Execution tool is only returned when ALL of:
-          (a) the acting user holds the ``code_execution.run`` capability;
-          (b) the agent has ``allow_code_execution`` enabled;
-          (c) the agent references an Execution Profile that is not disabled.
-        Tools of any other type pass straight through this gate.
+        Matches the SSH/Docker gate pattern: identify the tool by function_path
+        or tool_name (registry-synced tools are App Provided, not "Code
+        Execution" type) and enforce code_execution.run capability, agent opt-in,
+        and an enabled Execution Profile.
         """
-        if tool_doc.types != "Code Execution":
+        function_path = (getattr(tool_doc, "function_path", None) or "").strip()
+        tool_name = (getattr(tool_doc, "tool_name", None) or "").strip()
+        is_code_tool = (
+            tool_doc.types == "Code Execution"
+            or function_path == "huf.ai.tools.code_execution.run_python"
+            or tool_name == "run_python"
+        )
+        if not is_code_tool:
             return True
 
         from huf.permissions import has_capability

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1841,6 +1841,22 @@ DOCUMENT_ARTIFACT_TOOLS = [
 	},
 ]
 
+
+CODE_EXECUTION_TOOLS = [
+	{
+		"tool_name": "run_python",
+		"description": (
+			"Execute sandboxed Python code inside a restricted subprocess. "
+			"Requires the agent to have code execution enabled and an Execution Profile selected."
+		),
+		"function_path": "huf.ai.tools.code_execution.run_python",
+		"category": "Code Execution",
+		"parameters": [
+			_p("code", required=True, description="Python source code to execute"),
+		],
+	},
+]
+
 ALL_INTEGRATION_TOOLS = (
 	# Platform capabilities — no external account to connect.
 	RECIPIENT_TOOLS
@@ -1855,6 +1871,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS
 	+ DOCUMENT_ARTIFACT_TOOLS
+	+ CODE_EXECUTION_TOOLS
 	# Tools backed by a connectable service. Keys match Integration Service
 	# docnames and the SERVICE_NAME each tool module uses for credentials.
 	+ _with_service(SLACK_TOOLS, "slack")

--- a/huf/ai/tools/code_execution.py
+++ b/huf/ai/tools/code_execution.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 import hashlib
 import ipaddress
+
+import frappe
 import json
 import os
 import shutil

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -276,7 +276,7 @@ scheduler_events = {
 # Testing
 # -------
 
-# before_tests = "huf.install.before_tests"
+before_tests = "huf.install.before_tests"
 
 # Overriding Methods
 # ------------------------------

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -884,7 +884,8 @@
    "description": "Maximum size (in MB) for a single uploaded file. Capped by the global 25 MB limit.",
    "fieldname": "max_upload_size_mb",
    "fieldtype": "Int",
-   "label": "Max Upload Size (MB)"
+   "label": "Max Upload Size (MB)",
+   "non_negative": 1
   },
   {
    "description": "Opt-in to the elevated-risk Python Code Execution tool. Requires both this flag and a Code Execution tool assigned in the Tools tab, plus an Execution Profile below, before the tool becomes active.",

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -120,6 +120,7 @@ class Agent(Document):
             self._validate_prompt_caching()
 
         self._validate_advanced_models()
+        self._validate_voice_config()
         self._validate_skills()
         self._validate_starter_prompts()
         self._validate_allowed_users_and_roles()
@@ -345,6 +346,23 @@ class Agent(Document):
                     _("Selected STT Model does not support modality: Transcription"),
                     title=_("Invalid Model Capability"),
                 )
+
+    def _validate_voice_config(self):
+        """Ensure voice_config is valid JSON when voice is enabled."""
+        if not getattr(self, "voice_enabled", 0):
+            return
+
+        raw_config = getattr(self, "voice_config", None)
+        if not raw_config:
+            return
+
+        try:
+            json.loads(raw_config)
+        except (TypeError, ValueError):
+            frappe.throw(
+                _("Voice Configuration must be valid JSON."),
+                title=_("Invalid Voice Configuration"),
+            )
 
     def _validate_prompt_caching(self):
         if not self.model:

--- a/huf/install.py
+++ b/huf/install.py
@@ -99,6 +99,31 @@ def _setup_desktop_icon_as_workspace():
 	frappe.db.commit()
 
 
+def before_tests():
+	"""Clear the stale test-record cache before every `bench run-tests` invocation.
+
+	Frappe test_runner.main() calls frappe.utils.scheduler.disable_scheduler() (an
+	uncommitted write) before running any doctype/module tests. On a first run,
+	make_test_records(..., commit=True) happens to flush that write. But
+	make_test_records short-circuits per doctype once sites/<site>/.test_log
+	already lists it (see frappe/test_runner.py get_test_record_log /
+	add_to_test_record_log), so on any second-or-later run against the same site
+	no commit ever happens and the next frappe.db.begin() collides with the
+	still-uncommitted scheduler-disable write, raising
+	frappe.exceptions.ImplicitCommitError. Clearing the cache here forces
+	make_test_records to recreate (and commit) on every run, so this cannot
+	recur regardless of prior test-runner state on this site.
+	"""
+	import os
+
+	test_log_path = frappe.get_site_path(".test_log")
+	if os.path.exists(test_log_path):
+		os.remove(test_log_path)
+	frame = getattr(frappe, "flags", None)
+	if frame is not None and "test_record_log" in frame:
+		del frame["test_record_log"]
+
+
 def after_install():
     create_huf_roles()
     create_demo_ai_providers()


### PR DESCRIPTION
## Summary

Exhaustively tested agent configuration on a live bench: voice/STT/TTS,
chat, cache, prompt, and advanced settings, plus knowledge/embeddings,
execution analytics, and the code-execution tool. This fixes six real bugs
found during that pass, all verified live against a running bench before
being committed here.

## Changes

- **Chat**: retry once on a transient MariaDB deadlock when persisting a
  background-generated conversation title (`agent_integration.py`).
- **Voice config**: reject invalid JSON in `Agent.voice_config` at save
  time instead of persisting it and only failing later when a voice
  session starts (`doctype/agent/agent.py`).
- **Uploads**: enforce non-negative `Agent.max_upload_size_mb` — a negative
  value silently broke every chat upload by producing a negative byte
  limit (`doctype/agent/agent.json`).
- **Knowledge/embeddings**: fix embedding config resolution for knowledge
  sources — read the AI Provider's `api_base_url` (the field that actually
  exists, not `api_base`) and provider-prefix the model for LiteLLM, so
  local/Ollama-backed embeddings actually reach the provider
  (`knowledge/embedding.py`).
- **Code execution**: make the `run_python` tool reachable end-to-end —
  add a missing import, register it during tool sync, widen the
  code-execution capability gate to match registry-synced tools, and add
  the "Code Execution" type mapping in the two tool-consumer modules that
  lacked one (`tools/code_execution.py`, `tools/_registry.py`,
  `tool_registry.py`, `sdk_tools.py`, `flow_tool_executor.py`).
- **Execution analytics**: fix a naive/aware datetime comparison crash
  when the frontend sends ISO date strings with a timezone suffix
  (`agent_run_analytics_api.py`).
- **Test runner**: add a `before_tests` hook that clears the site's stale
  test-record cache, so `bench run-tests` no longer intermittently fails
  with `ImplicitCommitError` on repeated runs against the same site
  (`install.py`, `hooks.py`).

## Test plan

- [x] Reproduced each bug against a live bench before fixing
- [x] Retested each fix against the same live bench after the change
- [x] Ran `bench run-tests --doctype Agent` three times consecutively to
      confirm the test-runner fix is durable (previously failed on the
      2nd run every time)
- [x] Confirmed no overlap with the already-merged PR #601 (different
      files entirely) before rebasing onto current `pre-dev-stg`