### PR TITLE
sync: develop into pre-dev

### DIFF
--- a/.github/workflows/deploy-huf.yml
+++ b/.github/workflows/deploy-huf.yml
@@ -1,0 +1,37 @@
+name: Deploy HUF Bench
+
+on:
+  push:
+    branches:
+      - pre-develop
+      #- stage-1
+      #- stage-2
+      #- develop
+      #- test-1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.HUF_DEPLOY_SSH_KEY }}
+          SSH_HOST: ${{ secrets.HUF_DEPLOY_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+
+      - name: Deploy
+        env:
+          SSH_HOST: ${{ secrets.HUF_DEPLOY_HOST }}
+          SSH_USER: ${{ secrets.HUF_DEPLOY_USER }}
+        run: |
+          ssh "$SSH_USER@$SSH_HOST" \
+            "/home/ubuntu/deploy-huf.sh \
+            '${GITHUB_REF_NAME}' \
+            '${GITHUB_SHA}'"

--- a/.github/workflows/deploy-huf.yml
+++ b/.github/workflows/deploy-huf.yml
@@ -3,12 +3,8 @@ name: Deploy HUF Bench
 on:
   push:
     branches:
-      - pre-develop
-      #- stage-1
-      #- stage-2
-      #- develop
-      #- test-1
-
+      - develop
+     
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ build-backend = "flit_core.buildapi"
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0"
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
Brings develop's small deploy/dependency commits into pre-dev: pyproject.toml frappe-dependencies fix (#607), .github/workflows/deploy-huf.yml HUF deployment workflow (#605, #606). pre-dev is otherwise 149 commits ahead of develop (unaffected). One real conflict, resolved manually (a direct develop-to-pre-dev PR had mergeable:false, see closed #619): deploy-huf.yml's push-trigger branch list conflicted (pre-develop vs develop) - kept both triggers.