### PR TITLE
fix: Prevent empty integration credentials from being sent to backend

### DIFF
--- a/frontend/src/types/integration.types.ts
+++ b/frontend/src/types/integration.types.ts
@@ -146,27 +146,29 @@ export function buildCredentialsPayload(
 ): IntegrationCredentialRow[] {
   const existingMap = credentialsToMap(existingCredentials);
 
-  return schema.map((item) => {
-    const formValue = formValues[item.key]?.trim() ?? '';
-    const existingRow = existingCredentials?.find((c) => c.key === item.key);
+  return schema
+    .map((item): IntegrationCredentialRow => {
+      const formValue = formValues[item.key]?.trim() ?? '';
+      const existingRow = existingCredentials?.find((c) => c.key === item.key);
 
-    if (isNew) {
+      if (isNew) {
+        return {
+          key: item.key,
+          value: formValue,
+          description: item.label,
+          is_mandatory: item.required ? 1 : 0,
+        };
+      }
+
+      // On edit: blank field keeps existing value
+      const value = formValue || existingMap[item.key] || '';
       return {
+        ...(existingRow?.name ? { name: existingRow.name } : {}),
         key: item.key,
-        value: formValue,
+        value,
         description: item.label,
         is_mandatory: item.required ? 1 : 0,
       };
-    }
-
-    // On edit: blank field keeps existing value
-    const value = formValue || existingMap[item.key] || '';
-    return {
-      ...(existingRow?.name ? { name: existingRow.name } : {}),
-      key: item.key,
-      value,
-      description: item.label,
-      is_mandatory: item.required ? 1 : 0,
-    };
-  });
+    })
+    .filter((row) => row.value !== undefined && row.value !== '');
 }


### PR DESCRIPTION
## Description
This PR addresses an issue where optional integration credentials (such as the WhatsApp Meta App Secret) left blank in the UI were still being added to the backend child table as rows with an empty value. These empty keys were subsequently causing connection errors on the backend.

## Changes
- Updated `buildCredentialsPayload` in `frontend/src/types/integration.types.ts` to filter out any credential rows that have an empty or undefined `value`.
- This ensures that only credentials containing actual values are included in the payload.
