### PR TITLE
fix(agent-editor): create knowledge sources and prompt templates inline instead of navigating away

### DIFF
--- a/frontend/src/components/agent/AgentKnowledgeModal.tsx
+++ b/frontend/src/components/agent/AgentKnowledgeModal.tsx
@@ -27,13 +27,16 @@ import { getKnowledgeSources } from '@/services/knowledgeApi';
 import type { AgentKnowledgeRow } from '@/types/agent.types';
 import type { ComboboxOption } from '@/components/ui/combobox';
 import { linkRoutes } from '@/lib/link-routes';
+import { KnowledgeSourceCreateModal } from './KnowledgeSourceCreateModal';
+import type { KnowledgeSourceDoc } from '@/types/knowledge.types';
 
 interface AgentKnowledgeModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSave: (row: AgentKnowledgeRow) => void;
   initialData?: AgentKnowledgeRow | null;
-  onCreateNew?: () => void;
+  /** Called after a new knowledge source is created in-context; return false to no-op. */
+  onCreateNew?: () => boolean | void;
 }
 
 export function AgentKnowledgeModal({
@@ -44,6 +47,7 @@ export function AgentKnowledgeModal({
   onCreateNew,
 }: AgentKnowledgeModalProps) {
   const [knowledgeSource, setKnowledgeSource] = useState('');
+  const [createModalOpen, setCreateModalOpen] = useState(false);
   const [mode, setMode] = useState<'Mandatory' | 'Optional'>('Optional');
   const [priority, setPriority] = useState(0);
   const [maxChunks, setMaxChunks] = useState(5);
@@ -97,6 +101,19 @@ export function AgentKnowledgeModal({
     onOpenChange(false);
   };
 
+  const handleOpenCreate = () => {
+    if (onCreateNew && onCreateNew() === false) return;
+    setCreateModalOpen(true);
+  };
+
+  const handleSourceCreated = (source: KnowledgeSourceDoc) => {
+    setSourceOptions((prev) => [
+      { value: source.name, label: source.source_name || source.name },
+      ...prev,
+    ]);
+    setKnowledgeSource(source.name);
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogScrollContent className="sm:max-w-md">
@@ -113,7 +130,7 @@ export function AgentKnowledgeModal({
             {sourceOptions.length === 0 && onCreateNew ? (
               <div className="flex flex-col items-center gap-3 rounded-none border border-dashed py-6 text-center">
                 <p className="text-sm text-steel">No knowledge sources registered yet</p>
-                <Button type="button" variant="default" size="sm" onClick={onCreateNew}>
+                <Button type="button" variant="default" size="sm" onClick={handleOpenCreate}>
                   Register your first knowledge source →
                 </Button>
               </div>
@@ -133,7 +150,7 @@ export function AgentKnowledgeModal({
                 type="button"
                 variant="link"
                 className="h-auto p-0 text-xs"
-                onClick={onCreateNew}
+                onClick={handleOpenCreate}
               >
                 Don't see it? Create a new knowledge source →
               </Button>
@@ -209,6 +226,12 @@ export function AgentKnowledgeModal({
           </Button>
         </DialogScrollFooter>
       </DialogScrollContent>
+
+      <KnowledgeSourceCreateModal
+        open={createModalOpen}
+        onOpenChange={setCreateModalOpen}
+        onCreated={handleSourceCreated}
+      />
     </Dialog>
   );
 }

--- a/frontend/src/components/agent/GeneralTab.tsx
+++ b/frontend/src/components/agent/GeneralTab.tsx
@@ -30,6 +30,7 @@ interface GeneralTabProps {
   showAddNewPrompt?: boolean;
   /** True when protected fields must be read-only (system agent + non-admin). */
   locked?: boolean;
+  onPromptCreated?: (option: AgentPromptOption) => void;
 }
 
 export function GeneralTab({
@@ -43,6 +44,7 @@ export function GeneralTab({
   loadingPrompts,
   showAddNewPrompt = true,
   locked = false,
+  onPromptCreated,
 }: GeneralTabProps) {
   const watchEnablePromptCaching = form.watch('enable_prompt_caching');
   const watchModel = form.watch('model');
@@ -310,6 +312,7 @@ We generally recommend altering this or temperature but not both.`}
           loadingPrompts={loadingPrompts}
           showAddNew={showAddNewPrompt}
           locked={locked}
+          onPromptCreated={onPromptCreated}
         />
       )}
 

--- a/frontend/src/components/agent/KnowledgeSourceCreateModal.tsx
+++ b/frontend/src/components/agent/KnowledgeSourceCreateModal.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '@/components/ui/dialog-scroll';
+import {
+  KnowledgeSourceForm,
+  mapDocToFormValues,
+  buildKnowledgeSourcePayload,
+} from '@/components/knowledge/KnowledgeSourceForm';
+import { knowledgeSourceFormSchema, type KnowledgeSourceFormValues } from '@/components/knowledge/types';
+import { createKnowledgeSource } from '@/services/knowledgeApi';
+import { getProviders } from '@/services/providerApi';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+import type { AIProvider } from '@/types/agent.types';
+import type { KnowledgeSourceDoc } from '@/types/knowledge.types';
+
+interface KnowledgeSourceCreateModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (source: KnowledgeSourceDoc) => void;
+}
+
+/**
+ * In-context "create a knowledge source" dialog, used from the agent editor
+ * so users don't lose their in-progress agent form (see AgentKnowledgeModal).
+ * Renders the same field logic as the standalone /knowledge/new route via
+ * the shared KnowledgeSourceForm, but only creates the doc locally and hands
+ * the result back via onCreated — no navigation, no agent linking (the
+ * agent-linking side effect is handled by the caller).
+ */
+export function KnowledgeSourceCreateModal({
+  open,
+  onOpenChange,
+  onCreated,
+}: KnowledgeSourceCreateModalProps) {
+  const [saving, setSaving] = useState(false);
+  const [providers, setProviders] = useState<AIProvider[]>([]);
+
+  const form = useForm<KnowledgeSourceFormValues>({
+    resolver: zodResolver(knowledgeSourceFormSchema),
+    defaultValues: mapDocToFormValues({}),
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    form.reset(mapDocToFormValues({}));
+    getProviders()
+      .then((data) => setProviders(data as AIProvider[]))
+      .catch((err) => console.error('Error loading providers:', err));
+  }, [open, form]);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && form.formState.isDirty) {
+      const confirmed = window.confirm('Discard this knowledge source? Your changes will be lost.');
+      if (!confirmed) return;
+    }
+    onOpenChange(next);
+  };
+
+  const onSubmit = async (values: KnowledgeSourceFormValues) => {
+    setSaving(true);
+    try {
+      const payload = buildKnowledgeSourcePayload(values);
+      const created = await createKnowledgeSource(payload);
+      toast.success('Knowledge source created');
+      onCreated(created);
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Error creating knowledge source:', error);
+      const msg = getFrappeErrorMessage(error);
+      toast.error(msg || 'Failed to create knowledge source');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleFormSubmit = form.handleSubmit(onSubmit, () => {
+    toast.error('Please fix the highlighted fields');
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogScrollContent className="sm:max-w-2xl">
+        <DialogScrollHeader>
+          <DialogTitle>New Knowledge Source</DialogTitle>
+          <DialogDescription>
+            Register a knowledge source your agents can retrieve context from.
+          </DialogDescription>
+        </DialogScrollHeader>
+
+        <KnowledgeSourceForm
+          form={form}
+          isNew
+          providers={providers}
+          showStatusTab={false}
+          onSubmit={handleFormSubmit}
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          bodyWrapper={(children) => (
+            <DialogScrollBody className="space-y-4 pb-4">{children}</DialogScrollBody>
+          )}
+          footer={
+            <DialogScrollFooter>
+              <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? 'Creating...' : 'Create'}
+              </Button>
+            </DialogScrollFooter>
+          }
+        />
+      </DialogScrollContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/agent/PromptTemplateCreateModal.tsx
+++ b/frontend/src/components/agent/PromptTemplateCreateModal.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import {
+  DialogScrollBody,
+  DialogScrollContent,
+  DialogScrollFooter,
+  DialogScrollHeader,
+} from '@/components/ui/dialog-scroll';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { InstructionsTextarea } from '@/components/agent/InstructionsTextarea';
+import { createAgentPrompt, type AgentPromptDoc } from '@/services/agentPromptApi';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+
+const promptCreateSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().optional(),
+  is_active: z.boolean().default(true),
+  visibility: z.enum(['Public', 'App', 'Private']).default('Private'),
+  tags: z.string().optional(),
+  prompt_body: z.string().min(1, 'Prompt body is required'),
+});
+
+type PromptCreateFormValues = z.infer<typeof promptCreateSchema>;
+
+const defaultValues: PromptCreateFormValues = {
+  title: '',
+  description: '',
+  is_active: true,
+  visibility: 'Private',
+  tags: '',
+  prompt_body: '',
+};
+
+interface PromptTemplateCreateModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (prompt: AgentPromptDoc) => void;
+}
+
+/**
+ * In-context "create a prompt template" dialog, used from the agent editor
+ * so users don't lose their in-progress agent form (mirrors
+ * KnowledgeSourceCreateModal for Knowledge sources). This only covers prompt
+ * *creation* — full editing/versioning/forking still lives on the standalone
+ * /prompts/:id route (AgentPromptFormPage), which is deeply tied to
+ * page-level routing and version state and isn't a good fit for extraction
+ * into a shared modal-friendly form.
+ */
+export function PromptTemplateCreateModal({ open, onOpenChange, onCreated }: PromptTemplateCreateModalProps) {
+  const [saving, setSaving] = useState(false);
+
+  const form = useForm<PromptCreateFormValues>({
+    resolver: zodResolver(promptCreateSchema),
+    defaultValues,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    form.reset(defaultValues);
+  }, [open, form]);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && form.formState.isDirty) {
+      const confirmed = window.confirm('Discard this prompt template? Your changes will be lost.');
+      if (!confirmed) return;
+    }
+    onOpenChange(next);
+  };
+
+  const onSubmit = async (values: PromptCreateFormValues) => {
+    setSaving(true);
+    try {
+      const created = await createAgentPrompt({
+        title: values.title,
+        description: values.description || undefined,
+        is_active: values.is_active ? 1 : 0,
+        visibility: values.visibility,
+        tags: values.tags || undefined,
+        prompt_body: values.prompt_body,
+      });
+      toast.success('Prompt template created');
+      onCreated(created);
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Error creating prompt template:', error);
+      const msg = getFrappeErrorMessage(error);
+      toast.error(msg || 'Failed to create prompt template');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleFormSubmit = form.handleSubmit(onSubmit, () => {
+    toast.error('Please fix the highlighted fields');
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogScrollContent className="sm:max-w-2xl">
+        <DialogScrollHeader>
+          <DialogTitle>New Prompt Template</DialogTitle>
+          <DialogDescription>
+            Create a reusable prompt template your agents can link to.
+          </DialogDescription>
+        </DialogScrollHeader>
+
+        <Form {...form}>
+          <form onSubmit={handleFormSubmit} className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <DialogScrollBody className="space-y-4 pb-4">
+              <FormField
+                control={form.control}
+                name="title"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Title</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="Prompt title" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="visibility"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Visibility</FormLabel>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select visibility" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="Private">Private</SelectItem>
+                          <SelectItem value="App">App</SelectItem>
+                          <SelectItem value="Public">Public</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="tags"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tags</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="Comma-separated tags" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea {...field} placeholder="Describe what this prompt is for" rows={2} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="prompt_body"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Prompt Body</FormLabel>
+                    <FormControl>
+                      <InstructionsTextarea
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Write the prompt instructions here"
+                        className="min-h-[220px] font-mono resize-y"
+                        showOptimize={false}
+                        showExpand
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="is_active"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between rounded-none border p-4">
+                    <div className="space-y-0.5 pr-4">
+                      <FormLabel className="text-base">Active</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Switch checked={field.value} onCheckedChange={field.onChange} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </DialogScrollBody>
+
+            <DialogScrollFooter>
+              <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? 'Creating...' : 'Create'}
+              </Button>
+            </DialogScrollFooter>
+          </form>
+        </Form>
+      </DialogScrollContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/agent/PromptTemplateSection.tsx
+++ b/frontend/src/components/agent/PromptTemplateSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Combobox } from '@/components/ui/combobox';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -6,9 +7,9 @@ import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import type { AgentFormValues } from './types';
 import type { UseFormReturn } from 'react-hook-form';
-import { useNavigate, useLocation } from 'react-router-dom';
 import { Plus } from 'lucide-react';
 import { linkRoutes } from '@/lib/link-routes';
+import { PromptTemplateCreateModal } from './PromptTemplateCreateModal';
 
 export interface AgentPromptOption {
   value: string;
@@ -25,6 +26,8 @@ interface PromptTemplateSectionProps {
   showAddNew?: boolean;
   /** True when protected fields must be read-only (system agent + non-admin). */
   locked?: boolean;
+  /** Called after a new prompt template is created via the in-context modal, so the caller can add it to promptOptions. */
+  onPromptCreated?: (option: AgentPromptOption) => void;
 }
 
 export function PromptTemplateSection({
@@ -33,9 +36,9 @@ export function PromptTemplateSection({
   loadingPrompts = false,
   showAddNew = true,
   locked = false,
+  onPromptCreated,
 }: PromptTemplateSectionProps) {
-  const navigate = useNavigate();
-  const location = useLocation();
+  const [createModalOpen, setCreateModalOpen] = useState(false);
   const selectedPrompt = promptOptions.find((option) => option.value === form.watch('agent_prompt'));
   const promptComboboxOptions = promptOptions.map((option) => ({
     ...option,
@@ -71,31 +74,7 @@ export function PromptTemplateSection({
                   />
                 </FormControl>
                 {showAddNew ? (
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={() =>
-                      (() => {
-                        const returnTo = `${location.pathname}#general`;
-                        const selectedPromptField = 'agent_prompt';
-                        // Fallback for cases where react-router location.state is lost.
-                        try {
-                          localStorage.setItem(
-                            'agentPromptCreateReturnTo',
-                            JSON.stringify({ returnTo, selectedPromptField })
-                          );
-                        } catch {
-                          // ignore storage failures
-                        }
-                        navigate('/prompts/new', {
-                          state: {
-                            returnTo,
-                            selectedPromptField,
-                          },
-                        });
-                      })()
-                    }
-                  >
+                  <Button type="button" variant="secondary" onClick={() => setCreateModalOpen(true)}>
                     <Plus className="w-4 h-4 mr-2" />
                     New
                   </Button>
@@ -157,6 +136,20 @@ export function PromptTemplateSection({
           )}
         />
       </CardContent>
+      <PromptTemplateCreateModal
+        open={createModalOpen}
+        onOpenChange={setCreateModalOpen}
+        onCreated={(prompt) => {
+          onPromptCreated?.({
+            value: prompt.name,
+            label: prompt.title || prompt.name,
+            description: prompt.description || undefined,
+            version: typeof prompt.version === 'number' ? prompt.version : undefined,
+            isLatest: prompt.is_latest === 1,
+          });
+          form.setValue('agent_prompt', prompt.name, { shouldDirty: true });
+        }}
+      />
     </Card>
   );
 }

--- a/frontend/src/components/knowledge/KnowledgeSourceForm.tsx
+++ b/frontend/src/components/knowledge/KnowledgeSourceForm.tsx
@@ -1,0 +1,208 @@
+import type { ReactNode } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import { Form } from '@/components/ui/form';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { GeneralTab } from './GeneralTab';
+import { StatusTab } from './StatusTab';
+import type { KnowledgeSourceFormValues } from './types';
+import type { KnowledgeSourceDoc } from '@/types/knowledge.types';
+import type { AIProvider } from '@/types/agent.types';
+
+/**
+ * Field/label metadata for the tabs rendered by KnowledgeSourceForm.
+ * Shared between the standalone route page (which drives its own tab
+ * validation via createFormSubmitHandler) and any embedded usage.
+ */
+export const knowledgeSourceTabConfig = {
+  general: {
+    label: 'General',
+    fields: [
+      'source_name',
+      'description',
+      'knowledge_type',
+      'scope',
+      'storage_mode',
+      'chunk_size',
+      'chunk_overlap',
+      'embedding_model',
+      'vector_dimension',
+      'embedding_provider',
+      'chroma_mode',
+      'chroma_host',
+      'chroma_port',
+      'chroma_ssl',
+      'pgvector_connection_mode',
+      'pgvector_table_name',
+      'pgvector_distance_metric',
+      'pgvector_index_type',
+      'pgvector_host',
+      'pgvector_port',
+      'pgvector_database',
+      'pgvector_user',
+      'pgvector_password',
+      'pgvector_sslmode',
+      'advanced_config',
+    ],
+    default: true,
+  },
+  status: {
+    label: 'Status',
+    fields: [] as string[],
+    default: false,
+  },
+} as const;
+
+export function parseAdvancedConfig(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return JSON.parse(value) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function stringifyAdvancedConfig(value: Record<string, unknown> | undefined): string {
+  return JSON.stringify(value || {});
+}
+
+export function mapDocToFormValues(doc: Partial<KnowledgeSourceDoc>): KnowledgeSourceFormValues {
+  return {
+    source_name: doc.source_name || '',
+    description: doc.description || '',
+    knowledge_type: doc.knowledge_type || 'sqlite_fts',
+    scope: doc.scope || 'Site',
+    storage_mode: doc.storage_mode || 'Frappe File',
+    chunk_size: doc.chunk_size ?? 512,
+    chunk_overlap: doc.chunk_overlap ?? 50,
+    disabled: doc.disabled === 1,
+    embedding_model: doc.embedding_model || '',
+    vector_dimension: doc.vector_dimension ?? 1536,
+    embedding_provider: doc.embedding_provider || '',
+    chroma_mode: doc.chroma_mode || 'File',
+    chroma_host: doc.chroma_host || 'localhost',
+    chroma_port: doc.chroma_port ?? 8000,
+    chroma_ssl: doc.chroma_ssl === 1,
+    pgvector_connection_mode: doc.pgvector_connection_mode || 'External PostgreSQL',
+    pgvector_table_name: doc.pgvector_table_name || 'huf_knowledge_vectors',
+    pgvector_distance_metric: doc.pgvector_distance_metric || 'cosine',
+    pgvector_index_type: doc.pgvector_index_type || 'hnsw',
+    pgvector_host: doc.pgvector_host || 'localhost',
+    pgvector_port: doc.pgvector_port ?? 5432,
+    pgvector_database: doc.pgvector_database || '',
+    pgvector_user: doc.pgvector_user || '',
+    pgvector_password: doc.pgvector_password || '',
+    pgvector_sslmode: doc.pgvector_sslmode || 'prefer',
+    advanced_config: parseAdvancedConfig(doc.advanced_config),
+  };
+}
+
+/**
+ * Maps validated form values to the API payload shape expected by
+ * createKnowledgeSource / updateKnowledgeSource.
+ */
+export function buildKnowledgeSourcePayload(
+  values: KnowledgeSourceFormValues,
+): Partial<KnowledgeSourceDoc> {
+  return {
+    source_name: values.source_name,
+    description: values.description || '',
+    knowledge_type: values.knowledge_type,
+    scope: values.scope,
+    storage_mode: values.storage_mode as KnowledgeSourceDoc['storage_mode'],
+    chunk_size: values.chunk_size,
+    chunk_overlap: values.chunk_overlap,
+    disabled: values.disabled ? 1 : 0,
+    embedding_model: values.embedding_model || '',
+    vector_dimension: values.vector_dimension ?? 1536,
+    embedding_provider: values.embedding_provider || '',
+    chroma_mode: values.chroma_mode,
+    chroma_host: values.chroma_host || '',
+    chroma_port: values.chroma_port ?? 8000,
+    chroma_ssl: values.chroma_ssl ? 1 : 0,
+    pgvector_connection_mode: values.pgvector_connection_mode,
+    pgvector_table_name: values.pgvector_table_name || 'huf_knowledge_vectors',
+    pgvector_distance_metric: values.pgvector_distance_metric,
+    pgvector_index_type: values.pgvector_index_type,
+    pgvector_host: values.pgvector_host || '',
+    pgvector_port: values.pgvector_port ?? 5432,
+    pgvector_database: values.pgvector_database || '',
+    pgvector_user: values.pgvector_user || '',
+    pgvector_password: values.pgvector_password || '',
+    pgvector_sslmode: values.pgvector_sslmode,
+    advanced_config: stringifyAdvancedConfig(values.advanced_config),
+  };
+}
+
+interface KnowledgeSourceFormProps {
+  form: UseFormReturn<KnowledgeSourceFormValues>;
+  isNew: boolean;
+  providers: AIProvider[];
+  /** Only relevant when showStatusTab is true (existing sources). */
+  sourceDoc?: KnowledgeSourceDoc | null;
+  /** Standalone page shows General + Status tabs; the create modal only needs General. */
+  showStatusTab?: boolean;
+  activeTab?: string;
+  onTabChange?: (tab: string) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSubmit: (e?: any) => void | Promise<void>;
+  /** Rendered inside the <form> so Enter-to-submit and layout stay consistent. */
+  footer?: ReactNode;
+  className?: string;
+  /** Wraps the tab/field content (e.g. DialogScrollBody for a modal). Identity by default. */
+  bodyWrapper?: (children: ReactNode) => ReactNode;
+}
+
+/**
+ * Presentational knowledge-source form body: field groups + validation,
+ * shared by the standalone /knowledge/:id route page and the in-context
+ * agent-editor create modal. Callers own data loading, submission side
+ * effects (navigation, linking, toasts), and page/dialog chrome.
+ */
+export function KnowledgeSourceForm({
+  form,
+  isNew,
+  providers,
+  sourceDoc = null,
+  showStatusTab = true,
+  activeTab = 'general',
+  onTabChange,
+  onSubmit,
+  footer,
+  className = 'space-y-6',
+  bodyWrapper = (children) => children,
+}: KnowledgeSourceFormProps) {
+  const content = showStatusTab ? (
+    <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
+      <TabsList layout="grid" cols={2}>
+        <TabsTrigger value="general">{knowledgeSourceTabConfig.general.label}</TabsTrigger>
+        <TabsTrigger value="status" disabled={isNew}>
+          {knowledgeSourceTabConfig.status.label}
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="general" className="space-y-4">
+        <GeneralTab form={form} isNew={isNew} providers={providers} />
+      </TabsContent>
+
+      <TabsContent value="status" className="space-y-4">
+        <StatusTab source={sourceDoc} />
+      </TabsContent>
+    </Tabs>
+  ) : (
+    <GeneralTab form={form} isNew={isNew} providers={providers} />
+  );
+
+  return (
+    <Form {...form}>
+      <form onSubmit={onSubmit} className={className}>
+        {bodyWrapper(content)}
+        {footer}
+      </form>
+    </Form>
+  );
+}

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -2194,9 +2194,9 @@ export function AgentFormPage() {
   const handleCreateKnowledge = () => {
     if (!id || id === 'new') {
       toast.error('Please save the agent first before creating knowledge');
-      return;
+      return false;
     }
-    navigate(`/knowledge/new?agent=${encodeURIComponent(id)}`);
+    return true;
   };
 
   const handleCreateMCP = () => {
@@ -2437,6 +2437,12 @@ export function AgentFormPage() {
                   loadingPrompts={loadingPrompts}
                   showAddNewPrompt
                   locked={systemLocked}
+                  onPromptCreated={(option) => {
+                    setPromptOptions((prev) => {
+                      if (prev.some((p) => p.value === option.value)) return prev;
+                      return [option, ...prev];
+                    });
+                  }}
                 />
               </TabsContent>
 

--- a/frontend/src/pages/KnowledgeSourceFormPage.tsx
+++ b/frontend/src/pages/KnowledgeSourceFormPage.tsx
@@ -2,8 +2,6 @@ import { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { useParams, useNavigate, useBlocker, useSearchParams, type Location } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Form } from '../components/ui/form';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { toast } from 'sonner';
 import {
   getKnowledgeSource,
@@ -15,31 +13,14 @@ import { getProviders } from '../services/providerApi';
 import type { AIProvider } from '../types/agent.types';
 import { getFrappeErrorMessage } from '../lib/frappe-error';
 import { KnowledgeSourceHeader } from '../components/knowledge/KnowledgeSourceHeader';
-import { GeneralTab } from '../components/knowledge/GeneralTab';
-import { StatusTab } from '../components/knowledge/StatusTab';
 import { KnowledgeInputsModal } from '../components/knowledge/KnowledgeInputsModal';
+import { knowledgeSourceFormSchema, type KnowledgeSourceFormValues } from '../components/knowledge/types';
 import {
-  knowledgeSourceFormSchema,
-  type KnowledgeSourceFormValues,
-} from '../components/knowledge/types';
-
-function parseAdvancedConfig(value: unknown): Record<string, unknown> {
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      return JSON.parse(value) as Record<string, unknown>;
-    } catch {
-      return {};
-    }
-  }
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  return {};
-}
-
-function stringifyAdvancedConfig(value: Record<string, unknown> | undefined): string {
-  return JSON.stringify(value || {});
-}
+  KnowledgeSourceForm,
+  knowledgeSourceTabConfig,
+  mapDocToFormValues,
+  buildKnowledgeSourcePayload,
+} from '../components/knowledge/KnowledgeSourceForm';
 import type { KnowledgeSourceDoc } from '../types/knowledge.types';
 import { createFormSubmitHandler, type TabFieldMapping } from '../utils/formValidation';
 import { useSaveShortcut } from '../hooks/useSaveShortcut';
@@ -49,37 +30,6 @@ import { linkKnowledgeToAgent } from '../services/agentApi';
 export { KnowledgeSourceFormPage };
 export default KnowledgeSourceFormPage;
 
-function mapDocToFormValues(doc: Partial<KnowledgeSourceDoc>): KnowledgeSourceFormValues {
-  return {
-    source_name: doc.source_name || '',
-    description: doc.description || '',
-    knowledge_type: doc.knowledge_type || 'sqlite_fts',
-    scope: doc.scope || 'Site',
-    storage_mode: doc.storage_mode || 'Frappe File',
-    chunk_size: doc.chunk_size ?? 512,
-    chunk_overlap: doc.chunk_overlap ?? 50,
-    disabled: doc.disabled === 1,
-    embedding_model: doc.embedding_model || '',
-    vector_dimension: doc.vector_dimension ?? 1536,
-    embedding_provider: doc.embedding_provider || '',
-    chroma_mode: doc.chroma_mode || 'File',
-    chroma_host: doc.chroma_host || 'localhost',
-    chroma_port: doc.chroma_port ?? 8000,
-    chroma_ssl: doc.chroma_ssl === 1,
-    pgvector_connection_mode: doc.pgvector_connection_mode || 'External PostgreSQL',
-    pgvector_table_name: doc.pgvector_table_name || 'huf_knowledge_vectors',
-    pgvector_distance_metric: doc.pgvector_distance_metric || 'cosine',
-    pgvector_index_type: doc.pgvector_index_type || 'hnsw',
-    pgvector_host: doc.pgvector_host || 'localhost',
-    pgvector_port: doc.pgvector_port ?? 5432,
-    pgvector_database: doc.pgvector_database || '',
-    pgvector_user: doc.pgvector_user || '',
-    pgvector_password: doc.pgvector_password || '',
-    pgvector_sslmode: doc.pgvector_sslmode || 'prefer',
-    advanced_config: parseAdvancedConfig(doc.advanced_config),
-  };
-}
-
 function KnowledgeSourceFormPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -88,46 +38,7 @@ function KnowledgeSourceFormPage() {
   const isNew = id === 'new';
   const skipBlockRef = useRef(false);
 
-  const tabConfig = {
-    general: {
-      label: 'General',
-      fields: [
-        'source_name',
-        'description',
-        'knowledge_type',
-        'scope',
-        'storage_mode',
-        'chunk_size',
-        'chunk_overlap',
-        'embedding_model',
-        'vector_dimension',
-        'embedding_provider',
-        'chroma_mode',
-        'chroma_host',
-        'chroma_port',
-        'chroma_ssl',
-        'pgvector_connection_mode',
-        'pgvector_table_name',
-        'pgvector_distance_metric',
-        'pgvector_index_type',
-        'pgvector_host',
-        'pgvector_port',
-        'pgvector_database',
-        'pgvector_user',
-        'pgvector_password',
-        'pgvector_sslmode',
-        'advanced_config',
-      ],
-      default: true,
-      disabled: false,
-    },
-    status: {
-      label: 'Status',
-      fields: [],
-      default: false,
-      disabled: isNew,
-    },
-  } as const;
+  const tabConfig = knowledgeSourceTabConfig;
 
   const validTabs = useMemo(() => Object.keys(tabConfig), []);
   const defaultTab = useMemo(
@@ -248,34 +159,7 @@ function KnowledgeSourceFormPage() {
   const onSubmit = async (values: KnowledgeSourceFormValues) => {
     setSaving(true);
     try {
-      const payload: Partial<KnowledgeSourceDoc> = {
-        source_name: values.source_name,
-        description: values.description || '',
-        knowledge_type: values.knowledge_type,
-        scope: values.scope,
-        storage_mode: values.storage_mode as KnowledgeSourceDoc['storage_mode'],
-        chunk_size: values.chunk_size,
-        chunk_overlap: values.chunk_overlap,
-        disabled: values.disabled ? 1 : 0,
-        embedding_model: values.embedding_model || '',
-        vector_dimension: values.vector_dimension ?? 1536,
-        embedding_provider: values.embedding_provider || '',
-        chroma_mode: values.chroma_mode,
-        chroma_host: values.chroma_host || '',
-        chroma_port: values.chroma_port ?? 8000,
-        chroma_ssl: values.chroma_ssl ? 1 : 0,
-        pgvector_connection_mode: values.pgvector_connection_mode,
-        pgvector_table_name: values.pgvector_table_name || 'huf_knowledge_vectors',
-        pgvector_distance_metric: values.pgvector_distance_metric,
-        pgvector_index_type: values.pgvector_index_type,
-        pgvector_host: values.pgvector_host || '',
-        pgvector_port: values.pgvector_port ?? 5432,
-        pgvector_database: values.pgvector_database || '',
-        pgvector_user: values.pgvector_user || '',
-        pgvector_password: values.pgvector_password || '',
-        pgvector_sslmode: values.pgvector_sslmode,
-        advanced_config: stringifyAdvancedConfig(values.advanced_config),
-      };
+      const payload = buildKnowledgeSourcePayload(values);
 
       if (isNew) {
         const created = await createKnowledgeSource(payload);
@@ -398,27 +282,16 @@ function KnowledgeSourceFormPage() {
           onOpenInputs={() => setInputsModalOpen(true)}
         />
 
-        <Form {...form}>
-          <form onSubmit={handleFormSubmit} className="space-y-6">
-            <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-              <TabsList layout="grid" cols={2}>
-                {Object.entries(tabConfig).map(([tabKey, config]) => (
-                  <TabsTrigger key={tabKey} value={tabKey} disabled={config.disabled}>
-                    {config.label}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-
-              <TabsContent value="general" className="space-y-4">
-                <GeneralTab form={form} isNew={isNew} providers={providers} />
-              </TabsContent>
-
-              <TabsContent value="status" className="space-y-4">
-                <StatusTab source={sourceDoc} />
-              </TabsContent>
-            </Tabs>
-          </form>
-        </Form>
+        <KnowledgeSourceForm
+          form={form}
+          isNew={isNew}
+          providers={providers}
+          sourceDoc={sourceDoc}
+          showStatusTab
+          activeTab={activeTab}
+          onTabChange={handleTabChange}
+          onSubmit={handleFormSubmit}
+        />
 
         {!isNew && id && (
           <KnowledgeInputsModal


### PR DESCRIPTION
## Summary

Inside the Agent editor (`/agents/:id`), the agent-in-progress lives only in local `react-hook-form` state. Clicking "create a new knowledge source" or "New" prompt template used to call `navigate()` to a standalone route (`/knowledge/new`, `/prompts/new`), abandoning the in-progress agent form and taking the user out of flow entirely. Triggers already avoid this bug — `TriggersTab`/`TriggerModal` create in-context via a `Dialog`, no navigation. This PR extends that pattern to Knowledge and Prompt Templates.

- **Knowledge**: extracted `KnowledgeSourceForm` as a shared, presentational component now consumed by both the standalone `/knowledge/new`/`:id` route (behavior unchanged) and a new `KnowledgeSourceCreateModal`, opened in-context from `AgentKnowledgeModal`. New sources attach directly to the agent's local Knowledge state, same as linking an existing source.
- **Prompt Templates**: added a create-only `PromptTemplateCreateModal` for the agent editor's "New" button, replacing the `navigate()` + `returnTo`/localStorage round-trip with a direct in-modal create + auto-select. The standalone `/prompts/new` route and its other `returnTo` consumers (e.g. `AdvancedTab`'s summary-prompt flow) are untouched.

Both preserve the existing "agent must be saved first" precondition, and both new modals include a dirty-close confirm guard so accidental Escape/backdrop-click doesn't silently discard input.

## Scope / follow-ups
The same navigate-away-from-unsaved-agent-form pattern exists at four more entry points in the agent editor, not touched here: MCP servers, summary prompts, execution profiles, and SSH connections (all in `AgentFormPage.tsx`/`AdvancedTab.tsx`). Deferred as follow-up work using the same in-context-modal pattern established in this PR, not silently left broken.

"Automations" (from the original bug report) maps to Agent Triggers, which already uses the correct in-context pattern — no change needed there. The separate `/flows` Flow-builder feature (which has its own "Automation" flow type) is not currently invoked from the agent editor, so it's out of scope.

## Testing
- `yarn typecheck` passes with no errors.
- `yarn lint` fails with a pre-existing environment error (`minimatch`/ESLint 9 config-array crash) that reproduces identically on `develop` — not introduced by this change.
- Reviewed via an independent code-review pass: no correctness bugs found; the standalone `/knowledge/new` and `/prompts/new` routes were diffed to confirm the extraction is byte-for-byte equivalent, not a behavior change.

## Test plan
- [ ] Manually verify: open an existing agent, Knowledge tab, "create a new knowledge source" — modal opens in place, new source appears selected/linked without leaving the page.
- [ ] Manually verify: General tab, Prompt Template "New" — modal opens in place, new template is selected in the combobox without navigation.
- [ ] Manually verify nested-dialog stacking: ESC closes only the innermost create modal, not the parent picker dialog.
- [ ] Manually verify standalone `/knowledge/new` and `/prompts/new` (direct navigation, not from agent editor) still work identically.