### PR TITLE
docs: Add bug report for missing WhatsApp integration service

### DIFF
--- a/docs/GATEWAY_ALLOW_LIST_GAP.md
+++ b/docs/GATEWAY_ALLOW_LIST_GAP.md
@@ -1,0 +1,31 @@
+# Gateway Allow List: The Expiration Gap
+
+When you set your Telegram Gateway to **Allow list**, you are telling the bot: *"Act like a strict security guard. Only let people in if they are on my approved list. Ignore everyone else."*
+
+While this is great for security, there is a hidden "trap" in the current system that can cause your bot to silently ignore you, even when you think you are approved.
+
+---
+
+## The "Expiring Badge" Bug
+
+Imagine you hire an employee and print them a permanent ID badge. But because of a software glitch, the printer accidentally prints "Expires in 60 minutes" on the back of the badge. An hour later, the security guard kicks them out of the building, even though they are an approved employee!
+
+This is exactly what is happening in the Gateway system:
+1. When you first message the bot to get a Pairing Code, the system creates a temporary 60-minute expiration timer. 
+2. When the administrator approves you, the system is *supposed* to erase that timer to give you permanent access. 
+3. **The Bug:** The system forgets to erase the timer! 
+4. Exactly 60 minutes after you first messaged the bot, your access expires. Because the Gateway is in `Allow list` mode (strict security), it silently drops all your messages, making it look like the bot is completely broken.
+
+---
+
+## Proposed Fix
+
+To solve this issue permanently, we need to modify the underlying document logic for the `Gateway Access Entry`.
+
+**Target File:** `huf/doctype/gateway_access_entry/gateway_access_entry.py`
+
+**The Change:** 
+We will add an `on_update` or `before_save` python hook to the `GatewayAccessEntry` class. This hook will enforce a simple rule: 
+> *If the state is being changed to `Approved`, automatically clear the `expires_at` field (set it to `None`).*
+
+This ensures that whether a pairing code is approved via the chat interface, or manually approved by an administrator in the Frappe Desk UI, the 60-minute expiration timer is always erased, granting the user the permanent access they expect.

--- a/docs/GATEWAY_PAIRING_UI_GAP.md
+++ b/docs/GATEWAY_PAIRING_UI_GAP.md
@@ -1,0 +1,32 @@
+# Gateway Pairing UI Gap & Proposed Solution
+
+## 1. The Gap
+Currently, the Huf platform supports a chat-guided onboarding flow where a user can pair a bot via a `PAIR-XXXX` code from inside Hub Chat using `/pair approve`.
+
+However, if an administrator adds a Gateway and bot token directly via the **Frappe Desk (Gateway Doctype)**, there is no intuitive UI available in the Gateway form itself to complete the pairing process. 
+
+### The Problematic Flow (Current state):
+1. Administrator sets the Gateway's **Direct-message policy** to `Pairing`.
+2. A user sends a message to the bot and receives a `PAIR-XXXX` code.
+3. The administrator is forced to leave the Gateway form, navigate to the `Gateway Access Entry` list, manually search for the pending request, and change its state to `Approved`.
+4. **Issue 1 (Missing Welcome Message):** Because the administrator manually saved the `Gateway Access Entry` document, the python function `approve_pairing_code` is never called. As a result, the external user never receives the welcome message (`🎉 Your access pairing request has been approved...`).
+5. **Issue 2 (Infinite Pairing Loop):** The administrator must remember to navigate back to the Gateway form and manually switch the policy from `Pairing` back to `Allow list`. If they forget this step, the Gateway remains in strict "onboarding mode." It will ignore the approved entry and blindly generate a brand new `PAIR-XXXX` code for every subsequent message the user sends.
+
+## 2. Proposed Solution & UI Flow
+To close this gap, we propose embedding the pairing approval flow directly into the Gateway form in Frappe Desk.
+
+### UI Additions to `Gateway` Form (via `gateway.js`)
+1. **"Approve Pairing Request" Button**: 
+   - Add a custom button at the top of the Gateway form if the policy is currently set to `Pairing`.
+   - Clicking this button opens a standard Frappe Dialog with a single text field prompting the administrator to enter the 8-character pairing code (`PAIR-XXXX`).
+   
+2. **Pending Pairing Requests Section**: 
+   - Add a custom HTML section or Dashboard field at the bottom of the Gateway form to list all `Pending` Gateway Access Entries related to this specific gateway.
+   - Each row should have a quick 1-click "Approve" button, completely eliminating the need to copy-paste pairing codes.
+
+### Automated Policy Switching & Logic Trigger
+When a pairing code is successfully approved (either via the dialog or the quick-approve button):
+- The UI will explicitly call the backend API (`approve_pairing_code`), ensuring the welcome message is properly sent to the user on the external channel.
+- The system will **automatically** change the Gateway's `direct_policy` from `Pairing` back to `Allow list` and save the document.
+- A success toast will appear: `"Pairing approved, welcome message sent, and policy automatically switched back to Allow list."`
+- This ensures the bot immediately begins processing incoming messages, entirely preventing the scenario where it gets stuck in an infinite pairing loop.

--- a/docs/WHATSAPP_INTEGRATION_SETUP.md
+++ b/docs/WHATSAPP_INTEGRATION_SETUP.md
@@ -1,0 +1,36 @@
+# Bug Report: WhatsApp Missing from Integration Service
+
+## Issue Explanation
+When attempting to configure the WhatsApp Gateway in the `huf` application, the `whatsapp` service is not available in the dropdown when creating a new **Integration Settings** record. 
+
+While the WhatsApp Gateway Adapter logic is fully implemented (`WhatsAppGatewayAdapter` in `huf/ai/gateway_adapters/whatsapp.py`), the service was accidentally omitted from the default seed data during installation. This prevents users from configuring their Meta credentials through the standard Frappe Desk UI without using the Hub Chat pairing workflow.
+
+## Steps to Reproduce (Test Case)
+1. Log in to Frappe Desk and navigate to the **Integration Settings** list (`/desk/integration-settings`).
+2. Click **Add Integration Settings**.
+3. Open the **Service** dropdown menu.
+4. **Expected Result**: `whatsapp` should be an available option, which would reveal the credential fields (Phone Number ID, Access Token, Webhook Verify Token).
+5. **Actual Result**: `whatsapp` is missing from the list, making it impossible to create the integration setting manually.
+
+## Suggested Code Fix
+
+To fix this, we need to add the `whatsapp` service configuration to the `register_integration_services()` function in `huf/install.py`. 
+
+Add the following dictionary to the `services` list (around line 1065):
+
+```python
+{
+    "service_name": "whatsapp",
+    "category": "Communication",
+    "description": "Meta WhatsApp Cloud API for messaging",
+    "required_credentials": [
+        {"key": "phone_number_id", "label": "Phone Number ID", "required": True},
+        {"key": "access_token", "label": "Meta Permanent/System Access Token", "required": True},
+        {"key": "webhook_verify_token", "label": "Webhook Verify Token", "required": True}
+    ]
+}
+```
+
+*(Note: The `app_secret` has been intentionally omitted from the required schema because it is an optional field for HMAC signature verification. Advanced users can still add it manually via the UI if desired.)*
+
+Once this code change is merged, running `bench execute huf.install.register_integration_services` (or triggering `after_migrate`) will correctly seed the database, exposing the WhatsApp fields in the UI.


### PR DESCRIPTION
### Background
When attempting to configure a new WhatsApp Gateway, the `whatsapp` service is missing from the **Integration Settings** dropdown in the UI. 

While the `WhatsAppGatewayAdapter` is fully implemented in the backend, the service was accidentally omitted from the `register_integration_services` default seed data in `install.py`.

### What this PR does
This PR adds a comprehensive bug report document (`docs/WHATSAPP_INTEGRATION_SETUP.md`) explaining the missing integration issue. The document outlines the test case and provides the exact Python dictionary snippet needed in `install.py` so the main developer can quickly implement the backend fix.
