### PR TITLE
refactor: remove Discord, VK, WeCom, and SMS gateway integrations

### DIFF
--- a/frontend/src/data/serviceIdentity.test.ts
+++ b/frontend/src/data/serviceIdentity.test.ts
@@ -7,7 +7,6 @@ describe('service identities', () => {
     ['telegram', 'Telegram'],
     ['slack', 'Slack'],
     ['whatsapp', 'WhatsApp'],
-    ['discord', 'Discord'],
     ['teams', 'Microsoft Teams'],
     ['github', 'GitHub'],
     ['jira', 'Jira'],

--- a/frontend/src/data/serviceIdentity.ts
+++ b/frontend/src/data/serviceIdentity.ts
@@ -3,7 +3,6 @@ import type { ComponentType } from 'react';
 import { Cloud, Workflow } from 'lucide-react';
 import { FaMicrosoft, FaSlack } from 'react-icons/fa';
 import {
-  SiDiscord,
   SiGithub,
   SiGmail,
   SiGooglecalendar,
@@ -13,8 +12,6 @@ import {
   SiGooglesheets,
   SiJira,
   SiTelegram,
-  SiVk,
-  SiWechat,
   SiWhatsapp,
 } from 'react-icons/si';
 
@@ -58,11 +55,8 @@ const serviceIdentities: Record<string, { title: string; icon: ServiceIcon }> = 
   telegram: { title: 'Telegram', icon: SiTelegram },
   slack: { title: 'Slack', icon: FaSlack },
   whatsapp: { title: 'WhatsApp', icon: SiWhatsapp },
-  discord: { title: 'Discord', icon: SiDiscord },
   microsoft_teams: { title: 'Microsoft Teams', icon: FaMicrosoft },
   teams: { title: 'Microsoft Teams', icon: FaMicrosoft },
-  wecom: { title: 'WeCom', icon: SiWechat },
-  vk: { title: 'VK', icon: SiVk },
   github: { title: 'GitHub', icon: SiGithub },
   jira: { title: 'Jira', icon: SiJira },
   gmail: { title: 'Gmail', icon: SiGmail },

--- a/frontend/src/pages/GatewaysPage.tsx
+++ b/frontend/src/pages/GatewaysPage.tsx
@@ -74,13 +74,9 @@ const providerNames: Record<GatewayProvider, string> = {
   Instagram: 'Instagram Direct Account',
   Telegram: 'Telegram Bot',
   Slack: 'Slack Workspace',
-  Discord: 'Discord Server',
   Email: 'Shared Email Inbox',
-  SMS: 'Twilio / SMS Number',
   'Google Chat': 'Google Workspace Chat',
   'Microsoft Teams': 'MS Teams Channel',
-  VK: 'VK Community',
-  WeCom: 'WeCom Work Account',
 };
 
 const uiProviders: GatewayProvider[] = [
@@ -89,13 +85,9 @@ const uiProviders: GatewayProvider[] = [
   'Instagram',
   'Telegram',
   'Slack',
-  'Discord',
   'Email',
-  'SMS',
   'Google Chat',
   'Microsoft Teams',
-  'VK',
-  'WeCom',
 ];
 
 export default function GatewaysPage() {

--- a/frontend/src/services/gatewayApi.ts
+++ b/frontend/src/services/gatewayApi.ts
@@ -11,12 +11,8 @@ export type GatewayProvider =
   | 'Instagram'
   | 'Telegram'
   | 'Slack'
-  | 'Discord'
   | 'Email'
-  | 'SMS'
   | 'Google Chat'
-  | 'VK'
-  | 'WeCom'
   | 'Microsoft Teams';
 
 export type GatewayPolicy = 'Disabled' | 'Pairing' | 'Allow list' | 'Open';

--- a/huf/ai/gateway_adapters/registered.py
+++ b/huf/ai/gateway_adapters/registered.py
@@ -41,13 +41,9 @@ _ADAPTER_LOCATIONS: dict[str, tuple[str, str]] = {
 	"telegram": ("huf.ai.gateway_adapters.telegram", "TelegramGatewayAdapter"),
 	"messenger": ("huf.ai.gateway_adapters.messenger", "MessengerGatewayAdapter"),
 	"instagram": ("huf.ai.gateway_adapters.instagram", "InstagramGatewayAdapter"),
-	"discord": ("huf.ai.gateway_adapters.discord", "DiscordGatewayAdapter"),
 	"email": ("huf.ai.gateway_adapters.email", "EmailGatewayAdapter"),
-	"sms": ("huf.ai.gateway_adapters.sms", "SMSGatewayAdapter"),
 	"google_chat": ("huf.ai.gateway_adapters.google_chat", "GoogleChatGatewayAdapter"),
 	"microsoft_teams": ("huf.ai.gateway_adapters.teams", "TeamsGatewayAdapter"),
-	"vk": ("huf.ai.gateway_adapters.vk", "VKGatewayAdapter"),
-	"wecom": ("huf.ai.gateway_adapters.wecom", "WeComGatewayAdapter"),
 	"slack": ("huf.ai.gateway_adapters.slack", "SlackGatewayAdapter"),
 }
 

--- a/huf/ai/tests/test_all_gateway_adapters.py
+++ b/huf/ai/tests/test_all_gateway_adapters.py
@@ -3,33 +3,13 @@
 import unittest
 from unittest.mock import MagicMock
 
-from huf.ai.gateway_adapters.discord import DiscordGatewayAdapter
 from huf.ai.gateway_adapters.email import EmailGatewayAdapter
-from huf.ai.gateway_adapters.sms import SMSGatewayAdapter
 from huf.ai.gateway_adapters.google_chat import GoogleChatGatewayAdapter
 from huf.ai.gateway_adapters.teams import TeamsGatewayAdapter
 from huf.ai.gateway_adapters.types import GatewayInboundRequest, GatewayReply
 
 
 class TestAllGatewayAdapters(unittest.TestCase):
-	def test_discord_adapter_outbound(self):
-		mock_post = MagicMock()
-		mock_post.return_value.json.return_value = {"id": "msg_12345"}
-
-		adapter = DiscordGatewayAdapter(
-			{"bot_token": "test_bot_token", "public_key": "a" * 64},
-			http_post=mock_post,
-		)
-
-		reply = GatewayReply(
-			conversation_id="channel_99",
-			text="Hello Discord",
-			reply_to_provider_message_id=None,
-		)
-
-		delivery = adapter.send_reply(reply)
-		self.assertEqual(delivery.provider_message_id, "msg_12345")
-		mock_post.assert_called_once()
 
 	def test_email_adapter_inbound_and_outbound(self):
 		import frappe
@@ -64,35 +44,6 @@ class TestAllGatewayAdapters(unittest.TestCase):
 			if original_sendmail:
 				frappe.sendmail = original_sendmail
 
-	def test_sms_adapter_outbound(self):
-		mock_post = MagicMock()
-		mock_post.return_value.json.return_value = {"sid": "SM12345"}
-
-		adapter = SMSGatewayAdapter(
-			{
-				"account_sid": "AC123",
-				"auth_token": "secret",
-				"from_number": "+1234567890",
-			},
-			http_post=mock_post,
-		)
-
-		req = GatewayInboundRequest(
-			body=b"From=%2B1987654321&Body=Hello+SMS&MessageSid=SM999",
-			headers={},
-			query={},
-			method="POST",
-		)
-		event = adapter.normalize_inbound(req)
-		self.assertEqual(event.sender_id, "+1987654321")
-		self.assertEqual(event.message_text, "Hello SMS")
-
-		reply = GatewayReply(
-			conversation_id="+1987654321",
-			text="SMS Reply",
-		)
-		delivery = adapter.send_reply(reply)
-		self.assertEqual(delivery.provider_message_id, "SM12345")
 
 	def test_google_chat_adapter(self):
 		mock_post = MagicMock()

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1858,7 +1858,6 @@ ALL_INTEGRATION_TOOLS = (
 	# Tools backed by a connectable service. Keys match Integration Service
 	# docnames and the SERVICE_NAME each tool module uses for credentials.
 	+ _with_service(SLACK_TOOLS, "slack")
-	+ _with_service(DISCORD_TOOLS, "discord")
 	+ _with_service(TELEGRAM_TOOLS, "telegram")
 	+ _with_service(GITHUB_TOOLS, "github")
 	+ _with_service(GMAIL_TOOLS, "gmail")

--- a/huf/huf/doctype/gateway/gateway.json
+++ b/huf/huf/doctype/gateway/gateway.json
@@ -8,7 +8,7 @@
  "field_order": ["gateway_name", "provider", "is_enabled", "integration_settings", "execution_user", "description", "section_admission", "direct_policy", "room_policy", "room_sender_policy", "mention_required", "pairing_ttl_minutes", "pairing_reply_enabled", "section_default_route", "default_target_type", "default_agent", "default_flow", "section_status", "last_event_at", "last_error"],
  "fields": [
   {"fieldname":"gateway_name","fieldtype":"Data","in_list_view":1,"label":"Gateway name","reqd":1,"unique":1},
-  {"fieldname":"provider","fieldtype":"Select","in_list_view":1,"label":"Channel","options":"WhatsApp\nMessenger\nInstagram\nTelegram\nSlack\nDiscord\nEmail\nSMS\nGoogle Chat\nVK\nWeCom\nMicrosoft Teams","reqd":1},
+  {"fieldname":"provider","fieldtype":"Select","in_list_view":1,"label":"Channel","options":"WhatsApp\nMessenger\nInstagram\nTelegram\nSlack\nEmail\nGoogle Chat\nMicrosoft Teams","reqd":1},
   {"default":"1","fieldname":"is_enabled","fieldtype":"Check","in_list_view":1,"label":"Enabled"},
   {"description":"Existing integration that owns this channel's credentials. VK and WeCom gateways require it; use its Password credential rows for the adapter's documented keys.","fieldname":"integration_settings","fieldtype":"Link","label":"Connected integration","options":"Integration Settings"},
   {"description":"The least-privileged Huf user used when this gateway starts an Agent or Flow. Never use Administrator.","fieldname":"execution_user","fieldtype":"Link","label":"Run as user","options":"User"},

--- a/huf/install.py
+++ b/huf/install.py
@@ -1051,13 +1051,7 @@ def register_integration_services():
 			"description": "Slack messaging and channel management",
 			"required_credentials": [{"key": "token", "label": "Slack Bot Token", "required": True}]
 		},
-		{
-			"service_name": "discord",
-			"category": "Communication",
-			"surface": "Gateway",
-			"description": "Discord bot for messaging and channel management",
-			"required_credentials": [{"key": "bot_token", "label": "Discord Bot Token", "required": True}]
-		},
+
 		{
 			"service_name": "telegram",
 			"category": "Communication",
@@ -1111,17 +1105,7 @@ def register_integration_services():
 				{"key": "sender_email", "label": "Default Outbound Sender Email (Optional)", "required": False}
 			]
 		},
-		{
-			"service_name": "sms",
-			"category": "Communication",
-			"surface": "Gateway",
-			"description": "SMS messaging via Twilio or Frappe SMS Settings",
-			"required_credentials": [
-				{"key": "account_sid", "label": "Twilio Account SID (or 'frappe_sms' to use Frappe SMS Settings)", "required": False},
-				{"key": "auth_token", "label": "Twilio Auth Token (Optional if using Frappe SMS)", "required": False},
-				{"key": "from_number", "label": "Twilio Phone Number (+1... / Sender ID)", "required": False}
-			]
-		},
+
 		{
 			"service_name": "google_chat",
 			"category": "Communication",
@@ -1142,30 +1126,7 @@ def register_integration_services():
 				{"key": "app_password", "label": "Microsoft App Secret / Password", "required": True}
 			]
 		},
-		{
-			"service_name": "vk",
-			"category": "Communication",
-			"surface": "Gateway",
-			"description": "VKontakte community messaging",
-			"required_credentials": [
-				{"key": "community_token", "label": "Community access token", "required": True},
-				{"key": "callback_secret", "label": "Callback API secret", "required": True},
-				{"key": "confirmation_string", "label": "Callback confirmation string", "required": True}
-			]
-		},
-		{
-			"service_name": "wecom",
-			"category": "Communication",
-			"surface": "Gateway",
-			"description": "WeCom (WeChat Work) application messaging",
-			"required_credentials": [
-				{"key": "corp_id", "label": "Corporation ID", "required": True},
-				{"key": "agent_id", "label": "Application Agent ID", "required": True},
-				{"key": "corp_secret", "label": "Application Secret", "required": True},
-				{"key": "callback_token", "label": "Callback Token", "required": True},
-				{"key": "encoding_aes_key", "label": "Callback EncodingAESKey", "required": True}
-			]
-		},
+
 
 		# Developer Tools
 		{


### PR DESCRIPTION
### Description
This PR removes the `discord`, `vk`, `wecom`, and `sms` gateway integration services from the platform UI and registry. The underlying Python logic (adapters and tools) is kept intact for future use, but these providers will no longer be visible or configurable by users on the frontend or backend.

### Changes Made
- **Installation Code (`install.py`)**: Removed the auto-creation setup for the affected gateways.
- **Backend Schema (`gateway.json`)**: Removed Discord, SMS, VK, and WeCom from the Gateway provider dropdown options.
- **Adapter Registry (`registered.py`)**: Removed the provider configurations so they are no longer registered as active adapters.
- **Frontend App (`GatewaysPage.tsx`, `gatewayApi.ts`, `serviceIdentity.ts`)**: Removed the gateways from UI listings, type definitions, and icon mappings.
- **Tools Registry (`_registry.py`)**: Deregistered Discord tools since the underlying integration service is no longer available.
- **Tests**: Cleaned up both frontend and backend tests to prevent failures due to the removed references.
