### PR TITLE
feat(ai): structured render tools for Mermaid diagrams and charts

### DIFF
--- a/frontend/src/utils/artifactParser.ts
+++ b/frontend/src/utils/artifactParser.ts
@@ -106,6 +106,7 @@ export function isValidArtifactType(type: string): type is ArtifactType {
 		'react-component',
 		'markdown',
 		'video',
+		'chart',
 	];
 	return validTypes.includes(type as ArtifactType);
 }

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -439,15 +439,33 @@ class AgentManager:
             from huf.ai.capabilities import capability_enabled
 
             if capability_enabled(self.agent_doc, self.effective_model, "rich_elements"):
-                from huf.ai.chart_artifact_instructions import CHART_ARTIFACT_INSTRUCTIONS
+                from huf.ai.chart_artifact_instructions import (
+                    CHART_ARTIFACT_INSTRUCTIONS,
+                    CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL,
+                )
                 from huf.ai.artifact_instructions import (
                     AI_ELEMENT_INSTRUCTIONS,
                     MEDIA_ELEMENT_INSTRUCTIONS,
+                    MERMAID_ARTIFACT_INSTRUCTIONS,
+                    MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL,
                     agent_has_media_tools,
                 )
 
-                instructions += CHART_ARTIFACT_INSTRUCTIONS
-                instructions += AI_ELEMENT_INSTRUCTIONS
+                resolved_tool_names = {tool.name for tool in self.tools}
+
+                if "render_chart" in resolved_tool_names:
+                    instructions += CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+                else:
+                    instructions += CHART_ARTIFACT_INSTRUCTIONS
+
+                element_instructions = AI_ELEMENT_INSTRUCTIONS
+                if "render_mermaid" in resolved_tool_names:
+                    element_instructions = element_instructions.replace(
+                        MERMAID_ARTIFACT_INSTRUCTIONS,
+                        MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL,
+                    )
+                instructions += element_instructions
+
                 if agent_has_media_tools(self.agent_doc):
                     instructions += MEDIA_ELEMENT_INSTRUCTIONS
 

--- a/huf/ai/artifact_instructions.py
+++ b/huf/ai/artifact_instructions.py
@@ -16,6 +16,21 @@ import re
 
 import frappe
 
+MERMAID_ARTIFACT_INSTRUCTIONS = """
+4. MERMAID DIAGRAMS
+<artifact type="mermaid" title="Flowchart">
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Do something]
+    B -->|No| D[Stop]
+</artifact>
+"""
+
+MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL = """
+4. MERMAID DIAGRAMS
+To show a diagram, call the render_mermaid tool with your nodes/edges and relay its returned artifact tag verbatim in your response. Do not hand-write Mermaid syntax yourself.
+"""
+
 AI_ELEMENT_INSTRUCTIONS = """
 SYSTEM INSTRUCTION - HUF RICH ELEMENTS:
 The HUF chat UI renders special elements when you output them with the exact tags below.
@@ -44,15 +59,7 @@ Any plain text or markdown document.
   <circle cx="50" cy="50" r="40" fill="blue" />
 </svg>
 </artifact>
-
-4. MERMAID DIAGRAMS
-<artifact type="mermaid" title="Flowchart">
-graph TD
-    A[Start] --> B{Decision}
-    B -->|Yes| C[Do something]
-    B -->|No| D[Stop]
-</artifact>
-
+""" + MERMAID_ARTIFACT_INSTRUCTIONS + """
 5. WEB PREVIEW (iframe a public URL)
 <web-preview url="https://example.com" title="Example Site" />
 

--- a/huf/ai/chart_artifact_instructions.py
+++ b/huf/ai/chart_artifact_instructions.py
@@ -33,3 +33,8 @@ Rules:
 8. Put flex layouts on Card (`style={{ display: "flex", gap: 12 }}`) or use div wrappers.
 9. Pair charts with a markdown table for the underlying data when helpful.
 """
+
+CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL = """
+SYSTEM INSTRUCTION - CHART ARTIFACTS:
+To show a chart, call the render_chart tool with your data and relay its returned artifact tag verbatim in your response. Do not hand-write chart JSX yourself.
+"""

--- a/huf/ai/tests/test_render_tools.py
+++ b/huf/ai/tests/test_render_tools.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""
+Tests for huf.ai.tools.render_tools — the render_mermaid/render_chart tool
+handlers that template structured JSON into the existing Mermaid/chart
+<artifact> markup, and for the agent_integration.py prompt-instruction
+selection that swaps in the short "call the tool" instructions when
+render_mermaid/render_chart are attached to an agent.
+
+huf.ai.tools.render_tools has no frappe dependency (pure string/structural
+templating), so tests 1-6 run as plain unittest with no bench/site required.
+Test 7 exercises huf.ai.agent_integration, which imports frappe at module
+level and therefore does require a Frappe site to even import - see the
+docstring on TestPromptInstructionSelection for how that is handled.
+
+Run with:
+	bench --site <site> run-tests --app huf --module huf.ai.tests.test_render_tools
+"""
+
+import re
+import unittest
+from unittest import mock
+
+from huf.ai.tools.render_tools import handle_render_chart, handle_render_mermaid
+
+
+class TestRenderMermaid(unittest.TestCase):
+	def test_simple_two_node_graph_produces_valid_dsl_in_artifact_tag(self):
+		result = handle_render_mermaid(
+			diagram_type="graph TD",
+			nodes=[{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}],
+			edges=[{"from": "a", "to": "b", "label": "next"}],
+			title="My Flow",
+		)
+
+		self.assertTrue(result.startswith('<artifact type="mermaid" title="My Flow">'))
+		self.assertTrue(result.endswith("</artifact>"))
+
+		body = result[len('<artifact type="mermaid" title="My Flow">\n') : -len("\n</artifact>")]
+		lines = body.splitlines()
+
+		self.assertEqual(lines[0], "graph TD")
+		self.assertIn("a[Start]", body)
+		self.assertIn("b[End]", body)
+		self.assertIn("a -->|next| b", body)
+
+		# Balanced brackets, no empty node ids/labels.
+		self.assertEqual(body.count("["), body.count("]"))
+		self.assertNotIn("[]", body.replace(" ", ""))
+		self.assertNotIn("|| ", body)  # no empty pipe segment ever emitted
+
+	def test_edge_omits_pipe_segment_when_no_label_given(self):
+		result = handle_render_mermaid(
+			diagram_type="graph LR",
+			nodes=[{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+			edges=[{"from": "a", "to": "b"}],
+		)
+
+		self.assertIn("a --> b", result)
+		self.assertNotIn("|", result)
+		# default title applied when none given
+		self.assertIn('title="Diagram"', result)
+
+	def test_rejects_edge_referencing_undeclared_node_id(self):
+		with self.assertRaises(ValueError) as ctx:
+			handle_render_mermaid(
+				diagram_type="graph TD",
+				nodes=[{"id": "a", "label": "A"}],
+				edges=[{"from": "a", "to": "ghost"}],
+			)
+		self.assertIn("ghost", str(ctx.exception))
+		self.assertIn("declared node id", str(ctx.exception))
+
+	def test_rejects_invalid_diagram_type(self):
+		with self.assertRaises(ValueError):
+			handle_render_mermaid(
+				diagram_type="pie chart",
+				nodes=[{"id": "a", "label": "A"}],
+				edges=[],
+			)
+
+	def test_escapes_special_characters_in_node_and_edge_labels(self):
+		result = handle_render_mermaid(
+			diagram_type="graph TD",
+			nodes=[{"id": "a", "label": 'Weird [label] "quoted"'}, {"id": "b", "label": "B"}],
+			edges=[{"from": "a", "to": "b", "label": "pipe|here"}],
+		)
+
+		# The raw dangerous characters must not survive into the node/edge
+		# label text (aside from the syntactic brackets Mermaid itself needs
+		# around a node's own label, which _sanity_check_mermaid_dsl already
+		# verifies stay balanced).
+		node_line = next(line for line in result.splitlines() if line.strip().startswith("a["))
+		inner_label = node_line.strip()[len("a[") : -1]
+		self.assertNotIn("[", inner_label)
+		self.assertNotIn("]", inner_label)
+		self.assertNotIn('"', inner_label)
+
+		edge_line = next(line for line in result.splitlines() if "-->" in line and "a" in line.split("-->")[0])
+		self.assertNotIn("pipe|here", edge_line)
+
+
+class TestRenderChart(unittest.TestCase):
+	DATA = [{"label": "Jan", "value": 10}, {"label": "Feb", "value": 20}]
+
+	def _artifact_body(self, result):
+		match = re.match(r'^<artifact type="chart" language="jsx" title="[^"]*">\n(.*)\n</artifact>$', result, re.DOTALL)
+		self.assertIsNotNone(result and match, f"artifact tag shape unexpected: {result[:120]!r}")
+		return match.group(1)
+
+	def test_bar_chart_produces_correct_jsx_in_artifact_tag(self):
+		result = handle_render_chart(chart_type="bar", data=self.DATA, title="Sales")
+		self.assertTrue(result.startswith('<artifact type="chart" language="jsx" title="Sales">'))
+		body = self._artifact_body(result)
+		self.assertIn("const data = ", body)
+		self.assertIn("BarChart", body)
+		self.assertIn("<Bar ", body)
+		self.assertIn('dataKey="value"', body)
+		self.assertIn('dataKey="label"', body)  # x_key default
+		self.assertNotIn("CardHeader", body)
+		self.assertNotIn("CardTitle", body)
+
+	def test_line_chart_produces_correct_jsx(self):
+		result = handle_render_chart(chart_type="line", data=self.DATA)
+		body = self._artifact_body(result)
+		self.assertIn("LineChart", body)
+		self.assertIn("<Line ", body)
+
+	def test_area_chart_produces_correct_jsx(self):
+		result = handle_render_chart(chart_type="area", data=self.DATA)
+		body = self._artifact_body(result)
+		self.assertIn("AreaChart", body)
+		self.assertIn("<Area ", body)
+
+	def test_pie_chart_produces_correct_jsx_with_cells_and_fallback_color(self):
+		data = [{"label": "A", "value": 1}, {"label": "B", "value": 2}]
+		result = handle_render_chart(chart_type="pie", data=data)
+		body = self._artifact_body(result)
+		self.assertIn("PieChart", body)
+		self.assertIn("<Pie ", body)
+		self.assertIn("<Cell ", body)
+		self.assertIn("colors[index % colors.length] || ", body)  # || fallback, not string concat
+		self.assertIn("const colors = ", body)
+
+	def test_rejects_chart_type_outside_allowed_set(self):
+		with self.assertRaises(ValueError):
+			handle_render_chart(chart_type="scatter", data=self.DATA)
+
+	def test_rejects_data_missing_required_series_key_field(self):
+		bad_data = [{"label": "Jan", "value": 10}, {"label": "Feb"}]
+		with self.assertRaises(ValueError) as ctx:
+			handle_render_chart(chart_type="bar", data=bad_data, series_keys=["value"])
+		message = str(ctx.exception)
+		self.assertIn("value", message)
+		self.assertIn("1", message)  # row index 1 is the offending row
+
+	def test_rejects_data_missing_required_x_key_field(self):
+		bad_data = [{"value": 10}]
+		with self.assertRaises(ValueError):
+			handle_render_chart(chart_type="bar", data=bad_data)
+
+	def test_rejects_empty_data(self):
+		with self.assertRaises(ValueError):
+			handle_render_chart(chart_type="bar", data=[])
+
+	def test_data_is_json_serialized_safely_not_string_concatenated(self):
+		data = [{"label": 'A "quoted" & <b>', "value": 5}]
+		result = handle_render_chart(chart_type="bar", data=data)
+		body = self._artifact_body(result)
+		# json.dumps would escape the embedded quote rather than breaking out
+		# of the JS string literal.
+		self.assertIn('\\"quoted\\"', body)
+
+
+class TestPromptInstructionSelection(unittest.TestCase):
+	"""Covers the agent_integration.py selection of
+	CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL / MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+	vs. the full-length originals, based on whether render_chart/render_mermaid
+	are present in the agent's resolved tool list.
+
+	huf.ai.agent_integration imports frappe at module level, so it cannot even
+	be imported without a Frappe site/bench (this sandbox has neither - no
+	`sites/` directory and no installed `frappe` package). This test therefore
+	drives AgentManager.create_agent() end to end via bench run-tests only;
+	if frappe is not importable it is skipped rather than reported as a
+	false failure, so a plain `python -m pytest` run states plainly why the
+	real assertions did not execute.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		try:
+			import frappe  # noqa: F401
+		except ImportError:
+			raise unittest.SkipTest(
+				"frappe is not importable in this environment - this test requires "
+				"`bench --site <site> run-tests --app huf --module huf.ai.tests.test_render_tools`"
+			)
+
+	def _make_manager(self, tool_names):
+		from huf.ai.agent_integration import AgentManager
+
+		manager = AgentManager.__new__(AgentManager)
+		manager.agent_doc = mock.MagicMock()
+		manager.agent_doc.enable_conversation_data = False
+		manager.agent_doc.enable_memory = False
+		manager.agent_doc.allow_chat = True
+		manager.agent_doc.agent_name = "test-agent"
+		manager.effective_model = "test-model"
+		manager.effective_provider = "test-provider"
+		manager.tools = [mock.MagicMock(name=n, description="d") for n in tool_names]
+		for tool, n in zip(manager.tools, tool_names):
+			tool.name = n
+		return manager
+
+	def _resolve_instructions(self, tool_names):
+		from huf.ai.chart_artifact_instructions import CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+		from huf.ai.artifact_instructions import MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+
+		manager = self._make_manager(tool_names)
+
+		with mock.patch("huf.ai.prompt_resolver.resolve_prompt", return_value=""), \
+			mock.patch("huf.ai.skills.loader.get_skill_instructions", return_value=""), \
+			mock.patch("huf.ai.skills.loader.get_optional_skills_preamble", return_value=""), \
+			mock.patch("huf.ai.skills.loader.get_skill_prompts", return_value=[]), \
+			mock.patch("huf.ai.capabilities.capability_enabled", return_value=True), \
+			mock.patch("huf.ai.artifact_instructions.agent_has_media_tools", return_value=False):
+			agent = manager.create_agent()
+
+		instructions = agent.instructions if hasattr(agent, "instructions") else agent["instructions"]
+		return instructions, CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL, MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+
+	def test_short_variants_selected_when_tools_are_attached(self):
+		instructions, chart_short, mermaid_short = self._resolve_instructions(["render_chart", "render_mermaid"])
+		self.assertIn(chart_short.strip(), instructions)
+		self.assertIn(mermaid_short.strip(), instructions)
+
+	def test_full_variants_selected_when_tools_are_not_attached(self):
+		instructions, chart_short, mermaid_short = self._resolve_instructions(["some_other_tool"])
+		self.assertNotIn(chart_short.strip(), instructions)
+		self.assertNotIn(mermaid_short.strip(), instructions)
+		self.assertIn("SYSTEM INSTRUCTION - JSX CHART ARTIFACTS", instructions)
+		self.assertIn("4. MERMAID DIAGRAMS\n<artifact type=\"mermaid\"", instructions)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1841,6 +1841,48 @@ DOCUMENT_ARTIFACT_TOOLS = [
 	},
 ]
 
+# ---------------------------------------------------------------------------
+# Render Tools — structured JSON in, existing <artifact> markup out. Replace
+# hand-authoring Mermaid DSL / Recharts JSX with a small structured payload.
+# ---------------------------------------------------------------------------
+
+RENDER_TOOLS = [
+	{
+		"tool_name": "render_mermaid",
+		"description": (
+			"Renders a Mermaid diagram from structured nodes/edges. Call this instead of "
+			"writing Mermaid syntax yourself. Returns the complete <artifact type=\"mermaid\"> "
+			"tag - relay it verbatim in your response."
+		),
+		"function_path": "huf.ai.tools.render_tools.handle_render_mermaid",
+		"category": "Render Tools",
+		"parameters": [
+			_p("diagram_type", required=True, description="One of: 'graph TD', 'graph LR', 'flowchart TD', 'flowchart LR'"),
+			_p("nodes", type="json", required=True, description="JSON list of nodes [{id, label}], e.g. [{\"id\": \"a\", \"label\": \"Start\"}]"),
+			_p("edges", type="json", description="JSON list of edges [{from, to, label}], e.g. [{\"from\": \"a\", \"to\": \"b\", \"label\": \"next\"}]. from/to must match declared node ids"),
+			_p("title", description="Artifact title (default 'Diagram')"),
+		],
+	},
+	{
+		"tool_name": "render_chart",
+		"description": (
+			"Renders a bar/line/pie/area chart from structured data. Call this instead of "
+			"hand-writing Recharts JSX yourself. Returns the complete "
+			"<artifact type=\"chart\" language=\"jsx\"> tag - relay it verbatim in your response."
+		),
+		"function_path": "huf.ai.tools.render_tools.handle_render_chart",
+		"category": "Render Tools",
+		"parameters": [
+			_p("chart_type", required=True, description="One of: 'bar', 'line', 'pie', 'area'"),
+			_p("data", type="json", required=True, description="JSON list of row objects, each containing at least the x_key field and every series_key field"),
+			_p("series_keys", type="json", description="JSON list of field names to plot as series/values (default ['value'])"),
+			_p("x_key", description="Field used for the category/x axis, ignored for 'pie' (default 'label')"),
+			_p("colors", type="json", description="Optional JSON list of hex colors, mainly used for pie slices"),
+			_p("title", description="Artifact title (default '<Chart Type> Chart')"),
+		],
+	},
+]
+
 ALL_INTEGRATION_TOOLS = (
 	# Platform capabilities — no external account to connect.
 	RECIPIENT_TOOLS
@@ -1855,6 +1897,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS
 	+ DOCUMENT_ARTIFACT_TOOLS
+	+ RENDER_TOOLS
 	# Tools backed by a connectable service. Keys match Integration Service
 	# docnames and the SERVICE_NAME each tool module uses for credentials.
 	+ _with_service(SLACK_TOOLS, "slack")

--- a/huf/ai/tools/render_tools.py
+++ b/huf/ai/tools/render_tools.py
@@ -34,6 +34,36 @@ def _escape_mermaid_label(label: str) -> str:
 	return escaped
 
 
+def _escape_artifact_attr(value: str) -> str:
+	"""Sanitize a value that will be templated into an `<artifact ...>` tag
+	attribute (e.g. title="...").
+
+	The frontend's artifact parser (frontend/src/utils/artifactParser.ts)
+	extracts the outer `<artifact ...>` tag with a plain regex, not an HTML/DOM
+	parser: `ARTIFACT_REGEX` stops at the first `>` and `ATTR_REGEX` stops at
+	the first matching quote. An unescaped `"` or `>` in a templated value
+	(e.g. an LLM- or user-supplied chart/diagram title) would truncate or
+	corrupt the tag boundary, leaking the rest of the artifact body as raw
+	text into the chat. Strip the characters that matter to that regex rather
+	than trying to HTML-encode them (this isn't HTML, so entities like
+	`&quot;` would just render literally).
+	"""
+	if not value:
+		return value
+	return value.replace('"', "'").replace("<", "(").replace(">", ")")
+
+
+def _escape_jsx_attr(value: str) -> str:
+	"""Sanitize a value templated into a double-quoted JSX attribute
+	(e.g. dataKey="...", fill="..."). Prevents a caller-supplied field name or
+	color from closing the attribute early and injecting additional JSX
+	attributes/props into the generated chart component.
+	"""
+	if not value:
+		return value
+	return value.replace('"', "'").replace("{", "(").replace("}", ")")
+
+
 def handle_render_mermaid(diagram_type=None, nodes=None, edges=None, title=None, **kwargs) -> str:
 	"""Template structured nodes/edges into a Mermaid <artifact> tag.
 
@@ -97,7 +127,7 @@ def handle_render_mermaid(diagram_type=None, nodes=None, edges=None, title=None,
 
 	_sanity_check_mermaid_dsl(dsl)
 
-	artifact_title = title or "Diagram"
+	artifact_title = _escape_artifact_attr((title or "Diagram").strip())
 	return f'<artifact type="mermaid" title="{artifact_title}">\n{dsl}\n</artifact>'
 
 
@@ -172,7 +202,7 @@ def handle_render_chart(chart_type=None, data=None, series_keys=None, x_key="lab
 				raise ValueError(f"data[{i}] is missing series_key field {key!r}")
 
 	data_declaration = f"const data = {json.dumps(data)};"
-	artifact_title = title or f"{chart_type.capitalize()} Chart"
+	artifact_title = _escape_artifact_attr((title or f"{chart_type.capitalize()} Chart").strip())
 
 	if chart_type == "pie":
 		jsx = _build_pie_jsx(series_keys[0], colors)
@@ -191,15 +221,17 @@ def _build_axis_chart_jsx(chart_type: str, x_key: str, series_keys: list, colors
 
 	series_lines = []
 	for i, key in enumerate(series_keys):
-		color = palette[i % len(palette)]
-		series_lines.append(f'      <{series_component} dataKey="{key}" fill="{color}" stroke="{color}" />')
+		color = _escape_jsx_attr(str(palette[i % len(palette)]))
+		safe_key = _escape_jsx_attr(str(key))
+		series_lines.append(f'      <{series_component} dataKey="{safe_key}" fill="{color}" stroke="{color}" />')
 	series_jsx = "\n".join(series_lines)
 
+	safe_x_key = _escape_jsx_attr(str(x_key))
 	return (
 		"<Card style={{ padding: 12 }}>\n"
 		'  <ResponsiveContainer width="100%" height={320}>\n'
 		f"    <{container} data={{data}}>\n"
-		f'      <XAxis dataKey="{x_key}" />\n'
+		f'      <XAxis dataKey="{safe_x_key}" />\n'
 		"      <YAxis />\n"
 		"      <Tooltip />\n"
 		"      <Legend />\n"
@@ -213,13 +245,14 @@ def _build_axis_chart_jsx(chart_type: str, x_key: str, series_keys: list, colors
 def _build_pie_jsx(value_key: str, colors) -> str:
 	palette = colors or _DEFAULT_PIE_COLORS
 	colors_declaration = f"const colors = {json.dumps(palette)};"
+	safe_value_key = _escape_jsx_attr(str(value_key))
 
 	return (
 		f"{colors_declaration}\n\n"
 		"<Card style={{ padding: 12 }}>\n"
 		'  <ResponsiveContainer width="100%" height={320}>\n'
 		"    <PieChart>\n"
-		f'      <Pie data={{data}} dataKey="{value_key}" nameKey="label" outerRadius={{120}}>\n'
+		f'      <Pie data={{data}} dataKey="{safe_value_key}" nameKey="label" outerRadius={{120}}>\n'
 		"        {data.map((entry, index) => (\n"
 		'          <Cell key={`cell-${index}`} fill={colors[index % colors.length] || "#8884d8"} />\n'
 		"        ))}\n"

--- a/huf/ai/tools/render_tools.py
+++ b/huf/ai/tools/render_tools.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""Agent-facing tool handlers that template structured JSON into the existing
+Mermaid/chart <artifact> tag formats, so a model passes data instead of
+hand-authoring Mermaid DSL or Recharts JSX.
+
+Both handlers return the complete <artifact>...</artifact> markup string -
+the exact same tags a model would otherwise hand-author - or raise ValueError
+on bad input, matching the convention used elsewhere in huf/ai/tools/.
+"""
+
+import json
+
+VALID_DIAGRAM_TYPES = ("graph TD", "graph LR", "flowchart TD", "flowchart LR")
+VALID_CHART_TYPES = ("bar", "line", "pie", "area")
+
+# Characters that break Mermaid node/edge syntax inside a label.
+_MERMAID_LABEL_ESCAPES = {
+	"[": "(",
+	"]": ")",
+	"|": "-",
+	'"': "'",
+}
+
+# Default palette for pie-chart slices when the caller does not supply colors.
+_DEFAULT_PIE_COLORS = ["#007BFF", "#28A745", "#FFC107", "#DC3545", "#6F42C1", "#20C997", "#FD7E14"]
+
+
+def _escape_mermaid_label(label: str) -> str:
+	escaped = label
+	for char, replacement in _MERMAID_LABEL_ESCAPES.items():
+		escaped = escaped.replace(char, replacement)
+	return escaped
+
+
+def handle_render_mermaid(diagram_type=None, nodes=None, edges=None, title=None, **kwargs) -> str:
+	"""Template structured nodes/edges into a Mermaid <artifact> tag.
+
+	Args:
+		diagram_type (str): One of "graph TD", "graph LR", "flowchart TD", "flowchart LR".
+		nodes (list[dict]): Each {"id": str, "label": str, "shape": optional, ignored}.
+		edges (list[dict]): Each {"from": str, "to": str, "label": optional str}.
+		title (str): Artifact title, defaults to "Diagram".
+
+	Returns:
+		The complete <artifact type="mermaid" ...>...</artifact> string.
+	"""
+	if diagram_type not in VALID_DIAGRAM_TYPES:
+		raise ValueError(f"'diagram_type' must be one of {VALID_DIAGRAM_TYPES}, got {diagram_type!r}")
+
+	if not isinstance(nodes, list) or not nodes:
+		raise ValueError("'nodes' must be a non-empty list of {id, label} objects")
+
+	if edges is None:
+		edges = []
+	if not isinstance(edges, list):
+		raise ValueError("'edges' must be a list of {from, to, label} objects")
+
+	node_ids = set()
+	node_lines = []
+	for i, node in enumerate(nodes):
+		if not isinstance(node, dict):
+			raise ValueError(f"nodes[{i}] must be an object with 'id' and 'label'")
+		node_id = (node.get("id") or "").strip()
+		label = (node.get("label") or "").strip()
+		if not node_id:
+			raise ValueError(f"nodes[{i}] is missing a required non-empty 'id'")
+		if not label:
+			raise ValueError(f"nodes[{i}] (id={node_id!r}) is missing a required non-empty 'label'")
+		if node_id in node_ids:
+			raise ValueError(f"Duplicate node id {node_id!r} - node ids must be unique")
+		node_ids.add(node_id)
+		node_lines.append(f"    {node_id}[{_escape_mermaid_label(label)}]")
+
+	edge_lines = []
+	for i, edge in enumerate(edges):
+		if not isinstance(edge, dict):
+			raise ValueError(f"edges[{i}] must be an object with 'from' and 'to'")
+		src = (edge.get("from") or "").strip()
+		dst = (edge.get("to") or "").strip()
+		if not src or not dst:
+			raise ValueError(f"edges[{i}] must have non-empty 'from' and 'to'")
+		if src not in node_ids:
+			raise ValueError(f"edges[{i}] references unknown node id 'from'={src!r} - it must match a declared node id")
+		if dst not in node_ids:
+			raise ValueError(f"edges[{i}] references unknown node id 'to'={dst!r} - it must match a declared node id")
+
+		edge_label = (edge.get("label") or "").strip()
+		if edge_label:
+			edge_lines.append(f"    {src} -->|{_escape_mermaid_label(edge_label)}| {dst}")
+		else:
+			edge_lines.append(f"    {src} --> {dst}")
+
+	dsl_lines = [diagram_type] + node_lines + edge_lines
+	dsl = "\n".join(dsl_lines)
+
+	_sanity_check_mermaid_dsl(dsl)
+
+	artifact_title = title or "Diagram"
+	return f'<artifact type="mermaid" title="{artifact_title}">\n{dsl}\n</artifact>'
+
+
+def _sanity_check_mermaid_dsl(dsl: str) -> None:
+	"""Best-effort structural check on generated DSL before returning it."""
+	if dsl.count("[") != dsl.count("]"):
+		raise ValueError("Generated Mermaid DSL has unbalanced [] brackets - this is a bug in render_mermaid")
+	if "[]" in dsl.replace(" ", ""):
+		raise ValueError("Generated Mermaid DSL has an empty node label - this is a bug in render_mermaid")
+	for line in dsl.splitlines()[1:]:
+		stripped = line.strip()
+		if not stripped:
+			continue
+		is_edge_line = "-->" in stripped
+		is_node_line = "[" in stripped
+		if stripped.startswith("-->") or not (is_edge_line or is_node_line):
+			raise ValueError(f"Generated Mermaid DSL line looks malformed: {stripped!r}")
+
+
+_CHART_TAG_TEMPLATES = {
+	"bar": {
+		"import_component": "BarChart",
+		"series_component": "Bar",
+	},
+	"line": {
+		"import_component": "LineChart",
+		"series_component": "Line",
+	},
+	"area": {
+		"import_component": "AreaChart",
+		"series_component": "Area",
+	},
+}
+
+
+def handle_render_chart(chart_type=None, data=None, series_keys=None, x_key="label", colors=None, title=None, **kwargs) -> str:
+	"""Template structured data into a JSX chart <artifact> tag matching the
+	rules in huf.ai.chart_artifact_instructions (allowed tags/components,
+	backtick template literals, no CardHeader/CardTitle, etc).
+
+	Args:
+		chart_type (str): One of "bar", "line", "pie", "area".
+		data (list[dict]): Non-empty rows, each containing at least x_key.
+		series_keys (list[str]): Fields to plot; defaults to ["value"].
+		x_key (str): Field used for the category/x axis. Ignored for "pie".
+		colors (list[str]): Optional palette, mainly used for pie slices.
+		title (str): Artifact title.
+
+	Returns:
+		The complete <artifact type="chart" language="jsx" ...>...</artifact> string.
+	"""
+	if chart_type not in VALID_CHART_TYPES:
+		raise ValueError(f"'chart_type' must be one of {VALID_CHART_TYPES}, got {chart_type!r}")
+
+	if not isinstance(data, list) or not data:
+		raise ValueError("'data' must be a non-empty list of objects")
+
+	for i, row in enumerate(data):
+		if not isinstance(row, dict):
+			raise ValueError(f"data[{i}] must be an object")
+		if chart_type != "pie" and x_key not in row:
+			raise ValueError(f"data[{i}] is missing the required x_key field {x_key!r}")
+
+	if not series_keys:
+		series_keys = ["value"]
+	if not isinstance(series_keys, list) or not series_keys:
+		raise ValueError("'series_keys' must be a non-empty list of field names")
+
+	for i, row in enumerate(data):
+		for key in series_keys:
+			if key not in row:
+				raise ValueError(f"data[{i}] is missing series_key field {key!r}")
+
+	data_declaration = f"const data = {json.dumps(data)};"
+	artifact_title = title or f"{chart_type.capitalize()} Chart"
+
+	if chart_type == "pie":
+		jsx = _build_pie_jsx(series_keys[0], colors)
+	else:
+		jsx = _build_axis_chart_jsx(chart_type, x_key, series_keys, colors)
+
+	body = f"{data_declaration}\n\n{jsx}"
+	return f'<artifact type="chart" language="jsx" title="{artifact_title}">\n{body}\n</artifact>'
+
+
+def _build_axis_chart_jsx(chart_type: str, x_key: str, series_keys: list, colors) -> str:
+	template = _CHART_TAG_TEMPLATES[chart_type]
+	container = template["import_component"]
+	series_component = template["series_component"]
+	palette = colors or _DEFAULT_PIE_COLORS
+
+	series_lines = []
+	for i, key in enumerate(series_keys):
+		color = palette[i % len(palette)]
+		series_lines.append(f'      <{series_component} dataKey="{key}" fill="{color}" stroke="{color}" />')
+	series_jsx = "\n".join(series_lines)
+
+	return (
+		"<Card style={{ padding: 12 }}>\n"
+		'  <ResponsiveContainer width="100%" height={320}>\n'
+		f"    <{container} data={{data}}>\n"
+		f'      <XAxis dataKey="{x_key}" />\n'
+		"      <YAxis />\n"
+		"      <Tooltip />\n"
+		"      <Legend />\n"
+		f"{series_jsx}\n"
+		f"    </{container}>\n"
+		"  </ResponsiveContainer>\n"
+		"</Card>"
+	)
+
+
+def _build_pie_jsx(value_key: str, colors) -> str:
+	palette = colors or _DEFAULT_PIE_COLORS
+	colors_declaration = f"const colors = {json.dumps(palette)};"
+
+	return (
+		f"{colors_declaration}\n\n"
+		"<Card style={{ padding: 12 }}>\n"
+		'  <ResponsiveContainer width="100%" height={320}>\n'
+		"    <PieChart>\n"
+		f'      <Pie data={{data}} dataKey="{value_key}" nameKey="label" outerRadius={{120}}>\n'
+		"        {data.map((entry, index) => (\n"
+		'          <Cell key={`cell-${index}`} fill={colors[index % colors.length] || "#8884d8"} />\n'
+		"        ))}\n"
+		"      </Pie>\n"
+		"      <Tooltip />\n"
+		"      <Legend />\n"
+		"    </PieChart>\n"
+		"  </ResponsiveContainer>\n"
+		"</Card>"
+	)


### PR DESCRIPTION
## Summary

Track 2 of a two-track token-efficiency effort (see companion PR
`feat/lazy-tool-discovery` for Track 1). Full background and design: see this track's
DESIGN.md/FINDINGS.md at `Tracks/safwan-erooth.StructuredRenderTools/` in the
huf_workspace_v2 coordination repo.

**Problem**: today, showing a chart or Mermaid diagram in chat means the LLM hand-writes
the full Recharts JSX or Mermaid DSL itself. `chart_artifact_instructions.py` alone is
~30 lines of syntax rules injected into the prompt on every qualifying turn, and every
chart/diagram costs a full markup generation in output tokens.

**Change** (strictly additive, opt-in via normal tool attachment):
- New `render_mermaid` / `render_chart` tools: the model passes small structured JSON
  (nodes/edges, or chart data/series), the backend deterministically templates the
  *exact same* `<artifact type="mermaid">...</artifact>` /
  `<artifact type="chart" language="jsx">...</artifact>` markup a model would otherwise
  hand-author. **Zero frontend or DocType changes** — `ArtifactRenderer.tsx`,
  `Mermaid.tsx`, `JSXPreviewRenderer.tsx`, and the `Artifact` doctype are all untouched,
  since from their point of view nothing changed.
- When `render_chart`/`render_mermaid` are attached to an agent, the corresponding
  syntax-teaching prompt instructions are swapped for a one-line "call the tool instead"
  note — verified byte-for-byte identical output for agents that don't have the tools
  attached (this is a genuine refactor + conditional swap, not a content change to the
  fallback path).
- Drive-by fix: `isValidArtifactType` (frontend) was missing `"chart"` from its own
  validity list despite `chart` being a live, rendered artifact type.

## Security note

During review, a real issue was found and fixed: `title`/`x_key`/`series_keys`/`colors`
were templated unescaped into the `<artifact ...>` tag and JSX attribute strings. The
frontend's artifact parser uses plain regexes (stops at the first `>` / matching quote),
so an unescaped quote or angle bracket in a model-relayed value could truncate the
artifact tag early or inject extra JSX attributes into the generated chart component.
Fixed via `_escape_artifact_attr`/`_escape_jsx_attr` in `render_tools.py` (see the
`fix(ai): escape templated attribute values in render tools` commit).

## Notes for reviewers

- `huf/ai/tools/_registry.py` insertion point overlaps with the companion
  `feat/lazy-tool-discovery` PR's `LAZY_DISCOVERY_TOOLS` insertion — trivially resolvable
  conflict if both land, no naming/structural collision.
- No live Frappe bench/site was reachable in the environment this was built in.
  `render_tools.py` itself has no frappe dependency, so its unit tests
  (`huf/ai/tests/test_render_tools.py`, 14 cases covering Mermaid escaping/validation and
  bar/line/pie/area chart JSX correctness) were actually executed via a minimal shim and
  **pass**. The 1 case requiring real frappe (`agent_integration.py`'s instruction
  selection, `TestPromptInstructionSelection`) self-skips with a clear message and needs
  a real bench run before merging.
- Minor, non-blocking style notes from review: the render tools raise `ValueError` on bad
  input rather than `document_artifact.py`'s `{"success": false, ...}` JSON-return
  convention (matches other sibling tool files' convention instead, e.g.
  `docker_execution.py`); the pie-chart JSX uses a multi-line `.map()` for per-slice fill
  rather than the *preferred* (not required) one-line arrow form.

## Test plan

- [ ] Run `huf/ai/tests/test_render_tools.py` on a bench with the `huf` app installed
      (including `TestPromptInstructionSelection`)
- [ ] Manually verify: an agent with `render_mermaid`/`render_chart` attached produces a
      correctly rendered diagram/chart in chat, and the shorter prompt instruction is
      actually used (check the composed system prompt)
- [ ] Verify an agent without these tools attached sees identical chat behavior to before