### PR TITLE
feat(ai): lazy tool discovery to reduce agent tool-schema token cost

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -93,8 +93,9 @@ def _resolve_effective_model(agent_doc, model=None, provider=None):
 
 class AgentManager:
     """Manages the creation and execution of agents."""
-    def __init__(self, agent_name, file_handler=None, provider_override=None, model_override=None):
+    def __init__(self, agent_name, file_handler=None, provider_override=None, model_override=None, conversation_id=None):
         self.agent_doc = frappe.get_cached_doc("Agent", agent_name)
+        self.conversation_id = conversation_id
         (
             self.effective_provider,
             self.effective_model,
@@ -119,7 +120,12 @@ class AgentManager:
 
         try:
             from huf.ai.sdk_tools import create_agent_tools
-            agent_tools = create_agent_tools(self.agent_doc, model_name=self.effective_model)
+            agent_tools = create_agent_tools(
+                self.agent_doc,
+                model_name=self.effective_model,
+                conversation_id=self.conversation_id,
+                agent_name=self.agent_doc.name,
+            )
             if agent_tools:
                 self.tools.extend(agent_tools)
         except (ImportError, AttributeError, TypeError, ValueError, RuntimeError) as e:
@@ -1469,6 +1475,7 @@ def _execute_agent_run(
             agent_name,
             provider_override=resolved_provider,
             model_override=resolved_model,
+            conversation_id=conversation_id,
         )
 
         if (prompt_template or prompt_version) and resolved_prompt_template:
@@ -2684,6 +2691,7 @@ async def run_agent_stream(
             agent_name,
             provider_override=resolved_provider,
             model_override=resolved_model,
+            conversation_id=conversation.name,
         )
 
         if (prompt_template or prompt_version) and resolved_prompt_template:

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -94,7 +94,42 @@ def _check_tool_permission(tool_type: str, context: dict = None, allowed_for_gue
     return {"allowed": True}
 
 
-def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
+# Tools that must always be built eagerly for a lazy-discovery agent: the
+# discovery tools themselves (without them the agent could never unlock
+# anything else) plus the small set of always-on utility tools.
+_LAZY_DISCOVERY_TOOL_NAMES = {"list_tool_groups", "search_tools", "describe_tool_group", "load_tools"}
+_LAZY_DISCOVERY_ALWAYS_EAGER_TOOL_NAMES = _LAZY_DISCOVERY_TOOL_NAMES | {
+    "get_conversation_data", "set_conversation_data", "load_conversation_data",
+    "ask_user", "get_result_context",
+}
+
+
+def _get_lazy_discovered_tool_names(kwargs: dict) -> set:
+    """Tool names already unlocked via lazy discovery for the current conversation.
+
+    Fails safe (empty set) whenever no conversation context is available or
+    conversation_data can't be read, so lazy-tool agents never break outside
+    a conversation run (e.g. no conversation_id in this run context yet).
+    """
+    conversation_id = (kwargs or {}).get("conversation_id")
+    if not conversation_id:
+        return set()
+
+    try:
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+        for item in state["items"]:
+            if item.get("name") == "_lazy_tools":
+                discovered = (item.get("value") or {}).get("discovered") or []
+                return set(discovered)
+    except Exception as e:
+        logger.debug(f"Could not resolve lazy-discovered tools for {conversation_id}: {e!s}")
+        return set()
+
+    return set()
+
+
+def create_agent_tools(agent, model_name: str = None, **kwargs) -> list[FunctionTool]:
     """
     Create function tools for Huf Agent
 
@@ -106,8 +141,16 @@ def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
     agent.model when omitted) — passed through to the permission-aware
     registry so an AI Model's capability overrides (see huf.ai.capability_discovery)
     can gate tools like ask_user regardless of the agent's own setting.
+
+    When agent.enable_lazy_tools is set, native tools not yet unlocked via the
+    lazy-discovery flow (see huf.ai.tools.lazy_discovery) are skipped entirely
+    instead of being built, to save tokens on the tool schema payload sent to
+    the model. This is gated on kwargs["conversation_id"]; callers that don't
+    pass one get the fail-safe (nothing discovered yet) rather than an error.
     """
     tools = []
+    lazy_enabled = bool(getattr(agent, "enable_lazy_tools", False))
+    discovered_tool_names = _get_lazy_discovered_tool_names(kwargs) if lazy_enabled else set()
 
     # Load MCP tools from linked MCP servers
     if hasattr(agent, "agent_mcp_server") and agent.agent_mcp_server:
@@ -127,6 +170,16 @@ def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
 
     for function_doc in allowed_tool_docs:
         try:
+            if lazy_enabled:
+                tool_name = function_doc.tool_name or ""
+                is_always_eager = (
+                    tool_name in _LAZY_DISCOVERY_ALWAYS_EAGER_TOOL_NAMES
+                    or "memory" in tool_name.lower()
+                )
+                if not is_always_eager and tool_name not in discovered_tool_names:
+                    # Deferred: skip building this tool entirely (don't even
+                    # fetch its schema) until the model discovers it.
+                    continue
 
             function_path = None
             if function_doc.types in ["Custom Function", "App Provided"]:

--- a/huf/ai/tests/test_lazy_tool_discovery.py
+++ b/huf/ai/tests/test_lazy_tool_discovery.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""Tests for lazy tool discovery: Agent.enable_lazy_tools, the four
+huf.ai.tools.lazy_discovery handlers, and the eager/deferred partition in
+huf.ai.sdk_tools.create_agent_tools().
+
+Run with:
+	bench --site <site> run-tests --app huf --module huf.ai.tests.test_lazy_tool_discovery
+"""
+
+import json
+import unittest
+from unittest import mock
+
+import frappe
+
+from huf.ai.sdk_tools import create_agent_tools
+from huf.ai.tools.lazy_discovery import (
+	handle_describe_tool_group,
+	handle_list_tool_groups,
+	handle_load_tools,
+	handle_search_tools,
+)
+
+
+class TestLazyToolDiscovery(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		cls.provider = cls._ensure_provider()
+		cls.model = cls._ensure_model(cls.provider)
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self._agents = []
+		self._tools = []
+		self._tool_types = []
+		self._conversations = []
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for name in self._agents:
+			self._delete("Agent", name)
+		for name in self._tools:
+			self._delete("Agent Tool Function", name)
+		for name in self._tool_types:
+			self._delete("Agent Tool Type", name)
+		for name in self._conversations:
+			self._delete("Agent Conversation", name)
+		frappe.db.commit()
+
+	@staticmethod
+	def _delete(doctype, name):
+		try:
+			frappe.delete_doc(doctype, name, ignore_permissions=True, force=True)
+		except Exception:
+			pass
+
+	@staticmethod
+	def _ensure_provider():
+		existing = frappe.db.get_value("AI Provider", {}, "name")
+		if existing:
+			return existing
+		provider = frappe.get_doc(
+			{
+				"doctype": "AI Provider",
+				"provider_name": f"Lazy Discovery Test Provider {frappe.generate_hash(length=6)}",
+				"api_key": "test-key-not-used",
+				"provider_brand": "openai",
+			}
+		)
+		provider.insert(ignore_permissions=True)
+		return provider.name
+
+	@staticmethod
+	def _ensure_model(provider):
+		existing = frappe.db.get_value("AI Model", {"provider": provider}, "name")
+		if existing:
+			return existing
+		model = frappe.get_doc(
+			{
+				"doctype": "AI Model",
+				"model_name": f"lazy-discovery-test-model-{frappe.generate_hash(length=6)}",
+				"provider": provider,
+			}
+		)
+		model.insert(ignore_permissions=True)
+		return model.name
+
+	# -- fixtures -----------------------------------------------------------
+
+	def _make_tool_type(self):
+		tool_type = frappe.get_doc(
+			{"doctype": "Agent Tool Type", "name1": f"Lazy Discovery Test Tools {frappe.generate_hash(length=6)}"}
+		)
+		tool_type.insert(ignore_permissions=True)
+		self._tool_types.append(tool_type.name)
+		return tool_type.name
+
+	def _make_tool(self, service=None, provider_app=None, description="A test tool.", params=None):
+		tool_name = f"lazy-tool-{frappe.generate_hash(length=8)}"
+		tool = frappe.get_doc(
+			{
+				"doctype": "Agent Tool Function",
+				"tool_name": tool_name,
+				"description": description,
+				"tool_type": self._make_tool_type(),
+				"types": "App Provided",
+				"function_path": "huf.ai.tools.code_execution.run_python",
+				"service": service,
+				"provider_app": provider_app,
+				"params": json.dumps(params) if params is not None else None,
+			}
+		)
+		tool.insert(ignore_permissions=True)
+		self._tools.append(tool.name)
+		return tool
+
+	def _make_agent(self, tools, enable_lazy_tools=0):
+		agent = frappe.get_doc(
+			{
+				"doctype": "Agent",
+				"agent_name": f"lazy-discovery-agent-{frappe.generate_hash(length=8)}",
+				"instructions": "Test lazy discovery agent instructions",
+				"provider": self.provider,
+				"model": self.model,
+				"enable_lazy_tools": enable_lazy_tools,
+				"agent_tool": [{"tool": tool.name} for tool in tools],
+			}
+		)
+		agent.insert(ignore_permissions=True)
+		self._agents.append(agent.name)
+		return agent
+
+	def _make_conversation(self):
+		conversation = frappe.get_doc(
+			{
+				"doctype": "Agent Conversation",
+				"title": f"lazy-discovery-test-{frappe.generate_hash(length=6)}",
+				"session_id": f"test-session-{frappe.generate_hash(length=10)}",
+				"is_active": 1,
+			}
+		)
+		conversation.insert(ignore_permissions=True)
+		self._conversations.append(conversation.name)
+		return conversation.name
+
+	@staticmethod
+	def _tool_names(function_tools):
+		return {tool.name for tool in function_tools}
+
+	# -- (1) flag off leaves eager behavior unchanged ------------------------
+
+	def test_disabled_flag_builds_every_allowed_tool_eagerly(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool, crm_tool], enable_lazy_tools=0)
+
+		tools = create_agent_tools(agent)
+		names = self._tool_names(tools)
+
+		self.assertIn(email_tool.tool_name, names)
+		self.assertIn(crm_tool.tool_name, names)
+
+	# -- (2) flag on defers non-essential tools ------------------------------
+
+	def test_enabled_flag_defers_non_essential_tools_but_keeps_eager_set(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool, crm_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		tools = create_agent_tools(agent, conversation_id=conversation_id, agent_name=agent.name)
+		names = self._tool_names(tools)
+
+		# Neither non-essential tool has been discovered yet - both deferred.
+		self.assertNotIn(email_tool.tool_name, names)
+		self.assertNotIn(crm_tool.tool_name, names)
+
+		# The discovery tools themselves must always be present, or the model
+		# could never unlock anything.
+		for discovery_tool_name in ("list_tool_groups", "search_tools", "describe_tool_group", "load_tools"):
+			self.assertIn(discovery_tool_name, names)
+
+	# -- (3) load_tools rejects a tool the agent is not permitted to use -----
+
+	def test_load_tools_rejects_unpermitted_tool_name(self):
+		allowed_tool = self._make_tool(service="gmail", description="Send an email.")
+		agent = self._make_agent([allowed_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		result = json.loads(
+			handle_load_tools(
+				tool_names=[allowed_tool.tool_name, "not_a_real_or_permitted_tool"],
+				agent_name=agent.name,
+				conversation_id=conversation_id,
+			)
+		)
+
+		accepted_names = {entry["tool_name"] for entry in result["accepted"]}
+		self.assertIn(allowed_tool.tool_name, accepted_names)
+		self.assertIn("not_a_real_or_permitted_tool", result["rejected"])
+		self.assertNotIn("not_a_real_or_permitted_tool", accepted_names)
+
+	# -- (4) load_tools persists + promotes to eager on the next call -------
+
+	def test_load_tools_persists_and_promotes_tool_to_eager(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool, crm_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		# Still deferred before any discovery.
+		before = self._tool_names(
+			create_agent_tools(agent, conversation_id=conversation_id, agent_name=agent.name)
+		)
+		self.assertNotIn(email_tool.tool_name, before)
+
+		load_result = json.loads(
+			handle_load_tools(
+				tool_names=[email_tool.tool_name],
+				agent_name=agent.name,
+				conversation_id=conversation_id,
+			)
+		)
+		self.assertEqual(load_result["rejected"], [])
+
+		after = self._tool_names(
+			create_agent_tools(agent, conversation_id=conversation_id, agent_name=agent.name)
+		)
+		self.assertIn(email_tool.tool_name, after)
+		# The un-discovered sibling tool must remain deferred.
+		self.assertNotIn(crm_tool.tool_name, after)
+
+	def test_load_tools_accepts_json_encoded_tool_names(self):
+		"""HUF tool params often arrive JSON-encoded rather than as a real list."""
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		result = json.loads(
+			handle_load_tools(
+				tool_names=json.dumps([email_tool.tool_name]),
+				agent_name=agent.name,
+				conversation_id=conversation_id,
+			)
+		)
+
+		accepted_names = {entry["tool_name"] for entry in result["accepted"]}
+		self.assertIn(email_tool.tool_name, accepted_names)
+
+	# -- (5) discovery handlers only ever surface permitted tools ------------
+
+	def test_list_tool_groups_only_covers_allowed_tools(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email. Extra detail follows.")
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+		other_agent = self._make_agent([], enable_lazy_tools=1)
+
+		groups = json.loads(handle_list_tool_groups(agent_name=agent.name))
+		gmail_group = next((g for g in groups if g["service"] == "gmail"), None)
+		self.assertIsNotNone(gmail_group)
+		self.assertEqual(gmail_group["tool_count"], 1)
+		self.assertEqual(gmail_group["summary"], "Send an email.")
+
+		other_groups = json.loads(handle_list_tool_groups(agent_name=other_agent.name))
+		self.assertEqual(other_groups, [])
+
+	def test_describe_tool_group_only_covers_allowed_tools(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+
+		gmail_tools = json.loads(handle_describe_tool_group(service="gmail", agent_name=agent.name))
+		self.assertEqual([t["tool_name"] for t in gmail_tools], [email_tool.tool_name])
+
+		crm_tools = json.loads(handle_describe_tool_group(service="crm", agent_name=agent.name))
+		self.assertEqual(crm_tools, [])
+
+	def test_search_tools_only_covers_allowed_tools(self):
+		"""search_app_actions inspects real installed-app action metadata, which
+		this test cannot fabricate, so the underlying search is mocked; what is
+		under test here is the permission filter applied to its results."""
+		email_tool = self._make_tool(
+			service="gmail", provider_app="gmail", description="Send an email to a recipient."
+		)
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+		other_agent = self._make_agent([], enable_lazy_tools=1)
+
+		fake_descriptors = [
+			{"title": email_tool.tool_name, "description": "Send an email to a recipient."},
+			{"title": "not_a_permitted_tool", "description": "Some other app action."},
+		]
+		with mock.patch(
+			"huf.ai.capability_discovery.api.search_app_actions", return_value=fake_descriptors
+		):
+			results = json.loads(handle_search_tools(query="email", agent_name=agent.name))
+			other_results = json.loads(handle_search_tools(query="email", agent_name=other_agent.name))
+
+		self.assertEqual([r["tool_name"] for r in results], [email_tool.tool_name])
+		self.assertEqual(other_results, [])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1841,6 +1841,66 @@ DOCUMENT_ARTIFACT_TOOLS = [
 	},
 ]
 
+LAZY_DISCOVERY_TOOLS = [
+	{
+		"tool_name": "list_tool_groups",
+		"description": (
+			"List the groups your available tools are organized into (by service), with a tool "
+			"count and a one-line summary for each group. Use this first when you have many tools "
+			"and are not sure which ones are relevant yet - then call describe_tool_group on a "
+			"promising group to see its individual tools, and load_tools to actually make the ones "
+			"you need callable. If you already know roughly what you're looking for, call "
+			"search_tools instead and skip straight to load_tools."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_list_tool_groups",
+		"category": "Tool Discovery",
+		"parameters": [],
+	},
+	{
+		"tool_name": "search_tools",
+		"description": (
+			"Search for tools by keyword or description across everything you're permitted to use. "
+			"Use this when you know roughly what you want to do (e.g. 'send an email', 'create an "
+			"invoice') but don't know the exact tool name. Returns matching tools with their service "
+			"and description - call load_tools with the tool_name(s) you want before using them."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_search_tools",
+		"category": "Tool Discovery",
+		"parameters": [
+			_p("query", required=True, description="Keywords describing the action or capability you're looking for"),
+			_p("limit", type="integer", description="Max results to return (default 10)"),
+		],
+	},
+	{
+		"tool_name": "describe_tool_group",
+		"description": (
+			"List every tool in a specific service group (as returned by list_tool_groups), with "
+			"each tool's full description. Use this after list_tool_groups to see the individual "
+			"tools within a group you're interested in, then call load_tools with the tool_name(s) "
+			"you need."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_describe_tool_group",
+		"category": "Tool Discovery",
+		"parameters": [
+			_p("service", required=True, description="The service/group name, as returned by list_tool_groups"),
+		],
+	},
+	{
+		"tool_name": "load_tools",
+		"description": (
+			"Make the named tools callable for the rest of this conversation. Call this after "
+			"list_tool_groups + describe_tool_group, or after search_tools, once you know exactly "
+			"which tool(s) you need. Returns each accepted tool's description and parameters so you "
+			"can call it immediately, plus any requested names you're not permitted to use."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_load_tools",
+		"category": "Tool Discovery",
+		"parameters": [
+			_p("tool_names", type="json", required=True, description="List of tool_name strings to load"),
+		],
+	},
+]
+
 ALL_INTEGRATION_TOOLS = (
 	# Platform capabilities — no external account to connect.
 	RECIPIENT_TOOLS
@@ -1855,6 +1915,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS
 	+ DOCUMENT_ARTIFACT_TOOLS
+	+ LAZY_DISCOVERY_TOOLS
 	# Tools backed by a connectable service. Keys match Integration Service
 	# docnames and the SERVICE_NAME each tool module uses for credentials.
 	+ _with_service(SLACK_TOOLS, "slack")

--- a/huf/ai/tools/lazy_discovery.py
+++ b/huf/ai/tools/lazy_discovery.py
@@ -1,0 +1,229 @@
+"""Lazy tool discovery handlers.
+
+Lets an agent with a large tool surface discover tools on demand instead of
+having every tool's schema loaded into context up front: list_tool_groups ->
+describe_tool_group -> load_tools, or search_tools -> load_tools directly.
+"""
+
+import json
+
+import frappe
+
+from huf.ai.tool_registry import PermissionAwareToolRegistry
+from huf.ai.conversation_data_tools import _load_state
+
+logger = frappe.logger("huf")
+
+
+def _resolve_agent_doc(kwargs):
+    """Resolve the calling Agent doc the same way sdk_tools handlers do: via the
+    ``agent_name`` injected into kwargs from the huf run context."""
+    agent_name = kwargs.get("agent_name")
+    if not agent_name:
+        return None
+    try:
+        return frappe.get_cached_doc("Agent", agent_name)
+    except (frappe.DoesNotExistError, frappe.ValidationError):
+        return None
+
+
+def _tool_group(tool_doc) -> str:
+    return tool_doc.service or tool_doc.provider_app or "General"
+
+
+def _summarize(description: str) -> str:
+    if not description:
+        return ""
+    period_idx = description.find(". ")
+    if period_idx != -1:
+        return description[:period_idx + 1].strip()
+    return description[:120].strip()
+
+
+def handle_list_tool_groups(**kwargs):
+    """Group the calling agent's allowed tools by service (or provider_app/"General")."""
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps([])
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+
+    groups = {}
+    order = []
+    for tool_doc in allowed_tools:
+        group = _tool_group(tool_doc)
+        if group not in groups:
+            groups[group] = []
+            order.append(group)
+        groups[group].append(tool_doc)
+
+    result = []
+    for group in order:
+        tool_docs = groups[group]
+        summary = ""
+        for tool_doc in tool_docs:
+            summary = _summarize(tool_doc.description)
+            if summary:
+                break
+        result.append({
+            "service": group,
+            "tool_count": len(tool_docs),
+            "summary": summary,
+        })
+
+    return json.dumps(result)
+
+
+def handle_search_tools(query, limit=10, **kwargs):
+    """Search discoverable tools, filtered to what the calling agent is permitted to use."""
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps([])
+
+    limit = int(limit) if limit else 10
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+    allowed_by_name = {tool_doc.tool_name: tool_doc for tool_doc in allowed_tools}
+
+    # Call the underlying implementation directly, not the api.py wrapper —
+    # that wrapper admin-gates capability discovery (it exposes raw app
+    # manifests/function paths), but here results are already filtered down
+    # to the calling agent's own allowed tools before anything is returned,
+    # so the admin gate would just make this always return nothing for
+    # ordinary agents.
+    from huf.ai.capability_discovery.actions import search_app_actions
+
+    seen_apps = set()
+    matches = []
+    for tool_doc in allowed_tools:
+        app_name = tool_doc.provider_app
+        if not app_name or app_name in seen_apps:
+            continue
+        seen_apps.add(app_name)
+
+        try:
+            descriptors = search_app_actions(app_name, query, limit)
+        except (frappe.PermissionError, frappe.ValidationError, ValueError) as e:
+            # search_app_actions is admin-gated; a non-admin caller simply gets no
+            # results for that app rather than the whole discovery call failing.
+            logger.debug(f"handle_search_tools: skipping app {app_name}: {e!s}")
+            continue
+
+        for descriptor in descriptors:
+            tool_name = descriptor.get("title")
+            allowed_tool_doc = allowed_by_name.get(tool_name)
+            if not allowed_tool_doc:
+                continue
+            matches.append({
+                "tool_name": tool_name,
+                "service": _tool_group(allowed_tool_doc),
+                "description": descriptor.get("description") or "",
+            })
+            if len(matches) >= limit:
+                return json.dumps(matches[:limit])
+
+    return json.dumps(matches[:limit])
+
+
+def handle_describe_tool_group(service, **kwargs):
+    """List every allowed tool whose service (or provider_app/"General" fallback) matches."""
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps([])
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+
+    result = [
+        {"tool_name": tool_doc.tool_name, "description": tool_doc.description or ""}
+        for tool_doc in allowed_tools
+        if _tool_group(tool_doc) == service
+    ]
+
+    return json.dumps(result)
+
+
+def _get_conversation_data(conversation_id):
+    if not conversation_id:
+        return {"version": 1, "scope": {}, "items": []}
+    data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+    return _load_state(data_json)
+
+
+def _set_conversation_data(conversation_id, state):
+    frappe.db.set_value(
+        "Agent Conversation", conversation_id, "conversation_data",
+        json.dumps(state, ensure_ascii=False, indent=2),
+    )
+
+
+def _get_lazy_tools_item(state):
+    """Find (or create) the "_lazy_tools" entry in the items list.
+
+    conversation_data stores values as {"items": [{"name", "value", ...}]}
+    (see handle_get_conversation_data / handle_set_conversation_data) rather
+    than as top-level keys, so this must update an items-list entry to stay
+    visible to that same reader (huf.ai.sdk_tools._get_lazy_discovered_tool_names).
+    """
+    for item in state["items"]:
+        if item.get("name") == "_lazy_tools":
+            item.setdefault("value", {})
+            return item
+    item = {"name": "_lazy_tools", "value": {}}
+    state["items"].append(item)
+    return item
+
+
+def handle_load_tools(tool_names, **kwargs):
+    """Grant the requesting conversation access to previously-discovered tools.
+
+    Re-validates permissions here (rather than trusting the model's request)
+    because this is the actual permission boundary: it is what decides which
+    tools create_agent_tools() will build for later turns of this conversation.
+    """
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps({"accepted": [], "rejected": tool_names if isinstance(tool_names, list) else []})
+
+    if isinstance(tool_names, str):
+        try:
+            tool_names = json.loads(tool_names)
+        except (json.JSONDecodeError, TypeError):
+            tool_names = [tool_names]
+    if not isinstance(tool_names, list):
+        tool_names = []
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+    allowed_by_name = {tool_doc.tool_name: tool_doc for tool_doc in allowed_tools}
+
+    accepted_names = []
+    rejected_names = []
+    for name in tool_names:
+        if name in allowed_by_name and name not in accepted_names:
+            accepted_names.append(name)
+        elif name not in allowed_by_name:
+            rejected_names.append(name)
+
+    conversation_id = kwargs.get("conversation_id")
+    if conversation_id and accepted_names:
+        state = _get_conversation_data(conversation_id)
+        item = _get_lazy_tools_item(state)
+        discovered = item["value"].setdefault("discovered", [])
+        for name in accepted_names:
+            if name not in discovered:
+                discovered.append(name)
+        _set_conversation_data(conversation_id, state)
+
+    accepted = []
+    for name in accepted_names:
+        tool_doc = allowed_by_name[name]
+        try:
+            parameters = json.loads(tool_doc.params) if tool_doc.params else {}
+        except (json.JSONDecodeError, TypeError):
+            parameters = {}
+        accepted.append({
+            "tool_name": name,
+            "description": tool_doc.description or "",
+            "parameters": parameters,
+        })
+
+    return json.dumps({"accepted": accepted, "rejected": rejected_names})

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -103,6 +103,7 @@
   "agent_behaviors_section",
   "autonaming_of_conversation_title",
   "enable_conversation_data",
+  "enable_lazy_tools",
   "column_break_fl05",
   "conversation_lifecycle_section",
   "conversation_retention_policy",
@@ -767,6 +768,13 @@
    "fieldname": "enable_conversation_data",
    "fieldtype": "Check",
    "label": "Allow Conversation Data Management"
+  },
+  {
+   "default": "0",
+   "description": "Enable lazy discovery of tools to reduce token usage by loading tools on-demand instead of eager loading.",
+   "fieldname": "enable_lazy_tools",
+   "fieldtype": "Check",
+   "label": "Enable Lazy Tool Discovery"
   },
   {
    "default": "1",


### PR DESCRIPTION
## Summary

Track 1 of a two-track token-efficiency effort (see companion PR for Track 2:
`feat/structured-render-tools`). Full background and design: see the tracked
GOAL.md and this track's DESIGN.md/FINDINGS.md at
`Tracks/safwan-erooth.LazyToolDiscovery/` in the huf_workspace_v2 coordination repo.

**Problem**: today every allowed `Agent Tool Function` (and every MCP tool) gets a full
JSON schema built and sent to the model on every run, even when the agent only needs
one or two tools that turn. A single integration group (Frappe Cloud) alone is 45 tools;
121 tools reach `ALL_INTEGRATION_TOOLS` total.

**Change** (strictly additive, opt-in):
- New `Agent.enable_lazy_tools` checkbox, default off. Off = zero behavior change,
  verified line-for-line against the existing `create_agent_tools()` eager path.
- 4 new discovery tools: `list_tool_groups` → `describe_tool_group` → `load_tools`, or
  `search_tools` → `load_tools` directly (built on the existing, previously-disconnected
  `capability_discovery` module).
- `load_tools` re-validates every requested tool name against
  `PermissionAwareToolRegistry.get_allowed_tools()` before granting it — never trusts the
  model's request, so it can't be used to discover/leak schemas for tools the agent isn't
  permitted to use.
- Discovered tools are cached in `Agent Conversation.conversation_data["_lazy_tools"]`
  (existing plumbing) and promoted to eager on the next `create_agent_tools()` call.

## Explicitly out of scope / deferred

- **MCP tools are not yet covered.** `create_agent_tools()` still eagerly loads every
  MCP-linked server's tools regardless of `enable_lazy_tools` — per the original
  investigation this is actually the single biggest unconditional token cost, larger
  than the native-tool case this PR addresses. Flagging so it isn't mistaken for done;
  natural follow-up PR.
- Backward-compat and permission-boundary behavior were the focus of this PR; UX for
  *authoring* which tools are "always eager" per-agent (currently a hardcoded allowlist:
  the 4 discovery tools, conversation-data/`ask_user`/`get_result_context`/memory tools)
  is not configurable yet.

## Notes for reviewers

- `huf/ai/tools/_registry.py`: this PR inserts `LAZY_DISCOVERY_TOOLS` immediately after
  `DOCUMENT_ARTIFACT_TOOLS`. The companion `feat/structured-render-tools` PR inserts
  `RENDER_TOOLS` at the same location — landing both will produce a small, trivially
  resolvable textual conflict there (no naming/structural collision, tool names don't
  overlap).
- No live Frappe bench/site was reachable in the environment this was built in, so
  `huf/ai/tests/test_lazy_tool_discovery.py` (5 cases: flag-off unchanged, flag-on
  defers correctly, permission rejection, conversation-data promotion, permission
  filtering on all 3 read-only discovery tools) was written and manually traced against
  the real implementation but not executed against a live site — please run it in CI/on
  a bench before merging.
- During review, two real gaps were found and fixed on top of the initial implementation:
  `conversation_id`/`agent_name` weren't threaded into `create_agent_tools()` from either
  real call site (the feature was dead wiring end-to-end); and `search_tools` was routed
  through an admin-gated wrapper that made it always return `[]` for ordinary agents.

## Test plan

- [ ] Run `huf/ai/tests/test_lazy_tool_discovery.py` on a bench with the `huf` app
      installed
- [ ] Manually verify: an agent with `enable_lazy_tools=1` and a large integration
      attached sees only the discovery tools + always-eager set at run start, and can
      successfully `search_tools`/`load_tools` its way to calling a deferred tool
- [ ] Verify an agent with `enable_lazy_tools=0` (or unset) is unaffected