### PR TITLE
fix(dashboard): route Executions tab click to execution detail, not chat

### DIFF
--- a/frontend/src/components/dashboard/views/RecentExecutionsTab.tsx
+++ b/frontend/src/components/dashboard/views/RecentExecutionsTab.tsx
@@ -52,8 +52,8 @@ export function RecentExecutionsTab({ runs: providedRuns, loading: providedLoadi
   }, [providedRuns, providedLoading]);
 
   const handleExecutionClick = (run: AgentRunDoc) => {
-    if (run.conversation) {
-      navigate(`/chat/${run.conversation}`);
+    if (run.name) {
+      navigate(`/executions/${run.name}`);
     }
   };
 
@@ -77,7 +77,7 @@ export function RecentExecutionsTab({ runs: providedRuns, loading: providedLoadi
           const duration = calculateDuration(run.start_time, run.end_time);
           const timeAgo = formatTimeAgo(run.start_time);
           const status = getExecutionStatus(run.status);
-          const isClickable = Boolean(run.conversation);
+          const isClickable = Boolean(run.name);
 
           return (
             <LedgerRow


### PR DESCRIPTION
## Summary
- On `/huf/dashboard`, clicking an item in the Executions tab navigated to `/chat/<conversation>` instead of the execution detail page.
- `RecentExecutionsTab.tsx` now navigates to `/executions/<run.name>`, matching the pattern already used by the standalone Executions list page (`Executions.tsx`).
- `isClickable` gating updated from `Boolean(run.conversation)` to `Boolean(run.name)` (execution `name` is always present; `conversation` was often absent, which was also making some rows non-clickable).

## Test plan
- [x] `yarn typecheck` clean
- [x] Reproduced the reported bug live on the `pre-dev-stg` verification bench (headless authenticated session, no password entry) — clicking an execution row navigated to `/huf/chat/<conversation-id>`
- [x] Confirmed the destination route `/executions/:runId` already exists and renders via `AgentRunDetailPageWrapper`
- [ ] Not deployed/re-verified end-to-end against the shared `pre-dev-stg` bench, to avoid mutating shared staging infra for an unrelated verification pass — fix mirrors the identical, already-shipped navigation pattern in `Executions.tsx`