### PR TITLE
fix: telegram message routing and integration credentials optionality

### DIFF
--- a/frontend/src/types/integration.types.ts
+++ b/frontend/src/types/integration.types.ts
@@ -11,6 +11,7 @@ export interface IntegrationCredentialRow {
   key: string;
   value?: string;
   description?: string;
+  is_mandatory?: 0 | 1;
 }
 
 export interface IntegrationRecipientRow {
@@ -154,6 +155,7 @@ export function buildCredentialsPayload(
         key: item.key,
         value: formValue,
         description: item.label,
+        is_mandatory: item.required ? 1 : 0,
       };
     }
 
@@ -164,6 +166,7 @@ export function buildCredentialsPayload(
       key: item.key,
       value,
       description: item.label,
+      is_mandatory: item.required ? 1 : 0,
     };
   });
 }

--- a/huf/ai/gateway_service.py
+++ b/huf/ai/gateway_service.py
@@ -161,6 +161,8 @@ def _admission(gateway, context: dict[str, Any]) -> tuple[bool, str]:
     if not is_room:
         policy = gateway.direct_policy or "Allow list"
         if policy == "Pairing":
+            if _has_access_entry(gateway, "Sender", sender_id):
+                return True, ""
             display_name = str(context.get("display_name") or "") or None
             code = _create_pairing_request(
                 gateway, sender_id, conversation_id=conversation_id, display_name=display_name
@@ -239,26 +241,40 @@ def approve_gateway_pairing(code_or_entry_name: str, notes: str | None = None) -
 
     notification_status = "Not attempted"
     try:
+        from huf.ai.gateway_webhook import get_gateway_adapter
+        from huf.ai.gateway_adapters.types import GatewayReply
+
         gw_doc = frappe.get_doc("Gateway", entry.gateway)
         if gw_doc.integration_settings:
-            int_doc = frappe.get_doc("Integration Settings", gw_doc.integration_settings)
-            creds = {}
-            for row in getattr(int_doc, "credentials", []):
-                creds[row.key] = row.get_password("value") if hasattr(row, "get_password") else row.value
+            adapter = get_gateway_adapter(gw_doc)
+            
+            target_conv = entry.external_id
+            target_thread = None
+            recent_events = frappe.get_all(
+                "Gateway Event",
+                filters={"gateway": entry.gateway, "sender_id": entry.external_id},
+                fields=["conversation_id", "thread_id"],
+                order_by="creation desc",
+                limit=1
+            )
+            if recent_events and recent_events[0].conversation_id:
+                target_conv = recent_events[0].conversation_id
+                target_thread = recent_events[0].thread_id
 
-            from huf.ai.gateway_webhook import _adapter_class_for_provider
-            from huf.ai.gateway_adapters.types import GatewayReply
-
-            adapter_cls = _adapter_class_for_provider(gw_doc.provider)
-            adapter = adapter_cls(creds)
             welcome_text = (
                 "🎉 Your access pairing request has been approved!\n\n"
                 "You can now interact directly with this assistant."
             )
-            adapter.send_reply(GatewayReply(conversation_id=entry.external_id, text=welcome_text))
+            adapter.send_reply(GatewayReply(
+                conversation_id=target_conv, 
+                text=welcome_text,
+                thread_id=target_thread or None,
+                reply_to_provider_message_id=target_thread or None,
+            ))
             notification_status = "Welcome message sent to sender"
     except Exception as exc:
         notification_status = f"Approval saved, welcome message notice: {exc}"
+        frappe.log_error("Failed to send welcome message on frontend approval", f"{exc}\n{frappe.get_traceback()}")
 
     return {
         "name": entry.name,

--- a/huf/huf/doctype/integration_credential/integration_credential.json
+++ b/huf/huf/doctype/integration_credential/integration_credential.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "key",
+  "is_mandatory",
   "value",
   "description"
  ],
@@ -18,12 +19,19 @@
    "reqd": 1
   },
   {
+   "default": "1",
+   "fieldname": "is_mandatory",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is Mandatory"
+  },
+  {
    "fieldname": "value",
    "fieldtype": "Password",
    "in_list_view": 1,
    "label": "Value",
-   "length": 240,
-   "reqd": 1
+   "length": 1000,
+   "mandatory_depends_on": "eval:doc.is_mandatory"
   },
   {
    "fieldname": "description",


### PR DESCRIPTION
## Description
This PR applies fixes on top of the recent gateway pairing refactor (`#613`) to address remaining credential and routing edge cases:

1. **Interactive Allow List Bypass**: Ensures that when the Gateway policy is set to `"Pairing"`, senders that already have an approved `Gateway Access Entry` bypass the pairing prompt and are allowed admission (resolves edge cases causing infinite pairing loops).
2. **Telegram Welcome Message Routing**: Fixed a `400 Bad Request` error when sending welcome messages in Telegram group chats. The system now queries the `Gateway Event` table for the last known `conversation_id` and `thread_id` before sending welcome messages, ensuring messages route correctly to group chats and threads instead of attempting to direct-message the user. Error logging has also been upgraded to use `frappe.log_error` for full stack trace visibility in the Frappe Desk.
3. **Integration Credential Length & Optionality**: 
    - Increased the `value` field length in the `Integration Credential` DocType from 240 to 1000 characters to safely support long Meta access tokens and JWTs.
    - Implemented dynamic mandatory validation via a new hidden `is_mandatory` field. The React UI now dynamically sets `is_mandatory: 0` for optional fields (such as the Meta App Secret) defined in the integration's `required_credentials` schema, eliminating false "Mandatory Field" errors when saving.

## Changed Files
- `frontend/src/types/integration.types.ts`
- `huf/ai/gateway_service.py`
- `huf/huf/doctype/integration_credential/integration_credential.json`
