### PR TITLE
Knowledge upload UX, Models filter+delete, Playground compare/template UX

### DIFF
--- a/frontend/src/components/knowledge/GeneralTab.tsx
+++ b/frontend/src/components/knowledge/GeneralTab.tsx
@@ -565,6 +565,58 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
         </Card>
       )}
 
+      {watchKnowledgeType === 'sqlite_hybrid' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>SQLite Hybrid settings</CardTitle>
+            <CardDescription>
+              Combines SQLite FTS keyword search with SQLite Vec similarity search (reciprocal rank fusion)
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
+      {watchKnowledgeType === 'weaviate' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Weaviate connection settings</CardTitle>
+            <CardDescription>Connect HUF Knowledge to a Weaviate vector database</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
+      {watchKnowledgeType === 'faiss' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>FAISS settings</CardTitle>
+            <CardDescription>
+              Embedded similarity search index — runs in-process, stores to a local file
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
+      {watchKnowledgeType === 'pinecone' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Pinecone connection settings</CardTitle>
+            <CardDescription>Connect HUF Knowledge to a Pinecone vector database</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle>Chunking settings</CardTitle>

--- a/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
+++ b/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
@@ -13,10 +13,12 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { Progress } from '@/components/ui/progress';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
-import { Plus, Trash2, RefreshCw, FileText, Link, Type, Loader2, Upload } from 'lucide-react';
+import { Plus, Trash2, RefreshCw, FileText, Link, Type, Loader2, Upload, X, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
 import { knowledgeInputTypes } from '@/data/knowledge';
 import type { KnowledgeInputDoc, KnowledgeInputType } from '@/types/knowledge.types';
 import {
@@ -26,6 +28,14 @@ import {
   reprocessInput,
 } from '@/services/knowledgeApi';
 import { file as frappeFile } from '@/lib/frappe-sdk';
+
+interface QueuedUpload {
+  id: string;
+  fileName: string;
+  progress: number;
+  status: 'uploading' | 'creating' | 'error';
+  error?: string;
+}
 
 interface KnowledgeInputsModalProps {
   open: boolean;
@@ -81,13 +91,11 @@ export function KnowledgeInputsModal({
   const [loading, setLoading] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState(0);
+  const [dragOver, setDragOver] = useState(false);
+  const [uploadQueue, setUploadQueue] = useState<QueuedUpload[]>([]);
 
   // Create form state
   const [inputType, setInputType] = useState<KnowledgeInputType>('File');
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [uploadedFileUrl, setUploadedFileUrl] = useState('');
   const [text, setText] = useState('');
   const [url, setUrl] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -112,55 +120,76 @@ export function KnowledgeInputsModal({
 
   const resetForm = () => {
     setInputType('File');
-    setSelectedFile(null);
-    setUploadedFileUrl('');
     setText('');
     setUrl('');
-    setUploading(false);
-    setUploadProgress(0);
     setShowCreate(false);
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0];
-    if (f) {
-      setSelectedFile(f);
-      setUploadedFileUrl('');
-    }
+  const uploadOneFile = useCallback(
+    async (file: File) => {
+      const id = `${file.name}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      setUploadQueue((q) => [...q, { id, fileName: file.name, progress: 0, status: 'uploading' }]);
+      try {
+        const response = await frappeFile.uploadFile(
+          file,
+          {
+            isPrivate: true,
+            doctype: 'Knowledge Input',
+          },
+          (completed, total) => {
+            if (total) {
+              const progress = Math.round((completed / total) * 100);
+              setUploadQueue((q) => q.map((item) => (item.id === id ? { ...item, progress } : item)));
+            }
+          },
+        );
+        const res = response as { data?: { message?: { file_url?: string } } };
+        const fileUrl = res?.data?.message?.file_url;
+        if (!fileUrl) throw new Error('No file URL returned');
+
+        setUploadQueue((q) => q.map((item) => (item.id === id ? { ...item, status: 'creating' } : item)));
+        await createKnowledgeInput({
+          knowledge_source: knowledgeSource,
+          input_type: 'File',
+          file: fileUrl,
+        });
+        setUploadQueue((q) => q.filter((item) => item.id !== id));
+        await loadInputs();
+        onSourceChanged();
+      } catch {
+        setUploadQueue((q) =>
+          q.map((item) => (item.id === id ? { ...item, status: 'error', error: 'Upload failed' } : item)),
+        );
+        toast.error(`Failed to upload ${file.name}`);
+      }
+    },
+    [knowledgeSource, loadInputs, onSourceChanged],
+  );
+
+  const handleFilesSelected = useCallback(
+    (files: FileList | File[] | null) => {
+      if (!files || files.length === 0) return;
+      Array.from(files).forEach((file) => {
+        void uploadOneFile(file);
+      });
+    },
+    [uploadOneFile],
+  );
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFilesSelected(e.target.files);
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleUploadFile = async () => {
-    if (!selectedFile) {
-      toast.error('Please select a file first');
-      return;
-    }
-    setUploading(true);
-    setUploadProgress(0);
-    try {
-      const response = await frappeFile.uploadFile(
-        selectedFile,
-        {
-          isPrivate: true,
-          doctype: 'Knowledge Input',
-        },
-        (completed, total) => {
-          if (total) setUploadProgress(Math.round((completed / total) * 100));
-        },
-      );
-      const res = response as { data?: { message?: { file_url?: string } } };
-      const fileUrl = res?.data?.message?.file_url;
-      if (fileUrl) {
-        setUploadedFileUrl(fileUrl);
-        toast.success('File uploaded');
-      } else {
-        toast.error('Upload succeeded but no file URL returned');
-      }
-    } catch {
-      toast.error('Failed to upload file');
-    } finally {
-      setUploading(false);
-    }
+  const handleDropzoneDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    handleFilesSelected(e.dataTransfer.files);
+  };
+
+  const dismissQueuedUpload = (id: string) => {
+    setUploadQueue((q) => q.filter((item) => item.id !== id));
   };
 
   const handleCreate = async () => {
@@ -169,10 +198,6 @@ export function KnowledgeInputsModal({
       input_type: inputType,
     };
 
-    if (inputType === 'File' && !uploadedFileUrl) {
-      toast.error('Please upload a file first');
-      return;
-    }
     if (inputType === 'Text' && !text.trim()) {
       toast.error('Text content is required');
       return;
@@ -182,7 +207,6 @@ export function KnowledgeInputsModal({
       return;
     }
 
-    if (inputType === 'File') data.file = uploadedFileUrl;
     if (inputType === 'Text') data.text = text;
     if (inputType === 'URL') data.url = url;
 
@@ -267,34 +291,67 @@ export function KnowledgeInputsModal({
 
               {inputType === 'File' && (
                 <div className="space-y-3">
-                  <Label>File</Label>
-                  <div className="flex items-center gap-2">
+                  <Label>Files</Label>
+                  <div
+                    className={cn(
+                      'flex flex-col items-center justify-center gap-2 rounded-md border border-dashed p-6 text-center transition-colors cursor-pointer',
+                      dragOver ? 'border-primary bg-primary/5' : 'border-input',
+                    )}
+                    onClick={() => fileInputRef.current?.click()}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setDragOver(true);
+                    }}
+                    onDragLeave={() => setDragOver(false)}
+                    onDrop={handleDropzoneDrop}
+                  >
+                    <Upload className="w-6 h-6 text-steel-soft" />
+                    <p className="text-sm">Drag and drop files here, or click to browse</p>
+                    <p className="text-xs text-steel-soft">Select multiple files to upload them all at once</p>
                     <Input
                       ref={fileInputRef}
                       type="file"
-                      onChange={handleFileSelect}
-                      className="flex-1"
-                      disabled={uploading}
+                      multiple
+                      onChange={handleFileInputChange}
+                      className="hidden"
                     />
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={handleUploadFile}
-                      disabled={!selectedFile || uploading || !!uploadedFileUrl}
-                    >
-                      {uploading ? (
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      ) : (
-                        <Upload className="w-4 h-4 mr-2" />
-                      )}
-                      {uploading ? `${uploadProgress}%` : 'Upload'}
-                    </Button>
                   </div>
-                  {uploadedFileUrl && (
-                    <p className="text-xs text-steel-soft">
-                      Uploaded: <span className="font-mono">{uploadedFileUrl}</span>
-                    </p>
+
+                  {uploadQueue.length > 0 && (
+                    <div className="space-y-2">
+                      {uploadQueue.map((item) => (
+                        <div key={item.id} className="flex items-center gap-3 rounded-md border p-2.5">
+                          {item.status === 'error' ? (
+                            <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0" />
+                          ) : (
+                            <Loader2 className="w-4 h-4 animate-spin text-steel-soft flex-shrink-0" />
+                          )}
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm truncate">{item.fileName}</p>
+                            {item.status === 'error' ? (
+                              <p className="text-xs text-destructive">{item.error}</p>
+                            ) : (
+                              <>
+                                <p className="text-xs text-steel-soft">
+                                  {item.status === 'uploading' ? `Uploading... ${item.progress}%` : 'Creating input...'}
+                                </p>
+                                <Progress value={item.status === 'uploading' ? item.progress : 100} className="h-1 mt-1" />
+                              </>
+                            )}
+                          </div>
+                          {item.status === 'error' && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => dismissQueuedUpload(item.id)}
+                            >
+                              <X className="w-3.5 h-3.5" />
+                            </Button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
                   )}
                 </div>
               )}
@@ -324,16 +381,14 @@ export function KnowledgeInputsModal({
 
               <div className="flex justify-end gap-2">
                 <Button variant="outline" size="sm" onClick={resetForm}>
-                  Cancel
+                  {inputType === 'File' ? 'Done' : 'Cancel'}
                 </Button>
-                <Button
-                  size="sm"
-                  onClick={handleCreate}
-                  disabled={creating || uploading || (inputType === 'File' && !uploadedFileUrl)}
-                >
-                  {creating && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-                  Create
-                </Button>
+                {inputType !== 'File' && (
+                  <Button size="sm" onClick={handleCreate} disabled={creating}>
+                    {creating && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    Create
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/frontend/src/components/knowledge/types.ts
+++ b/frontend/src/components/knowledge/types.ts
@@ -4,10 +4,23 @@ import { isVectorKnowledgeType } from '@/data/knowledge';
 export const knowledgeSourceFormSchema = z.object({
 	source_name: z.string().min(1, 'Source name is required'),
 	description: z.string().optional(),
-	knowledge_type: z.enum(['sqlite_fts', 'sqlite_vec', 'chroma', 'pgvector', 'redis', 'zvec'], {
-
-		required_error: 'Knowledge type is required',
-	}),
+	knowledge_type: z.enum(
+		[
+			'sqlite_fts',
+			'sqlite_vec',
+			'sqlite_hybrid',
+			'chroma',
+			'pgvector',
+			'redis',
+			'zvec',
+			'weaviate',
+			'faiss',
+			'pinecone',
+		],
+		{
+			required_error: 'Knowledge type is required',
+		},
+	),
 	scope: z.enum(['Site', 'Workspace', 'Agent', 'Global']).default('Site'),
 	storage_mode: z.string().default('Frappe File'),
 	chunk_size: z.number().int().min(100, 'Minimum chunk size is 100').default(512),

--- a/frontend/src/components/playground/CompareView.tsx
+++ b/frontend/src/components/playground/CompareView.tsx
@@ -3,12 +3,21 @@ import { ArrowRightLeft, Copy, GitCompare, Pencil } from 'lucide-react';
 import type { AgentDoc, AIProvider } from '@/types/agent.types';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ShortcutKey } from '@/components/ui/shortcut-key';
+import { useKeyboardShortcut } from '@/lib/shortcuts/useKeyboardShortcut';
+import { formatBinding } from '@/lib/shortcuts/registry';
+import { usePlatform } from '@/lib/shortcuts/platform';
 import { ConfigStrip } from './ConfigStrip';
 import { PromptPanel } from './PromptPanel';
 import { ResponsePanel } from './ResponsePanel';
 import { RunLedger, type RunLedgerProps } from './RunLedger';
 import { wordDiff } from './wordDiff';
 import type { PlaygroundConfig, SlotState } from './types';
+
+const COPY_A_TO_B_BINDING = { key: 'c', mod: true, shift: true } as const;
+const SWAP_BINDING = { key: 'x', mod: true, shift: true } as const;
+const TOGGLE_DIFF_BINDING = { key: 'd', mod: true, shift: true } as const;
 
 interface CompareViewProps {
   agents: AgentDoc[];
@@ -105,6 +114,7 @@ export function CompareView({
   const [labelA, setLabelA] = useState('Baseline');
   const [labelB, setLabelB] = useState('Challenger');
   const [diffEnabled, setDiffEnabled] = useState(true);
+  const platform = usePlatform();
 
   const diff = useMemo(() => {
     if (!diffEnabled) return null;
@@ -131,61 +141,22 @@ export function CompareView({
     setLabelB(nextLabelB);
   };
 
+  const toggleDiff = () => setDiffEnabled((on) => !on);
+
+  useKeyboardShortcut(COPY_A_TO_B_BINDING, handleCopyAtoB, { allowInEditable: true });
+  useKeyboardShortcut(SWAP_BINDING, handleSwap, { allowInEditable: true });
+  useKeyboardShortcut(TOGGLE_DIFF_BINDING, toggleDiff, { allowInEditable: true });
+
   return (
     <div className="flex h-full min-h-0 flex-col overflow-y-auto">
-      {/* Control row */}
-      <div className="flex items-center justify-between px-5 pt-3">
+      <div className="flex items-center px-5 pt-3">
         <div className="flex items-center gap-2 font-mono text-eyebrow uppercase text-steel-soft">
           Two configurations
         </div>
-        <div className="flex items-center gap-4">
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={handleCopyAtoB}
-            className="h-auto gap-1.5 p-0 text-[12.5px] font-normal text-steel hover:bg-transparent hover:text-ink"
-          >
-            <Copy className="h-3.5 w-3.5" strokeWidth={1.8} />
-            Copy A → B
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={handleSwap}
-            className="h-auto gap-1.5 p-0 text-[12.5px] font-normal text-steel hover:bg-transparent hover:text-ink"
-          >
-            <ArrowRightLeft className="h-3.5 w-3.5" strokeWidth={1.8} />
-            Swap
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            role="switch"
-            aria-checked={diffEnabled}
-            onClick={() => setDiffEnabled((on) => !on)}
-            className="h-auto gap-1.5 p-0 text-[12.5px] font-normal text-ink hover:bg-transparent"
-          >
-            <GitCompare className="h-3.5 w-3.5 text-steel" strokeWidth={1.8} />
-            Diff responses
-            <span
-              className={cn(
-                'relative inline-flex h-[19px] w-[32px] shrink-0 items-center rounded-full p-[2px] transition-colors',
-                diffEnabled ? 'bg-signal' : 'bg-steel-soft',
-              )}
-            >
-              <span
-                className={cn(
-                  'block h-[15px] w-[15px] rounded-full bg-panel shadow-sm transition-transform',
-                  diffEnabled ? 'translate-x-[13px]' : 'translate-x-0',
-                )}
-              />
-            </span>
-          </Button>
-        </div>
       </div>
 
-      {/* Columns */}
-      <div className="grid flex-1 grid-cols-1 gap-4 p-5 lg:grid-cols-2">
+      {/* Columns, with a center console acting on both */}
+      <div className="grid flex-1 grid-cols-1 gap-4 p-5 lg:grid-cols-[1fr_auto_1fr] lg:items-stretch">
         <div>
           <EditableLabel glyph="A" label={labelA} onLabelChange={setLabelA} />
           <ConfigStrip
@@ -210,6 +181,72 @@ export function CompareView({
             onRun={onRunA}
             className="mt-4 min-h-[170px]"
           />
+        </div>
+
+        <div className="flex flex-row items-center justify-center gap-3 border-y border-line py-2 lg:h-full lg:w-14 lg:flex-col lg:justify-center lg:gap-4 lg:border-x lg:border-y-0 lg:py-4">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={handleCopyAtoB}
+                aria-label="Copy A to B"
+                className="text-steel hover:bg-paper-deep hover:text-ink"
+              >
+                <Copy className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="flex items-center gap-2">
+              <span>Copy A → B</span>
+              <ShortcutKey keys={formatBinding(COPY_A_TO_B_BINDING, platform)} size="sm" />
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={handleSwap}
+                aria-label="Swap A and B"
+                className="text-steel hover:bg-paper-deep hover:text-ink"
+              >
+                <ArrowRightLeft className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="flex items-center gap-2">
+              <span>Swap A and B</span>
+              <ShortcutKey keys={formatBinding(SWAP_BINDING, platform)} size="sm" />
+            </TooltipContent>
+          </Tooltip>
+
+          <div className="h-6 w-px bg-line lg:h-px lg:w-6" />
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                role="switch"
+                aria-checked={diffEnabled}
+                aria-label="Toggle diff responses"
+                onClick={toggleDiff}
+                className={cn(
+                  'hover:bg-paper-deep',
+                  diffEnabled ? 'text-signal' : 'text-steel',
+                )}
+              >
+                <GitCompare className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="flex items-center gap-2">
+              <span>Diff responses: {diffEnabled ? 'on' : 'off'}</span>
+              <ShortcutKey keys={formatBinding(TOGGLE_DIFF_BINDING, platform)} size="sm" />
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <div>

--- a/frontend/src/components/playground/PromptPanel.tsx
+++ b/frontend/src/components/playground/PromptPanel.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { ChevronRight, Loader2, Pencil } from 'lucide-react';
+import { toast } from 'sonner';
+import { ChevronRight, Loader2, Pencil, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import { improvePrompt } from '@/services/consoleApi';
+import { wordDiff } from './wordDiff';
 import type { PlaygroundConfig } from './types';
 
 interface PromptPanelProps {
@@ -21,6 +24,8 @@ export function PromptPanel({
   className,
 }: PromptPanelProps) {
   const [criteriaOpen, setCriteriaOpen] = useState(() => !!config.evaluationCriteria.trim());
+  const [improving, setImproving] = useState(false);
+  const [improvedPrompt, setImprovedPrompt] = useState<string | null>(null);
 
   // Auto-expand the disclosure when criteria arrive from outside (e.g. a
   // restored ledger entry or a loaded template).
@@ -31,34 +36,127 @@ export function PromptPanel({
     hadCriteria.current = has;
   }, [config.evaluationCriteria]);
 
+  const handleImprove = async () => {
+    if (!config.prompt.trim()) {
+      toast.info('Write a prompt first, then use Improve prompt.');
+      return;
+    }
+    setImproving(true);
+    try {
+      const result = await improvePrompt({
+        prompt_body: config.prompt,
+        provider: config.provider || undefined,
+        model: config.model || undefined,
+      });
+      setImprovedPrompt(result.prompt);
+    } catch {
+      // The service already surfaces the error toast.
+    } finally {
+      setImproving(false);
+    }
+  };
+
+  const handleAcceptImprovement = () => {
+    if (improvedPrompt === null) return;
+    onConfigChange({ ...config, prompt: improvedPrompt });
+    setImprovedPrompt(null);
+    toast.success('Improved prompt applied');
+  };
+
+  const handleDiscardImprovement = () => setImprovedPrompt(null);
+
+  const diff = improvedPrompt !== null ? wordDiff(config.prompt, improvedPrompt) : null;
+
   return (
     <div className={cn('flex min-h-[260px] flex-col rounded border border-line bg-panel', className)}>
       <div className="flex items-center justify-between border-b border-line px-3.5 py-2.5">
         <span className="font-mono text-eyebrow font-medium uppercase text-steel">Prompt</span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          onClick={onDraft}
-          title="Draft prompt"
-          aria-label="Draft prompt"
-          className="h-auto w-auto p-0 text-steel hover:bg-transparent hover:text-ink disabled:opacity-40"
-          disabled={generating}
-        >
-          {generating ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Pencil className="h-4 w-4" strokeWidth={1.8} />
-          )}
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleImprove}
+            title="Improve prompt"
+            aria-label="Improve prompt"
+            className="h-auto w-auto p-0 text-steel hover:bg-transparent hover:text-ink disabled:opacity-40"
+            disabled={improving || improvedPrompt !== null}
+          >
+            {improving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" strokeWidth={1.8} />
+            )}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onDraft}
+            title="Draft prompt"
+            aria-label="Draft prompt"
+            className="h-auto w-auto p-0 text-steel hover:bg-transparent hover:text-ink disabled:opacity-40"
+            disabled={generating}
+          >
+            {generating ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Pencil className="h-4 w-4" strokeWidth={1.8} />
+            )}
+          </Button>
+        </div>
       </div>
 
-      <Textarea
-        value={config.prompt}
-        onChange={(e) => onConfigChange({ ...config, prompt: e.target.value })}
-        placeholder="Type a prompt to send to the agent…"
-        className="min-h-0 flex-1 resize-none rounded border-0 px-3.5 py-3 font-sans text-[13.5px] leading-relaxed shadow-sm placeholder:text-steel focus-visible:ring-0"
-      />
+      {improvedPrompt !== null && diff ? (
+        <div className="flex min-h-0 flex-1 flex-col divide-y divide-line overflow-y-auto">
+          <div className="px-3.5 py-2.5">
+            <div className="mb-1 font-mono text-[11px] uppercase text-steel-soft">Current</div>
+            <p className="whitespace-pre-wrap text-[12.5px] leading-relaxed">
+              {diff.a.map((segment, index) => (
+                <span
+                  key={index}
+                  className={cn(
+                    segment.type === 'removed' && 'bg-red-100 text-red-900 line-through decoration-red-400',
+                  )}
+                >
+                  {segment.text}
+                </span>
+              ))}
+            </p>
+          </div>
+          <div className="px-3.5 py-2.5">
+            <div className="mb-1 font-mono text-[11px] uppercase text-steel-soft">Improved</div>
+            <p className="whitespace-pre-wrap text-[12.5px] leading-relaxed">
+              {diff.b.map((segment, index) => (
+                <span
+                  key={index}
+                  className={cn(segment.type === 'added' && 'bg-emerald-100 text-emerald-900')}
+                >
+                  {segment.text}
+                </span>
+              ))}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <Textarea
+          value={config.prompt}
+          onChange={(e) => onConfigChange({ ...config, prompt: e.target.value })}
+          placeholder="Type a prompt to send to the agent…"
+          className="min-h-0 flex-1 resize-none rounded border-0 px-3.5 py-3 font-sans text-[13.5px] leading-relaxed shadow-sm placeholder:text-steel focus-visible:ring-0"
+        />
+      )}
+
+      {improvedPrompt !== null && (
+        <div className="flex items-center justify-end gap-2 border-t border-line px-3.5 py-2">
+          <Button type="button" variant="outline" size="sm" onClick={handleDiscardImprovement}>
+            Discard
+          </Button>
+          <Button type="button" size="sm" onClick={handleAcceptImprovement}>
+            Accept
+          </Button>
+        </div>
+      )}
 
       <div className="border-t border-line px-3.5 py-2.5">
         <Button

--- a/frontend/src/components/playground/SaveTemplateDialog.tsx
+++ b/frontend/src/components/playground/SaveTemplateDialog.tsx
@@ -19,23 +19,43 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { savePromptTemplate, type SavePromptTemplateResult } from '@/services/consoleApi';
+import {
+  updateAgentPrompt,
+  createAgentPromptNewVersion,
+  forkAgentPrompt,
+  type AgentPromptDoc,
+} from '@/services/agentPromptApi';
 import { getCategories, type CategoryDoc } from '@/services/categoryApi';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
+
+type SaveMode = 'new' | 'update' | 'version' | 'fork';
+
+export interface SaveTemplateResult {
+  mode: SaveMode;
+  name: string;
+  title?: string;
+  version?: number;
+}
 
 interface SaveTemplateDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   promptBody: string;
-  onSaved?: (result: SavePromptTemplateResult) => void;
+  /** The Agent Prompt currently loaded into the bench, if any — enables update/version/fork. */
+  loadedTemplate?: Pick<AgentPromptDoc, 'name' | 'title' | 'version'> | null;
+  onSaved?: (result: SaveTemplateResult) => void;
 }
 
 export function SaveTemplateDialog({
   open,
   onOpenChange,
   promptBody,
+  loadedTemplate,
   onSaved,
 }: SaveTemplateDialogProps) {
+  const [mode, setMode] = useState<SaveMode>('new');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [visibility, setVisibility] = useState<'Public' | 'App' | 'Private'>('Private');
@@ -61,31 +81,55 @@ export function SaveTemplateDialog({
 
   useEffect(() => {
     if (open) {
+      setMode(loadedTemplate ? 'version' : 'new');
       setTitle('');
       setDescription('');
       setVisibility('Private');
       setCategory('');
       setTags('');
     }
-  }, [open]);
+  }, [open, loadedTemplate]);
 
   const handleSave = async () => {
-    if (!title.trim()) {
+    if (mode === 'new' && !title.trim()) {
       toast.error('Title is required');
       return;
     }
     setSaving(true);
     try {
-      const result = await savePromptTemplate({
-        prompt_body: promptBody,
-        title: title.trim(),
-        description: description.trim() || undefined,
-        visibility,
-        category: category || undefined,
-        tags: tags.trim() || undefined,
-      });
-      toast.success('Prompt saved as template');
-      onSaved?.(result);
+      if (mode === 'new') {
+        const result: SavePromptTemplateResult = await savePromptTemplate({
+          prompt_body: promptBody,
+          title: title.trim(),
+          description: description.trim() || undefined,
+          visibility,
+          category: category || undefined,
+          tags: tags.trim() || undefined,
+        });
+        toast.success('Prompt saved as template');
+        onSaved?.({ mode, name: result.name, title: title.trim(), version: result.version });
+      } else if (mode === 'update' && loadedTemplate) {
+        const result = await updateAgentPrompt(loadedTemplate.name, {
+          prompt_body: promptBody,
+          ...(title.trim() && { title: title.trim() }),
+          ...(description.trim() && { description: description.trim() }),
+        });
+        toast.success('Template updated');
+        onSaved?.({ mode, name: result.name, title: result.title, version: result.version });
+      } else if (mode === 'version' && loadedTemplate) {
+        const result = await createAgentPromptNewVersion(
+          loadedTemplate.name,
+          promptBody,
+          title.trim() || undefined,
+          description.trim() || undefined,
+        );
+        toast.success(`Saved as version ${result.version}`);
+        onSaved?.({ mode, name: result.name, title: title.trim() || loadedTemplate.title, version: result.version });
+      } else if (mode === 'fork' && loadedTemplate) {
+        const result = await forkAgentPrompt(loadedTemplate.name, title.trim() || undefined);
+        toast.success('Forked as a new template');
+        onSaved?.({ mode, name: result.name, title: title.trim() || undefined, version: result.version });
+      }
       onOpenChange(false);
     } catch (error) {
       toast.error(`Failed to save template: ${getFrappeErrorMessage(error)}`);
@@ -94,80 +138,146 @@ export function SaveTemplateDialog({
     }
   };
 
+  const saveLabel =
+    mode === 'update'
+      ? 'Update template'
+      : mode === 'version'
+        ? 'Save as new version'
+        : mode === 'fork'
+          ? 'Fork template'
+          : 'Save template';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Save as template</DialogTitle>
-          <DialogDescription>Save the current prompt as a reusable Agent Prompt template.</DialogDescription>
+          <DialogDescription>
+            {loadedTemplate
+              ? `"${loadedTemplate.title}" is currently loaded. Choose how to save your changes.`
+              : 'Save the current prompt as a reusable Agent Prompt template.'}
+          </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-2">
+          {loadedTemplate && (
+            <RadioGroup
+              value={mode}
+              onValueChange={(v) => setMode(v as SaveMode)}
+              className="gap-2.5"
+            >
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="update" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Update this template</span>
+                  <span className="block text-xs text-steel">
+                    Overwrite “{loadedTemplate.title}” in place.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="version" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Save as new version</span>
+                  <span className="block text-xs text-steel">
+                    Keep the current version and publish a new one in its place.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="fork" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Fork as new template</span>
+                  <span className="block text-xs text-steel">
+                    Create an independent copy, unlinked from “{loadedTemplate.title}”.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="new" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Save as new template</span>
+                  <span className="block text-xs text-steel">Start an unrelated template.</span>
+                </span>
+              </label>
+            </RadioGroup>
+          )}
+
           <div className="space-y-2">
             <Label htmlFor="template-title">Title</Label>
             <Input
               id="template-title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g. Customer support greeting"
+              placeholder={
+                mode === 'new' || !loadedTemplate
+                  ? 'e.g. Customer support greeting'
+                  : `Defaults to "${loadedTemplate.title}"`
+              }
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="template-description">Description</Label>
-            <Textarea
-              id="template-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="What is this prompt for?"
-              rows={2}
-            />
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2">
+          {mode !== 'fork' && (
             <div className="space-y-2">
-              <Label>Visibility</Label>
-              <Select value={visibility} onValueChange={(v) => setVisibility(v as typeof visibility)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="Private">Private</SelectItem>
-                  <SelectItem value="App">App</SelectItem>
-                  <SelectItem value="Public">Public</SelectItem>
-                </SelectContent>
-              </Select>
+              <Label htmlFor="template-description">Description</Label>
+              <Textarea
+                id="template-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What is this prompt for?"
+                rows={2}
+              />
             </div>
-            <div className="space-y-2">
-              <Label>Category</Label>
-              <Select value={category} onValueChange={setCategory}>
-                <SelectTrigger>
-                  <SelectValue placeholder="None" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">None</SelectItem>
-                  {categories.map((c) => (
-                    <SelectItem key={c.name} value={c.name}>
-                      {c.category_name || c.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="template-tags">Tags</Label>
-            <Input
-              id="template-tags"
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
-              placeholder="Comma-separated tags"
-            />
-          </div>
+          )}
+          {mode === 'new' && (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Visibility</Label>
+                  <Select value={visibility} onValueChange={(v) => setVisibility(v as typeof visibility)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Private">Private</SelectItem>
+                      <SelectItem value="App">App</SelectItem>
+                      <SelectItem value="Public">Public</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Category</Label>
+                  <Select value={category} onValueChange={setCategory}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="None" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">None</SelectItem>
+                      {categories.map((c) => (
+                        <SelectItem key={c.name} value={c.name}>
+                          {c.category_name || c.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="template-tags">Tags</Label>
+                <Input
+                  id="template-tags"
+                  value={tags}
+                  onChange={(e) => setTags(e.target.value)}
+                  placeholder="Comma-separated tags"
+                />
+              </div>
+            </>
+          )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={saving || !title.trim()}>
-            {saving ? 'Saving...' : 'Save template'}
+          <Button onClick={handleSave} disabled={saving || (mode === 'new' && !title.trim())}>
+            {saving ? 'Saving...' : saveLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/shortcuts/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/components/shortcuts/KeyboardShortcutsDialog.tsx
@@ -9,7 +9,7 @@ import { ShortcutKey } from '@/components/ui/shortcut-key';
 import { SHORTCUTS, formatBinding, type ShortcutScope } from '@/lib/shortcuts/registry';
 import { usePlatform } from '@/lib/shortcuts/platform';
 
-const SCOPE_ORDER: ShortcutScope[] = ['Global', 'Chat', 'Sidebar'];
+const SCOPE_ORDER: ShortcutScope[] = ['Global', 'Chat', 'Playground', 'Sidebar'];
 
 interface KeyboardShortcutsDialogProps {
   open: boolean;

--- a/frontend/src/data/knowledge.ts
+++ b/frontend/src/data/knowledge.ts
@@ -6,16 +6,30 @@
 export const knowledgeTypes = [
 	{ label: 'SQLite FTS', value: 'sqlite_fts' },
 	{ label: 'SQLite Vec', value: 'sqlite_vec' },
+	{ label: 'SQLite Hybrid (FTS + Vec)', value: 'sqlite_hybrid' },
 	{ label: 'ChromaDB', value: 'chroma' },
 	{ label: 'PGVector', value: 'pgvector' },
 	{ label: 'zvec (Embedded)', value: 'zvec' },
 	{ label: 'Redis', value: 'redis' },
+	{ label: 'Weaviate', value: 'weaviate' },
+	{ label: 'FAISS', value: 'faiss' },
+	{ label: 'Pinecone', value: 'pinecone' },
 
 ] as const;
 
 export type KnowledgeTypeOption = (typeof knowledgeTypes)[number]['value'];
 
-export const VECTOR_KNOWLEDGE_TYPES = ['sqlite_vec', 'chroma', 'pgvector', 'redis', 'zvec'] as const;
+export const VECTOR_KNOWLEDGE_TYPES = [
+	'sqlite_vec',
+	'sqlite_hybrid',
+	'chroma',
+	'pgvector',
+	'redis',
+	'zvec',
+	'weaviate',
+	'faiss',
+	'pinecone',
+] as const;
 
 
 export function isVectorKnowledgeType(type: string): boolean {
@@ -25,10 +39,14 @@ export function isVectorKnowledgeType(type: string): boolean {
 export const knowledgeTypeLabels: Record<string, string> = {
 	sqlite_fts: 'FTS',
 	sqlite_vec: 'Vec',
+	sqlite_hybrid: 'Hybrid',
 	chroma: 'Chroma',
 	pgvector: 'PGVector',
 	zvec: 'zvec',
 	redis: 'Redis',
+	weaviate: 'Weaviate',
+	faiss: 'FAISS',
+	pinecone: 'Pinecone',
 
 };
 

--- a/frontend/src/lib/shortcuts/registry.ts
+++ b/frontend/src/lib/shortcuts/registry.ts
@@ -1,7 +1,7 @@
 import type { ShortcutBinding } from './matching';
 import { getModifierKey, type Platform } from './platform';
 
-export type ShortcutScope = 'Global' | 'Chat' | 'Sidebar';
+export type ShortcutScope = 'Global' | 'Chat' | 'Sidebar' | 'Playground';
 
 export interface ShortcutDescriptor {
   id: string;
@@ -53,6 +53,24 @@ export const SHORTCUTS: ShortcutDescriptor[] = [
     binding: { key: 'Enter', shift: true },
     description: 'Insert new line',
     scope: 'Chat',
+  },
+  {
+    id: 'playground-copy-a-to-b',
+    binding: { key: 'c', mod: true, shift: true },
+    description: 'Copy A → B',
+    scope: 'Playground',
+  },
+  {
+    id: 'playground-swap',
+    binding: { key: 'x', mod: true, shift: true },
+    description: 'Swap A and B',
+    scope: 'Playground',
+  },
+  {
+    id: 'playground-toggle-diff',
+    binding: { key: 'd', mod: true, shift: true },
+    description: 'Toggle diff responses',
+    scope: 'Playground',
   },
 ];
 

--- a/frontend/src/pages/AiProvidersPage.tsx
+++ b/frontend/src/pages/AiProvidersPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Check, CheckCircle2, Cloud, ExternalLink, KeyRound, Loader2, Settings, Sparkles, XCircle } from 'lucide-react';
+import { ArrowRight, Check, CheckCircle2, Cloud, ExternalLink, KeyRound, Loader2, Settings, Sparkles, Trash2, XCircle } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import {
@@ -9,6 +9,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../components/ui/alert-dialog';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Checkbox } from '../components/ui/checkbox';
@@ -23,6 +33,7 @@ import {
   getProviders,
   updateProvider,
   createProvider,
+  deleteProvider,
   testProviderConnection,
 } from '../services/providerApi';
 import type { ProviderConnectionTestResult } from '../services/providerApi';
@@ -100,6 +111,8 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
   });
   const [testingConnection, setTestingConnection] = useState(false);
   const [connectionTest, setConnectionTest] = useState<ProviderConnectionTestResult | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AIProvider | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const emptyFormData = {
     provider_name: '',
@@ -418,6 +431,25 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
     allowInDialog: true,
   });
 
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteProvider(deleteTarget.name);
+      toast.success('Provider deleted');
+      setDeleteTarget(null);
+      reset();
+    } catch (deleteError) {
+      toast.error('Failed to delete provider', {
+        description: getFrappeErrorMessage(deleteError),
+        duration: 8000,
+      });
+      console.error(deleteError);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   return (
     <PageFrame
       title="AI providers"
@@ -529,6 +561,14 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
                   label: 'Configure',
                   onClick: () => handleConfigure(provider),
                   variant: 'ghost',
+                },
+              ]}
+              menuActions={[
+                {
+                  icon: Trash2,
+                  label: 'Delete',
+                  onClick: () => setDeleteTarget(provider),
+                  variant: 'destructive',
                 },
               ]}
               onClick={() => handleConfigure(provider)}
@@ -777,6 +817,28 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
           })()}
         </DialogContent>
       </Dialog>
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!deleting && !open) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{deleteTarget?.provider_name}"?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the provider. Models linked to this provider will need
+              a different provider before they can be used. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageFrame>
   );
 }

--- a/frontend/src/pages/KnowledgeSourceFormPage.tsx
+++ b/frontend/src/pages/KnowledgeSourceFormPage.tsx
@@ -83,8 +83,9 @@ function mapDocToFormValues(doc: Partial<KnowledgeSourceDoc>): KnowledgeSourceFo
 function KnowledgeSourceFormPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const fromAgent = searchParams.get('agent');
+  const autoOpenUpload = searchParams.get('upload') === '1';
   const isNew = id === 'new';
   const skipBlockRef = useRef(false);
 
@@ -245,6 +246,22 @@ function KnowledgeSourceFormPage() {
     }
   }, [id, isNew, loadSource]);
 
+  // After a freshly-created source redirects here with ?upload=1, jump straight
+  // into the inputs modal so uploading files doesn't need an extra click.
+  useEffect(() => {
+    if (!isNew && id && autoOpenUpload) {
+      setInputsModalOpen(true);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete('upload');
+          return next;
+        },
+        { replace: true },
+      );
+    }
+  }, [isNew, id, autoOpenUpload, setSearchParams]);
+
   const onSubmit = async (values: KnowledgeSourceFormValues) => {
     setSaving(true);
     try {
@@ -297,7 +314,7 @@ function KnowledgeSourceFormPage() {
         toast.success('Knowledge source created');
         setSourceDoc(created);
         allowNavigationRef.current = true;
-        navigate(`/knowledge/${created.name}`);
+        navigate(`/knowledge/${created.name}?upload=1`);
       } else if (id) {
         const updated = await updateKnowledgeSource(id, payload);
         toast.success('Knowledge source updated');

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -1,4 +1,4 @@
-import { Cpu, Settings, Loader2, DollarSign } from 'lucide-react';
+import { Cpu, Settings, Loader2, DollarSign, Trash2 } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import {
   Dialog,
@@ -8,6 +8,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../components/ui/alert-dialog';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Switch } from '../components/ui/switch';
@@ -27,6 +37,7 @@ import {
   getModel,
   updateModel,
   createModel,
+  deleteModel,
   getProviders,
   getModalityOptions,
   buildProviderNameMap,
@@ -40,6 +51,7 @@ import { LinkFieldControl } from '../components/ui/link-field-control';
 import { MultiSelectCombobox } from '../components/ui/multi-select-combobox';
 import { linkRoutes } from '../lib/link-routes';
 import { useSaveShortcut } from '@/hooks/useSaveShortcut';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
 
 interface ModelsPageProps {
   addModelKey?: number;
@@ -98,6 +110,8 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
   const [loadingModel, setLoadingModel] = useState(false);
   const [saving, setSaving] = useState(false);
   const [formData, setFormData] = useState<ModelFormData>(emptyFormData);
+  const [deleteTarget, setDeleteTarget] = useState<AIModel | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const providerMap = useMemo(() => buildProviderNameMap(providers), [providers]);
 
@@ -108,12 +122,14 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
     loadingMore,
     search,
     setSearch,
+    filters,
+    setFilter,
     loadMore,
     total,
     reset,
     error,
   } = useInfiniteScroll<
-    { page?: number; limit?: number; start?: number; search?: string },
+    { provider?: string; page?: number; limit?: number; start?: number; search?: string },
     AIModel
   >({
     fetchFn: async (params) => {
@@ -122,6 +138,7 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         limit: params.limit,
         start: params.start,
         search: params.search,
+        provider: params.provider && params.provider !== 'all' ? params.provider : undefined,
       });
 
       if (Array.isArray(response)) {
@@ -320,6 +337,27 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
     allowInDialog: true,
   });
 
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteModel(deleteTarget.name);
+      toast.success('Model deleted');
+      setDeleteTarget(null);
+      reset();
+    } catch (deleteError) {
+      toast.error('Failed to delete model', {
+        description: getFrappeErrorMessage(deleteError),
+        duration: 8000,
+      });
+      console.error(deleteError);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const isFiltered = !!search || (filters.provider && filters.provider !== 'all');
+
   return (
     <PageFrame
       title="Models"
@@ -328,6 +366,17 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
           searchPlaceholder="Search models..."
           searchValue={search}
           onSearchChange={setSearch}
+          filters={[
+            {
+              label: 'Provider',
+              value: filters.provider || 'all',
+              options: [
+                { label: 'All providers', value: 'all' },
+                ...providers.map((p) => ({ label: p.provider_name, value: p.name })),
+              ],
+              onChange: (value) => setFilter('provider', value),
+            },
+          ]}
         />
       }
     >
@@ -343,13 +392,19 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          search ? (
+          isFiltered ? (
             <EmptyState
               variant="no-results"
               icon={Cpu}
               title="No models found"
               filterTerm={search}
-              secondaryAction={{ label: 'Clear search', onClick: () => setSearch('') }}
+              secondaryAction={{
+                label: 'Clear filters',
+                onClick: () => {
+                  setSearch('');
+                  setFilter('provider', 'all');
+                },
+              }}
             />
           ) : (
             <EmptyState
@@ -385,6 +440,14 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
                   label: 'Configure',
                   onClick: () => handleConfigure(model),
                   variant: 'ghost',
+                },
+              ]}
+              menuActions={[
+                {
+                  icon: Trash2,
+                  label: 'Delete',
+                  onClick: () => setDeleteTarget(model),
+                  variant: 'destructive',
                 },
               ]}
               onClick={() => handleConfigure(model)}
@@ -633,6 +696,28 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!deleting && !open) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{deleteTarget?.model_name}"?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the model. Agents using this model will need to be
+              reconfigured with a different one. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageFrame>
   );
 }

--- a/frontend/src/pages/PlaygroundPage.tsx
+++ b/frontend/src/pages/PlaygroundPage.tsx
@@ -41,6 +41,7 @@ function PlaygroundPage() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [savePromptOverride, setSavePromptOverride] = useState<string | null>(null);
+  const [loadedTemplate, setLoadedTemplate] = useState<AgentPromptDoc | null>(null);
 
   // Close the global app sidebar so the playground uses the full viewport width.
   useEffect(() => {
@@ -103,6 +104,7 @@ function PlaygroundPage() {
     } else {
       setPlaygroundConfig((prev) => ({ ...prev, prompt: prompt.prompt_body }));
     }
+    setLoadedTemplate(prompt);
   };
 
   const handleRestore = (entry: LedgerEntry) => {
@@ -210,6 +212,23 @@ function PlaygroundPage() {
           if (!open) setSavePromptOverride(null);
         }}
         promptBody={savePromptOverride ?? activePromptBody()}
+        loadedTemplate={savePromptOverride === null ? loadedTemplate : null}
+        onSaved={(result) => {
+          if (savePromptOverride !== null) return;
+          if (result.mode === 'update') {
+            setLoadedTemplate((prev) =>
+              prev ? { ...prev, title: result.title ?? prev.title, version: result.version ?? prev.version } : prev,
+            );
+          } else if (result.mode === 'version' || result.mode === 'fork') {
+            setLoadedTemplate((prev) =>
+              prev
+                ? { ...prev, name: result.name, title: result.title ?? prev.title, version: result.version ?? 1 }
+                : prev,
+            );
+          } else {
+            setLoadedTemplate(null);
+          }
+        }}
       />
     </>
   );

--- a/frontend/src/services/consoleApi.ts
+++ b/frontend/src/services/consoleApi.ts
@@ -53,6 +53,17 @@ export interface GeneratePromptResult {
   prompt: string;
 }
 
+export interface ImprovePromptParams {
+  prompt_body: string;
+  instruction?: string;
+  provider?: string;
+  model?: string;
+}
+
+export interface ImprovePromptResult {
+  prompt: string;
+}
+
 export interface EvaluateRunParams {
   response: string;
   criteria: string;
@@ -148,6 +159,16 @@ export async function generatePrompt(params: GeneratePromptParams): Promise<Gene
     return (result?.message ?? result) as GeneratePromptResult;
   } catch (error) {
     handleFrappeError(error, 'Error generating prompt');
+    throw error;
+  }
+}
+
+export async function improvePrompt(params: ImprovePromptParams): Promise<ImprovePromptResult> {
+  try {
+    const result = await call.post('huf.ai.console_api.improve_prompt', params);
+    return (result?.message ?? result) as ImprovePromptResult;
+  } catch (error) {
+    handleFrappeError(error, 'Error improving prompt');
     throw error;
   }
 }

--- a/frontend/src/services/providerApi.ts
+++ b/frontend/src/services/providerApi.ts
@@ -213,6 +213,17 @@ export async function updateProvider(name: string, data: Partial<AIProviderDoc>)
 }
 
 /**
+ * Delete an AI Provider document
+ */
+export async function deleteProvider(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype['AI Provider'], name);
+  } catch (error) {
+    handleFrappeError(error, `Error deleting provider ${name}`);
+  }
+}
+
+/**
  * Result of probing a single linked AI Model on a provider
  */
 export interface ProviderConnectionModelResult {
@@ -388,6 +399,17 @@ export async function updateModel(name: string, data: Partial<AIModelDoc>): Prom
     return updatedModel as AIModelDoc;
   } catch (error) {
     handleFrappeError(error, `Error updating model ${name}`);
+  }
+}
+
+/**
+ * Delete an AI Model document
+ */
+export async function deleteModel(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype['AI Model'], name);
+  } catch (error) {
+    handleFrappeError(error, `Error deleting model ${name}`);
   }
 }
 

--- a/frontend/src/types/knowledge.types.ts
+++ b/frontend/src/types/knowledge.types.ts
@@ -1,4 +1,14 @@
-export type KnowledgeType = 'sqlite_fts' | 'sqlite_vec' | 'chroma' | 'pgvector' | 'redis' | 'zvec';
+export type KnowledgeType =
+	| 'sqlite_fts'
+	| 'sqlite_vec'
+	| 'sqlite_hybrid'
+	| 'chroma'
+	| 'pgvector'
+	| 'redis'
+	| 'zvec'
+	| 'weaviate'
+	| 'faiss'
+	| 'pinecone';
 
 export type ChromaMode = 'File' | 'Server';
 export type KnowledgeScope = 'Site' | 'Workspace' | 'Agent' | 'Global';

--- a/huf/ai/console_api.py
+++ b/huf/ai/console_api.py
@@ -6,6 +6,7 @@ Whitelisted API methods for the Console prompt-engineering workspace.
 
 Provides:
 - Prompt generation from a natural-language description.
+- Prompt improvement (one-shot rewrite of an existing prompt).
 - Pass/fail evaluation of a model response against criteria.
 - Saving an arbitrary prompt body as an Agent Prompt template.
 """
@@ -25,6 +26,7 @@ from huf.permissions import has_capability
 
 
 GENERATE_PROMPT_CAPABILITY = "agent.use"
+IMPROVE_PROMPT_CAPABILITY = "agent.use"
 EVALUATE_RUN_CAPABILITY = "agent.use"
 SAVE_PROMPT_TEMPLATE_CAPABILITY = "agent.create"
 
@@ -235,6 +237,73 @@ def generate_prompt(
 		frappe.throw(_("No prompt was generated. Please try again with a different description or provider."))
 
 	return {"prompt": generated.strip()}
+
+
+@frappe.whitelist()
+def improve_prompt(
+	prompt_body: str,
+	instruction: str | None = None,
+	provider: str | None = None,
+	model: str | None = None,
+):
+	"""Rewrite an existing prompt for clarity and effectiveness via a one-shot LLM call.
+
+	Standalone helper for the Playground's prompt panel — works on whatever
+	prompt text is currently in the bench, independent of whether it is tied
+	to a saved Agent Prompt template.
+
+	Args:
+		prompt_body: The prompt text to improve.
+		instruction: Optional improvement goal (e.g. "make it more concise").
+		provider: Optional provider to use (defaults to console config).
+		model: Optional model to use (defaults to console config).
+
+	Returns:
+		dict: ``{"prompt": "<improved prompt text>"}``
+	"""
+	_require(IMPROVE_PROMPT_CAPABILITY)
+
+	if not prompt_body or not prompt_body.strip():
+		frappe.throw(_("Prompt is required."), frappe.ValidationError)
+
+	if provider and model:
+		if not frappe.db.exists("AI Provider", provider):
+			frappe.throw(_("Selected provider does not exist."), frappe.ValidationError)
+		if not frappe.db.exists("AI Model", model):
+			frappe.throw(_("Selected model does not exist."), frappe.ValidationError)
+	else:
+		provider, model = _get_console_model_config()
+		if not provider or not model:
+			frappe.throw(
+				_(
+					"No AI provider is available for prompt improvement. "
+					"Configure one with an API key or set 'huf_console_prompt_engineer_model' in site config."
+				),
+				frappe.ValidationError,
+			)
+
+	parts = [
+		"You are an expert prompt engineer. Improve the following prompt for clarity, "
+		"specificity, and effectiveness, while preserving its original intent and scope. "
+		"Return only the improved prompt text, with no explanation, preamble, or markdown fences."
+	]
+	if instruction and instruction.strip():
+		parts.append(f"Improvement goal: {instruction.strip()}")
+	parts.append(f"Original prompt:\n{prompt_body.strip()}")
+	parts.append("Improved prompt:")
+
+	messages = [{"role": "user", "content": "\n\n".join(parts)}]
+
+	try:
+		improved = _simple_completion_sync(provider, model, messages)
+	except Exception as e:
+		frappe.log_error(f"improve_prompt failed: {e!s}\n{frappe.get_traceback()}", "Console Prompt Improvement")
+		frappe.throw(_("Prompt improvement failed. Please try again or choose a different provider."))
+
+	if not improved:
+		frappe.throw(_("No improved prompt was returned. Please try again."))
+
+	return {"prompt": improved.strip()}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary

Four related frontend UX gaps identified from a screenshot-driven audit of
`/huf/knowledge`, `/huf/models`, and `/huf/playground`, implemented in
parallel:

**Knowledge** (`/huf/knowledge/new`)
- File upload is now reachable from the create flow: a freshly-created
  source redirects with `?upload=1`, auto-opening the inputs modal instead
  of leaving the user to find it manually.
- Replaced the plain `<input type="file">` with a real drag-and-drop
  dropzone, multi-file support, per-file progress, inline error rows.
- Exposed 4 backend-supported `knowledge_type` options the frontend was
  missing (`sqlite_hybrid`, `weaviate`, `faiss`, `pinecone`) — these already
  had working backend implementations, just no UI, rendered through the
  existing schema-driven `AdvancedConfigFields` mechanism (no fabricated
  fields).

**Models & Providers** (`/huf/models`, `/huf/providers`)
- Added a provider filter to the previously search-only `/models` list.
- Wired delete for both models and providers (confirmation dialog, surfaces
  Frappe link-integrity errors on failed deletes instead of leaving the UI
  stuck). Note: Add Model / Add Provider dialogs already existed and worked
  — this PR only adds the filter and delete paths.

**Playground** (`/huf/playground`, Compare tab)
- Relocated Copy A→B / Swap / Diff controls out of the full-width header
  row into a center console between the two prompt panels (was flagged as
  bad UX sitting far from either panel); collapses to a horizontal strip on
  narrow viewports.
- Added a `Playground` keyboard-shortcut scope: `Cmd/Ctrl+Shift+C` copy,
  `+X` swap, `+D` toggle diff — with tooltip hints and entries in the `?`
  shortcuts help dialog.
- Added save-as-new-version / fork UI to the template save dialog, reusing
  already-built but previously unwired `createAgentPromptNewVersion` /
  `forkAgentPrompt` APIs.
- Added a "Improve prompt" action to the prompt panel — new
  `huf.ai.console_api.improve_prompt` one-shot LLM call (follows the exact
  pattern of the sibling `generate_prompt`/`evaluate_run` methods), with an
  accept/discard diff preview before applying.

## How this was built

Scoped and dispatched as 4 independent parallel sub-agents (non-overlapping
file sets), each verified with `tsc --noEmit` / `py_compile`, followed by a
dedicated cross-file correctness review pass (wiring, race conditions,
type-shape matches) before this commit — no blocking issues found.

## Test plan
- [x] `yarn typecheck` clean across all changed files
- [x] `yarn lint` — no new errors/warnings in changed files (pre-existing
      issues in untouched files only)
- [x] `python3 -m py_compile huf/ai/console_api.py`
- [ ] Manual verification in a running bench (upload dropzone, provider
      filter, delete confirm/error states, compare shortcuts, template
      versioning, prompt-improve accept/discard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)