### PR TITLE
fix(ui): improve agent tools usage badge readability

### DIFF
--- a/frontend/src/components/agent/ToolsTab.tsx
+++ b/frontend/src/components/agent/ToolsTab.tsx
@@ -171,7 +171,7 @@ export function ToolsTab({
                           {tool.description || 'No description available.'}
                         </p>
                         {isShared && (
-                          <div className="flex w-fit items-center text-warning bg-warning px-2 py-0.5 rounded mt-2 text-[11px] font-semibold">
+                          <div className="flex w-fit items-center text-white bg-warning px-2 py-0.5 rounded mt-2 text-[11px] font-semibold">
                             <Users className="w-3 h-3 mr-1.5" />
                             <span>Used in {usedByAgents.length} agent{usedByAgents.length > 1 ? 's' : ''}</span>
                           </div>


### PR DESCRIPTION
### Description
This PR fixes a contrast issue with the "Used in X agents" badge in the Agent Tools configuration interface. 

Previously, the badge applied the same warning color to both the text and the background (`text-warning` on `bg-warning`), which made the text unreadable. This update changes the text color to `text-white`, ensuring the badge content is clearly visible while keeping the rest of the styling exactly the same.

### Changes
- Changed text color from `text-warning` to `text-white` in `ToolsTab.tsx`
