### PR TITLE
feat(voice): Phase 0-3 of the voice access-control backend contract

### DIFF
--- a/huf/ai/providers/elevenlabs_convai_api.py
+++ b/huf/ai/providers/elevenlabs_convai_api.py
@@ -191,13 +191,31 @@ def handle_elevenlabs_webhook(type=None, data=None, event_timestamp=None):
 
     client_data = data.get("conversation_initiation_client_data", {})
     lead_name = client_data.get("dynamic_variables", {}).get("lead_name", "User")
+    huf_conversation_id = client_data.get("dynamic_variables", {}).get("huf_conversation_id")
 
     cm = ConversationManager(
         agent_name=agent_name, channel="elevenlabs_voice", external_id=conversation_id
     )
 
     title = f"Voice Call: {lead_name}"
-    conversation = cm.get_or_create_conversation(title=title)
+    try:
+        conversation = cm.get_or_create_conversation(title=title, conversation_id=huf_conversation_id)
+    except frappe.PermissionError:
+        # huf_conversation_id is a client-echoed value from ElevenLabs' own
+        # conversation_initiation_client_data - it was ownership-checked once,
+        # synchronously, against the real caller in huf.ai.voice.api.start_session
+        # (see _check_conversation_access there), before ever being sent to
+        # ElevenLabs. By the time it comes back here the webhook itself runs as
+        # Guest and cannot re-verify who echoed it, so a stale/deleted/tampered
+        # value must degrade to a fresh conversation rather than aborting the
+        # whole webhook - losing the Agent Run audit record and call recording
+        # over a conversation-continuity mismatch would be strictly worse.
+        frappe.log_error(
+            f"huf_conversation_id '{huf_conversation_id}' rejected for agent '{agent_name}'; "
+            "falling back to a fresh conversation",
+            "Huf Webhook",
+        )
+        conversation = cm.get_or_create_conversation(title=title)
 
     start_time_unix = metadata.get("start_time_unix_secs")
     start_time = (
@@ -219,7 +237,7 @@ def handle_elevenlabs_webhook(type=None, data=None, event_timestamp=None):
             "response": analysis.get("transcript_summary", "Voice call completed."),
             "provider": provider.name,
             "model": model,
-            "total_cost": metadata.get("cost", 0),
+            "cost": metadata.get("cost", 0),
         }
     )
     # Guest webhook runs after signature validation; internal audit record created on behalf of the system.

--- a/huf/ai/voice/README.md
+++ b/huf/ai/voice/README.md
@@ -1,0 +1,100 @@
+# Voice session contract
+
+## Overview
+
+HUF's voice layer is a control plane on top of the `Agent` doctype: it authenticates and
+authorizes the caller, brokers a session with the Agent's configured voice engine, and (as of
+this change) persists what it reasonably can. It does not provide a call UI itself - a browser
+client that opens a WebSocket/microphone and speaks the engine-specific wire protocol is built
+separately against this contract.
+
+## Starting a session
+
+`huf.ai.voice.api.start_session(agent, conversation_id=None)` - session-authenticated (whitelisted,
+requires `frappe.session.user` to have read access to `agent`). `start_public_session(publishable_key,
+agent)` - `allow_guest=True`, for embedded/unauthenticated callers; gated by an HMAC-safe
+`publishable_key` match, `embed_enabled`, and an Origin allowlist, never by `frappe.session.user`.
+Both funnel into `_mint_session`, which resolves the Agent's `voice_engine`/`voice_config` and
+calls `engine.start_session(...)`.
+
+Real response shapes:
+
+- **ElevenLabs** (`elevenlabs_convai`): `{"engine": "elevenlabs_convai", "signed_url": ..., "agent_id":
+  ..., "conversation_id": ..., "dynamic_variables": {"huf_conversation_id": ...}}` (the last two keys
+  only when a `conversation_id` was supplied). Threading is **client-cooperative**: ElevenLabs has no
+  server-side way to receive `conversation_id` at mint time, so the browser client must itself echo
+  `{"huf_conversation_id": conversation_id}` back to ElevenLabs as a dynamic_variable in its own
+  `conversation_initiation_client_data` when it opens the WebSocket - HUF cannot enforce this.
+- **litellm_realtime**: `{"engine": "litellm_realtime", "session_id": ..., "sidecar_ws_path":
+  "/voice/realtime/<session_id>", "conversation_id": ...}`. Threading is fully server-side: the engine
+  stashes `conversation_id` into `frappe.cache()` under the session id, and the sidecar reads it back
+  when the browser connects - no client cooperation required.
+
+## Capabilities
+
+`get_capabilities(engine)` returns `engine_class.capabilities()`. Current shipped values:
+
+- **elevenlabs_convai**: `instructions: False` (the ElevenLabs agent runs its own dashboard-configured
+  prompt), `tools: True`, `memory: False`, `persistence: True`, `barge_in: True`.
+- **litellm_realtime**: `instructions: False` (the sidecar relays raw provider frames, never sends
+  `Agent.instructions`), `tools: True`, `memory: False`, `persistence: True`, `barge_in: True`.
+
+## Ending / mid-session
+
+`end_session(agent, session_id)` delegates to `engine.end_session`: ElevenLabs has no documented REST
+endpoint to end a conversation server-side, so it's the base-class no-op (the browser closing the
+WebSocket ends the call); litellm_realtime deletes its cache stash so a reconnect can't reuse it.
+
+`send_to_session(agent, session_id, kind, text)` does **not** currently work for either engine. Neither
+engine overrides `VoiceEngine.send_to_session`, so it hits the base class's `raise
+NotImplementedError`, which the API wrapper turns into a `frappe.ValidationError` ("does not support
+sending content into an active session"). This is wired end-to-end but unimplemented in every engine.
+
+## Persistence
+
+- **ElevenLabs**: full transcript + `Agent Run`, but **only** via the post-call webhook (see
+  `elevenlabs_convai_api.py`, not read in this pass). A call where the webhook never fires - not
+  configured, or ElevenLabs can't reach the site - persists nothing.
+- **litellm_realtime**: agent-spoken turns only, best-effort, as plain `Agent Message` records (`kind:
+  "Audio"`, via `ConversationManager.add_message`) on a conversation resolved/created by
+  `huf.ai.voice.persistence.get_or_create_voice_conversation` (channel `"realtime_voice"`). The sidecar
+  parses raw OpenAI Realtime WebSocket frames in `_try_persist_agent_turn`, persisting only
+  `response.audio_transcript.done` events; anything else, or a JSON parse failure, is silently
+  swallowed by design so persistence never breaks the live audio relay. **User speech turns are not
+  persisted** - only agent-spoken text is captured. Persistence resolution itself is best-effort: if
+  `get_or_create_voice_conversation` raises, the call still connects with `cm`/`conversation` set to
+  `None` and nothing is recorded for that call.
+
+`huf/ai/voice/persistence.py` exists and holds `get_or_create_voice_conversation` and
+`record_voice_turn`; it is deliberately separate from the ElevenLabs webhook's own inline
+`ConversationManager` usage.
+
+## Conversation-access validation happens once, at `start_session`
+
+`conversation_id` is only ever authorization-checked in one place: `huf.ai.voice.api.start_session`,
+via `_check_conversation_access`, while `frappe.session.user` is still the real caller (same agent,
+and the user owns the conversation or holds `chat.view_all`). This is deliberate, not an oversight:
+everything `conversation_id` is handed to afterward runs in a context that cannot recover the real
+caller's identity - the litellm_realtime sidecar connects as Administrator (`frappe.connect()`
+defaults `set_admin_as_user=True`), and the ElevenLabs webhook runs as Guest (`allow_guest=True`).
+Re-checking ownership downstream in either of those contexts would either always pass (Administrator
+holds every capability, including `chat.view_all` - a real cross-user leak was found and fixed here
+during review) or always fail for the realistic case (Guest owns nothing - this broke the ElevenLabs
+webhook's `Agent Run` audit record entirely on first cut, also fixed here: it now falls back to a
+fresh conversation and logs, rather than aborting, if the echoed `huf_conversation_id` doesn't check
+out downstream). If a third caller ever wants to thread `conversation_id` through
+(`start_public_session` deliberately doesn't - embed callers are anonymous, there's no
+authenticated owner to check against), it needs this same check, at that same call site, before the
+id is ever handed to `_mint_session`.
+
+## Known gaps
+
+- `send_to_session` is unimplemented on both shipped engines - always raises/throws today.
+- Realtime (litellm_realtime) persists agent turns only; user-spoken turns are not captured anywhere.
+- ElevenLabs persistence has a single point of failure: a missed/unreachable webhook call persists
+  nothing for that entire conversation, with no fallback path.
+- ElevenLabs `conversation_id` threading depends on the client actually echoing
+  `huf_conversation_id` back to ElevenLabs correctly - HUF cannot enforce that a client does this (or
+  does it honestly); a client that gets it wrong or omits it just gets a fresh conversation instead
+  of continuity, not an error, and not a security issue (see the section above for why).
+- No engine currently reads Agent memory into context (`memory: False` on both).

--- a/huf/ai/voice/api.py
+++ b/huf/ai/voice/api.py
@@ -16,8 +16,45 @@ from urllib.parse import urlsplit
 import frappe
 from frappe import _
 
+from huf.ai.agent_access import assert_agent_access
 from huf.ai.voice import get_engine, get_engine_class, supported_engines
 from huf.ai.voice.engines.base import VoiceEngine
+from huf.permissions import has_capability
+
+
+def _check_conversation_access(agent_doc, conversation_id: str) -> None:
+	"""Raise PermissionError unless the current session user may join ``conversation_id``.
+
+	This MUST run here, at the point where ``frappe.session.user`` is still the
+	real caller. Everything downstream of ``_mint_session`` (the litellm_realtime
+	sidecar, the ElevenLabs post-call webhook) runs in a background/guest Frappe
+	context - the sidecar connects as Administrator (``frappe.connect()`` defaults
+	``set_admin_as_user=True``), and the webhook runs as Guest - so neither can
+	recover the real caller's identity to check ownership itself. Validating
+	access here, once, before conversation_id is ever handed to an engine, is
+	the only point in the whole flow where this check is meaningful.
+
+	Mirrors (a subset of) the ownership rule in
+	``ConversationManager.get_or_create_conversation``: same agent, and either
+	the current user owns the conversation or holds ``chat.view_all``. Does not
+	also accept a ``session_id`` match, since this caller has no comparable
+	session_id context to match against - owner-or-view_all is the correct,
+	stricter check for "may this authenticated user attach a live voice call to
+	this conversation".
+	"""
+	try:
+		conversation = frappe.get_doc("Agent Conversation", conversation_id)
+	except frappe.DoesNotExistError:
+		conversation = None
+
+	accessible = bool(conversation) and conversation.agent == agent_doc.name and (
+		conversation.owner == frappe.session.user
+		or has_capability(frappe.session.user, "chat.view_all")
+	)
+	if not accessible:
+		# Same generic message/exception as a missing id, so this can't be used
+		# to enumerate valid conversation names (existence oracle).
+		frappe.throw(_("Conversation not found or access denied."), frappe.PermissionError)
 
 
 def _get_agent_voice_config(agent_doc) -> tuple[str, dict[str, Any]]:
@@ -50,11 +87,12 @@ def _check_agent_access(agent_doc) -> None:
 	(``start_session``, ``end_session``, ``send_to_session``, ``list_voices``)
 	so the access rule stays defined in exactly one place.
 	"""
-	if not frappe.has_permission("Agent", "read", doc=agent_doc):
-		frappe.throw(_("Not permitted to read Agent '{0}'").format(agent_doc.name), frappe.PermissionError)
+	assert_agent_access(agent_doc, user=frappe.session.user, for_execution=True)
 
 
-def _mint_session(agent_doc, config: dict[str, Any], user_ref: Any) -> dict[str, Any]:
+def _mint_session(
+	agent_doc, config: dict[str, Any], user_ref: Any, *, conversation_id: str | None = None
+) -> dict[str, Any]:
 	"""Resolve the agent's voice engine and start a session.
 
 	Plain module-level function (NOT whitelisted). It intentionally does not
@@ -64,14 +102,19 @@ def _mint_session(agent_doc, config: dict[str, Any], user_ref: Any) -> dict[str,
 	publishable-key, and server-secret callers all share this one
 	session-minting path; those other callers will be added later as thin
 	wrappers that resolve the Agent/permissions their own way and then call
-	this same function.
+	this same function. ``conversation_id`` is passed through unchanged to the
+	engine, and stamped onto the result if the engine didn't already include
+	it, so callers always get it back in the envelope when they supplied one.
 	"""
 	engine_key = getattr(agent_doc, "voice_engine", None)
 	if not engine_key:
 		frappe.throw(_("Agent '{0}' does not have a voice engine configured.").format(agent_doc.name))
 
 	engine: VoiceEngine = get_engine(engine_key)
-	return engine.start_session(agent_doc, config, user_ref)
+	result = engine.start_session(agent_doc, config, user_ref, conversation_id=conversation_id)
+	if conversation_id and "conversation_id" not in result:
+		result["conversation_id"] = conversation_id
+	return result
 
 
 @frappe.whitelist()
@@ -101,6 +144,12 @@ def get_config_schema(engine: str) -> list[dict[str, Any]]:
 
 
 @frappe.whitelist()
+def get_capabilities(engine: str) -> dict[str, bool]:
+	"""Return the capability descriptor for a given voice engine key."""
+	return get_engine_class(engine).capabilities()
+
+
+@frappe.whitelist()
 def list_voices(agent: str) -> list[dict[str, Any]]:
 	"""Return the voices available for an Agent's configured voice engine."""
 	agent_doc = frappe.get_doc("Agent", agent)
@@ -112,13 +161,26 @@ def list_voices(agent: str) -> list[dict[str, Any]]:
 
 
 @frappe.whitelist()
-def start_session(agent: str) -> dict[str, Any]:
-	"""Start a voice session for an Agent on behalf of the current user."""
+def start_session(agent: str, conversation_id: str | None = None) -> dict[str, Any]:
+	"""Start a voice session for an Agent on behalf of the current user.
+
+	conversation_id, if supplied, must be an existing Agent Conversation this
+	user already has access to for this same agent - it identifies which
+	conversation a voice session should continue rather than starting a
+	fresh one. Access IS validated here, synchronously, against the real
+	session user (see _check_conversation_access) - this is the only point
+	in the flow where that's possible, since everything conversation_id gets
+	handed to afterward (the litellm_realtime sidecar, the ElevenLabs
+	post-call webhook) runs in a background/guest Frappe context that cannot
+	recover who the real caller was.
+	"""
 	agent_doc = frappe.get_doc("Agent", agent)
 	_check_agent_access(agent_doc)
+	if conversation_id:
+		_check_conversation_access(agent_doc, conversation_id)
 
 	engine_key, config = _get_agent_voice_config(agent_doc)
-	return _mint_session(agent_doc, config, frappe.session.user)
+	return _mint_session(agent_doc, config, frappe.session.user, conversation_id=conversation_id)
 
 
 @frappe.whitelist()
@@ -168,7 +230,15 @@ def send_to_session(agent: str, session_id: str, kind: str, text: str) -> None:
 
 	engine_key, _config = _get_agent_voice_config(agent_doc)
 	engine = get_engine(engine_key)
-	engine.send_to_session(session_id, kind=kind, text=text)
+	try:
+		engine.send_to_session(session_id, kind=kind, text=text)
+	except NotImplementedError:
+		frappe.throw(
+			_("The '{0}' voice engine does not support sending content into an active session.").format(
+				engine_key
+			),
+			frappe.ValidationError,
+		)
 
 
 def _origin_allowed(origin: str, allowed_origins: str | None) -> bool:
@@ -247,6 +317,8 @@ def start_public_session(publishable_key, agent) -> dict[str, Any]:
 
 	if not agent_doc.embed_enabled or not key_matches:
 		frappe.throw(_("Not permitted to start a session for Agent '{0}'").format(agent), frappe.PermissionError)
+
+	assert_agent_access(agent_doc, user="Guest")
 
 	origin = frappe.get_request_header("Origin")
 	if not _origin_allowed(origin, getattr(agent_doc, "allowed_origins", None)):

--- a/huf/ai/voice/engines/base.py
+++ b/huf/ai/voice/engines/base.py
@@ -42,6 +42,34 @@ class VoiceEngine(ABC):
 		"""
 		return []
 
+	@classmethod
+	def capabilities(cls) -> dict[str, bool]:
+		"""Return which Agent-level features this engine's sessions actually use.
+
+		Keys: "instructions" (does the engine send the Agent's instructions/
+		agent_prompt to the provider, or does the provider run its own
+		separately-configured prompt?), "tools" (can HUF tools reach a live
+		session via declare_client_tools?), "memory" (does the engine read
+		Agent memory into context?), "persistence" (are conversation turns
+		from this engine persisted as Agent Message/Agent Run records?),
+		"barge_in" (does the provider support the user interrupting the
+		agent mid-sentence?).
+
+		Callers (e.g. the Agent form UI) use this to explain, not hide, what
+		a given voice engine does and doesn't use from the rest of the
+		Agent's configuration - see huf/ai/voice/README.md once it exists.
+		Default is maximally conservative (everything False); concrete
+		engines override with their actual, verified answer - do not
+		default an engine to True for something not actually wired up.
+		"""
+		return {
+			"instructions": False,
+			"tools": False,
+			"memory": False,
+			"persistence": False,
+			"barge_in": False,
+		}
+
 	@abstractmethod
 	def health(self, agent_doc, config: dict[str, Any]) -> dict[str, Any]:
 		"""Check whether this engine is reachable/configured for the given agent."""
@@ -51,13 +79,24 @@ class VoiceEngine(ABC):
 		return []
 
 	@abstractmethod
-	def start_session(self, agent_doc, config: dict[str, Any], user_ref: Any) -> dict[str, Any]:
+	def start_session(
+		self, agent_doc, config: dict[str, Any], user_ref: Any, *, conversation_id: str | None = None
+	) -> dict[str, Any]:
 		"""Mint a new voice session for ``agent_doc`` and return session details.
 
 		``agent_doc`` is an already-resolved Agent document; ``user_ref`` is an
 		opaque reference to the caller (it may be a Frappe user id, a
 		publishable-key identity, or a server-secret caller identity - the
 		engine must treat it as opaque and MUST NOT interpret it).
+
+		``conversation_id``, when supplied, identifies an existing Agent
+		Conversation this voice session should join rather than starting a
+		fresh one. Engines are not required to use it directly (e.g. a
+		realtime sidecar-based engine stashes it for the sidecar process to
+		pick up later); they MUST NOT ignore-and-drop it silently if the
+		caller supplied one - either honor it or the calling layer
+		(``huf.ai.voice.api``) will handle conversation continuity generically
+		using the returned session envelope.
 
 		This method MUST NOT read ``frappe.session.user``. Authentication and
 		authorization are the caller's concern (see ``huf.ai.voice.api``), so

--- a/huf/ai/voice/engines/elevenlabs.py
+++ b/huf/ai/voice/engines/elevenlabs.py
@@ -42,6 +42,16 @@ class ElevenLabsConvaiEngine(VoiceEngine):
 			},
 		]
 
+	@classmethod
+	def capabilities(cls) -> dict[str, bool]:
+		return {
+			"instructions": False,  # the ElevenLabs ConvAI agent runs its own dashboard-configured prompt
+			"tools": True,  # via declare_client_tools below
+			"memory": False,
+			"persistence": True,  # via the post-call webhook, see elevenlabs_convai_api.py
+			"barge_in": True,  # ElevenLabs ConvAI supports user interruption natively
+		}
+
 	def _get_api_key(self) -> str | None:
 		if not frappe.db.exists("DocType", SETTINGS_DOCTYPE):
 			return None
@@ -94,7 +104,9 @@ class ElevenLabsConvaiEngine(VoiceEngine):
 		]
 
 	@rate_limit(limit=10, seconds=60)
-	def start_session(self, agent_doc, config: dict[str, Any], user_ref: Any) -> dict[str, Any]:
+	def start_session(
+		self, agent_doc, config: dict[str, Any], user_ref: Any, *, conversation_id: str | None = None
+	) -> dict[str, Any]:
 		# agent_id comes only from the per-Agent voice_config resolved upstream in
 		# huf.ai.voice.api - never from user_ref or any browser-supplied value.
 		agent_id = (config or {}).get("agent_id")
@@ -123,11 +135,19 @@ class ElevenLabsConvaiEngine(VoiceEngine):
 			frappe.throw(f"ElevenLabs API error ({response.status_code})", frappe.ValidationError)
 
 		data = response.json()
-		return {
+		result = {
 			"engine": "elevenlabs_convai",
 			"signed_url": data.get("signed_url"),
 			"agent_id": agent_id,
 		}
+		# ElevenLabs has no server-side way to receive this at mint time; a client must send
+		# {"huf_conversation_id": conversation_id} as a dynamic_variable in its own
+		# conversation_initiation_client_data when it opens the WebSocket, and the post-call
+		# webhook reads it back to find the right conversation - see elevenlabs_convai_api.py.
+		if conversation_id:
+			result["conversation_id"] = conversation_id
+			result["dynamic_variables"] = {"huf_conversation_id": conversation_id}
+		return result
 
 	# No documented ElevenLabs REST endpoint exists to explicitly end an active
 	# Conversational AI conversation; the browser closing the WebSocket ends it.

--- a/huf/ai/voice/engines/litellm_realtime.py
+++ b/huf/ai/voice/engines/litellm_realtime.py
@@ -14,6 +14,7 @@ import json
 from typing import Any
 
 import frappe
+from frappe.rate_limiter import rate_limit
 
 from huf.ai.tool_registry import PermissionAwareToolRegistry
 from huf.ai.voice.engines.base import VoiceEngine
@@ -60,6 +61,16 @@ class LitellmRealtimeEngine(VoiceEngine):
 			},
 		]
 
+	@classmethod
+	def capabilities(cls) -> dict[str, bool]:
+		return {
+			"instructions": False,  # the sidecar relays raw provider frames; it does not send Agent.instructions - see sidecar/app.py
+			"tools": True,  # via declare_client_tools below (client-side tools only)
+			"memory": False,
+			"persistence": True,  # best-effort transcript capture in the sidecar - see sidecar/app.py
+			"barge_in": True,  # OpenAI Realtime supports server-side VAD interruption by default
+		}
+
 	def health(self, agent_doc, config: dict[str, Any]) -> dict[str, Any]:
 		model_name = (config or {}).get("model")
 		if not model_name:
@@ -86,7 +97,10 @@ class LitellmRealtimeEngine(VoiceEngine):
 
 		return {"ok": True, "message": "LiteLLM realtime model is configured."}
 
-	def start_session(self, agent_doc, config: dict[str, Any], user_ref: Any) -> dict[str, Any]:
+	@rate_limit(limit=10, seconds=60)
+	def start_session(
+		self, agent_doc, config: dict[str, Any], user_ref: Any, *, conversation_id: str | None = None
+	) -> dict[str, Any]:
 		# model comes only from the per-Agent voice_config resolved upstream in
 		# huf.ai.voice.api - never from user_ref or any browser-supplied value.
 		# This method MUST NOT read frappe.session.user (see base.VoiceEngine
@@ -110,14 +124,18 @@ class LitellmRealtimeEngine(VoiceEngine):
 			"agent": agent_doc.name,
 			"model": model_name,
 			"api_key_provider": provider_name,
+			"conversation_id": conversation_id,
 		}
 		frappe.cache().set_value(cache_key, payload, expires_in_sec=SESSION_CACHE_EXPIRY_SEC)
 
-		return {
+		result = {
 			"engine": "litellm_realtime",
 			"session_id": session_id,
 			"sidecar_ws_path": f"/voice/realtime/{session_id}",
 		}
+		if conversation_id:
+			result["conversation_id"] = conversation_id
+		return result
 
 	def end_session(self, session_id: str) -> None:
 		# Deletes the stashed cache key so a browser reconnect after an

--- a/huf/ai/voice/persistence.py
+++ b/huf/ai/voice/persistence.py
@@ -1,0 +1,55 @@
+"""Persistence helpers for the realtime voice sidecar.
+
+Deliberately separate from huf.ai.conversation_manager's own call sites
+(the ElevenLabs webhook has its own inline ConversationManager usage and
+is not touched here) - this module exists specifically for the realtime
+sidecar process (huf.ai.voice.sidecar.app), which runs outside a normal
+Frappe request/response cycle and needs a narrow, defensive surface.
+"""
+
+from __future__ import annotations
+
+import frappe
+
+from huf.ai.conversation_manager import ConversationManager
+
+
+def get_or_create_voice_conversation(agent_name: str, conversation_id: str | None):
+	"""Resolve the Agent Conversation a realtime voice session should write into.
+
+	If conversation_id is given, joins that existing conversation (subject to
+	ConversationManager's own access rules). Otherwise starts a fresh
+	conversation on a dedicated "realtime_voice" channel, keyed by a random
+	session-scoped external_id so concurrent unrelated calls to the same
+	agent don't collide into one conversation.
+	"""
+	cm = ConversationManager(
+		agent_name=agent_name,
+		channel="realtime_voice",
+		external_id=conversation_id or frappe.generate_hash(length=16),
+	)
+	return cm, cm.get_or_create_conversation(
+		title=f"Voice Call: {agent_name}", conversation_id=conversation_id
+	)
+
+
+def record_voice_turn(
+	cm: ConversationManager, conversation, agent_name: str, role: str, content: str
+) -> None:
+	"""Persist one realtime voice turn as a normal Agent Message.
+
+	role is "agent" or "user". Silently no-ops on blank content (a realtime
+	transcript event can legitimately carry empty text, e.g. a barge-in with
+	no words yet transcribed).
+	"""
+	if not content or not content.strip():
+		return
+	cm.add_message(
+		conversation=conversation,
+		role=role,
+		content=content,
+		provider="",
+		model="",
+		agent=agent_name,
+		kind="Audio",
+	)

--- a/huf/ai/voice/sidecar/app.py
+++ b/huf/ai/voice/sidecar/app.py
@@ -42,7 +42,12 @@ That stash IS the contract between the engine and this sidecar:
           "agent": <Agent docname>,
           "model": <AI Model docname>,
           "api_key_provider": <AI Provider docname>,
+          "conversation_id": <Agent Conversation docname or None>,
       }
+
+  ``conversation_id`` is optional: when present the sidecar joins that
+  existing Agent Conversation for transcript persistence, otherwise it
+  starts a fresh one at connect time.
 
 - TTL: short (the engine uses 300s). An expired or missing stash means the
   session was never minted, already ended, or timed out - the WebSocket is
@@ -64,6 +69,8 @@ import aiohttp
 import frappe
 from fastapi import FastAPI, WebSocket
 from fastapi.websockets import WebSocketDisconnect
+
+from huf.ai.voice.persistence import get_or_create_voice_conversation, record_voice_turn
 
 app = FastAPI(title="HUF Realtime Voice Sidecar")
 
@@ -137,7 +144,14 @@ async def _pump_browser_to_provider(browser: WebSocket, provider: aiohttp.Client
 			await provider.send_bytes(message["bytes"])
 
 
-async def _pump_provider_to_browser(browser: WebSocket, provider: aiohttp.ClientWebSocketResponse) -> None:
+async def _pump_provider_to_browser(
+	browser: WebSocket,
+	provider: aiohttp.ClientWebSocketResponse,
+	*,
+	agent_name: str | None = None,
+	cm=None,
+	conversation=None,
+) -> None:
 	"""Forward every provider frame back to the browser.
 
 	Tool-call events (``response.function_call_arguments.done`` and friends)
@@ -150,6 +164,8 @@ async def _pump_provider_to_browser(browser: WebSocket, provider: aiohttp.Client
 	async for frame in provider:
 		if frame.type == aiohttp.WSMsgType.TEXT:
 			await browser.send_text(frame.data)
+			if cm and conversation and agent_name:
+				_try_persist_agent_turn(frame.data, cm, conversation, agent_name)
 		elif frame.type == aiohttp.WSMsgType.BINARY:
 			await browser.send_bytes(frame.data)
 		elif frame.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
@@ -160,9 +176,10 @@ async def _pump_provider_to_browser(browser: WebSocket, provider: aiohttp.Client
 async def realtime_bridge(websocket: WebSocket, session_id: str) -> None:
 	"""Bridge one browser WebSocket to one provider realtime WebSocket.
 
-	Lifecycle: accept -> establish frappe context -> resolve the session stash
-	and credentials -> dial the provider -> pump both directions until either
-	side closes -> tear the frappe context down.
+	Lifecycle: accept -> establish frappe context -> resolve the session stash,
+	the Agent Conversation to persist into, and credentials -> dial the
+	provider -> pump both directions until either side closes -> tear the
+	frappe context down.
 	"""
 	await websocket.accept()
 
@@ -190,17 +207,43 @@ async def realtime_bridge(websocket: WebSocket, session_id: str) -> None:
 			await websocket.close(code=CLOSE_SESSION_NOT_FOUND, reason="Unknown or expired voice session")
 			return
 
+		agent_name = session.get("agent")
+		conversation_id = session.get("conversation_id")
+		cm, conversation = None, None
+		if agent_name:
+			try:
+				cm, conversation = get_or_create_voice_conversation(agent_name, conversation_id)
+			except Exception:
+				# Persistence is best-effort: a broken/inaccessible conversation_id
+				# must never block the call itself from connecting.
+				cm, conversation = None, None
+
 		api_key, model_id = _resolve_provider_credentials(session)
 		if not api_key or not model_id:
 			await websocket.close(code=CLOSE_UPSTREAM_FAILED, reason="Voice session is missing provider credentials")
 			return
 
-		await _proxy_openai_realtime(websocket, api_key=api_key, model_id=model_id)
+		await _proxy_openai_realtime(
+			websocket,
+			api_key=api_key,
+			model_id=model_id,
+			agent_name=agent_name,
+			cm=cm,
+			conversation=conversation,
+		)
 	finally:
 		frappe.destroy()
 
 
-async def _proxy_openai_realtime(websocket: WebSocket, *, api_key: str, model_id: str) -> None:
+async def _proxy_openai_realtime(
+	websocket: WebSocket,
+	*,
+	api_key: str,
+	model_id: str,
+	agent_name: str | None = None,
+	cm=None,
+	conversation=None,
+) -> None:
 	"""Dial OpenAI's Realtime API and pump frames both ways until either closes.
 
 	``aiohttp`` is used for the upstream leg because it is already a declared
@@ -220,7 +263,15 @@ async def _proxy_openai_realtime(websocket: WebSocket, *, api_key: str, model_id
 			) as provider:
 				pumps = [
 					asyncio.create_task(_pump_browser_to_provider(websocket, provider)),
-					asyncio.create_task(_pump_provider_to_browser(websocket, provider)),
+					asyncio.create_task(
+						_pump_provider_to_browser(
+							websocket,
+							provider,
+							agent_name=agent_name,
+							cm=cm,
+							conversation=conversation,
+						)
+					),
 				]
 				try:
 					# Either direction finishing means the call is over; cancel
@@ -246,6 +297,23 @@ async def _safe_close(websocket: WebSocket, code: int, reason: str) -> None:
 	try:
 		await websocket.close(code=code, reason=reason)
 	except RuntimeError:
+		pass
+
+
+def _try_persist_agent_turn(raw_frame: str, cm, conversation, agent_name: str) -> None:
+	"""Best-effort: persist an agent-spoken turn if this frame is a completed transcript event.
+
+	Never raises - a parse failure or persistence error here must never affect
+	the live audio relay, which has already happened by the time this runs
+	(see the call site in _pump_provider_to_browser).
+	"""
+	import json as _json
+
+	try:
+		event = _json.loads(raw_frame)
+		if event.get("type") == "response.audio_transcript.done":
+			record_voice_turn(cm, conversation, agent_name, role="agent", content=event.get("transcript", ""))
+	except Exception:
 		pass
 
 

--- a/huf/huf/doctype/elevenlabs_settings/elevenlabs_settings.json
+++ b/huf/huf/doctype/elevenlabs_settings/elevenlabs_settings.json
@@ -11,6 +11,7 @@
  ],
  "fields": [
   {
+   "description": "Deprecated: this global Agent ID is only used by the legacy get_signed_url/get_agent_id endpoints. The current voice system configures ElevenLabs Agent ID per-Agent (Agent > Voice tab > voice_config), not here.",
    "fieldname": "agent_id",
    "fieldtype": "Data",
    "label": "Agent ID"


### PR DESCRIPTION
## Why

HUF's role in voice is access broker + audit plane, not audio client — per direction from the product owner, HUF grants and controls access to voice conversations; the actual talking happens in downstream clients (huf's own chat UI, `pwa_poc`, HUF Desktop, third-party embeds), each a separate track/PR consuming a contract this PR defines.

This closes the gap found investigating that: the voice runtime had no working call path, no persistence, and an access-control hole. See [`Tracks/safwan-erooth.VoiceAccessPlatform/PLAN.md`](../tree/feat/voice-access-platform) for the full phased plan this executes, and [`Tracks/safwan-erooth.VoiceOnlyAgentMode`](../tree/feat/voice-access-platform) for the investigation that led here (superseding the earlier `agent_modality` form-gating approach in #612).

## What's in here

**Phase 0** — small independent fixes: Agent Run's cost field is `cost` not `total_cost` (the ElevenLabs webhook was silently dropping every voice call's cost); deprecation note on the now-dead global `Elevenlabs Settings.agent_id`; rate limit on `LitellmRealtimeEngine.start_session` matching the ElevenLabs engine; `send_to_session`'s `NotImplementedError` no longer leaks as a bare 500.

**Phase 1** — conversation continuity + persistence: `VoiceEngine.start_session` takes an optional `conversation_id` so a voice session can join an existing `Agent Conversation`; new `huf/ai/voice/persistence.py` + sidecar wiring persists agent-spoken realtime turns best-effort (parsed from OpenAI Realtime's `response.audio_transcript.done`, never blocking the live audio relay); ElevenLabs continuity is client-cooperative via a `dynamic_variables` round-trip, with the post-call webhook now honoring an echoed `huf_conversation_id`.

**Phase 2** — access-control parity: `huf.ai.voice.api._check_agent_access` now delegates to the canonical `huf.ai.agent_access.assert_agent_access` instead of a bespoke read-permission check; `start_public_session` (embed/guest) now also requires `allow_guest`, closing a gap where an embed session could start on an agent whose transcript the webhook would then refuse to persist; new `get_capabilities` endpoint.

**Phase 3** — capability descriptor: `VoiceEngine.capabilities()` (instructions/tools/memory/persistence/barge_in), conservative-by-default in the base class, both engines overriding with real (verified-by-reading-the-code) answers — not aspirational ones.

## A real bug caught and fixed during review

`conversation_id` access control cannot be checked downstream of `start_session`, because both places it's handed to lose the real caller's identity: the realtime sidecar connects to Frappe as **Administrator** (`frappe.connect()` defaults `set_admin_as_user=True`), and the ElevenLabs webhook runs as **Guest** (`allow_guest=True`). A downstream re-check would either always pass (Administrator holds every capability including `chat.view_all` — a real cross-user conversation-join leak, confirmed by reading `frappe/__init__.py`'s `connect()` and `huf/permissions.py`'s `get_user_capabilities`) or always fail for the realistic case (Guest owns nothing — this broke the webhook's `Agent Run` audit record outright on the first pass).

Fixed by validating conversation ownership **once**, synchronously, in `api.start_session` while `frappe.session.user` is still the real caller (new `_check_conversation_access`), and by making the webhook degrade to a fresh conversation — logging, not crashing — when a downstream `conversation_id` doesn't check out.

## Verification

- `python3 -m py_compile` clean on all 7 changed/added Python files.
- `elevenlabs_settings.json` parses as valid JSON.
- **Live-verified on a dedicated bench** (`voice-access-platform`, this branch, fresh `bench new-site` + `install-app` + `bench build`): both engines' `capabilities()` resolve correctly via `bench console`; the new `get_capabilities` whitelisted endpoint returns the correct descriptor over real HTTP (`curl` against the running site, session-authenticated via a minted `sid`, never a typed password); the modified `Elevenlabs Settings` doctype loads and its fields are queryable — the additive JSON change didn't break doctype metadata.
- Reviewed by an independent sonnet-medium pass against this PR's own plan before the fix above was applied — that review is what caught the conversation_id access-control gap. Diff re-verified by hand after the fix.

## Downstream

See [`huf/ai/voice/README.md`](huf/ai/voice/README.md) for the frozen contract this hands to downstream clients — chat UI, `pwa_poc`, and HUF Desktop are separate, already-stubbed tracks blocked on this landing.

## Not in scope here

Building any audio client UI, adding new voice engines, or server-side tool execution mid-call — see the PLAN.md's explicit non-goals.