### PR TITLE
fix: add frappe-dependencies to pyproject.toml for Frappe Cloud compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ build-backend = "flit_core.buildapi"
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
## Description
This PR resolves an installation failure that occurs when adding the `huf` app from GitHub via Frappe Cloud (or newer bench versions). 

The installer was throwing the following error:
> "Could not find compatible Frappe version in pyproject.toml file. Please ensure `[tool.bench.frappe-dependencies]` is defined."

## Changes
- Added the `[tool.bench.frappe-dependencies]` section to `pyproject.toml`.
- Explicitly set the supported Frappe version to `>=15.0.0`.

## Impact
This change enables successful remote installations and deployments of the app on environments that enforce this `pyproject.toml` configuration check (like Frappe Cloud).
