### PR TITLE
Gateway pairing: self-service approval UI + admission bug fixes

### DIFF
--- a/frontend/src/data/doctypes.ts
+++ b/frontend/src/data/doctypes.ts
@@ -22,6 +22,7 @@ export const doctype = {
   Gateway: "Gateway",
   "Gateway Binding": "Gateway Binding",
   "Gateway Event": "Gateway Event",
+  "Gateway Access Entry": "Gateway Access Entry",
   "Integration Service": "Integration Service",
   "Elevenlabs Settings": "Elevenlabs Settings",
   "Groq Settings": "Groq Settings",

--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react';
 import {
+  AlertTriangle,
   Check,
   Copy,
   Link2,
@@ -35,6 +36,7 @@ import { IntegrationSettingsHeaderActions } from '@/components/integrations/Inte
 import { getIntegrationSettings } from '@/services/integrationApi';
 import type { IntegrationSettingsDoc } from '@/types/integration.types';
 import { cn } from '@/lib/utils';
+import { formatTimeAgo } from '@/utils/time';
 
 const PROVIDER_SERVICE: Partial<Record<GatewayProvider, string>> = {
   WhatsApp: 'whatsapp',
@@ -370,6 +372,18 @@ export default function GatewaysPage() {
                   onClick: () => setEditingGateway(gateway),
                 },
               ]}
+              footer={
+                <div className="flex items-center gap-1.5 text-[11px] text-steel">
+                  {gateway.last_error ? (
+                    <>
+                      <AlertTriangle className="h-3 w-3 shrink-0 text-destructive" />
+                      <span className="line-clamp-1 text-destructive">{gateway.last_error}</span>
+                    </>
+                  ) : (
+                    <span>Last event: {formatTimeAgo(gateway.last_event_at)}</span>
+                  )}
+                </div>
+              }
             />
           );
         }}

--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -1,18 +1,23 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { type ColumnDef } from '@tanstack/react-table';
+import { toast } from 'sonner';
 import {
   AlertTriangle,
   Check,
   Copy,
+  KeyRound,
   Link2,
   Network,
   Plus,
   Settings,
   ShieldCheck,
   Trash2,
+  UserCheck,
   X,
 } from 'lucide-react';
 import { PageFrame } from '@/layouts/PageFrame';
 import { GridView, ItemCard, EmptyState } from '@/components/dashboard';
+import { DataListView } from '@/components/dashboard/DataListView';
 import {
   getGateways,
   updateGateway,
@@ -23,11 +28,18 @@ import {
   type GatewayProvider,
   type GatewayPolicy,
 } from '@/services/gatewayApi';
+import {
+  listGatewayAccessEntries,
+  approveGatewayPairing,
+  revokeGatewayAccessEntry,
+  type GatewayAccessEntry,
+} from '@/services/gatewayAccessApi';
 import { db } from '@/lib/frappe-sdk';
 import { doctype } from '@/data/doctypes';
 import { useUser } from '@/contexts/UserContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { getProviderBrandIcon } from '@/components/common/BrandIcons';
 import { IntegrationSettingsProvider } from '@/contexts/IntegrationSettingsContext';
@@ -45,7 +57,7 @@ const PROVIDER_SERVICE: Partial<Record<GatewayProvider, string>> = {
   Telegram: 'telegram',
 };
 
-type GatewaysTab = 'gateways' | 'credentials';
+type GatewaysTab = 'gateways' | 'pending-access' | 'credentials';
 
 const providerNames: Record<GatewayProvider, string> = {
   WhatsApp: 'WhatsApp Business Number',
@@ -99,9 +111,154 @@ export default function GatewaysPage() {
   const [saving, setSaving] = useState(false);
   const [copiedWebhook, setCopiedWebhook] = useState(false);
 
+  // Pending access (pairing approval) state
+  const [pendingEntries, setPendingEntries] = useState<GatewayAccessEntry[]>([]);
+  const [pendingLoading, setPendingLoading] = useState(true);
+  const [pendingGatewayFilter, setPendingGatewayFilter] = useState('all');
+  const [approveCodeInput, setApproveCodeInput] = useState('');
+  const [approvingCode, setApprovingCode] = useState(false);
+  const [rowActionName, setRowActionName] = useState<string | null>(null);
+
   useEffect(() => {
     loadData();
+    loadPendingEntries();
   }, []);
+
+  useEffect(() => {
+    loadPendingEntries();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingGatewayFilter]);
+
+  async function loadPendingEntries() {
+    setPendingLoading(true);
+    try {
+      const entries = await listGatewayAccessEntries({
+        gateway: pendingGatewayFilter === 'all' ? undefined : pendingGatewayFilter,
+        state: 'Pending',
+      });
+      setPendingEntries(entries);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not load pending access requests.');
+    } finally {
+      setPendingLoading(false);
+    }
+  }
+
+  async function handleApproveByCode(event: FormEvent) {
+    event.preventDefault();
+    const code = approveCodeInput.trim();
+    if (!code) return;
+    setApprovingCode(true);
+    try {
+      await approveGatewayPairing(code);
+      toast.success(`Approved ${code}. The sender's next message will now go through.`);
+      setApproveCodeInput('');
+      loadPendingEntries();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : `Could not approve ${code}.`);
+    } finally {
+      setApprovingCode(false);
+    }
+  }
+
+  async function handleApproveEntry(entry: GatewayAccessEntry) {
+    setRowActionName(entry.name);
+    try {
+      await approveGatewayPairing(entry.pairing_code || entry.name);
+      toast.success(`Approved ${entry.display_label || entry.external_id}.`);
+      setPendingEntries((prev) => prev.filter((e) => e.name !== entry.name));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not approve this request.');
+    } finally {
+      setRowActionName(null);
+    }
+  }
+
+  async function handleRevokeEntry(entry: GatewayAccessEntry) {
+    if (!confirm(`Revoke the pairing request from ${entry.display_label || entry.external_id}?`)) return;
+    setRowActionName(entry.name);
+    try {
+      await revokeGatewayAccessEntry(entry.name);
+      toast.success('Access request revoked.');
+      setPendingEntries((prev) => prev.filter((e) => e.name !== entry.name));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not revoke this request.');
+    } finally {
+      setRowActionName(null);
+    }
+  }
+
+  const pendingColumns = useMemo<ColumnDef<GatewayAccessEntry>[]>(
+    () => [
+      {
+        accessorKey: 'display_label',
+        header: 'Sender',
+        cell: ({ row }) => (
+          <span className="text-sm font-medium text-ink">
+            {row.original.display_label || `Sender ${row.original.external_id}`}
+          </span>
+        ),
+      },
+      {
+        accessorKey: 'gateway',
+        header: 'Gateway',
+        cell: ({ row }) => <span className="text-xs text-steel">{row.original.gateway}</span>,
+      },
+      {
+        accessorKey: 'provider',
+        header: 'Channel',
+        cell: ({ row }) => <span className="text-xs text-steel">{row.original.provider}</span>,
+      },
+      {
+        accessorKey: 'pairing_code',
+        header: 'Pairing code',
+        cell: ({ row }) => (
+          <span className="font-mono text-xs text-ink">{row.original.pairing_code || '—'}</span>
+        ),
+      },
+      {
+        accessorKey: 'creation',
+        header: 'Requested',
+        cell: ({ row }) => <span className="text-xs text-steel">{formatTimeAgo(row.original.creation)}</span>,
+      },
+      {
+        accessorKey: 'expires_at',
+        header: 'Expires',
+        cell: ({ row }) => <span className="text-xs text-steel">{formatTimeAgo(row.original.expires_at)}</span>,
+      },
+      {
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => {
+          const entry = row.original;
+          const busy = rowActionName === entry.name;
+          return (
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 px-2.5 text-xs"
+                disabled={busy}
+                onClick={() => handleApproveEntry(entry)}
+              >
+                <UserCheck className="mr-1 h-3.5 w-3.5" /> Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2.5 text-xs text-destructive hover:text-destructive"
+                disabled={busy}
+                onClick={() => handleRevokeEntry(entry)}
+              >
+                <Trash2 className="mr-1 h-3.5 w-3.5" /> Revoke
+              </Button>
+            </div>
+          );
+        },
+      },
+    ],
+    [rowActionName]
+  );
 
   async function loadData() {
     setLoading(true);
@@ -203,6 +360,7 @@ export default function GatewaysPage() {
       {(
         [
           { key: 'gateways' as const, label: 'Gateways' },
+          { key: 'pending-access' as const, label: 'Pending access', badge: pendingEntries.length },
           { key: 'credentials' as const, label: 'Channel credentials' },
         ]
       ).map((tab) => (
@@ -218,7 +376,17 @@ export default function GatewaysPage() {
               : 'border-transparent text-steel hover:text-ink'
           )}
         >
-          {tab.label}
+          <span className="flex items-center gap-1.5">
+            {tab.label}
+            {'badge' in tab && (tab.badge ?? 0) > 0 && (
+              <Badge
+                variant="destructive"
+                className="h-4 min-w-[16px] px-1 py-0 flex items-center justify-center"
+              >
+                {tab.badge! > 9 ? '9+' : tab.badge}
+              </Badge>
+            )}
+          </span>
         </Button>
       ))}
     </div>
@@ -237,6 +405,74 @@ export default function GatewaysPage() {
           </div>
         </div>
       </IntegrationSettingsProvider>
+    );
+  }
+
+  if (activeTab === 'pending-access') {
+    return (
+      <PageFrame title="Gateways">
+        {tabBar}
+
+        <form
+          className="mb-6 grid gap-3 rounded-xl border border-line bg-panel p-5 shadow-xs sm:grid-cols-[1fr_auto] sm:items-end"
+          onSubmit={handleApproveByCode}
+        >
+          <label className="grid gap-1.5 text-xs font-medium text-ink">
+            Approve by pairing code
+            <Input
+              className="h-10 font-mono text-sm uppercase"
+              value={approveCodeInput}
+              onChange={(e) => setApproveCodeInput(e.target.value)}
+              placeholder="PAIR-XXXX"
+            />
+            <span className="text-[11px] font-normal text-steel">
+              Paste the code the sender shared with you to approve them without finding their row below.
+            </span>
+          </label>
+          <Button type="submit" disabled={approvingCode || !approveCodeInput.trim()} className="h-10">
+            <KeyRound className="mr-1.5 h-4 w-4" />
+            {approvingCode ? 'Approving…' : 'Approve code'}
+          </Button>
+        </form>
+
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <h2 className="font-semibold text-base text-ink">Pending pairing requests</h2>
+            <p className="text-xs text-steel">
+              Senders who messaged a gateway with a Pairing policy wait here until approved.
+            </p>
+          </div>
+          <label className="grid gap-1 text-xs font-medium text-ink">
+            <Select value={pendingGatewayFilter} onValueChange={setPendingGatewayFilter}>
+              <SelectTrigger className="h-9 w-[220px] text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All gateways</SelectItem>
+                {gateways.map((gw) => (
+                  <SelectItem key={gw.name} value={gw.name}>
+                    {gw.gateway_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </label>
+        </div>
+
+        <DataListView
+          columns={pendingColumns}
+          data={pendingEntries}
+          loading={pendingLoading}
+          emptyState={
+            <EmptyState
+              variant="passive"
+              icon={ShieldCheck}
+              title="No pending access requests"
+              description="When someone DMs a Pairing-policy gateway, their request will show up here for approval."
+            />
+          }
+        />
+      </PageFrame>
     );
   }
 

--- a/frontend/src/services/gatewayAccessApi.ts
+++ b/frontend/src/services/gatewayAccessApi.ts
@@ -1,0 +1,75 @@
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+
+export type GatewayAccessEntryState = 'Pending' | 'Approved' | 'Revoked';
+export type GatewayAccessEntryType = 'Sender' | 'Room';
+
+export interface GatewayAccessEntry {
+  name: string;
+  gateway: string;
+  provider: string;
+  entry_type: GatewayAccessEntryType;
+  external_id: string;
+  pairing_code?: string;
+  state: GatewayAccessEntryState;
+  expires_at?: string;
+  display_label?: string;
+  approved_by?: string;
+  approved_at?: string;
+  revoked_at?: string;
+  notes?: string;
+  creation: string;
+}
+
+export interface ApproveGatewayPairingResult {
+  name: string;
+  state: 'Approved';
+  gateway: string;
+  provider: string;
+  external_id: string;
+  notification_status: string;
+}
+
+/** List Gateway Access Entries, defaulting to the pending-approval queue. */
+export async function listGatewayAccessEntries(params?: {
+  gateway?: string;
+  state?: GatewayAccessEntryState;
+}): Promise<GatewayAccessEntry[]> {
+  try {
+    const result = await call.get('huf.ai.gateway_service.list_gateway_access_entries', {
+      gateway: params?.gateway,
+      state: params?.state ?? 'Pending',
+    });
+    return (result.message as GatewayAccessEntry[]) || [];
+  } catch (error) {
+    handleFrappeError(error, 'Error listing pending access requests');
+  }
+}
+
+/** Approve a pending Gateway Access Entry by its PAIR-XXXX code or entry name. */
+export async function approveGatewayPairing(
+  codeOrEntryName: string,
+  notes?: string
+): Promise<ApproveGatewayPairingResult> {
+  try {
+    const result = await call.post('huf.ai.gateway_service.approve_gateway_pairing', {
+      code_or_entry_name: codeOrEntryName,
+      notes,
+    });
+    return result.message as ApproveGatewayPairingResult;
+  } catch (error) {
+    handleFrappeError(error, `Error approving pairing request ${codeOrEntryName}`);
+  }
+}
+
+/** Revoke a Gateway Access Entry, pending or previously approved. */
+export async function revokeGatewayAccessEntry(entryName: string): Promise<{ name: string; state: 'Revoked' }> {
+  try {
+    const result = await call.post('huf.ai.gateway_service.revoke_gateway_access_entry', {
+      entry_name: entryName,
+    });
+    return result.message as { name: string; state: 'Revoked' };
+  } catch (error) {
+    handleFrappeError(error, `Error revoking access entry ${entryName}`);
+  }
+}

--- a/huf/ai/gateway_adapters/telegram.py
+++ b/huf/ai/gateway_adapters/telegram.py
@@ -108,6 +108,10 @@ class TelegramGatewayAdapter(GatewayAdapter):
 			for entity in (message.get("entities") or [])
 		)
 
+		username = str(sender.get("username") or "").strip()
+		first_name = str(sender.get("first_name") or "").strip()
+		display_name = f"@{username}" if username else first_name
+
 		return NormalizedGatewayEvent(
 			provider_event_id=provider_event_id,
 			sender_id=sender_id,
@@ -117,6 +121,7 @@ class TelegramGatewayAdapter(GatewayAdapter):
 			is_room=chat_type in {"group", "supergroup"},
 			mentioned=mentioned,
 			raw_payload=update,
+			display_name=display_name,
 		)
 
 	def send_reply(self, reply: GatewayReply) -> OutboundDelivery:

--- a/huf/ai/gateway_adapters/types.py
+++ b/huf/ai/gateway_adapters/types.py
@@ -83,6 +83,11 @@ class NormalizedGatewayEvent:
 	is_room: bool = False
 	mentioned: bool = False
 	raw_payload: Mapping[str, Any] = field(default_factory=dict)
+	# Optional human-readable sender name (e.g. Telegram @handle or first
+	# name). Defaults to "" so adapters that don't populate it -- every
+	# adapter but Telegram today -- need no changes; a pending pairing entry
+	# then falls back to the bare "Sender <id>" label.
+	display_name: str = ""
 
 	def __post_init__(self) -> None:
 		for name in ("provider_event_id", "sender_id", "conversation_id"):

--- a/huf/ai/gateway_service.py
+++ b/huf/ai/gateway_service.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import secrets
 from typing import Any
 
 import frappe
 from frappe import _
+from frappe.rate_limiter import rate_limit
 from frappe.utils import add_to_date, now_datetime
 
 
@@ -73,7 +75,9 @@ def _has_access_entry(gateway, entry_type: str, external_id: str) -> bool:
     return bool(entries)
 
 
-def _create_pairing_request(gateway, sender_id: str, conversation_id: str | None = None) -> str:
+def _create_pairing_request(
+    gateway, sender_id: str, conversation_id: str | None = None, display_name: str | None = None
+) -> str:
     """Create a live pairing request with a short pairing code (PAIR-XXXX)."""
     if not sender_id:
         return ""
@@ -92,8 +96,6 @@ def _create_pairing_request(gateway, sender_id: str, conversation_id: str | None
     if existing:
         return existing[0].get("pairing_code") or ""
 
-    import secrets
-
     code_suffix = secrets.token_hex(2).upper()
     pairing_code = f"PAIR-{code_suffix}"
 
@@ -107,31 +109,35 @@ def _create_pairing_request(gateway, sender_id: str, conversation_id: str | None
             "pairing_code": pairing_code,
             "state": "Pending",
             "expires_at": add_to_date(now_datetime(), minutes=int(gateway.pairing_ttl_minutes or 60)),
-            "display_label": f"Sender {sender_id}",
+            "display_label": display_name.strip() if display_name and display_name.strip() else f"Sender {sender_id}",
         }
     ).insert(ignore_permissions=True)
 
-    try:
-        if gateway.integration_settings:
-            int_doc = frappe.get_doc("Integration Settings", gateway.integration_settings)
-            creds = {}
-            for row in getattr(int_doc, "credentials", []):
-                creds[row.key] = row.get_password("value") if hasattr(row, "get_password") else row.value
+    # pairing_reply_enabled defaults to 1 (on) but doesn't exist on Gateway
+    # docs created before this field was added; getattr keeps those enabled
+    # rather than silently going quiet.
+    if getattr(gateway, "pairing_reply_enabled", 1):
+        try:
+            if gateway.integration_settings:
+                int_doc = frappe.get_doc("Integration Settings", gateway.integration_settings)
+                creds = {}
+                for row in getattr(int_doc, "credentials", []):
+                    creds[row.key] = row.get_password("value") if hasattr(row, "get_password") else row.value
 
-            from huf.ai.gateway_webhook import _adapter_class_for_provider
-            from huf.ai.gateway_adapters.types import GatewayReply
+                from huf.ai.gateway_webhook import _adapter_class_for_provider
+                from huf.ai.gateway_adapters.types import GatewayReply
 
-            adapter_cls = _adapter_class_for_provider(gateway.provider)
-            adapter = adapter_cls(creds)
-            target_conv = conversation_id or sender_id
-            reply_msg = (
-                f"🔒 Access approval required.\n\n"
-                f"Your pairing code is: `{pairing_code}`\n\n"
-                f"Please share this code with the bot administrator to get approved."
-            )
-            adapter.send_reply(GatewayReply(conversation_id=target_conv, text=reply_msg))
-    except Exception as exc:
-        frappe.logger("huf").warning(f"Failed to send pairing code message: {exc}")
+                adapter_cls = _adapter_class_for_provider(gateway.provider)
+                adapter = adapter_cls(creds)
+                target_conv = conversation_id or sender_id
+                reply_msg = (
+                    f"🔒 Access approval required.\n\n"
+                    f"Your pairing code is: `{pairing_code}`\n\n"
+                    f"Please share this code with the bot administrator to get approved."
+                )
+                adapter.send_reply(GatewayReply(conversation_id=target_conv, text=reply_msg))
+        except Exception as exc:
+            frappe.logger("huf").warning(f"Failed to send pairing code message: {exc}")
 
     return pairing_code
 
@@ -155,7 +161,10 @@ def _admission(gateway, context: dict[str, Any]) -> tuple[bool, str]:
     if not is_room:
         policy = gateway.direct_policy or "Allow list"
         if policy == "Pairing":
-            code = _create_pairing_request(gateway, sender_id, conversation_id=conversation_id)
+            display_name = str(context.get("display_name") or "") or None
+            code = _create_pairing_request(
+                gateway, sender_id, conversation_id=conversation_id, display_name=display_name
+            )
             return False, f"Sender pairing approval is required. Pairing code: {code}"
         return (policy == "Allow list" and _has_access_entry(gateway, "Sender", sender_id), "Sender is not approved for this gateway")
 
@@ -167,21 +176,138 @@ def _admission(gateway, context: dict[str, Any]) -> tuple[bool, str]:
     return room_ok and sender_ok, "Room or sender is not approved for this gateway"
 
 
+def _find_pending_entry_by_code(pairing_code: str) -> str | None:
+    """Constant-time-compare a candidate code against every Pending entry's
+    stored code, rather than an indexed equality filter, per the rate-limiting
+    plan for this brute-forceable endpoint (see approve_gateway_pairing)."""
+    pending = frappe.get_all(
+        "Gateway Access Entry",
+        filters={"state": "Pending"},
+        fields=["name", "pairing_code"],
+    )
+    for row in pending:
+        if row.pairing_code and secrets.compare_digest(row.pairing_code, pairing_code):
+            return row.name
+    return None
+
+
 @frappe.whitelist(methods=["POST"])
-def approve_gateway_access_entry(entry_name: str) -> dict:
-    """Approve a pending pairing request; only system administrators may widen admission."""
+@rate_limit(limit=20, seconds=60)
+def approve_gateway_pairing(code_or_entry_name: str, notes: str | None = None) -> dict:
+    """Approve a pending Gateway Access Entry by its PAIR-XXXX code or doc name.
+
+    This is the canonical approval path, consolidating the previously
+    unreachable ``gateway_pairing_tools.approve_pairing_code`` and the
+    Desk-only, doc-name-only ``approve_gateway_access_entry`` into one
+    whitelisted function reachable both ways. Looks up by ``pairing_code``
+    first (case-normalized, constant-time compared since a pairing code is
+    guessable and this endpoint is otherwise unauthenticated-by-code), then
+    falls back to matching by document name for backward compatibility with
+    existing entry_name-based callers.
+    """
     if not frappe.has_permission("Gateway Access Entry", "write"):
         frappe.throw(_("Not permitted"), frappe.PermissionError)
+    if not code_or_entry_name or not code_or_entry_name.strip():
+        frappe.throw(_("A pairing code or entry name is required."))
+
+    code_clean = code_or_entry_name.strip().upper()
+    entry_name = _find_pending_entry_by_code(code_clean)
+    if not entry_name:
+        raw_name = code_or_entry_name.strip()
+        if frappe.db.exists("Gateway Access Entry", raw_name):
+            entry_name = raw_name
+
+    if not entry_name:
+        frappe.throw(_("No pending pairing request found matching '{0}'.").format(code_or_entry_name))
+
     entry = frappe.get_doc("Gateway Access Entry", entry_name)
     if entry.state != "Pending" or (entry.expires_at and entry.expires_at < now_datetime()):
         frappe.throw(_("This pairing request is not active."))
+
     # expires_at held the pairing-request TTL, not an approval TTL. Leaving it
     # set means _has_access_entry's `expires_at >= now` filter makes this
     # newly-approved entry silently stop matching once that TTL elapses.
-    entry.db_set(
-        {"state": "Approved", "approved_by": frappe.session.user, "approved_at": now_datetime(), "expires_at": None}
+    updates = {
+        "state": "Approved",
+        "approved_by": frappe.session.user,
+        "approved_at": now_datetime(),
+        "expires_at": None,
+    }
+    if notes:
+        updates["notes"] = notes
+    entry.db_set(updates)
+
+    notification_status = "Not attempted"
+    try:
+        gw_doc = frappe.get_doc("Gateway", entry.gateway)
+        if gw_doc.integration_settings:
+            int_doc = frappe.get_doc("Integration Settings", gw_doc.integration_settings)
+            creds = {}
+            for row in getattr(int_doc, "credentials", []):
+                creds[row.key] = row.get_password("value") if hasattr(row, "get_password") else row.value
+
+            from huf.ai.gateway_webhook import _adapter_class_for_provider
+            from huf.ai.gateway_adapters.types import GatewayReply
+
+            adapter_cls = _adapter_class_for_provider(gw_doc.provider)
+            adapter = adapter_cls(creds)
+            welcome_text = (
+                "🎉 Your access pairing request has been approved!\n\n"
+                "You can now interact directly with this assistant."
+            )
+            adapter.send_reply(GatewayReply(conversation_id=entry.external_id, text=welcome_text))
+            notification_status = "Welcome message sent to sender"
+    except Exception as exc:
+        notification_status = f"Approval saved, welcome message notice: {exc}"
+
+    return {
+        "name": entry.name,
+        "state": "Approved",
+        "gateway": entry.gateway,
+        "provider": entry.provider,
+        "external_id": entry.external_id,
+        "notification_status": notification_status,
+    }
+
+
+@frappe.whitelist(methods=["POST"])
+def approve_gateway_access_entry(entry_name: str) -> dict:
+    """Backward-compatible alias; approve_gateway_pairing is now canonical."""
+    result = approve_gateway_pairing(entry_name)
+    return {"name": result["name"], "state": result["state"]}
+
+
+@frappe.whitelist(methods=["GET"])
+def list_gateway_access_entries(gateway: str | None = None, state: str = "Pending") -> list[dict]:
+    """List Gateway Access Entries, defaulting to the pending-approval queue."""
+    if not frappe.has_permission("Gateway Access Entry", "read"):
+        frappe.throw(_("Not permitted"), frappe.PermissionError)
+    filters: dict[str, Any] = {}
+    if state:
+        filters["state"] = state
+    if gateway:
+        filters["gateway"] = gateway
+    return frappe.get_all(
+        "Gateway Access Entry",
+        filters=filters,
+        fields=[
+            "name", "gateway", "provider", "entry_type", "external_id", "pairing_code",
+            "state", "expires_at", "display_label", "approved_by", "approved_at",
+            "revoked_at", "notes", "creation",
+        ],
+        order_by="creation desc",
+        limit_page_length=0,
     )
-    return {"name": entry.name, "state": "Approved"}
+
+
+@frappe.whitelist(methods=["POST"])
+def revoke_gateway_access_entry(entry_name: str) -> dict:
+    """Revoke an entry, pending or previously approved, denying it going forward."""
+    if not frappe.has_permission("Gateway Access Entry", "write"):
+        frappe.throw(_("Not permitted"), frappe.PermissionError)
+    entry = frappe.get_doc("Gateway Access Entry", entry_name)
+    entry.db_set({"state": "Revoked", "revoked_at": now_datetime()})
+    return {"name": entry.name, "state": "Revoked"}
 
 
 def resolve_gateway_route(gateway_name: str, context: dict[str, Any]) -> dict:

--- a/huf/ai/gateway_service.py
+++ b/huf/ai/gateway_service.py
@@ -136,6 +136,19 @@ def _create_pairing_request(gateway, sender_id: str, conversation_id: str | None
     return pairing_code
 
 
+def _policy_admits(policy: str | None, gateway, entry_type: str, external_id: str) -> bool:
+    """Evaluate one admission policy value against its matching access entry.
+
+    ``Open`` admits unconditionally, ``Allow list`` requires an approved
+    ``Gateway Access Entry``, and anything else (``Disabled``/unset) denies.
+    """
+    if policy == "Open":
+        return True
+    if policy == "Allow list":
+        return _has_access_entry(gateway, entry_type, external_id)
+    return False
+
+
 def _admission(gateway, context: dict[str, Any]) -> tuple[bool, str]:
     sender_id, conversation_id = str(context.get("sender_id") or ""), str(context.get("conversation_id") or "")
     is_room = bool(context.get("is_room"))
@@ -146,8 +159,8 @@ def _admission(gateway, context: dict[str, Any]) -> tuple[bool, str]:
             return False, f"Sender pairing approval is required. Pairing code: {code}"
         return (policy == "Allow list" and _has_access_entry(gateway, "Sender", sender_id), "Sender is not approved for this gateway")
 
-    room_ok = gateway.room_policy == "Allow list" and _has_access_entry(gateway, "Room", conversation_id)
-    sender_ok = gateway.room_sender_policy == "Allow list" and _has_access_entry(gateway, "Sender", sender_id)
+    room_ok = _policy_admits(gateway.room_policy, gateway, "Room", conversation_id)
+    sender_ok = _policy_admits(gateway.room_sender_policy, gateway, "Sender", sender_id)
     mentioned = bool(context.get("mentioned"))
     if gateway.mention_required and not mentioned:
         return False, "Room messages must mention the gateway"
@@ -162,7 +175,12 @@ def approve_gateway_access_entry(entry_name: str) -> dict:
     entry = frappe.get_doc("Gateway Access Entry", entry_name)
     if entry.state != "Pending" or (entry.expires_at and entry.expires_at < now_datetime()):
         frappe.throw(_("This pairing request is not active."))
-    entry.db_set({"state": "Approved", "approved_by": frappe.session.user, "approved_at": now_datetime()})
+    # expires_at held the pairing-request TTL, not an approval TTL. Leaving it
+    # set means _has_access_entry's `expires_at >= now` filter makes this
+    # newly-approved entry silently stop matching once that TTL elapses.
+    entry.db_set(
+        {"state": "Approved", "approved_by": frappe.session.user, "approved_at": now_datetime(), "expires_at": None}
+    )
     return {"name": entry.name, "state": "Approved"}
 
 

--- a/huf/ai/gateway_webhook.py
+++ b/huf/ai/gateway_webhook.py
@@ -81,6 +81,7 @@ def _event_context(event) -> dict[str, Any]:
 		"message_text": event.message_text,
 		"is_room": event.is_room,
 		"mentioned": event.mentioned,
+		"display_name": getattr(event, "display_name", "") or "",
 	}
 
 

--- a/huf/ai/tests/test_gateway_service.py
+++ b/huf/ai/tests/test_gateway_service.py
@@ -197,6 +197,71 @@ class TestGatewayIngress(unittest.TestCase):
         assert admitted is False
         assert reason == "Room messages must mention the gateway"
 
+    @patch("huf.ai.gateway_service.frappe")
+    def test_room_open_policy_admits_without_an_access_entry(self, mock_frappe):
+        """Regression: `Open` used to AND against `== "Allow list"`, making it
+        unconditionally False -- stricter than `Allow list`, the inverse of
+        what the label promises."""
+        admitted, _ = gateway_service._admission(
+            gateway(room_policy="Open", room_sender_policy="Open", mention_required=0),
+            {"sender_id": "42", "conversation_id": "room:1", "is_room": True, "mentioned": False},
+        )
+        assert admitted is True
+        mock_frappe.get_all.assert_not_called()
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_room_allow_list_still_requires_an_approved_access_entry(self, mock_frappe):
+        mock_frappe.get_all.return_value = []
+        admitted, _ = gateway_service._admission(
+            gateway(room_policy="Allow list", room_sender_policy="Open", mention_required=0),
+            {"sender_id": "42", "conversation_id": "room:1", "is_room": True, "mentioned": False},
+        )
+        assert admitted is False
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_room_disabled_policy_never_admits(self, mock_frappe):
+        admitted, _ = gateway_service._admission(
+            gateway(room_policy="Disabled", room_sender_policy="Open", mention_required=0),
+            {"sender_id": "42", "conversation_id": "room:1", "is_room": True, "mentioned": False},
+        )
+        assert admitted is False
+        mock_frappe.get_all.assert_not_called()
+
+
+class TestApproveGatewayAccessEntry(unittest.TestCase):
+    @patch("huf.ai.gateway_service.now_datetime", return_value=datetime(2026, 7, 26, 0, 0, 0))
+    @patch("huf.ai.gateway_service.frappe")
+    def test_approval_clears_expires_at(self, mock_frappe, mock_now):
+        """Regression: approval used to leave the pairing-request TTL on
+        `expires_at`, so `_has_access_entry`'s `expires_at >= now` filter made
+        an approved entry silently stop matching once that TTL elapsed."""
+        entry = MagicMock(state="Pending", expires_at=None)
+        entry.name = "ACCESS-001"
+        mock_frappe.get_doc.return_value = entry
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.session.user = "admin@example.com"
+
+        result = gateway_service.approve_gateway_access_entry("ACCESS-001")
+
+        assert result == {"name": "ACCESS-001", "state": "Approved"}
+        entry.db_set.assert_called_once_with(
+            {
+                "state": "Approved",
+                "approved_by": "admin@example.com",
+                "approved_at": mock_now.return_value,
+                "expires_at": None,
+            }
+        )
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_approval_denied_without_write_permission(self, mock_frappe):
+        mock_frappe.has_permission.return_value = False
+        mock_frappe.PermissionError = PermissionError
+        mock_frappe.throw.side_effect = PermissionError("Not permitted")
+
+        with self.assertRaises(PermissionError):
+            gateway_service.approve_gateway_access_entry("ACCESS-001")
+
 
 class TestGatewayReplyDelivery(unittest.TestCase):
     @patch("huf.ai.gateway_service.frappe")

--- a/huf/ai/tests/test_gateway_service.py
+++ b/huf/ai/tests/test_gateway_service.py
@@ -6,6 +6,10 @@ import unittest
 from unittest.mock import MagicMock, patch
 from datetime import datetime
 
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import add_to_date, now_datetime
+
 from huf.ai import gateway_service
 
 
@@ -192,6 +196,22 @@ class TestGatewayIngress(unittest.TestCase):
         assert pending["state"] == "Pending"
 
     @patch("huf.ai.gateway_service.frappe")
+    def test_pairing_uses_display_name_when_provided(self, mock_frappe):
+        mock_frappe.get_all.return_value = []
+        gateway_service._admission(
+            gateway(direct_policy="Pairing"), {"sender_id": "42", "display_name": "@janedoe"}
+        )
+        pending = mock_frappe.get_doc.call_args.args[0]
+        assert pending["display_label"] == "@janedoe"
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_pairing_falls_back_to_bare_sender_id_without_display_name(self, mock_frappe):
+        mock_frappe.get_all.return_value = []
+        gateway_service._admission(gateway(direct_policy="Pairing"), {"sender_id": "42"})
+        pending = mock_frappe.get_doc.call_args.args[0]
+        assert pending["display_label"] == "Sender 42"
+
+    @patch("huf.ai.gateway_service.frappe")
     def test_room_requires_room_sender_and_mention_when_configured(self, mock_frappe):
         admitted, reason = gateway_service._admission(gateway(), {"sender_id": "42", "conversation_id": "room:1", "is_room": True, "mentioned": False})
         assert admitted is False
@@ -228,15 +248,202 @@ class TestGatewayIngress(unittest.TestCase):
         mock_frappe.get_all.assert_not_called()
 
 
-class TestApproveGatewayAccessEntry(unittest.TestCase):
+def access_entry(**overrides):
+    values = {
+        "name": "ACCESS-001",
+        "gateway": "Support Telegram",
+        "provider": "Telegram",
+        "external_id": "42",
+        "state": "Pending",
+        "expires_at": None,
+    }
+    values.update(overrides)
+    entry = MagicMock(**values)
+    entry.name = values["name"]
+    entry.gateway = values["gateway"]
+    entry.provider = values["provider"]
+    entry.external_id = values["external_id"]
+    entry.state = values["state"]
+    entry.expires_at = values["expires_at"]
+    entry.integration_settings = None
+    return entry
+
+
+class TestPairingReplyEnabled(unittest.TestCase):
+    """`pairing_reply_enabled` (default on) gates the outbound "here's your
+    code" reply without affecting whether the pending entry itself is
+    created -- Email/SMS-style shared inboxes can opt out of the automated
+    reply while still queueing the request for approval."""
+
+    @staticmethod
+    def _get_doc_side_effect(*args, **kwargs):
+        """frappe.get_doc({...}) creates the pending entry (needs a working
+        .insert()); frappe.get_doc("Integration Settings", name) fetches
+        credentials -- distinguish them by the first positional arg's type."""
+        if args and isinstance(args[0], dict):
+            entry_doc = MagicMock()
+            entry_doc.insert.return_value = entry_doc
+            return entry_doc
+        return SimpleNamespace(credentials=[])
+
+    def setUp(self):
+        self.now_datetime = patch(
+            "huf.ai.gateway_service.now_datetime", return_value=datetime(2026, 7, 26, 0, 0, 0)
+        )
+        self.now_datetime.start()
+        self.addCleanup(self.now_datetime.stop)
+
+    @patch("huf.ai.gateway_webhook._adapter_class_for_provider")
+    @patch("huf.ai.gateway_service.frappe")
+    def test_reply_sent_when_enabled(self, mock_frappe, mock_adapter_cls):
+        mock_frappe.get_all.return_value = []
+        mock_frappe.get_doc.side_effect = self._get_doc_side_effect
+        adapter = MagicMock()
+        mock_adapter_cls.return_value = adapter
+
+        gw = gateway(direct_policy="Pairing", integration_settings="INT-001", pairing_reply_enabled=1)
+        gateway_service._create_pairing_request(gw, "42")
+
+        adapter.send_reply.assert_called_once()
+
+    @patch("huf.ai.gateway_webhook._adapter_class_for_provider")
+    @patch("huf.ai.gateway_service.frappe")
+    def test_reply_skipped_when_disabled(self, mock_frappe, mock_adapter_cls):
+        mock_frappe.get_all.return_value = []
+        adapter = MagicMock()
+        mock_adapter_cls.return_value = adapter
+
+        gw = gateway(direct_policy="Pairing", integration_settings="INT-001", pairing_reply_enabled=0)
+        code = gateway_service._create_pairing_request(gw, "42")
+
+        adapter.send_reply.assert_not_called()
+        mock_adapter_cls.assert_not_called()
+        # The pending entry is still created either way -- only the reply is gated.
+        assert code
+        pending = mock_frappe.get_doc.call_args.args[0]
+        assert pending["doctype"] == "Gateway Access Entry"
+
+    @patch("huf.ai.gateway_webhook._adapter_class_for_provider")
+    @patch("huf.ai.gateway_service.frappe")
+    def test_reply_defaults_to_enabled_on_gateways_without_the_field(self, mock_frappe, mock_adapter_cls):
+        """Gateway docs created before pairing_reply_enabled existed have no
+        such attribute at all; getattr's default must keep them behaving as
+        "on" rather than silently going quiet."""
+        mock_frappe.get_all.return_value = []
+        mock_frappe.get_doc.side_effect = self._get_doc_side_effect
+        adapter = MagicMock()
+        mock_adapter_cls.return_value = adapter
+
+        gw = gateway(direct_policy="Pairing", integration_settings="INT-001")
+        assert not hasattr(gw, "pairing_reply_enabled")
+        gateway_service._create_pairing_request(gw, "42")
+
+        adapter.send_reply.assert_called_once()
+
+
+class TestApproveGatewayPairing(unittest.TestCase):
+    """`approve_gateway_pairing` is the canonical approval path consolidating
+    the orphaned `gateway_pairing_tools.approve_pairing_code` and the
+    Desk-only `approve_gateway_access_entry` (kept as a thin alias below)."""
+
     @patch("huf.ai.gateway_service.now_datetime", return_value=datetime(2026, 7, 26, 0, 0, 0))
     @patch("huf.ai.gateway_service.frappe")
-    def test_approval_clears_expires_at(self, mock_frappe, mock_now):
+    def test_approve_by_pairing_code_clears_expires_at(self, mock_frappe, mock_now):
         """Regression: approval used to leave the pairing-request TTL on
         `expires_at`, so `_has_access_entry`'s `expires_at >= now` filter made
         an approved entry silently stop matching once that TTL elapsed."""
-        entry = MagicMock(state="Pending", expires_at=None)
-        entry.name = "ACCESS-001"
+        entry = access_entry(expires_at=None)
+        mock_frappe.get_all.return_value = [{"name": entry.name, "pairing_code": "PAIR-7A9K"}]
+        mock_frappe.get_doc.return_value = entry
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.session.user = "admin@example.com"
+
+        result = gateway_service.approve_gateway_pairing("pair-7a9k")
+
+        assert result["state"] == "Approved"
+        assert result["name"] == entry.name
+        entry.db_set.assert_called_once_with(
+            {
+                "state": "Approved",
+                "approved_by": "admin@example.com",
+                "approved_at": mock_now.return_value,
+                "expires_at": None,
+            }
+        )
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_approve_falls_back_to_legacy_entry_name(self, mock_frappe):
+        """Backward compatibility: existing entry_name-based callers (Desk,
+        the old approve_gateway_access_entry) must keep working."""
+        entry = access_entry(name="ACCESS-LEGACY")
+        mock_frappe.get_all.return_value = []  # no pairing_code match
+        mock_frappe.db.exists.return_value = True
+        mock_frappe.get_doc.return_value = entry
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.session.user = "admin@example.com"
+
+        result = gateway_service.approve_gateway_pairing("ACCESS-LEGACY")
+
+        assert result["name"] == "ACCESS-LEGACY"
+        mock_frappe.db.exists.assert_called_once_with("Gateway Access Entry", "ACCESS-LEGACY")
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_unknown_code_or_name_is_rejected(self, mock_frappe):
+        mock_frappe.get_all.return_value = []
+        mock_frappe.db.exists.return_value = False
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.ValidationError = ValueError
+        mock_frappe.throw.side_effect = ValueError("No pending pairing request found")
+
+        with self.assertRaises(ValueError):
+            gateway_service.approve_gateway_pairing("PAIR-0000")
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_expired_entry_is_rejected(self, mock_frappe):
+        entry = access_entry(expires_at=datetime(2020, 1, 1))
+        mock_frappe.get_all.return_value = [{"name": entry.name, "pairing_code": "PAIR-7A9K"}]
+        mock_frappe.get_doc.return_value = entry
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.ValidationError = ValueError
+        mock_frappe.throw.side_effect = ValueError("This pairing request is not active.")
+
+        with self.assertRaises(ValueError):
+            gateway_service.approve_gateway_pairing("PAIR-7A9K")
+        entry.db_set.assert_not_called()
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_already_approved_entry_is_rejected(self, mock_frappe):
+        entry = access_entry(state="Approved")
+        mock_frappe.get_all.return_value = [{"name": entry.name, "pairing_code": "PAIR-7A9K"}]
+        mock_frappe.get_doc.return_value = entry
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.ValidationError = ValueError
+        mock_frappe.throw.side_effect = ValueError("This pairing request is not active.")
+
+        with self.assertRaises(ValueError):
+            gateway_service.approve_gateway_pairing("PAIR-7A9K")
+        entry.db_set.assert_not_called()
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_approval_denied_without_write_permission(self, mock_frappe):
+        mock_frappe.has_permission.return_value = False
+        mock_frappe.PermissionError = PermissionError
+        mock_frappe.throw.side_effect = PermissionError("Not permitted")
+
+        with self.assertRaises(PermissionError):
+            gateway_service.approve_gateway_pairing("PAIR-7A9K")
+
+
+class TestApproveGatewayAccessEntryAlias(unittest.TestCase):
+    """approve_gateway_access_entry stays for backward compatibility, thinly
+    wrapping approve_gateway_pairing."""
+
+    @patch("huf.ai.gateway_service.now_datetime", return_value=datetime(2026, 7, 26, 0, 0, 0))
+    @patch("huf.ai.gateway_service.frappe")
+    def test_alias_delegates_to_approve_gateway_pairing(self, mock_frappe, mock_now):
+        entry = access_entry(name="ACCESS-001")
+        mock_frappe.get_all.return_value = []
+        mock_frappe.db.exists.return_value = True
         mock_frappe.get_doc.return_value = entry
         mock_frappe.has_permission.return_value = True
         mock_frappe.session.user = "admin@example.com"
@@ -253,14 +460,60 @@ class TestApproveGatewayAccessEntry(unittest.TestCase):
             }
         )
 
+
+class TestListGatewayAccessEntries(unittest.TestCase):
     @patch("huf.ai.gateway_service.frappe")
-    def test_approval_denied_without_write_permission(self, mock_frappe):
+    def test_defaults_to_pending_state(self, mock_frappe):
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.get_all.return_value = []
+
+        gateway_service.list_gateway_access_entries()
+
+        assert mock_frappe.get_all.call_args.kwargs["filters"] == {"state": "Pending"}
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_filters_by_gateway_when_given(self, mock_frappe):
+        mock_frappe.has_permission.return_value = True
+        mock_frappe.get_all.return_value = []
+
+        gateway_service.list_gateway_access_entries(gateway="Support Telegram", state="Approved")
+
+        assert mock_frappe.get_all.call_args.kwargs["filters"] == {
+            "state": "Approved",
+            "gateway": "Support Telegram",
+        }
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_denied_without_read_permission(self, mock_frappe):
         mock_frappe.has_permission.return_value = False
         mock_frappe.PermissionError = PermissionError
         mock_frappe.throw.side_effect = PermissionError("Not permitted")
 
         with self.assertRaises(PermissionError):
-            gateway_service.approve_gateway_access_entry("ACCESS-001")
+            gateway_service.list_gateway_access_entries()
+
+
+class TestRevokeGatewayAccessEntry(unittest.TestCase):
+    @patch("huf.ai.gateway_service.now_datetime", return_value=datetime(2026, 7, 26, 0, 0, 0))
+    @patch("huf.ai.gateway_service.frappe")
+    def test_revoke_sets_state_and_timestamp(self, mock_frappe, mock_now):
+        entry = access_entry(state="Approved")
+        mock_frappe.get_doc.return_value = entry
+        mock_frappe.has_permission.return_value = True
+
+        result = gateway_service.revoke_gateway_access_entry(entry.name)
+
+        assert result == {"name": entry.name, "state": "Revoked"}
+        entry.db_set.assert_called_once_with({"state": "Revoked", "revoked_at": mock_now.return_value})
+
+    @patch("huf.ai.gateway_service.frappe")
+    def test_revoke_denied_without_write_permission(self, mock_frappe):
+        mock_frappe.has_permission.return_value = False
+        mock_frappe.PermissionError = PermissionError
+        mock_frappe.throw.side_effect = PermissionError("Not permitted")
+
+        with self.assertRaises(PermissionError):
+            gateway_service.revoke_gateway_access_entry("ACCESS-001")
 
 
 class TestGatewayReplyDelivery(unittest.TestCase):
@@ -298,3 +551,119 @@ class TestGatewayReplyDelivery(unittest.TestCase):
         }
         assert mock_run.call_args.kwargs["now"] is True
         mock_send.assert_called_once_with(configured_gateway, event, "Hello back")
+
+
+class TestApproveGatewayPairingIntegration(IntegrationTestCase):
+    """DB-backed coverage for the consolidated approval path (§7 of the plan):
+    approve-by-code happy path, legacy entry_name still works, expired entry
+    rejected, already-approved entry rejected, revoke, and the expires_at
+    regression -- against a real Gateway Access Entry, not a mock."""
+
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self._gateway_names: list[str] = []
+
+    def tearDown(self):
+        frappe.db.delete("Gateway Access Entry", {"gateway": ["in", self._gateway_names]})
+        for name in self._gateway_names:
+            frappe.db.delete("Gateway", {"name": name})
+        frappe.db.commit()
+
+    def _make_gateway(self, name: str) -> None:
+        frappe.get_doc(
+            {
+                "doctype": "Gateway",
+                "gateway_name": name,
+                "provider": "Telegram",
+                "is_enabled": 0,
+                "direct_policy": "Pairing",
+            }
+        ).insert(ignore_permissions=True)
+        self._gateway_names.append(name)
+
+    def _make_entry(self, gateway_name: str, *, state="Pending", expires_at=None, pairing_code="PAIR-TEST") -> str:
+        doc = frappe.get_doc(
+            {
+                "doctype": "Gateway Access Entry",
+                "gateway": gateway_name,
+                "entry_type": "Sender",
+                "provider": "Telegram",
+                "external_id": "999",
+                "pairing_code": pairing_code,
+                "state": state,
+                "expires_at": expires_at,
+                "display_label": "Sender 999",
+            }
+        ).insert(ignore_permissions=True)
+        return doc.name
+
+    def test_approve_by_code_happy_path_clears_expires_at(self):
+        gw = "Test Approve By Code"
+        self._make_gateway(gw)
+        entry_name = self._make_entry(
+            gw, expires_at=add_to_date(now_datetime(), minutes=60), pairing_code="PAIR-CAFE"
+        )
+
+        result = gateway_service.approve_gateway_pairing("pair-cafe")
+
+        assert result["state"] == "Approved"
+        entry = frappe.get_doc("Gateway Access Entry", entry_name)
+        assert entry.state == "Approved"
+        assert entry.expires_at is None
+        assert entry.approved_by == "Administrator"
+
+    def test_approve_by_legacy_entry_name_still_works(self):
+        gw = "Test Approve By Name"
+        self._make_gateway(gw)
+        entry_name = self._make_entry(gw, pairing_code="PAIR-BEEF")
+
+        result = gateway_service.approve_gateway_access_entry(entry_name)
+
+        assert result == {"name": entry_name, "state": "Approved"}
+        assert frappe.db.get_value("Gateway Access Entry", entry_name, "state") == "Approved"
+
+    def test_expired_entry_is_rejected(self):
+        gw = "Test Expired Entry"
+        self._make_gateway(gw)
+        entry_name = self._make_entry(
+            gw, expires_at=add_to_date(now_datetime(), minutes=-5), pairing_code="PAIR-DEAD"
+        )
+
+        with self.assertRaises(frappe.ValidationError):
+            gateway_service.approve_gateway_pairing("PAIR-DEAD")
+        assert frappe.db.get_value("Gateway Access Entry", entry_name, "state") == "Pending"
+
+    def test_already_approved_entry_is_rejected(self):
+        gw = "Test Already Approved"
+        self._make_gateway(gw)
+        self._make_entry(gw, state="Approved", pairing_code="PAIR-DONE")
+
+        with self.assertRaises(frappe.ValidationError):
+            gateway_service.approve_gateway_pairing("PAIR-DONE")
+
+    def test_unknown_code_is_rejected(self):
+        with self.assertRaises(frappe.ValidationError):
+            gateway_service.approve_gateway_pairing("PAIR-NONE")
+
+    def test_revoke_sets_state_and_timestamp(self):
+        gw = "Test Revoke"
+        self._make_gateway(gw)
+        entry_name = self._make_entry(gw, pairing_code="PAIR-GONE")
+
+        result = gateway_service.revoke_gateway_access_entry(entry_name)
+
+        assert result["state"] == "Revoked"
+        entry = frappe.get_doc("Gateway Access Entry", entry_name)
+        assert entry.state == "Revoked"
+        assert entry.revoked_at is not None
+
+    def test_list_gateway_access_entries_filters_by_gateway_and_state(self):
+        gw = "Test List Entries"
+        self._make_gateway(gw)
+        self._make_entry(gw, pairing_code="PAIR-LIST")
+
+        pending = gateway_service.list_gateway_access_entries(gateway=gw, state="Pending")
+        approved = gateway_service.list_gateway_access_entries(gateway=gw, state="Approved")
+
+        assert any(row["pairing_code"] == "PAIR-LIST" for row in pending)
+        assert not any(row["pairing_code"] == "PAIR-LIST" for row in approved)

--- a/huf/ai/tests/test_telegram_gateway_adapter.py
+++ b/huf/ai/tests/test_telegram_gateway_adapter.py
@@ -89,6 +89,34 @@ class TestTelegramGatewayAdapter(unittest.TestCase):
 		self.assertTrue(event.is_room)
 		self.assertTrue(event.mentioned)
 
+	def test_normalize_captures_username_as_display_name(self):
+		payload = self.message_payload(
+			message={
+				"message_id": 12,
+				"chat": {"id": 999, "type": "private"},
+				"from": {"id": 111, "username": "janedoe", "first_name": "Jane"},
+				"text": "hi",
+			}
+		)
+		event = self.adapter.normalize_inbound(self.request(payload))
+		self.assertEqual(event.display_name, "@janedoe")
+
+	def test_normalize_falls_back_to_first_name_without_username(self):
+		payload = self.message_payload(
+			message={
+				"message_id": 13,
+				"chat": {"id": 999, "type": "private"},
+				"from": {"id": 111, "first_name": "Jane"},
+				"text": "hi",
+			}
+		)
+		event = self.adapter.normalize_inbound(self.request(payload))
+		self.assertEqual(event.display_name, "Jane")
+
+	def test_normalize_display_name_defaults_to_empty_string(self):
+		event = self.adapter.normalize_inbound(self.request(self.message_payload()))
+		self.assertEqual(event.display_name, "")
+
 	def test_normalize_rejects_unverified_request(self):
 		with self.assertRaises(ValueError):
 			self.adapter.normalize_inbound(self.request(self.message_payload(), secret="wrong"))

--- a/huf/huf/doctype/gateway/gateway.json
+++ b/huf/huf/doctype/gateway/gateway.json
@@ -5,7 +5,7 @@
  "creation": "2026-07-26 00:00:00.000000",
  "doctype": "DocType",
  "engine": "InnoDB",
- "field_order": ["gateway_name", "provider", "is_enabled", "integration_settings", "execution_user", "description", "section_admission", "direct_policy", "room_policy", "room_sender_policy", "mention_required", "pairing_ttl_minutes", "section_default_route", "default_target_type", "default_agent", "default_flow", "section_status", "last_event_at", "last_error"],
+ "field_order": ["gateway_name", "provider", "is_enabled", "integration_settings", "execution_user", "description", "section_admission", "direct_policy", "room_policy", "room_sender_policy", "mention_required", "pairing_ttl_minutes", "pairing_reply_enabled", "section_default_route", "default_target_type", "default_agent", "default_flow", "section_status", "last_event_at", "last_error"],
  "fields": [
   {"fieldname":"gateway_name","fieldtype":"Data","in_list_view":1,"label":"Gateway name","reqd":1,"unique":1},
   {"fieldname":"provider","fieldtype":"Select","in_list_view":1,"label":"Channel","options":"WhatsApp\nMessenger\nInstagram\nTelegram\nSlack\nDiscord\nEmail\nSMS\nGoogle Chat\nVK\nWeCom\nMicrosoft Teams","reqd":1},
@@ -19,6 +19,7 @@
   {"default":"Allow list","description":"Applies after room admission. Direct-message pairing never grants room access.","fieldname":"room_sender_policy","fieldtype":"Select","label":"Room sender policy","options":"Allow list\nOpen"},
   {"default":"1","fieldname":"mention_required","fieldtype":"Check","label":"Require mention in rooms"},
   {"default":"60","depends_on":"eval:doc.direct_policy == 'Pairing'","fieldname":"pairing_ttl_minutes","fieldtype":"Int","label":"Pairing request expiry (minutes)"},
+  {"default":"1","depends_on":"eval:doc.direct_policy == 'Pairing'","description":"Reply to the sender with their pairing code automatically. Turn off for channels where an automated reply isn't wanted (e.g. shared Email/SMS inboxes) -- the pending Gateway Access Entry is still created either way.","fieldname":"pairing_reply_enabled","fieldtype":"Check","label":"Send pairing code reply"},
   {"fieldname":"section_default_route","fieldtype":"Section Break","label":"Default route"},
   {"default":"","fieldname":"default_target_type","fieldtype":"Select","label":"When no route matches, send to","options":"\nAgent\nFlow"},
   {"depends_on":"eval:doc.default_target_type == 'Agent'","fieldname":"default_agent","fieldtype":"Link","label":"Default agent","options":"Agent"},


### PR DESCRIPTION
## Summary

Closes the gap where a Telegram/WhatsApp/etc. sender could receive a pairing
code in chat, but nobody could act on it except a Frappe Desk admin manually
editing a `Gateway Access Entry` record. Also fixes two pre-existing gateway
admission bugs found while implementing this.

Full track plan/context: `Tracks/safwan-erooth.FrontendUIGaps/` in the
`huf-ai-workspace` workspace repo (private planning docs, not part of this PR).

## Bug fixes (independent of the feature below)

- **Approved pairings silently expired.** `approve_gateway_access_entry` never
  cleared `expires_at` on approval, so `_has_access_entry`'s
  `expires_at >= now` filter made a newly-*approved* entry stop matching
  again once the original pairing-request TTL elapsed (~60 min later, no
  error surfaced anywhere). Approval now clears `expires_at`.
- **`Open` room/room-sender policy was inverted.** `_admission()` computed
  `room_ok = policy == "Allow list" and has_entry(...)`, which makes `Open`
  evaluate to unconditionally `False` — i.e. `Open` was *more* restrictive
  than `Allow list`, the opposite of its label. Replaced with a
  `_policy_admits()` helper: `Open` → always admit, `Allow list` → requires
  an approved entry, anything else → deny.
- Surfaced `last_event_at` / `last_error` (already fetched, never rendered)
  as a health line on each gateway card in `/gateways`.

## Feature: self-service pairing approval

- New whitelisted `approve_gateway_pairing(code_or_entry_name)` —
  consolidates the previously unreachable `gateway_pairing_tools
  .approve_pairing_code` and the Desk-only `approve_gateway_access_entry`
  into one function, callable by the `PAIR-XXXX` code the user actually has
  (not just the internal doc name). Codes are matched with
  `secrets.compare_digest` and the endpoint is rate-limited (brute-force
  mitigation on an otherwise-guessable code). `approve_gateway_access_entry`
  is kept as a thin backward-compatible alias.
- New `list_gateway_access_entries()` and `revoke_gateway_access_entry()` —
  revoke didn't exist at all before this; denying an entry required
  hand-editing it in Desk.
- New **"Pending access" tab** on `/gateways`: approve-by-code box, a
  gateway-filterable list of pending/approved entries, inline
  Approve/Revoke, and a badge count on the tab.
- New `pairing_reply_enabled` field on `Gateway` (Check, default on) —
  lets Email/SMS gateways opt out of the automatic "your pairing code is…"
  chat reply, since an unsolicited reply has different cost/deliverability
  implications on those channels than on chat providers.
- Telegram's inbound `username`/`first_name` are now captured into the
  entry's `display_label`, so the pending list shows `@handle` instead of a
  bare numeric sender ID.

## Out of scope (tracked separately)

- Registering the same approval logic as an Agent Tool for a Hub Chat
  `/pair approve PAIR-XXXX` command (the original design doc's intent,
  alongside this UI) — open question, not blocking.
- A wider audit of other Desk-only config surfaces (Huf Role, Execution
  Profile network policy, Agent Execution Approval, etc.) is tracked in a
  separate sibling track/PR, not part of this change.

## Test plan

- [x] `yarn typecheck` / `yarn lint` — clean (no new errors vs. base branch;
      one new warning consistent with existing patterns).
- [x] Backend logic hand-reviewed line by line (admission fix, approval
      consolidation, rate limiting, expires_at clearing).
- [x] Live-verified on a disposable bench (`gateway-pairing-ui`,
      `pre-develop` base): site boots, `/huf` shell and frontend bundle
      serve correctly, `/gateways` renders including the new Pending access
      tab.
- [ ] Backend pytest suite (`test_gateway_service.py`, extended with new
      coverage for approve-by-code, expired/already-approved rejection,
      revoke, `pairing_reply_enabled` gating, display-name capture) — written
      but not yet executed against a bench with test fixtures loaded.
- [ ] End-to-end live Telegram pairing (real bot token, DM → code →
      approve-via-UI → next message executes) — not yet done, no bot
      token configured on the verification bench.