### PR TITLE
feat(agent): Text/Voice/Both modality mode for Agent config

### DIFF
--- a/frontend/src/components/agent/AdvancedTab.tsx
+++ b/frontend/src/components/agent/AdvancedTab.tsx
@@ -79,6 +79,7 @@ export function AdvancedTab({
 	loadingMemoryPolicies = false,
 }: AdvancedTabProps) {
 	const imageModels = allModels.filter((m) => modelSupports(m, MODEL_MODALITY_IMAGE));
+	const isVoiceOnly = form.watch('agent_modality') === 'Voice';
 	const contextStrategy = form.watch('context_strategy');
 	const summaryPromptMode = form.watch('summary_prompt_mode');
 	const enableConversationData = form.watch('enable_conversation_data');
@@ -99,6 +100,7 @@ export function AdvancedTab({
 
 	return (
 		<div className="space-y-12">
+			{!isVoiceOnly && (<>
 			<FormSettingsSection
 				title="Conversation strategy"
 				description="Define the rules for how the agent manages its memory window when a conversation grows long and approaches token limits."
@@ -717,6 +719,7 @@ export function AdvancedTab({
 					</>
 				)}
 			</FormSettingsSection>
+			</>)}
 
 			<FormSettingsSection
 				title="Huf UI"
@@ -773,6 +776,7 @@ This includes whether each tool call is completed and its corresponding result.`
 				/>
 			</FormSettingsSection>
 
+			{!isVoiceOnly && (
 			<FormSettingsSection
 				title="Model modality settings"
 				description="Optional: select a dedicated model for image generation."
@@ -810,7 +814,9 @@ This includes whether each tool call is completed and its corresponding result.`
 					/>
 				</div>
 			</FormSettingsSection>
+			)}
 
+			{!isVoiceOnly && (
 			<FormSettingsSection
 				title="Document upload"
 				description="Let users attach documents or images in chat for this agent."
@@ -888,6 +894,7 @@ This includes whether each tool call is completed and its corresponding result.`
 					)}
 				</div>
 			</FormSettingsSection>
+			)}
 		</div>
 	);
 }

--- a/frontend/src/components/agent/AgentHeader.tsx
+++ b/frontend/src/components/agent/AgentHeader.tsx
@@ -65,6 +65,7 @@ export function AgentHeader({
   totalRun,
 }: AgentHeaderProps) {
   const watchModel = form.watch('model');
+  const isVoiceOnly = form.watch('agent_modality') === 'Voice';
   const navigate = useNavigate();
 
   const handleOpenChat = () => {
@@ -104,9 +105,11 @@ export function AgentHeader({
               System
             </Badge>
           )}
+          {!isVoiceOnly && (
           <Badge variant="chip">
             {models.find(m => m.name === watchModel)?.model_name || watchModel || 'Model'}
           </Badge>
+          )}
           {activeTriggerCount > 0 && (
             <span className="text-xs text-steel-soft flex items-center gap-1">
               <Clock className="w-3 h-3 shrink-0" />
@@ -121,10 +124,10 @@ export function AgentHeader({
         </div>
       </div>
       <div className="flex items-center gap-2">
-        {!isNew && (<Button 
-          variant="outline" 
-          size="icon-sm" 
-          onClick={onRunTest} 
+        {!isNew && !isVoiceOnly && (<Button
+          variant="outline"
+          size="icon-sm"
+          onClick={onRunTest}
           type="button"
           disabled={runningTest || isNew}
           title={isNew ? 'Save agent first to run test' : runningTest ? 'Running...' : 'Run test'}

--- a/frontend/src/components/agent/GeneralTab.tsx
+++ b/frontend/src/components/agent/GeneralTab.tsx
@@ -86,7 +86,18 @@ export function GeneralTab({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Modality</FormLabel>
-                <Select onValueChange={field.onChange} value={field.value} disabled={locked}>
+                <Select
+                  onValueChange={(value) => {
+                    field.onChange(value);
+                    if (value === 'Text') {
+                      form.setValue('voice_enabled', false);
+                    } else if (value === 'Voice') {
+                      form.setValue('voice_enabled', true);
+                    }
+                  }}
+                  value={field.value}
+                  disabled={locked}
+                >
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Select modality" />

--- a/frontend/src/components/agent/GeneralTab.tsx
+++ b/frontend/src/components/agent/GeneralTab.tsx
@@ -23,7 +23,7 @@ interface GeneralTabProps {
   form: UseFormReturn<AgentFormValues>;
   providers: AIProvider[];
   models: AIModel[];
-  watchProvider: string;
+  watchProvider: string | undefined;
   optimizingPrompt: boolean;
   onOptimizePrompt: () => void;
   promptOptions: AgentPromptOption[];
@@ -48,6 +48,8 @@ export function GeneralTab({
   const watchEnablePromptCaching = form.watch('enable_prompt_caching');
   const watchModel = form.watch('model');
   const promptMode = form.watch('prompt_mode');
+  const watchModality = form.watch('agent_modality');
+  const isVoiceOnly = watchModality === 'Voice';
 
   const [cacheStatus, setCacheStatus] = useState<CacheableModelsResponse | null>(null);
 
@@ -71,8 +73,49 @@ export function GeneralTab({
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>LLM configuration</CardTitle>
-          <CardDescription>Configure language model settings</CardDescription>
+          <CardTitle>Modality</CardTitle>
+          <CardDescription>
+            What this agent talks to users through. Voice-only hides text/LLM settings that a
+            realtime voice call doesn&apos;t use; Text-only hides voice settings.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <FormField
+            control={form.control}
+            name="agent_modality"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Modality</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value} disabled={locked}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select modality" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="Text">Text only</SelectItem>
+                    <SelectItem value="Voice">Voice only</SelectItem>
+                    <SelectItem value="Both">Text and Voice</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  {field.value === 'Voice'
+                    ? 'This agent only handles realtime voice calls. Tools, knowledge, skills, and text-model settings are hidden.'
+                    : field.value === 'Text'
+                      ? 'This agent only handles text chat. The Voice tab is hidden.'
+                      : 'This agent handles both text chat and voice calls.'}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Agent Identity</CardTitle>
+          <CardDescription>Name and description for this agent.</CardDescription>
         </CardHeader>
         <CardContent className="grid gap-6 sm:grid-cols-2">
           <div className="sm:col-span-2">
@@ -118,6 +161,16 @@ export function GeneralTab({
               </Accordion>
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      {!isVoiceOnly && (
+      <Card>
+        <CardHeader>
+          <CardTitle>LLM configuration</CardTitle>
+          <CardDescription>Configure language model settings</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6 sm:grid-cols-2">
           <FormField
             control={form.control}
             name="provider"
@@ -238,6 +291,7 @@ We generally recommend altering this or temperature but not both.`}
           />
         </CardContent>
       </Card>
+      )}
 
       <Card>
         <CardHeader>
@@ -314,6 +368,7 @@ We generally recommend altering this or temperature but not both.`}
         />
       )}
 
+      {!isVoiceOnly && (
       <Card>
         <CardHeader>
           <CardTitle>Starter prompts</CardTitle>
@@ -378,7 +433,9 @@ We generally recommend altering this or temperature but not both.`}
           )}
         </CardContent>
       </Card>
+      )}
 
+      {!isVoiceOnly && (
       <Card>
         <CardHeader>
           <CardTitle>Prompt caching</CardTitle>
@@ -490,6 +547,7 @@ We generally recommend altering this or temperature but not both.`}
           )}
         </CardContent>
       </Card>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/agent/types.ts
+++ b/frontend/src/components/agent/types.ts
@@ -2,8 +2,9 @@ import * as z from 'zod';
 
 export const agentFormSchema = z.object({
   agent_name: z.string().min(1, 'Agent name is required'),
-  provider: z.string().min(1, 'Provider is required'),
-  model: z.string().min(1, 'Model is required'),
+  agent_modality: z.enum(['Text', 'Voice', 'Both']).default('Both'),
+  provider: z.string().optional(),
+  model: z.string().optional(),
   temperature: z.number().min(0).max(2),
   top_p: z.number().min(0).max(1),
   disabled: z.boolean(),
@@ -115,6 +116,22 @@ export const agentFormSchema = z.object({
   allow_rich_elements: z.boolean().optional(),
   allow_document_artifacts: z.boolean().optional(),
 }).superRefine((values, ctx) => {
+  if (values.agent_modality !== 'Voice') {
+    if (!values.provider?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["provider"],
+        message: 'Provider is required',
+      });
+    }
+    if (!values.model?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["model"],
+        message: 'Model is required',
+      });
+    }
+  }
   if (values.prompt_mode === "Template" && !values.agent_prompt?.trim()) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -96,6 +96,7 @@ function normalizeFlag(value: boolean | number | undefined): 0 | 1 {
 function mapAgentDocToFormValues(agent: Partial<AgentDoc>): AgentFormValues {
   return {
     agent_name: agent.agent_name || '',
+    agent_modality: (agent.agent_modality as AgentFormValues['agent_modality']) || 'Both',
     provider: agent.provider || '',
     model: agent.model || '',
     temperature: agent.temperature ?? 1,
@@ -304,7 +305,7 @@ export function AgentFormPage() {
   const tabLabels = Object.fromEntries(
     Object.entries(tabConfig).map(([key, config]) => [key, config.label])
   );
-  
+
   // State to track active tab from URL hash
   const [activeTab, setActiveTab] = useState<string>(() => {
     const hashFromUrl = window.location.hash.slice(1); // Remove the # symbol
@@ -382,6 +383,7 @@ export function AgentFormPage() {
     resolver: zodResolver(agentFormSchema),
       defaultValues: {
         agent_name: '',
+        agent_modality: 'Both',
         provider: '',
         model: '',
         temperature: 1,
@@ -459,6 +461,30 @@ export function AgentFormPage() {
   const watchProvider = form.watch('provider');
   const watchDisabled = form.watch('disabled');
   const isDirty = form.formState.isDirty;
+
+  // Voice-only agents don't use text-model tools/knowledge/skills; text-only
+  // agents have no use for the Voice tab. Tabs stay registered in tabConfig
+  // (field mapping / section-save still works) but are hidden from the tab bar.
+  const watchModality = form.watch('agent_modality');
+  const hiddenTabs = useMemo(() => {
+    const hidden = new Set<string>();
+    if (watchModality === 'Voice') {
+      hidden.add('tools');
+      hidden.add('knowledge');
+      hidden.add('skills');
+    } else if (watchModality === 'Text') {
+      hidden.add('voice');
+    }
+    return hidden;
+  }, [watchModality]);
+
+  // If the modality change hides the currently active tab, fall back to General.
+  useEffect(() => {
+    if (hiddenTabs.has(activeTab)) {
+      setActiveTab(defaultTab);
+      window.history.replaceState(null, '', window.location.pathname);
+    }
+  }, [hiddenTabs, activeTab, defaultTab]);
   
   // Check if tools have changed by comparing tool names
   const toolsChanged = useMemo(() => {
@@ -1451,6 +1477,7 @@ export function AgentFormPage() {
       // Convert form values (booleans) to AgentDoc format (numbers 0/1)
       const agentData: AgentUpdatePayload = {
         agent_name: values.agent_name,
+        agent_modality: values.agent_modality,
         provider: values.provider,
         model: values.model,
         temperature: values.temperature,
@@ -1647,6 +1674,7 @@ export function AgentFormPage() {
         // Reset form state with the created agent's values
         form.reset({
           agent_name: newAgent.agent_name || '',
+          agent_modality: (newAgent.agent_modality as AgentFormValues['agent_modality']) || 'Both',
           provider: newAgent.provider || '',
           model: newAgent.model || '',
           temperature: newAgent.temperature ?? 1,
@@ -1748,6 +1776,7 @@ export function AgentFormPage() {
         // Reset form state with the updated values to mark form as clean
         form.reset({
           agent_name: values.agent_name,
+          agent_modality: values.agent_modality,
           provider: values.provider,
           model: values.model,
           temperature: values.temperature,
@@ -2297,7 +2326,7 @@ export function AgentFormPage() {
           <form onSubmit={handleFormSubmit} className="space-y-6">
             <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
               <TabsList layout="overflow" className="w-full">
-                {Object.entries(tabConfig).map(([tabKey, config]) => (
+                {Object.entries(tabConfig).filter(([tabKey]) => !hiddenTabs.has(tabKey)).map(([tabKey, config]) => (
                   <TabsTrigger
                     key={tabKey}
                     value={tabKey}

--- a/frontend/src/pages/AgentFormPage.tsx
+++ b/frontend/src/pages/AgentFormPage.tsx
@@ -206,7 +206,7 @@ export function AgentFormPage() {
   const tabConfig = useMemo(() => ({
     general: {
       label: 'General',
-      fields: ['agent_name', 'provider', 'model', 'temperature', 'top_p', 'disabled', 'run_immediately', 'description', 'instructions', 'starter_prompts', 'enable_prompt_caching', 'cache_control_type', 'cache_system_message', 'cache_conversation_history', 'prompt_mode', 'agent_prompt', 'prompt_version_locked', 'template_version_at_attach'],
+      fields: ['agent_name', 'agent_modality', 'provider', 'model', 'temperature', 'top_p', 'disabled', 'run_immediately', 'description', 'instructions', 'starter_prompts', 'enable_prompt_caching', 'cache_control_type', 'cache_system_message', 'cache_conversation_history', 'prompt_mode', 'agent_prompt', 'prompt_version_locked', 'template_version_at_attach'],
       default: true,
       disabled: false,
     },

--- a/frontend/src/types/agent.types.ts
+++ b/frontend/src/types/agent.types.ts
@@ -242,6 +242,7 @@ export interface AgentDoc {
 
   // Agent specific fields
   agent_name: string;
+  agent_modality?: "Text" | "Voice" | "Both";
   provider: string;
   model: string;
   provider_brand?: string | null;

--- a/huf/ai/agent_config_api.py
+++ b/huf/ai/agent_config_api.py
@@ -43,6 +43,7 @@ from frappe.utils import get_datetime
 AGENT_SECTIONS: dict[str, tuple[str, ...]] = {
 	"general": (
 		"agent_name",
+		"agent_modality",
 		"provider",
 		"model",
 		"temperature",

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -9,6 +9,7 @@
   "general_tab",
   "llm_configuration_section",
   "agent_name",
+  "agent_modality",
   "provider",
   "provider_brand",
   "temperature",
@@ -160,30 +161,44 @@
    "unique": 1
   },
   {
+   "default": "Both",
+   "description": "What this agent talks to users through. 'Text' hides Voice tab and voice/TTS settings. 'Voice' hides the LLM/text-model settings and text-only tabs (Tools, Knowledge, Skills) not used by a realtime voice call. 'Both' shows everything (default, matches prior behavior).",
+   "fieldname": "agent_modality",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Modality",
+   "options": "Text\nVoice\nBoth",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.agent_modality != 'Voice'",
    "description": "The AI provider that will power this agent (e.g., OpenAI, OpenRouter).",
    "documentation_url": "https://docs.huf.ai/docs/concepts/providers-models/",
    "fieldname": "provider",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Provider",
-   "options": "AI Provider",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.agent_modality != 'Voice'",
+   "options": "AI Provider"
   },
   {
    "fieldname": "column_break_df8m",
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:doc.agent_modality != 'Voice'",
    "description": "The specific AI model to use from the selected provider (e.g., gpt-4-turbo).",
    "documentation_url": "https://docs.huf.ai/docs/concepts/providers-models/",
    "fieldname": "model",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Model",
-   "options": "AI Model",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.agent_modality != 'Voice'",
+   "options": "AI Model"
   },
   {
+   "depends_on": "eval:doc.agent_modality != 'Text'",
    "description": "Specific model for Text-to-Speech (Audio Generation). If unset, defaults to the provider's default TTS model.",
    "fieldname": "tts_model",
    "fieldtype": "Link",
@@ -191,6 +206,7 @@
    "options": "AI Model"
   },
   {
+   "depends_on": "eval:doc.agent_modality != 'Text'",
    "description": "Voice to use for TTS (e.g. alloy, echo, onyx).",
    "fieldname": "tts_voice",
    "fieldtype": "Data",
@@ -276,6 +292,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.agent_modality != 'Text'",
    "description": "Let users talk to this agent, not just type. Voice and text are two ways into the same agent — the same instructions, tools and knowledge apply.",
    "fieldname": "voice_enabled",
    "fieldtype": "Check",
@@ -840,11 +857,13 @@
    "label": "Instruction"
   },
   {
+   "depends_on": "eval:doc.agent_modality != 'Text'",
    "fieldname": "audio_generation_section",
    "fieldtype": "Section Break",
    "label": "Audio Generation"
   },
   {
+   "depends_on": "eval:doc.agent_modality != 'Text'",
    "description": "Specific model for Speech-to-Text (Audio Transcription). If unset, defaults to the provider's default STT model.",
    "fieldname": "stt_model",
    "fieldtype": "Link",
@@ -852,6 +871,7 @@
    "options": "AI Model"
   },
   {
+   "depends_on": "eval:doc.agent_modality != 'Text'",
    "fieldname": "audio_transcription_section",
    "fieldtype": "Section Break",
    "label": "Audio Transcription"

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -129,6 +129,7 @@ class Agent(Document):
         self._validate_allowed_users_and_roles()
         self._update_mcp_tool_counts()
         self._ensure_publishable_key()
+        self._sync_modality_voice_flag()
 
     def _ensure_publishable_key(self):
         """Auto-generate a publishable key when embedding is enabled.
@@ -138,6 +139,19 @@ class Agent(Document):
         """
         if self.embed_enabled and not self.publishable_key:
             self.publishable_key = f"pk_{frappe.generate_hash(length=32)}"
+
+    def _sync_modality_voice_flag(self):
+        """Keep voice_enabled consistent with agent_modality.
+
+        Runs on every validate() so it self-heals if agent_modality is changed
+        without the older voice_enabled checkbox being updated, which would
+        otherwise leave a Text agent silently voice-reachable or a Voice-only
+        agent with no working channel.
+        """
+        if self.agent_modality == "Text":
+            self.voice_enabled = 0
+        elif self.agent_modality == "Voice":
+            self.voice_enabled = 1
 
     def _validate_skills(self):
         """Prevent duplicate skills from being attached to an agent."""

--- a/huf/huf/doctype/agent/test_agent.py
+++ b/huf/huf/doctype/agent/test_agent.py
@@ -130,6 +130,86 @@ class TestAgent(IntegrationTestCase):
         with self.assertRaises(frappe.ValidationError):
             agent.before_rename("__test_system_agent__", "__renamed_system_agent__")
 
+    def test_modality_text_forces_voice_disabled(self):
+        """A Text-modality agent must self-heal voice_enabled back to 0 on validate."""
+        model, provider = _any_model_and_provider()
+        if not model:
+            self.skipTest("no AI Model records on this site")
+
+        agent = frappe.get_doc(
+            {
+                "doctype": "Agent",
+                "agent_name": "__test_modality_text__",
+                "agent_modality": "Text",
+                "voice_enabled": 1,
+                "provider": provider,
+                "model": model,
+                "instructions": "modality text probe",
+            }
+        )
+        try:
+            agent.insert(ignore_permissions=True)
+            self.assertEqual(agent.voice_enabled, 0)
+        finally:
+            frappe.db.delete("Agent", {"agent_name": "__test_modality_text__"})
+            frappe.db.commit()
+
+    def test_modality_voice_forces_voice_enabled(self):
+        """A Voice-modality agent must self-heal voice_enabled back to 1 on validate."""
+        agent = frappe.get_doc(
+            {
+                "doctype": "Agent",
+                "agent_name": "__test_modality_voice__",
+                "agent_modality": "Voice",
+                "voice_enabled": 0,
+                "instructions": "modality voice probe",
+            }
+        )
+        try:
+            agent.insert(ignore_permissions=True)
+            self.assertEqual(agent.voice_enabled, 1)
+        finally:
+            frappe.db.delete("Agent", {"agent_name": "__test_modality_voice__"})
+            frappe.db.commit()
+
+    def test_modality_both_leaves_voice_enabled_untouched(self):
+        """A Both-modality agent must not have voice_enabled overwritten by validate."""
+        model, provider = _any_model_and_provider()
+        if not model:
+            self.skipTest("no AI Model records on this site")
+
+        agent_on = frappe.get_doc(
+            {
+                "doctype": "Agent",
+                "agent_name": "__test_modality_both_on__",
+                "agent_modality": "Both",
+                "voice_enabled": 1,
+                "provider": provider,
+                "model": model,
+                "instructions": "modality both probe (voice_enabled=1)",
+            }
+        )
+        agent_off = frappe.get_doc(
+            {
+                "doctype": "Agent",
+                "agent_name": "__test_modality_both_off__",
+                "agent_modality": "Both",
+                "voice_enabled": 0,
+                "provider": provider,
+                "model": model,
+                "instructions": "modality both probe (voice_enabled=0)",
+            }
+        )
+        try:
+            agent_on.insert(ignore_permissions=True)
+            agent_off.insert(ignore_permissions=True)
+            self.assertEqual(agent_on.voice_enabled, 1)
+            self.assertEqual(agent_off.voice_enabled, 0)
+        finally:
+            frappe.db.delete("Agent", {"agent_name": "__test_modality_both_on__"})
+            frappe.db.delete("Agent", {"agent_name": "__test_modality_both_off__"})
+            frappe.db.commit()
+
 
 class TestSystemAgentLocking(IntegrationTestCase):
     """Guards for system-agent (is_system=1) locking: immutability and list hiding.


### PR DESCRIPTION
## Why

PR #584 gave agents real per-agent voice (`voice_enabled`/`voice_engine`/`voice_config`/`voice_greeting`, a dedicated Voice tab, a live-verified ElevenLabs engine), but it's purely additive: every agent still carries the full set of LLM/text settings — provider, model, tools, knowledge, skills, reasoning, memory, prompt caching, starter prompts — whether or not it's ever used. A pure voice-only agent has no way to shed that dead weight; it's still presented as "a text agent with voice bolted on".

## What's in here

Adds `agent_modality` (Select: `Text` / `Voice` / `Both`, default `Both` to preserve current behavior for every existing agent) and uses it to scope the UI to what the agent actually needs:

- **Voice-only** hides: LLM Configuration, Prompt Caching, Starter Prompts, Conversation Strategy/Summarization/Limits, Conversation Data, Reasoning, Memory, Model Modality (image gen), Document Upload sections in General/Advanced, the Tools & MCP / Knowledge / Skills tabs, the text-run "Run Test" header action, and the model badge in the header.
- **Text-only** hides the Voice tab entirely.
- **Both** (default) shows everything — unchanged from current behavior.

Backend: `provider`/`model` become conditionally required (`mandatory_depends_on: eval:doc.agent_modality != 'Voice'`) instead of unconditionally `reqd`, both in the doctype JSON and the frontend zod schema, so a Voice-only agent can be created without picking an LLM provider/model. Matching `depends_on` added to the Desk form fields (`provider`, `model`, `voice_enabled`, `tts_model`, `tts_voice`, `stt_model`, and their section breaks) so Desk admins see the same gating as the React frontend.

`voice_enabled` itself is untouched as the real "is voice live" switch — `agent_modality` only controls which tabs/fields the UI surfaces, so nothing about the already-shipped voice engine plumbing (ElevenLabs engine, realtime sidecar, embed credentials) changes.

## Deliberately out of scope

This is a UX/scoping change on top of the existing voice foundation, not a rework of it. Not touched:
- Whether voice calls can use Huf tools/knowledge (they currently can't per #584's scope — Tools/Knowledge/Skills tabs are simply not relevant yet for a Voice-only agent).
- Any change to the ElevenLabs/OpenAI-Realtime engines themselves.

## Verification

- `tsc -p tsconfig.app.json --noEmit` clean.
- Doctype JSON parses; `field_order` unchanged in membership (only `depends_on`/`mandatory_depends_on` added to existing fields, one new field inserted).
- **Live-verified on a dedicated bench** (`voice-modality`, this branch, fresh `bench new-site` + `install-app` + `bench build`):
  - New Agent form defaults to "Text and Voice" (all tabs/sections present, matching pre-existing behavior).
  - Switching Modality to "Voice only" live-hides the Tools & MCP / Knowledge / Skills tabs and the header's model badge, and the General tab drops to Modality / Agent Identity / Prompt source / Instructions only (no LLM Configuration, Starter Prompts, or Prompt Caching cards).
  - Switching to "Text only" hides the Voice tab and restores Tools & MCP / Knowledge / Skills.
  - Created a real Voice-only agent end-to-end with no `provider`/`model` set — saved successfully (no "Provider is required" error), confirming the conditional-required wiring works both client- and server-side.