### PR TITLE
fix(gateway): route email replies to sender instead of bot

### DIFF
--- a/huf/ai/gateway_adapters/email.py
+++ b/huf/ai/gateway_adapters/email.py
@@ -59,7 +59,7 @@ class EmailGatewayAdapter(GatewayAdapter):
 			payload = request.query
 
 		sender_id = payload.get("from") or payload.get("sender") or ""
-		conversation_id = payload.get("to") or payload.get("recipient") or sender_id
+		conversation_id = sender_id
 		message_text = payload.get("body") or payload.get("text") or payload.get("subject") or ""
 		event_id = payload.get("message_id") or payload.get("id") or str(hash(f"{sender_id}:{message_text}"))
 
@@ -129,7 +129,7 @@ def on_communication_inserted(doc, method=None):
 	for gw in gateways:
 		context = {
 			"sender_id": doc.sender or "",
-			"conversation_id": doc.recipients or doc.sender or "",
+			"conversation_id": doc.sender or "",
 			"thread_id": doc.in_reply_to or None,
 			"message_text": doc.content or doc.subject or "",
 		}


### PR DESCRIPTION
## Description
This PR fixes a routing bug in the `EmailGatewayAdapter` where outbound replies (including pairing codes, welcome messages, and AI Agent responses) were being incorrectly sent to the bot's own email address instead of the original sender.

## Root Cause
In 1-on-1 direct emails, the bot receives an email where `to` (or `recipients`) is the bot, and `from` (or `sender`) is the user. 
The gateway was incorrectly mapping the `conversation_id` to the `to` / `recipients` address. Because `EmailGatewayAdapter.send_reply()` uses `reply.conversation_id` as the recipient destination, it resulted in the bot sending emails to itself.

## Fix
- Updated `normalize_inbound()` to map `conversation_id` directly to `sender_id`.
- Updated the `on_communication_inserted` doc event hook to map `conversation_id` directly to `doc.sender`. 
- Replies are now correctly routed back to the user who initiated the email thread.
