### PR TITLE
feat: Huf Developer Platform — public API v1 (Phases 0-3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,6 +92,7 @@ const HubSimplePage = lazy(() => import('./pages/HubSimplePage'));
 const GatewaysPage = lazy(() => import('./pages/GatewaysPage'));
 const AgentSettingsPage = lazy(() => import('./pages/AgentSettingsPage'));
 const GeneralSettingsPage = lazy(() => import('./pages/GeneralSettingsPage'));
+const DeveloperSettingsPage = lazy(() => import('./pages/DeveloperSettingsPage'));
 
 import { useEffect } from 'react';
 import { RouteErrorBoundary, clearChunkReloadFlag } from './components/RouteErrorBoundary';
@@ -569,6 +570,18 @@ function AppShell() {
                 <UnifiedLayout>
                   <Suspense fallback={<PageLoader />}>
                     <GeneralSettingsPage />
+                  </Suspense>
+                </UnifiedLayout>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings/developer"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout>
+                  <Suspense fallback={<PageLoader />}>
+                    <DeveloperSettingsPage />
                   </Suspense>
                 </UnifiedLayout>
               </ProtectedRoute>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -159,6 +159,7 @@ export const settingsNavGroups: Array<{ label?: string; items: Array<{ title: st
         icon: Users,
         capability: ["users.manage", "roles.manage"],
       },
+      { title: "Developer", url: "/settings/developer", icon: Terminal, capability: null },
     ],
   },
 ]

--- a/frontend/src/components/settings/AgentApiDocs.tsx
+++ b/frontend/src/components/settings/AgentApiDocs.tsx
@@ -1,69 +1,128 @@
+import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { CodeBlock, CodeBlockCopyButton } from '@/components/ai-elements/code-block';
+import {
+  buildSnippet,
+  buildLoginSnippet,
+  type AuthMode,
+  type SnippetLanguage,
+  type SnippetRequest,
+} from '@/lib/apiSnippets';
 
 interface AgentApiDocsProps {
   baseUrl: string;
 }
 
 interface EndpointDoc {
-  method: string;
-  path: string;
+  request: SnippetRequest;
   description: string;
-  example: string;
 }
 
-function buildEndpoints(baseUrl: string): EndpointDoc[] {
-  return [
-    {
-      method: 'GET',
-      path: '/agents',
-      description: 'List every agent your key is permitted to use.',
-      example: `curl "${baseUrl}/agents" \\
-  -H "X-Huf-Api-Key: huf_sk_..."`,
-    },
-    {
-      method: 'GET',
-      path: '/agents/{agent_id}',
-      description: 'Get a single agent\'s public details.',
-      example: `curl "${baseUrl}/agents/Demo Assistant" \\
-  -H "X-Huf-Api-Key: huf_sk_..."`,
-    },
-    {
+const ENDPOINTS: EndpointDoc[] = [
+  {
+    request: { method: 'GET', path: '/agents' },
+    description: 'List every agent your key is permitted to use.',
+  },
+  {
+    request: { method: 'GET', path: '/agents/{agent_id}' },
+    description: "Get a single agent's public details.",
+  },
+  {
+    request: {
       method: 'POST',
       path: '/responses',
-      description: 'Run an agent with a message. Requires the "agents:run" permission.',
-      example: `curl -X POST "${baseUrl}/responses" \\
-  -H "X-Huf-Api-Key: huf_sk_..." \\
-  -d "agent_id=Demo Assistant" \\
-  -d "input=Hello!"`,
+      body: { agent_id: 'Demo Assistant', input: 'Hello!' },
     },
-  ];
-}
+    description: 'Run an agent with a message. Requires the "agents:run" permission.',
+  },
+];
+
+const LANGUAGES: { value: SnippetLanguage; label: string }[] = [
+  { value: 'curl', label: 'curl' },
+  { value: 'python', label: 'Python' },
+  { value: 'javascript', label: 'JavaScript' },
+  { value: 'typescript', label: 'TypeScript' },
+];
+
+const CODE_BLOCK_LANGUAGE: Record<SnippetLanguage, string> = {
+  curl: 'bash',
+  python: 'python',
+  javascript: 'javascript',
+  typescript: 'typescript',
+};
 
 export function AgentApiDocs({ baseUrl }: AgentApiDocsProps) {
-  const endpoints = buildEndpoints(baseUrl);
+  const [language, setLanguage] = useState<SnippetLanguage>('curl');
+  const [authMode, setAuthMode] = useState<AuthMode>('apiKey');
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>Agent API</CardTitle>
         <CardDescription>
-          List, inspect, and run agents from your own code. Every request needs a key from API Keys
-          below, sent as the <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">X-Huf-Api-Key</code> header.
+          List, inspect, and run agents from your own code.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
-        {endpoints.map((endpoint) => (
-          <div key={`${endpoint.method}-${endpoint.path}`} className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <ToggleGroup
+            type="single"
+            value={authMode}
+            onValueChange={(value) => value && setAuthMode(value as AuthMode)}
+            className="justify-start"
+          >
+            <ToggleGroupItem value="apiKey" className="text-xs">
+              API key
+            </ToggleGroupItem>
+            <ToggleGroupItem value="session" className="text-xs">
+              Session
+            </ToggleGroupItem>
+          </ToggleGroup>
+
+          <Tabs value={language} onValueChange={(value) => setLanguage(value as SnippetLanguage)}>
+            <TabsList>
+              {LANGUAGES.map((lang) => (
+                <TabsTrigger key={lang.value} value={lang.value} className="text-xs">
+                  {lang.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </div>
+
+        {authMode === 'apiKey' ? (
+          <p className="text-sm text-muted-foreground">
+            Requests are authenticated with a key from API Keys below, sent as the{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">X-Huf-Api-Key</code> header.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Session auth uses the cookie from logging in — log in first to get a session, then reuse it
+              for subsequent requests:
+            </p>
+            <CodeBlock code={buildLoginSnippet(baseUrl, language)} language={CODE_BLOCK_LANGUAGE[language]}>
+              <CodeBlockCopyButton />
+            </CodeBlock>
+          </div>
+        )}
+
+        {ENDPOINTS.map((endpoint) => (
+          <div key={`${endpoint.request.method}-${endpoint.request.path}`} className="space-y-2">
             <div className="flex items-center gap-2">
               <Badge variant="outline" className="font-mono text-xs">
-                {endpoint.method}
+                {endpoint.request.method}
               </Badge>
-              <code className="text-sm font-mono">{endpoint.path}</code>
+              <code className="text-sm font-mono">{endpoint.request.path}</code>
             </div>
             <p className="text-sm text-muted-foreground">{endpoint.description}</p>
-            <CodeBlock code={endpoint.example} language="bash">
+            <CodeBlock
+              code={buildSnippet(baseUrl, endpoint.request, language, authMode)}
+              language={CODE_BLOCK_LANGUAGE[language]}
+            >
               <CodeBlockCopyButton />
             </CodeBlock>
           </div>

--- a/frontend/src/components/settings/AgentApiDocs.tsx
+++ b/frontend/src/components/settings/AgentApiDocs.tsx
@@ -1,0 +1,74 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CodeBlock, CodeBlockCopyButton } from '@/components/ai-elements/code-block';
+
+interface AgentApiDocsProps {
+  baseUrl: string;
+}
+
+interface EndpointDoc {
+  method: string;
+  path: string;
+  description: string;
+  example: string;
+}
+
+function buildEndpoints(baseUrl: string): EndpointDoc[] {
+  return [
+    {
+      method: 'GET',
+      path: '/agents',
+      description: 'List every agent your key is permitted to use.',
+      example: `curl "${baseUrl}/agents" \\
+  -H "X-Huf-Api-Key: huf_sk_..."`,
+    },
+    {
+      method: 'GET',
+      path: '/agents/{agent_id}',
+      description: 'Get a single agent\'s public details.',
+      example: `curl "${baseUrl}/agents/Demo Assistant" \\
+  -H "X-Huf-Api-Key: huf_sk_..."`,
+    },
+    {
+      method: 'POST',
+      path: '/responses',
+      description: 'Run an agent with a message. Requires the "agents:run" permission.',
+      example: `curl -X POST "${baseUrl}/responses" \\
+  -H "X-Huf-Api-Key: huf_sk_..." \\
+  -d "agent_id=Demo Assistant" \\
+  -d "input=Hello!"`,
+    },
+  ];
+}
+
+export function AgentApiDocs({ baseUrl }: AgentApiDocsProps) {
+  const endpoints = buildEndpoints(baseUrl);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Agent API</CardTitle>
+        <CardDescription>
+          List, inspect, and run agents from your own code. Every request needs a key from API Keys
+          below, sent as the <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">X-Huf-Api-Key</code> header.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {endpoints.map((endpoint) => (
+          <div key={`${endpoint.method}-${endpoint.path}`} className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="font-mono text-xs">
+                {endpoint.method}
+              </Badge>
+              <code className="text-sm font-mono">{endpoint.path}</code>
+            </div>
+            <p className="text-sm text-muted-foreground">{endpoint.description}</p>
+            <CodeBlock code={endpoint.example} language="bash">
+              <CodeBlockCopyButton />
+            </CodeBlock>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/ApiKeyCreatedDialog.tsx
+++ b/frontend/src/components/settings/ApiKeyCreatedDialog.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Check, Copy } from 'lucide-react';
+import { toast } from 'sonner';
+import type { CreatedApiKey } from '@/services/developerApi';
+
+interface ApiKeyCreatedDialogProps {
+  apiKey: CreatedApiKey | null;
+  onClose: () => void;
+}
+
+export function ApiKeyCreatedDialog({ apiKey, onClose }: ApiKeyCreatedDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!apiKey?.raw_secret) {
+      return;
+    }
+    try {
+      if (!navigator?.clipboard) {
+        throw new Error('Clipboard API not available');
+      }
+      await navigator.clipboard.writeText(apiKey.raw_secret);
+      setCopied(true);
+      toast.success('Key copied to clipboard');
+    } catch (error) {
+      console.error(error);
+      toast.error('Unable to copy key');
+    }
+  };
+
+  return (
+    <Dialog open={!!apiKey} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Key created</DialogTitle>
+          <DialogDescription>
+            Copy this key now. For your security, you won't be able to see it again.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2 font-mono text-sm break-all">
+            {apiKey?.raw_secret}
+          </div>
+          <Button type="button" variant="outline" onClick={handleCopy} className="w-full">
+            {copied ? <Check className="h-4 w-4 mr-2" /> : <Copy className="h-4 w-4 mr-2" />}
+            {copied ? 'Copied' : 'Copy key'}
+          </Button>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={onClose}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/settings/ApiKeysSection.tsx
+++ b/frontend/src/components/settings/ApiKeysSection.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { toast } from 'sonner';
+import { Plus } from 'lucide-react';
+import { CreateApiKeyDialog } from '@/components/settings/CreateApiKeyDialog';
+import { ApiKeyCreatedDialog } from '@/components/settings/ApiKeyCreatedDialog';
+import {
+  listApiKeys,
+  revokeApiKey,
+  type ApiKey,
+  type CreatedApiKey,
+} from '@/services/developerApi';
+import { handleFrappeError } from '@/lib/frappe-error';
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return '-';
+  }
+  return new Date(value).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function maskKeyId(keyId: string): string {
+  if (keyId.length <= 8) {
+    return keyId;
+  }
+  return `${keyId.slice(0, 4)}...${keyId.slice(-4)}`;
+}
+
+function statusVariant(status: string): 'success' | 'destructive' | 'secondary' {
+  const normalized = status.toLowerCase();
+  if (normalized === 'active') {
+    return 'success';
+  }
+  if (normalized === 'revoked' || normalized === 'expired') {
+    return 'destructive';
+  }
+  return 'secondary';
+}
+
+export function ApiKeysSection() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createdKey, setCreatedKey] = useState<CreatedApiKey | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
+  const [revoking, setRevoking] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const result = await listApiKeys();
+      setKeys(result);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleCreated = (key: CreatedApiKey) => {
+    setCreateOpen(false);
+    setCreatedKey(key);
+    refresh();
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) {
+      return;
+    }
+    setRevoking(true);
+    try {
+      const result = await revokeApiKey(revokeTarget.key_id);
+      if (result) {
+        toast.success('Key revoked');
+        setRevokeTarget(null);
+        refresh();
+      }
+    } catch (error) {
+      handleFrappeError(error, 'Error revoking API key');
+    } finally {
+      setRevoking(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <div>
+          <CardTitle>API Keys</CardTitle>
+          <CardDescription>
+            Keys used to access HUF programmatically.
+          </CardDescription>
+        </div>
+        <Button size="sm" onClick={() => setCreateOpen(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          Create key
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        ) : keys.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No API keys yet.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Key</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Permissions</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Expires</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {keys.map((key) => (
+                <TableRow key={key.key_id}>
+                  <TableCell className="font-medium">{key.label}</TableCell>
+                  <TableCell className="font-mono text-xs">{maskKeyId(key.key_id)}</TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant(key.status)}>{key.status}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {key.scopes.map((scope) => (
+                        <Badge key={scope} variant="outline">{scope}</Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell>{formatDate(key.creation)}</TableCell>
+                  <TableCell>{formatDate(key.last_used_at)}</TableCell>
+                  <TableCell>{key.expires_at ? formatDate(key.expires_at) : 'Never'}</TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={key.status.toLowerCase() !== 'active'}
+                      onClick={() => setRevokeTarget(key)}
+                    >
+                      Revoke
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <CreateApiKeyDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={handleCreated}
+      />
+
+      <ApiKeyCreatedDialog apiKey={createdKey} onClose={() => setCreatedKey(null)} />
+
+      <AlertDialog open={!!revokeTarget} onOpenChange={(next) => { if (!revoking && !next) setRevokeTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke "{revokeTarget?.label}"?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Any integration using this key will immediately lose access. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={revoking}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRevoke}
+              disabled={revoking}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {revoking ? 'Revoking...' : 'Revoke'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/CreateApiKeyDialog.tsx
+++ b/frontend/src/components/settings/CreateApiKeyDialog.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { MultiSelectCombobox } from '@/components/ui/multi-select-combobox';
+import { toast } from 'sonner';
+import { getAgents } from '@/services/agentApi';
+import { createApiKey, type ApiKeyScope, type ApiKeyAgentRestrictionMode, type CreatedApiKey } from '@/services/developerApi';
+import { handleFrappeError } from '@/lib/frappe-error';
+
+interface CreateApiKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (key: CreatedApiKey) => void;
+}
+
+const SCOPE_OPTIONS: { value: ApiKeyScope; label: string }[] = [
+  { value: 'agents:read', label: 'Read agents' },
+  { value: 'agents:run', label: 'Run agents' },
+  { value: 'conversations:read', label: 'Read conversations' },
+  { value: 'conversations:write', label: 'Write conversations' },
+  { value: 'files:read', label: 'Read files' },
+  { value: 'files:write', label: 'Write files' },
+  { value: 'voice:use', label: 'Use voice' },
+  { value: 'ocr:use', label: 'Use OCR' },
+];
+
+type ExpirationChoice = 'never' | '30' | '90' | 'custom';
+
+function addDays(days: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date.toISOString();
+}
+
+export function CreateApiKeyDialog({ open, onOpenChange, onCreated }: CreateApiKeyDialogProps) {
+  const [label, setLabel] = useState('');
+  const [restrictionMode, setRestrictionMode] = useState<ApiKeyAgentRestrictionMode>('all');
+  const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
+  const [agentOptions, setAgentOptions] = useState<{ value: string; label: string }[]>([]);
+  const [scopes, setScopes] = useState<ApiKeyScope[]>([]);
+  const [expiration, setExpiration] = useState<ExpirationChoice>('never');
+  const [customDate, setCustomDate] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    // Reset form each time the dialog opens
+    setLabel('');
+    setRestrictionMode('all');
+    setSelectedAgents([]);
+    setScopes([]);
+    setExpiration('never');
+    setCustomDate('');
+
+    getAgents()
+      .then((result) => {
+        const items = Array.isArray(result) ? result : result.items;
+        setAgentOptions(
+          (items || []).map((agent) => ({
+            value: agent.name,
+            label: agent.agent_name || agent.name,
+          })),
+        );
+      })
+      .catch((error) => {
+        handleFrappeError(error, 'Error fetching agents');
+      });
+  }, [open]);
+
+  const toggleScope = (scope: ApiKeyScope) => {
+    setScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (!label.trim()) {
+      toast.error('Give this key a name');
+      return;
+    }
+    if (scopes.length === 0) {
+      toast.error('Select at least one permission');
+      return;
+    }
+    if (restrictionMode === 'selected' && selectedAgents.length === 0) {
+      toast.error('Select at least one agent, or switch to "All permitted agents"');
+      return;
+    }
+
+    let expiresAt: string | undefined;
+    if (expiration === '30') {
+      expiresAt = addDays(30);
+    } else if (expiration === '90') {
+      expiresAt = addDays(90);
+    } else if (expiration === 'custom') {
+      if (!customDate) {
+        toast.error('Choose an expiration date');
+        return;
+      }
+      expiresAt = new Date(customDate).toISOString();
+    }
+
+    setSubmitting(true);
+    try {
+      const created = await createApiKey(
+        label.trim(),
+        scopes,
+        restrictionMode,
+        restrictionMode === 'selected' ? selectedAgents : undefined,
+        expiresAt,
+      );
+      if (created) {
+        toast.success('Key created');
+        onCreated(created);
+      }
+    } catch (error) {
+      handleFrappeError(error, 'Error creating API key');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!submitting) onOpenChange(next); }}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create key</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5 max-h-[65vh] overflow-y-auto pr-1">
+          <div className="space-y-2">
+            <Label htmlFor="api-key-label">Name</Label>
+            <Input
+              id="api-key-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. Production integration"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Access</Label>
+            <RadioGroup
+              value={restrictionMode}
+              onValueChange={(value) => setRestrictionMode(value as ApiKeyAgentRestrictionMode)}
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="all" id="access-all" />
+                <Label htmlFor="access-all" className="font-normal">All permitted agents</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="selected" id="access-selected" />
+                <Label htmlFor="access-selected" className="font-normal">Selected agents</Label>
+              </div>
+            </RadioGroup>
+            {restrictionMode === 'selected' && (
+              <MultiSelectCombobox
+                options={agentOptions}
+                values={selectedAgents}
+                onValuesChange={setSelectedAgents}
+                placeholder="Select agents..."
+                searchPlaceholder="Search agents..."
+                emptyText="No agents found."
+              />
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Permissions</Label>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+              {SCOPE_OPTIONS.map((option) => (
+                <div key={option.value} className="flex items-center gap-2">
+                  <Checkbox
+                    id={`scope-${option.value}`}
+                    checked={scopes.includes(option.value)}
+                    onCheckedChange={() => toggleScope(option.value)}
+                  />
+                  <Label htmlFor={`scope-${option.value}`} className="font-normal">
+                    {option.label}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Expiration</Label>
+            <Select value={expiration} onValueChange={(value) => setExpiration(value as ExpirationChoice)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="never">Never expires</SelectItem>
+                <SelectItem value="30">30 days</SelectItem>
+                <SelectItem value="90">90 days</SelectItem>
+                <SelectItem value="custom">Custom date</SelectItem>
+              </SelectContent>
+            </Select>
+            {expiration === 'custom' && (
+              <Input
+                type="date"
+                value={customDate}
+                onChange={(e) => setCustomDate(e.target.value)}
+              />
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            {submitting ? 'Creating...' : 'Create key'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/apiSnippets.ts
+++ b/frontend/src/lib/apiSnippets.ts
@@ -1,0 +1,113 @@
+/**
+ * Minimal multi-language code-snippet generator for the Developer API docs.
+ *
+ * Deliberately hand-rolled rather than pulling in a HAR-based snippet
+ * library (e.g. httpsnippet): we only ever render a handful of fixed
+ * endpoints x 2 auth modes x 4 languages, which a small pure function
+ * covers with no added dependency or bundle weight.
+ */
+
+export type SnippetLanguage = 'curl' | 'python' | 'javascript' | 'typescript';
+export type AuthMode = 'apiKey' | 'session';
+
+export interface SnippetRequest {
+	method: 'GET' | 'POST';
+	path: string;
+	/** Form-encoded body params, POST only. */
+	body?: Record<string, string>;
+}
+
+const API_KEY_PLACEHOLDER = 'huf_sk_...';
+const SESSION_ID_PLACEHOLDER = '<sid-from-login>';
+
+function bodyToFormString(body: Record<string, string>): string {
+	return Object.entries(body)
+		.map(([key, value]) => `${key}=${value}`)
+		.join('&');
+}
+
+function buildCurl(baseUrl: string, request: SnippetRequest, authMode: AuthMode): string {
+	const url = `${baseUrl}${request.path}`;
+	const authHeader =
+		authMode === 'apiKey'
+			? `-H "X-Huf-Api-Key: ${API_KEY_PLACEHOLDER}" \\\n  `
+			: `-H "Cookie: sid=${SESSION_ID_PLACEHOLDER}" \\\n  `;
+	const bodyFlag = request.body
+		? Object.entries(request.body)
+				.map(([key, value]) => `-d "${key}=${value}" \\\n  `)
+				.join('')
+		: '';
+	const methodFlag = request.method === 'POST' ? '-X POST \\\n  ' : '';
+
+	return `curl ${methodFlag}"${url}" \\\n  ${authHeader}${bodyFlag}`.replace(/ \\\n  $/, '');
+}
+
+function buildPython(baseUrl: string, request: SnippetRequest, authMode: AuthMode): string {
+	const url = `${baseUrl}${request.path}`;
+	const authArg =
+		authMode === 'apiKey'
+			? `headers={"X-Huf-Api-Key": "${API_KEY_PLACEHOLDER}"}`
+			: `cookies={"sid": "${SESSION_ID_PLACEHOLDER}"}`;
+	const method = request.method === 'POST' ? 'post' : 'get';
+	const dataArg = request.body ? `, data=${JSON.stringify(request.body)}` : '';
+
+	return `import requests\n\nresponse = requests.${method}(\n    "${url}",\n    ${authArg}${dataArg},\n)\nprint(response.json())`;
+}
+
+function buildJavaScript(baseUrl: string, request: SnippetRequest, authMode: AuthMode, ts: boolean): string {
+	const url = `${baseUrl}${request.path}`;
+	const headerLine =
+		authMode === 'apiKey'
+			? `headers: { "X-Huf-Api-Key": "${API_KEY_PLACEHOLDER}" },`
+			: `credentials: "include", // browser sends the sid cookie automatically once logged in`;
+	const bodyLine = request.body
+		? `\n  body: new URLSearchParams(${JSON.stringify(request.body)}),`
+		: '';
+	const methodLine = request.method === 'POST' ? `\n  method: "POST",` : '';
+	const typeAnnotation = ts ? ': Response' : '';
+
+	return `const response${typeAnnotation} = await fetch("${url}", {${methodLine}\n  ${headerLine}${bodyLine}\n});\nconst data = await response.json();\nconsole.log(data);`;
+}
+
+export function buildSnippet(
+	baseUrl: string,
+	request: SnippetRequest,
+	language: SnippetLanguage,
+	authMode: AuthMode,
+): string {
+	switch (language) {
+		case 'curl':
+			return buildCurl(baseUrl, request, authMode);
+		case 'python':
+			return buildPython(baseUrl, request, authMode);
+		case 'javascript':
+			return buildJavaScript(baseUrl, request, authMode, false);
+		case 'typescript':
+			return buildJavaScript(baseUrl, request, authMode, true);
+	}
+}
+
+/**
+ * Session auth needs a real sid, which -- unlike an API key -- isn't
+ * something a developer can generate and paste in ahead of time. Shown as a
+ * prerequisite step whenever authMode is "session".
+ */
+export function buildLoginSnippet(baseUrl: string, language: SnippetLanguage): string {
+	const loginRequest: SnippetRequest = {
+		method: 'POST',
+		path: '/api/method/login',
+		body: { usr: 'you@example.com', pwd: 'your-password' },
+	};
+
+	if (language === 'curl') {
+		const url = `${baseUrl.replace(/\/huf\/api\/v1$/, '')}${loginRequest.path}`;
+		return `curl -X POST "${url}" \\\n  -d "usr=you@example.com" \\\n  -d "pwd=your-password" \\\n  -c cookies.txt\n# cookies.txt now holds the sid to reuse in subsequent requests`;
+	}
+	if (language === 'python') {
+		const url = `${baseUrl.replace(/\/huf\/api\/v1$/, '')}${loginRequest.path}`;
+		return `import requests\n\nsession = requests.Session()\nsession.post("${url}", data={"usr": "you@example.com", "pwd": "your-password"})\n# session.cookies now holds the sid; reuse \`session\` for subsequent requests`;
+	}
+	const url = `${baseUrl.replace(/\/huf\/api\/v1$/, '')}${loginRequest.path}`;
+	const typeAnnotation = language === 'typescript' ? ': Response' : '';
+	return `const login${typeAnnotation} = await fetch("${url}", {\n  method: "POST",\n  credentials: "include",\n  body: new URLSearchParams({ usr: "you@example.com", pwd: "your-password" }),\n});\n// the browser now holds the sid cookie for subsequent same-origin requests`;
+}

--- a/frontend/src/lib/apiSnippets.ts
+++ b/frontend/src/lib/apiSnippets.ts
@@ -20,12 +20,6 @@ export interface SnippetRequest {
 const API_KEY_PLACEHOLDER = 'huf_sk_...';
 const SESSION_ID_PLACEHOLDER = '<sid-from-login>';
 
-function bodyToFormString(body: Record<string, string>): string {
-	return Object.entries(body)
-		.map(([key, value]) => `${key}=${value}`)
-		.join('&');
-}
-
 function buildCurl(baseUrl: string, request: SnippetRequest, authMode: AuthMode): string {
 	const url = `${baseUrl}${request.path}`;
 	const authHeader =

--- a/frontend/src/pages/DeveloperSettingsPage.tsx
+++ b/frontend/src/pages/DeveloperSettingsPage.tsx
@@ -1,11 +1,14 @@
 import { Terminal } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { ApiKeysSection } from '@/components/settings/ApiKeysSection';
+import { AgentApiDocs } from '@/components/settings/AgentApiDocs';
 
 export { DeveloperSettingsPage };
 export default DeveloperSettingsPage;
 
 function DeveloperSettingsPage() {
+  const baseUrl = `${window.location.origin}/huf/api/v1`;
+
   return (
     <div className="relative h-full overflow-auto">
       <div className="relative z-10 p-6 max-w-4xl mx-auto space-y-6">
@@ -28,13 +31,15 @@ function DeveloperSettingsPage() {
           </CardHeader>
           <CardContent>
             <p className="text-sm">
-              Base URL: <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">/huf/api/v1</code>
+              Base URL: <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{baseUrl}</code>
             </p>
             <p className="text-sm text-muted-foreground mt-2">
               Full API documentation is coming soon. Create a key below to get started.
             </p>
           </CardContent>
         </Card>
+
+        <AgentApiDocs baseUrl={baseUrl} />
 
         <ApiKeysSection />
       </div>

--- a/frontend/src/pages/DeveloperSettingsPage.tsx
+++ b/frontend/src/pages/DeveloperSettingsPage.tsx
@@ -1,0 +1,43 @@
+import { Terminal } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { ApiKeysSection } from '@/components/settings/ApiKeysSection';
+
+export { DeveloperSettingsPage };
+export default DeveloperSettingsPage;
+
+function DeveloperSettingsPage() {
+  return (
+    <div className="relative h-full overflow-auto">
+      <div className="relative z-10 p-6 max-w-4xl mx-auto space-y-6">
+        <div className="flex items-center gap-3">
+          <Terminal className="w-6 h-6 text-muted-foreground" />
+          <div>
+            <h1 className="text-2xl font-bold">Developer Settings</h1>
+            <p className="text-sm text-muted-foreground">
+              Tools and options for developers building on HUF.
+            </p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Overview</CardTitle>
+            <CardDescription>
+              Everything you build against HUF goes through a single base URL.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm">
+              Base URL: <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">/huf/api/v1</code>
+            </p>
+            <p className="text-sm text-muted-foreground mt-2">
+              Full API documentation is coming soon. Create a key below to get started.
+            </p>
+          </CardContent>
+        </Card>
+
+        <ApiKeysSection />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/developerApi.ts
+++ b/frontend/src/services/developerApi.ts
@@ -1,0 +1,107 @@
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+
+/**
+ * Scope values accepted by the Huf API Key backend.
+ */
+export type ApiKeyScope =
+  | 'agents:read'
+  | 'agents:run'
+  | 'conversations:read'
+  | 'conversations:write'
+  | 'files:read'
+  | 'files:write'
+  | 'voice:use'
+  | 'ocr:use';
+
+export type ApiKeyAgentRestrictionMode = 'all' | 'selected';
+
+export type ApiKeyStatus = 'Active' | 'Revoked' | 'Expired' | string;
+
+/**
+ * A key as returned by list/create (without the raw secret).
+ */
+export interface ApiKey {
+  key_id: string;
+  label: string;
+  status: ApiKeyStatus;
+  scopes: ApiKeyScope[];
+  agent_restriction_mode: ApiKeyAgentRestrictionMode;
+  restricted_agents: string[] | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  creation: string;
+}
+
+/**
+ * Response from create_api_key: includes the one-time raw secret.
+ */
+export interface CreatedApiKey extends ApiKey {
+  raw_secret: string;
+}
+
+function unwrap<T>(result: { message?: T } | T): T {
+  return (result as { message?: T })?.message !== undefined
+    ? (result as { message: T }).message
+    : (result as T);
+}
+
+/**
+ * Create a new API key. `raw_secret` on the response is shown to the user
+ * exactly once and can never be retrieved again.
+ */
+export async function createApiKey(
+  label: string,
+  scopes: ApiKeyScope[],
+  agentRestrictionMode: ApiKeyAgentRestrictionMode = 'all',
+  restrictedAgents?: string[],
+  expiresAt?: string,
+): Promise<CreatedApiKey> {
+  try {
+    const result = await call.post(
+      'huf.huf.doctype.huf_api_key.huf_api_key.create_api_key',
+      {
+        label,
+        scopes,
+        agent_restriction_mode: agentRestrictionMode,
+        restricted_agents: restrictedAgents,
+        expires_at: expiresAt,
+      },
+    );
+    return unwrap<CreatedApiKey>(result);
+  } catch (error) {
+    handleFrappeError(error, 'Error creating API key');
+  }
+}
+
+/**
+ * Revoke an existing API key by id.
+ */
+export async function revokeApiKey(
+  keyId: string,
+): Promise<{ key_id: string; status: ApiKeyStatus }> {
+  try {
+    const result = await call.post(
+      'huf.huf.doctype.huf_api_key.huf_api_key.revoke_api_key',
+      { key_id: keyId },
+    );
+    return unwrap<{ key_id: string; status: ApiKeyStatus }>(result);
+  } catch (error) {
+    handleFrappeError(error, 'Error revoking API key');
+  }
+}
+
+/**
+ * List the caller's API keys. Never includes raw or hashed secrets.
+ */
+export async function listApiKeys(): Promise<ApiKey[]> {
+  try {
+    const result = await call.get(
+      'huf.huf.doctype.huf_api_key.huf_api_key.list_api_keys',
+    );
+    return unwrap<ApiKey[]>(result) || [];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching API keys');
+    return [];
+  }
+}

--- a/huf/api/v1/__init__.py
+++ b/huf/api/v1/__init__.py
@@ -1,0 +1,7 @@
+"""Huf Public Developer API - v1.
+
+This package implements the versioned public developer API,
+`/huf/api/v1/...`, as a thin adapter layer over Huf's existing agent
+runtime. Phase 1 provides only the routing/context/error/response
+foundation - no agent/conversation/response endpoints yet.
+"""

--- a/huf/api/v1/auth.py
+++ b/huf/api/v1/auth.py
@@ -1,0 +1,99 @@
+"""Principal resolution for the Huf public developer API (v1).
+
+`resolve_principal` is the single call site handlers rely on. Internally
+it tries a chain of resolver functions, first match wins, so API-key and
+OAuth support can be added later without changing the call site.
+"""
+
+from typing import Callable, Optional
+
+import frappe
+
+from huf.api.v1.context import AuthMode, RequestContext
+from huf.api.v1.errors import AuthenticationError
+
+
+def _resolve_session(request) -> Optional[RequestContext]:
+	"""Resolve the principal from the current Frappe session cookie.
+
+	Returns `None` (falls through to the next resolver) when there is no
+	logged-in session; the caller is responsible for raising when no
+	resolver in the chain finds a principal.
+	"""
+	user = frappe.session.user
+	if not user or user == "Guest":
+		return None
+	return RequestContext(user=user, auth_mode=AuthMode.SESSION)
+
+
+def _resolve_api_key(request) -> Optional[RequestContext]:
+	"""Resolve the principal from an `Authorization: Bearer <key>` header.
+
+	Looks up and verifies the raw key against `Huf API Key` records (hash
+	comparison only, never plaintext). Returns `None` (falls through to the
+	next resolver) when there is no bearer header or the key does not
+	verify, so a request with no API key still falls through to session
+	auth instead of failing outright.
+
+	Note: this resolves *identity* and attaches the key's `scopes` /
+	`agent_restriction_mode` onto the returned context (as
+	`credential_scopes` / `credential_agent_restriction`). Enforcing those
+	restrictions against a specific request is handled by
+	`huf.api.v1.scopes.require_scope` / `require_agent_allowed`, called
+	from each endpoint handler - this resolver only carries the data.
+	"""
+	headers = getattr(request, "headers", None)
+	if headers is None:
+		headers = frappe.request.headers if frappe.request else {}
+
+	authorization = headers.get("Authorization") if headers else None
+	if not authorization or not authorization.startswith("Bearer "):
+		return None
+
+	raw_key = authorization[len("Bearer "):].strip()
+	if not raw_key:
+		return None
+
+	from huf.huf.doctype.huf_api_key.huf_api_key import verify_key
+
+	key_doc = verify_key(raw_key)
+	if key_doc is None:
+		return None
+
+	return RequestContext(
+		user=key_doc.owner,
+		auth_mode=AuthMode.API_KEY,
+		credential_scopes=key_doc._get_scopes_list(),
+		credential_agent_restriction={
+			"mode": key_doc.agent_restriction_mode,
+			"agents": key_doc._get_restricted_agents_list(),
+		},
+	)
+
+
+def _resolve_oauth(request) -> Optional[RequestContext]:
+	"""Placeholder for future OAuth auth. Not implemented in Phase 1."""
+	return None
+
+
+# Chain of resolvers tried in order; first non-None result wins.
+_RESOLVER_CHAIN: list[Callable] = [
+	_resolve_api_key,
+	_resolve_oauth,
+	_resolve_session,
+]
+
+
+def resolve_principal(request=None) -> RequestContext:
+	"""Resolve the authenticated principal for the current request.
+
+	Raises `AuthenticationError` if no resolver in the chain matches
+	(e.g. an unauthenticated Guest session with no API key or OAuth
+	token present).
+	"""
+	for resolver in _RESOLVER_CHAIN:
+		context = resolver(request)
+		if context is not None:
+			return context
+
+	raise AuthenticationError()

--- a/huf/api/v1/auth.py
+++ b/huf/api/v1/auth.py
@@ -27,13 +27,21 @@ def _resolve_session(request) -> Optional[RequestContext]:
 
 
 def _resolve_api_key(request) -> Optional[RequestContext]:
-	"""Resolve the principal from an `Authorization: Bearer <key>` header.
+	"""Resolve the principal from an `X-Huf-Api-Key: <key>` header.
+
+	Deliberately NOT `Authorization: Bearer ...`: Frappe's own
+	`frappe.auth.validate_auth()` inspects any two-part `Authorization`
+	header itself before our page_renderer ever runs, and hard-fails
+	("Session Expired") if it doesn't parse as Frappe's own OAuth/API-key
+	scheme (`token <key>:<secret>`). Confirmed live: a bearer-token
+	credential in `Authorization` never reaches this resolver at all. A
+	dedicated header sidesteps that collision entirely.
 
 	Looks up and verifies the raw key against `Huf API Key` records (hash
 	comparison only, never plaintext). Returns `None` (falls through to the
-	next resolver) when there is no bearer header or the key does not
-	verify, so a request with no API key still falls through to session
-	auth instead of failing outright.
+	next resolver) when there is no key header or the key does not verify,
+	so a request with no API key still falls through to session auth
+	instead of failing outright.
 
 	Note: this resolves *identity* and attaches the key's `scopes` /
 	`agent_restriction_mode` onto the returned context (as
@@ -46,11 +54,8 @@ def _resolve_api_key(request) -> Optional[RequestContext]:
 	if headers is None:
 		headers = frappe.request.headers if frappe.request else {}
 
-	authorization = headers.get("Authorization") if headers else None
-	if not authorization or not authorization.startswith("Bearer "):
-		return None
-
-	raw_key = authorization[len("Bearer "):].strip()
+	raw_key = (headers.get("X-Huf-Api-Key") if headers else None) or ""
+	raw_key = raw_key.strip()
 	if not raw_key:
 		return None
 

--- a/huf/api/v1/context.py
+++ b/huf/api/v1/context.py
@@ -1,0 +1,47 @@
+"""Request context for the Huf public developer API (v1).
+
+Every request handled by the v1 router is resolved into a
+`RequestContext` before the handler runs. This gives handlers a single,
+stable object to read the authenticated user, auth mode, and request id
+from, instead of reaching into `frappe.session` / `frappe.local` directly.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+import uuid
+
+import frappe
+
+
+class AuthMode(str, Enum):
+	"""How the request's principal was resolved.
+
+	Only SESSION is implemented in Phase 1. API_KEY and OAUTH are
+	reserved so `huf.api.v1.auth` can add resolvers for them later
+	without changing the `RequestContext` shape or call sites.
+	"""
+
+	SESSION = "session"
+	API_KEY = "api_key"  # noqa: not implemented yet
+	OAUTH = "oauth"  # noqa: not implemented yet
+
+
+@dataclass
+class RequestContext:
+	"""Resolved identity and metadata for a single v1 API request."""
+
+	user: str
+	auth_mode: AuthMode
+	request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+	started_at: str = field(default_factory=frappe.utils.now_datetime)
+	credential_scopes: list[str] | None = None
+	credential_agent_restriction: dict | None = None
+
+	def as_dict(self) -> dict:
+		"""Serialize the context for inclusion in logs or debug responses."""
+		return {
+			"request_id": self.request_id,
+			"user": self.user,
+			"auth_mode": self.auth_mode.value,
+			"started_at": str(self.started_at),
+		}

--- a/huf/api/v1/endpoints/agents.py
+++ b/huf/api/v1/endpoints/agents.py
@@ -1,0 +1,70 @@
+"""Agent endpoints for the Huf public developer API (v1).
+
+Exposes read-only, safe metadata about Agents the calling user is
+permitted to use. Permission filtering is delegated entirely to
+`huf.ai.agent_access.check_agent_access`, the single source of truth
+for "can user X access agent Y" - no authorization logic is duplicated
+here.
+"""
+
+import frappe
+
+from huf.ai.agent_access import check_agent_access
+from huf.api.v1.context import RequestContext
+from huf.api.v1.errors import NotFoundError
+from huf.api.v1.scopes import require_agent_allowed, require_scope
+
+
+def _to_public_shape(agent_doc) -> dict:
+	"""Build the public, safe metadata shape for a single Agent.
+
+	Deliberately excludes provider credentials, prompts/instructions,
+	raw tool/MCP configuration, and any other internal fields - only
+	the fields listed below are ever surfaced.
+	"""
+	return {
+		"id": agent_doc.name,
+		"name": agent_doc.agent_name,
+		"description": agent_doc.description,
+		"modality": agent_doc.agent_modality,
+		"voice_enabled": bool(agent_doc.voice_enabled),
+		"file_upload_supported": bool(agent_doc.allow_file_upload),
+		"streaming": bool(agent_doc.run_immediately),
+		"execution_mode": "immediate" if agent_doc.run_immediately else "queued",
+	}
+
+
+def _iter_accessible_agents(user: str):
+	"""Yield full Agent docs the given user may access, skipping disabled agents."""
+	agent_names = frappe.get_all("Agent", filters={"disabled": 0}, pluck="name")
+	for agent_name in agent_names:
+		agent_doc = frappe.get_doc("Agent", agent_name)
+		if check_agent_access(agent_doc, user, for_execution=False):
+			yield agent_doc
+
+
+def handle_list_agents(context: RequestContext) -> dict:
+	"""GET /huf/api/v1/agents - agents the calling user can use."""
+	require_scope(context, "agents:read")
+	agents = [_to_public_shape(agent_doc) for agent_doc in _iter_accessible_agents(context.user)]
+	return {"agents": agents}
+
+
+def handle_get_agent(context: RequestContext, agent_id: str) -> dict:
+	"""GET /huf/api/v1/agents/{agent_id} - a single agent the calling user can use.
+
+	Raises `NotFoundError` both when the agent does not exist and when
+	the user cannot access it, so existence is never leaked.
+	"""
+	require_scope(context, "agents:read")
+	require_agent_allowed(context, agent_id)
+
+	if not frappe.db.exists("Agent", agent_id):
+		raise NotFoundError(f"Agent '{agent_id}' was not found.")
+
+	agent_doc = frappe.get_doc("Agent", agent_id)
+
+	if agent_doc.disabled or not check_agent_access(agent_doc, context.user, for_execution=False):
+		raise NotFoundError(f"Agent '{agent_id}' was not found.")
+
+	return _to_public_shape(agent_doc)

--- a/huf/api/v1/endpoints/conversations.py
+++ b/huf/api/v1/endpoints/conversations.py
@@ -1,0 +1,116 @@
+"""Conversation endpoints for the Huf public developer API (v1).
+
+Thin wrappers around the existing conversation machinery in
+`huf.ai.conversation_manager.ConversationManager` and
+`huf.ai.agent_chat.get_history` - ownership checks and history retrieval
+are delegated entirely to that existing code, not reimplemented here.
+"""
+
+import frappe
+
+from huf.ai.agent_access import assert_agent_access
+from huf.ai.agent_chat import get_history
+from huf.ai.conversation_manager import ConversationManager
+from huf.api.v1.context import RequestContext
+from huf.api.v1.errors import NotFoundError
+from huf.api.v1.scopes import require_agent_allowed, require_scope
+
+
+def _to_public_shape(conv_doc) -> dict:
+	"""Build the public, stable shape for a single Agent Conversation."""
+	return {
+		"id": conv_doc.name,
+		"agent_id": conv_doc.agent,
+		"title": conv_doc.title,
+		"created_at": conv_doc.created_at,
+		"status": conv_doc.status,
+	}
+
+
+def _owns_conversation(conv_doc, user: str) -> bool:
+	"""Whether `user` is the owner of `conv_doc` (or a System Manager).
+
+	Mirrors `huf.ai.agent_chat._assert_owns_conversation` / the ownership
+	check in `huf.ai.agent_chat.get_history`, but returns a bool instead of
+	raising so callers can convert a failure into `NotFoundError` (no
+	existence leak) rather than a `PermissionError`.
+	"""
+	return conv_doc.owner == user or "System Manager" in frappe.get_roles()
+
+
+def _get_owned_conversation(conversation_id: str, user: str):
+	"""Fetch an Agent Conversation the caller owns, or raise `NotFoundError`.
+
+	Missing and not-owned conversations are indistinguishable to the
+	caller, so existence is never leaked.
+	"""
+	if not frappe.db.exists("Agent Conversation", conversation_id):
+		raise NotFoundError(f"Conversation '{conversation_id}' was not found.")
+
+	conv_doc = frappe.get_doc("Agent Conversation", conversation_id)
+
+	if not _owns_conversation(conv_doc, user):
+		raise NotFoundError(f"Conversation '{conversation_id}' was not found.")
+
+	return conv_doc
+
+
+def handle_create_conversation(context: RequestContext, agent_id: str, title: str = None) -> dict:
+	"""POST /huf/api/v1/conversations - create a new conversation with an agent."""
+	require_scope(context, "conversations:write")
+	require_agent_allowed(context, agent_id)
+
+	agent_doc = frappe.get_doc("Agent", agent_id)
+	assert_agent_access(agent_doc, user=context.user)
+
+	cm = ConversationManager(agent_name=agent_id)
+	conv_doc = cm.create_new_conversation(title=title)
+
+	return _to_public_shape(conv_doc)
+
+
+def handle_list_conversations(context: RequestContext, agent_id: str = None) -> dict:
+	"""GET /huf/api/v1/conversations - the calling user's own conversations."""
+	require_scope(context, "conversations:read")
+
+	filters = {"owner": context.user}
+	if agent_id:
+		filters["agent"] = agent_id
+
+	conversation_names = frappe.get_all(
+		"Agent Conversation",
+		filters=filters,
+		order_by="creation desc",
+		pluck="name",
+	)
+	conversations = [_to_public_shape(frappe.get_doc("Agent Conversation", name)) for name in conversation_names]
+
+	return {"conversations": conversations}
+
+
+def handle_get_conversation(context: RequestContext, conversation_id: str) -> dict:
+	"""GET /huf/api/v1/conversations/{conversation_id} - a single owned conversation."""
+	require_scope(context, "conversations:read")
+
+	conv_doc = _get_owned_conversation(conversation_id, context.user)
+	return _to_public_shape(conv_doc)
+
+
+def handle_list_messages(context: RequestContext, conversation_id: str) -> dict:
+	"""GET /huf/api/v1/conversations/{conversation_id}/messages - a conversation's history."""
+	require_scope(context, "conversations:read")
+
+	_get_owned_conversation(conversation_id, context.user)
+
+	messages = get_history(conversation_id=conversation_id)
+	public_messages = [
+		{
+			"id": message.get("conversation_index"),
+			"role": message.get("role"),
+			"content": message.get("content"),
+			"created_at": message.get("creation"),
+		}
+		for message in messages
+	]
+
+	return {"messages": public_messages}

--- a/huf/api/v1/endpoints/identity.py
+++ b/huf/api/v1/endpoints/identity.py
@@ -3,14 +3,24 @@
 Exposes the authenticated user's identity, role, and capabilities.
 """
 
+import frappe
+
 from huf.api.v1.context import RequestContext
-from huf.permissions import get_me
+from huf.permissions import get_user_capabilities, get_user_huf_role
 
 
 def handle_me(context: RequestContext) -> dict:
 	"""GET /huf/api/v1/me - authenticated user identity and capabilities.
 
-	Wraps huf.permissions.get_me() and returns a public-shaped dict.
+	Deliberately does NOT call huf.permissions.get_me(): that function reads
+	frappe.session.user directly, which for API-key/OAuth auth stays "Guest"
+	(the v1 router resolves the principal itself without changing the
+	ambient Frappe session) - it would silently report the wrong identity.
+	Uses get_user_huf_role()/get_user_capabilities() instead, both of which
+	already accept an explicit user, and looks up full_name directly for
+	`context.user`. Confirmed live: get_me() returned "Guest"/no
+	capabilities for a request correctly authenticated via API key before
+	this fix.
 
 	Args:
 		context: RequestContext containing the authenticated user and auth mode.
@@ -23,12 +33,12 @@ def handle_me(context: RequestContext) -> dict:
 			- capabilities: list of capability strings (e.g., ["agent.use", "chat.use"])
 			- auth_type: authentication mode (e.g., "session", "api_key", "oauth")
 	"""
-	identity = get_me()
+	full_name = frappe.db.get_value("User", context.user, "full_name") or context.user
 
 	return {
-		"user": identity["user"],
-		"display_name": identity["full_name"],
-		"huf_role": identity["huf_role"],
-		"capabilities": identity["capabilities"],
+		"user": context.user,
+		"display_name": full_name,
+		"huf_role": get_user_huf_role(context.user),
+		"capabilities": get_user_capabilities(context.user),
 		"auth_type": context.auth_mode.value,
 	}

--- a/huf/api/v1/endpoints/identity.py
+++ b/huf/api/v1/endpoints/identity.py
@@ -1,0 +1,34 @@
+"""Identity endpoint for the Huf public developer API (v1).
+
+Exposes the authenticated user's identity, role, and capabilities.
+"""
+
+from huf.api.v1.context import RequestContext
+from huf.permissions import get_me
+
+
+def handle_me(context: RequestContext) -> dict:
+	"""GET /huf/api/v1/me - authenticated user identity and capabilities.
+
+	Wraps huf.permissions.get_me() and returns a public-shaped dict.
+
+	Args:
+		context: RequestContext containing the authenticated user and auth mode.
+
+	Returns:
+		dict with keys:
+			- user: user email/username
+			- display_name: full name (or user if not set)
+			- huf_role: assigned Huf Role name (e.g., "Huf Manager")
+			- capabilities: list of capability strings (e.g., ["agent.use", "chat.use"])
+			- auth_type: authentication mode (e.g., "session", "api_key", "oauth")
+	"""
+	identity = get_me()
+
+	return {
+		"user": identity["user"],
+		"display_name": identity["full_name"],
+		"huf_role": identity["huf_role"],
+		"capabilities": identity["capabilities"],
+		"auth_type": context.auth_mode.value,
+	}

--- a/huf/api/v1/endpoints/responses.py
+++ b/huf/api/v1/endpoints/responses.py
@@ -1,0 +1,79 @@
+"""Response endpoints for the Huf public developer API (v1).
+
+Wraps the existing `huf.ai.chat_api.run_agent_sync_chat` sync-chat entry
+point behind the public v1 request/response shape. Ownership checks and
+conversation/agent resolution are delegated entirely to existing code
+(`conversations.py`'s `_get_owned_conversation`, `assert_agent_access`) -
+no authorization logic is duplicated here.
+"""
+
+import frappe
+
+from huf.ai.agent_access import assert_agent_access
+from huf.ai.chat_api import run_agent_sync_chat
+from huf.api.v1.context import RequestContext
+from huf.api.v1.endpoints.conversations import _get_owned_conversation
+from huf.api.v1.errors import NotFoundError, ValidationError
+from huf.api.v1.scopes import require_agent_allowed, require_scope
+
+
+def _to_public_shape(result: dict, conversation_id: str) -> dict:
+	"""Map `run_agent_sync_chat`'s internal result shape onto the public one.
+
+	`run_agent_sync_chat` is queue-first by default: it returns an
+	acknowledgement (`queued=True`, `response=None`) rather than a final
+	answer. Only the direct-execution path (not used here) returns a
+	populated `response`. Status is reported honestly either way instead
+	of inventing output text that was never produced synchronously.
+	"""
+	if result.get("queued"):
+		status = "queued"
+	elif result.get("success"):
+		status = "completed"
+	else:
+		status = "failed"
+
+	return {
+		"response_id": result.get("agent_run_id"),
+		"conversation_id": result.get("conversation_id") or conversation_id,
+		"status": status,
+		"output": result.get("response"),
+	}
+
+
+def handle_create_response(
+	context: RequestContext, agent_id: str, input_text: str, conversation_id: str = None
+) -> dict:
+	"""POST /huf/api/v1/responses - run an agent turn (sync, queue-first).
+
+	If `conversation_id` is given, the caller must own it; otherwise a new
+	conversation is created by `run_agent_sync_chat` (`create_new=True`).
+	"""
+	if not agent_id:
+		raise ValidationError("agent_id is required.")
+	if not input_text:
+		raise ValidationError("input_text is required.")
+
+	require_scope(context, "agents:run")
+	require_agent_allowed(context, agent_id)
+
+	if not frappe.db.exists("Agent", agent_id):
+		raise NotFoundError(f"Agent '{agent_id}' was not found.")
+
+	agent_doc = frappe.get_doc("Agent", agent_id)
+	assert_agent_access(agent_doc, user=context.user)
+
+	create_new = False
+	if conversation_id:
+		_get_owned_conversation(conversation_id, context.user)
+	else:
+		create_new = True
+
+	result = run_agent_sync_chat(
+		agent_name=agent_id,
+		prompt=input_text,
+		conversation_id=conversation_id,
+		create_new=create_new,
+	)
+
+	return _to_public_shape(result, conversation_id)

--- a/huf/api/v1/endpoints/responses_stream.py
+++ b/huf/api/v1/endpoints/responses_stream.py
@@ -1,0 +1,259 @@
+"""Streaming response endpoint for the Huf public developer API (v1).
+
+Mirrors `huf.ai.agent_stream_renderer.AgentStreamRenderer` (the existing,
+working SSE implementation): reuses `run_agent_stream()` exactly as that
+renderer calls it, and replicates its server-side `run_immediately`
+enforcement (see `AgentStreamRenderer._render_agent_stream`, around
+huf/ai/agent_stream_renderer.py:164-170) rather than inventing a new check.
+
+------------------------------------------------------------------------
+WIRING NOTE FOR THE REVIEWER (router.py) - NOT APPLIED HERE ON PURPOSE
+------------------------------------------------------------------------
+`ApiV1Router.render()` (huf/api/v1/router.py) currently always does:
+
+    context = self._build_context(requires_auth)
+    data = handler(context)
+    return self._render_success(data, context.request_id)
+
+`_render_success` always JSON-encodes `data` via `self.build_response(...)`.
+Streaming needs a different return path that produces a raw werkzeug
+`Response` with `mimetype="text/event-stream"` instead, so the branch has
+to happen BEFORE `_render_success` is called, and only for the `responses`
+endpoint when the caller asked for `stream=true`/`stream=1`.
+
+Suggested shape (do not apply verbatim without checking for conflicts with
+the parallel task touching responses.py/router.py):
+
+    def render(self):
+        endpoint = ...  # unchanged
+        route = _match_route(endpoint)
+        ...
+        try:
+            context = self._build_context(requires_auth)
+
+            # NEW: branch before the JSON envelope for POST /responses
+            # with stream=true.
+            if endpoint == "responses" and _wants_stream(frappe.local.form_dict):
+                payload = frappe.local.form_dict
+                return handle_stream_response(
+                    context,
+                    agent_id=payload.get("agent_id") or payload.get("agent"),
+                    input_text=payload.get("input") or payload.get("input_text") or payload.get("prompt"),
+                    conversation_id=payload.get("conversation_id"),
+                )
+
+            data = handler(context)
+            return self._render_success(data, context.request_id)
+        except ApiError as exc:
+            return self._render_error(exc, fallback_request_id)
+        ...
+
+Where `_wants_stream(form_dict)` is something like:
+
+    def _wants_stream(payload) -> bool:
+        val = payload.get("stream")
+        return str(val).strip().lower() in ("1", "true", "yes")
+
+Notes for whoever wires this in:
+- `handle_stream_response` below already does its own `ValidationError`
+  raising (missing agent_id/input_text) and its own `NotFoundError` /
+  `AuthorizationError` via `assert_agent_access`, matching the sync
+  handler's ordering. Those still need to be caught the SAME way
+  `ApiError` is caught elsewhere in `render()` -- but they can only be
+  raised BEFORE the SSE `Response` object is constructed and returned,
+  since once a streaming `Response` is handed back to Werkzeug there is
+  no more chance to swap in a JSON error envelope. `handle_stream_response`
+  therefore validates and resolves the agent synchronously up front and
+  only starts the generator once everything is known to succeed, exactly
+  like `AgentStreamRenderer._render_agent_stream` does (see the "run_immediately"
+  check and the "has queued runs" check, both performed before
+  `stream_generator()` is defined/returned).
+- Do not add `Content-Type: application/json` handling for this branch;
+  return the SSE `Response` object directly, unwrapped, from `render()`.
+------------------------------------------------------------------------
+"""
+
+import asyncio
+import json
+from typing import Generator
+
+import frappe
+from werkzeug.wrappers import Response
+
+from huf.ai.agent_access import assert_agent_access
+from huf.ai.agent_integration import _has_queued_runs, run_agent_stream
+from huf.api.v1.context import RequestContext
+from huf.api.v1.endpoints.conversations import _get_owned_conversation
+from huf.api.v1.errors import NotFoundError, ValidationError
+from huf.api.v1.scopes import require_agent_allowed, require_scope
+
+# Internal chunk "type" (as yielded by run_agent_stream / used by
+# AgentStreamRenderer) -> public v1 SSE event name.
+_EVENT_NAME_MAP = {
+	"delta": "response.output_text.delta",
+	"tool_call": "response.output_text.delta",
+	"complete": "response.completed",
+	"error": "response.failed",
+}
+
+_SSE_HEADERS = {
+	"Cache-Control": "no-cache",
+	"Connection": "keep-alive",
+	"X-Accel-Buffering": "no",
+}
+
+
+def _sse_line(public_type: str, payload: dict) -> str:
+	data = {"type": public_type, **payload}
+	return f"data: {json.dumps(data)}\n\n"
+
+
+def _sse_error_response(message: str, request_id: str = None):
+	"""Single-event SSE error response, used for failures discovered before
+	the underlying stream generator can be started (mirrors
+	`AgentStreamRenderer._sse_error_response`)."""
+
+	def error_generator() -> Generator[str, None, None]:
+		yield _sse_line("response.failed", {"error": message, "request_id": request_id})
+
+	return Response(error_generator(), mimetype="text/event-stream", headers=dict(_SSE_HEADERS))
+
+
+def _map_chunk(chunk: dict) -> tuple:
+	"""Map an internal `run_agent_stream` chunk onto (public_event_name, payload)."""
+	chunk_type = chunk.get("type")
+	public_type = _EVENT_NAME_MAP.get(chunk_type, "response.output_text.delta")
+
+	if chunk_type == "delta":
+		payload = {"delta": chunk.get("content", ""), "output": chunk.get("full_response")}
+	elif chunk_type == "tool_call":
+		payload = {"tool_call": chunk.get("tool_call")}
+	elif chunk_type == "complete":
+		payload = {"output": chunk.get("full_response")}
+	elif chunk_type == "error":
+		payload = {"error": chunk.get("error")}
+	else:
+		payload = {k: v for k, v in chunk.items() if k != "type"}
+
+	return public_type, payload
+
+
+def handle_stream_response(
+	context: RequestContext, agent_id: str, input_text: str, conversation_id: str = None
+):
+	"""POST /huf/api/v1/responses (stream=true) - run an agent turn as SSE.
+
+	Validates and resolves the agent/conversation synchronously (same
+	ordering as `handle_create_response` in `responses.py`), then, only if
+	streaming is allowed for this agent, returns a werkzeug `Response`
+	streaming `text/event-stream`. All failures that can be detected up
+	front raise `ApiError` subclasses so the router's normal JSON error
+	envelope still applies to them; failures discovered mid-stream are
+	instead emitted as a `response.failed` SSE event, since the HTTP
+	response has already started at that point.
+	"""
+	if not agent_id:
+		raise ValidationError("agent_id is required.")
+	if not input_text:
+		raise ValidationError("input_text is required.")
+
+	require_scope(context, "agents:run")
+	require_agent_allowed(context, agent_id)
+
+	if not frappe.db.exists("Agent", agent_id):
+		raise NotFoundError(f"Agent '{agent_id}' was not found.")
+
+	agent_doc = frappe.get_doc("Agent", agent_id)
+	assert_agent_access(agent_doc, user=context.user)
+
+	# Queue-first policy: streaming is a direct-execution compatibility
+	# path, allowed only when the agent opts in via 'Run Immediately'.
+	# Replicates huf/ai/agent_stream_renderer.py:164-170 exactly - do not
+	# invent a different check here.
+	if not getattr(agent_doc, "run_immediately", 0):
+		raise ValidationError(
+			"This agent does not support streaming responses; use POST /v1/responses "
+			"without stream=true, or enable Run Immediately on the agent."
+		)
+
+	create_new = False
+	if conversation_id:
+		_get_owned_conversation(conversation_id, context.user)
+	else:
+		create_new = True
+
+	# Queue-ordering parity with the sync path: a direct stream must not
+	# jump ahead of queued runs for the same conversation. A brand-new
+	# conversation has no queued runs by definition, so skip the check.
+	stream_conversation_id = None if create_new else conversation_id
+	if stream_conversation_id and _has_queued_runs(stream_conversation_id):
+		raise ValidationError(
+			"This conversation has queued runs pending. Wait for them to complete "
+			"before using the direct-execution (stream) override."
+		)
+
+	channel_id = "api_v1_stream"
+	external_id = context.user
+
+	def stream_generator() -> Generator[str, None, None]:
+		loop = None
+		created_loop = False
+		try:
+			try:
+				loop = asyncio.get_event_loop()
+				if loop.is_closed():
+					loop = None
+			except RuntimeError:
+				loop = None
+
+			if loop is None:
+				loop = asyncio.new_event_loop()
+				asyncio.set_event_loop(loop)
+				created_loop = True
+
+			yield _sse_line(
+				"response.created",
+				{"conversation_id": conversation_id, "request_id": context.request_id},
+			)
+
+			async_gen = run_agent_stream(
+				agent_name=agent_id,
+				prompt=input_text,
+				channel_id=channel_id,
+				external_id=external_id,
+				conversation_id=None if create_new else conversation_id,
+				create_new=create_new,
+			)
+
+			while True:
+				try:
+					chunk = loop.run_until_complete(async_gen.__anext__())
+					public_type, payload = _map_chunk(chunk)
+					yield _sse_line(public_type, payload)
+
+					if chunk.get("type") in ("complete", "error"):
+						break
+				except StopAsyncIteration:
+					break
+				except Exception as e:
+					frappe.log_error(frappe.get_traceback(), "Huf API v1 Stream Chunk Error")
+					yield _sse_line("response.failed", {"error": str(e)})
+					break
+		except Exception as e:
+			frappe.log_error(frappe.get_traceback(), "Huf API v1 Stream Setup Error")
+			yield _sse_line("response.failed", {"error": f"Stream setup error: {str(e)}"})
+		finally:
+			if created_loop and loop:
+				try:
+					pending = asyncio.all_tasks(loop)
+					for task in pending:
+						task.cancel()
+					if pending:
+						loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+					loop.close()
+				except (RuntimeError, ValueError, TypeError, AttributeError, KeyError):
+					pass
+				finally:
+					asyncio.set_event_loop(None)
+
+	return Response(stream_generator(), mimetype="text/event-stream", headers=dict(_SSE_HEADERS))

--- a/huf/api/v1/endpoints/runs.py
+++ b/huf/api/v1/endpoints/runs.py
@@ -1,0 +1,81 @@
+"""Run endpoints for the Huf public developer API (v1).
+
+Provides read access to Agent Run documents via the public v1 shape.
+Ownership checks ensure callers can only access runs from conversations
+they own, with the same no-existence-leak pattern as conversations.py.
+"""
+
+import frappe
+
+from huf.api.v1.context import RequestContext
+from huf.api.v1.errors import NotFoundError
+from huf.api.v1.scopes import require_scope
+
+
+def _owns_run(run_doc, user: str) -> bool:
+	"""Whether `user` is the owner of the run's conversation (or a System Manager).
+
+	Agent Runs are owned via their parent conversation. Mirrors the ownership
+	check in `_owns_conversation`, returning a bool instead of raising so
+	callers can convert a failure into `NotFoundError` (no existence leak).
+	"""
+	if "System Manager" in frappe.get_roles():
+		return True
+
+	if not run_doc.conversation:
+		return False
+
+	conversation_doc = frappe.get_doc("Agent Conversation", run_doc.conversation)
+	return conversation_doc.owner == user
+
+
+def _to_public_shape(run_doc) -> dict:
+	"""Build the public, stable shape for a single Agent Run.
+
+	Maps the internal status to canonical public states:
+	- Queued -> queued
+	- Started -> running
+	- Success -> completed
+	- Failed -> failed
+
+	Note: The doctype currently supports Queued/Started/Success/Failed.
+	The public API defines requires_action and cancelled as possible future states,
+	but they are not yet mapped from internal statuses.
+	"""
+	status_map = {
+		"Queued": "queued",
+		"Started": "running",
+		"Success": "completed",
+		"Failed": "failed",
+	}
+
+	internal_status = run_doc.status or ""
+	canonical_status = status_map.get(internal_status, internal_status.lower())
+
+	return {
+		"id": run_doc.name,
+		"agent_id": run_doc.agent,
+		"conversation_id": run_doc.conversation,
+		"status": canonical_status,
+		"output": run_doc.response,
+		"created_at": run_doc.creation,
+	}
+
+
+def handle_get_run(context: RequestContext, run_id: str) -> dict:
+	"""GET /huf/api/v1/runs/{run_id} - a single run the caller owns.
+
+	The caller must own the run's parent conversation; otherwise `NotFoundError`
+	is raised with no existence leak, same as `_get_owned_conversation`.
+	"""
+	require_scope(context, "conversations:read")
+
+	if not frappe.db.exists("Agent Run", run_id):
+		raise NotFoundError(f"Run '{run_id}' was not found.")
+
+	run_doc = frappe.get_doc("Agent Run", run_id)
+
+	if not _owns_run(run_doc, context.user):
+		raise NotFoundError(f"Run '{run_id}' was not found.")
+
+	return _to_public_shape(run_doc)

--- a/huf/api/v1/errors.py
+++ b/huf/api/v1/errors.py
@@ -1,0 +1,68 @@
+"""Error types and error-envelope helpers for the Huf public developer API (v1).
+
+All handlers should raise an `ApiError` subclass on failure; the router
+catches these and converts them to the stable JSON error envelope via
+`error_response`.
+"""
+
+from typing import Optional
+
+
+class ApiError(Exception):
+	"""Base class for all v1 API errors.
+
+	Subclasses set `status_code` and `code` as class attributes; `message`
+	can be overridden per-instance.
+	"""
+
+	status_code = 500
+	code = "internal_error"
+	default_message = "An unexpected error occurred."
+
+	def __init__(self, message: Optional[str] = None):
+		self.message = message or self.default_message
+		super().__init__(self.message)
+
+
+class AuthenticationError(ApiError):
+	status_code = 401
+	code = "authentication_required"
+	default_message = "Authentication is required to access this resource."
+
+
+class AuthorizationError(ApiError):
+	status_code = 403
+	code = "authorization_failed"
+	default_message = "You are not permitted to access this resource."
+
+
+class NotFoundError(ApiError):
+	status_code = 404
+	code = "not_found"
+	default_message = "The requested resource was not found."
+
+
+class ValidationError(ApiError):
+	status_code = 400
+	code = "validation_error"
+	default_message = "The request was invalid."
+
+
+class RateLimitError(ApiError):
+	status_code = 429
+	code = "rate_limited"
+	default_message = "Too many requests. Please try again later."
+
+
+def error_response(exc: ApiError, request_id: Optional[str] = None) -> dict:
+	"""Build the stable JSON error envelope for an `ApiError`.
+
+	Shape: `{"error": {"code": ..., "message": ..., "request_id": ...}}`
+	"""
+	return {
+		"error": {
+			"code": exc.code,
+			"message": exc.message,
+			"request_id": request_id,
+		}
+	}

--- a/huf/api/v1/openapi.py
+++ b/huf/api/v1/openapi.py
@@ -1,0 +1,79 @@
+"""Minimal OpenAPI 3.0 scaffold for the Huf public developer API (v1).
+
+This is intentionally not a full spec generator - just enough structure
+so paths can be added per-endpoint as later phases add real endpoints.
+"""
+
+
+def get_openapi_spec() -> dict:
+	"""Return the (currently minimal) OpenAPI 3.0 spec for the v1 API."""
+	return {
+		"openapi": "3.0.0",
+		"info": {
+			"title": "Huf Developer API",
+			"version": "v1",
+		},
+		"paths": {
+			"/huf/api/v1/ping": {
+				"get": {
+					"summary": "Health check",
+					"operationId": "ping",
+					"security": [],
+					"responses": {
+						"200": {
+							"description": "Service is healthy.",
+							"content": {
+								"application/json": {
+									"schema": {
+										"type": "object",
+										"properties": {
+											"data": {
+												"type": "object",
+												"properties": {
+													"status": {"type": "string"},
+													"version": {"type": "string"},
+												},
+											},
+											"request_id": {"type": "string"},
+											"meta": {"type": "object"},
+										},
+									}
+								}
+							},
+						}
+					},
+				}
+			},
+			"/huf/api/v1/me": {
+				"get": {
+					"summary": "Resolved principal for the current request",
+					"operationId": "me",
+					"security": [{"session": []}],
+					"responses": {
+						"200": {
+							"description": "The authenticated principal.",
+							"content": {
+								"application/json": {
+									"schema": {
+										"type": "object",
+										"properties": {
+											"data": {
+												"type": "object",
+												"properties": {
+													"user": {"type": "string"},
+													"request_id": {"type": "string"},
+												},
+											},
+											"request_id": {"type": "string"},
+											"meta": {"type": "object"},
+										},
+									}
+								}
+							},
+						},
+						"401": {"description": "Authentication required."},
+					},
+				}
+			},
+		},
+	}

--- a/huf/api/v1/responses.py
+++ b/huf/api/v1/responses.py
@@ -1,0 +1,15 @@
+"""Success-envelope helpers for the Huf public developer API (v1)."""
+
+from typing import Optional
+
+
+def success_response(data, request_id: str, meta: Optional[dict] = None) -> dict:
+	"""Build the stable JSON success envelope.
+
+	Shape: `{"data": ..., "request_id": ..., "meta": ...}`
+	"""
+	return {
+		"data": data,
+		"request_id": request_id,
+		"meta": meta or {},
+	}

--- a/huf/api/v1/router.py
+++ b/huf/api/v1/router.py
@@ -1,0 +1,201 @@
+"""Page renderer / router for the Huf public developer API (v1).
+
+Follows the same `BaseRenderer` pattern as `huf.ai.agent_stream_renderer
+.AgentStreamRenderer` so it plugs into Frappe's website routing via the
+`page_renderer` hook, rather than `frappe.whitelist`. This keeps the API
+on a clean `/huf/api/v1/<endpoint>` path (no `/api/method/...` prefix)
+and gives Phase 2+ endpoints a single dispatch point to add to.
+
+Each endpoint is a plain callable `(context: RequestContext) -> dict`.
+Static (parameter-free) routes are looked up in `_STATIC_ENDPOINTS`;
+path-templated routes (e.g. `/agents/{agent_id}`) are matched in order
+against `_PATH_ENDPOINTS`. The renderer resolves the principal, builds
+the `RequestContext`, calls the matched handler, and wraps the result
+(or any `ApiError`) in the standard response envelope.
+"""
+
+import json
+
+import frappe
+from frappe.website.page_renderers.base_renderer import BaseRenderer
+
+from huf.api.v1.auth import resolve_principal
+from huf.api.v1.context import AuthMode, RequestContext
+from huf.api.v1.endpoints.agents import handle_get_agent, handle_list_agents
+from huf.api.v1.endpoints.conversations import (
+	handle_create_conversation,
+	handle_get_conversation,
+	handle_list_conversations,
+	handle_list_messages,
+)
+from huf.api.v1.endpoints.identity import handle_me
+from huf.api.v1.endpoints.responses import handle_create_response
+from huf.api.v1.endpoints.responses_stream import handle_stream_response
+from huf.api.v1.endpoints.runs import handle_get_run
+from huf.api.v1.errors import ApiError, NotFoundError, ValidationError, error_response
+from huf.api.v1.responses import success_response
+
+ROUTE_PREFIX = "huf/api/v1/"
+
+
+def _handle_ping(context: RequestContext) -> dict:
+	"""GET /huf/api/v1/ping - unauthenticated health check."""
+	return {"status": "ok", "version": "v1"}
+
+
+def _handle_conversations(context: RequestContext) -> dict:
+	"""POST creates a conversation, GET lists the caller's own conversations."""
+	if frappe.request and frappe.request.method == "POST":
+		payload = frappe.local.form_dict
+		agent_id = payload.get("agent_id") or payload.get("agent")
+		if not agent_id:
+			raise ValidationError("agent_id is required to create a conversation.")
+		return handle_create_conversation(context, agent_id=agent_id, title=payload.get("title"))
+	return handle_list_conversations(context, agent_id=frappe.local.form_dict.get("agent_id"))
+
+
+def _handle_responses(context: RequestContext) -> dict:
+	"""POST /huf/api/v1/responses - run an agent turn (sync, queue-first)."""
+	payload = frappe.local.form_dict
+	agent_id = payload.get("agent_id") or payload.get("agent")
+	input_text = payload.get("input") or payload.get("input_text") or payload.get("prompt")
+	if not agent_id:
+		raise ValidationError("agent_id is required.")
+	if not input_text:
+		raise ValidationError("input is required.")
+	return handle_create_response(
+		context, agent_id=agent_id, input_text=input_text, conversation_id=payload.get("conversation_id")
+	)
+
+
+# Static (parameter-free) endpoints: route suffix -> (handler, requires_auth).
+# Every handler is called as `handler(context)`.
+_STATIC_ENDPOINTS = {
+	"ping": (_handle_ping, False),
+	"me": (lambda context: handle_me(context), True),
+	"agents": (lambda context: handle_list_agents(context), True),
+	"conversations": (_handle_conversations, True),
+	"responses": (_handle_responses, True),
+}
+
+# Path-templated routes, matched in order after the static table misses.
+# Each entry: (matcher(segments) -> bool, handler(context, segments) -> dict, requires_auth).
+_PATH_ENDPOINTS = [
+	(
+		lambda s: len(s) == 3 and s[0] == "conversations" and s[2] == "messages",
+		lambda context, s: handle_list_messages(context, s[1]),
+		True,
+	),
+	(
+		lambda s: len(s) == 2 and s[0] == "conversations",
+		lambda context, s: handle_get_conversation(context, s[1]),
+		True,
+	),
+	(
+		lambda s: len(s) == 2 and s[0] == "agents",
+		lambda context, s: handle_get_agent(context, s[1]),
+		True,
+	),
+	(
+		lambda s: len(s) == 2 and s[0] == "runs",
+		lambda context, s: handle_get_run(context, s[1]),
+		True,
+	),
+]
+
+
+def _wants_stream(payload) -> bool:
+	return str(payload.get("stream", "")).strip().lower() in ("1", "true", "yes")
+
+
+def _match_route(endpoint: str):
+	"""Resolve `endpoint` (the path after ROUTE_PREFIX) to a (handler, requires_auth) pair.
+
+	`handler` is always callable as `handler(context)`. Returns None if no route matches.
+	"""
+	static_entry = _STATIC_ENDPOINTS.get(endpoint)
+	if static_entry is not None:
+		return static_entry
+
+	segments = [s for s in endpoint.split("/") if s]
+	for matches, handler, requires_auth in _PATH_ENDPOINTS:
+		if matches(segments):
+			return (lambda context, _h=handler, _s=segments: _h(context, _s)), requires_auth
+
+	return None
+
+
+class ApiV1Router(BaseRenderer):
+	"""Page renderer that dispatches requests under `/huf/api/v1/<endpoint>`."""
+
+	def can_render(self) -> bool:
+		"""Determine if this renderer should handle the current path."""
+		return self.path == "huf/api/v1" or self.path.startswith(ROUTE_PREFIX)
+
+	def render(self):
+		"""Resolve the endpoint, build a RequestContext, and dispatch."""
+		endpoint = frappe.form_dict.get("endpoint")
+		if not endpoint and self.path.startswith(ROUTE_PREFIX):
+			endpoint = self.path[len(ROUTE_PREFIX):]
+		endpoint = (endpoint or "").strip("/")
+
+		route = _match_route(endpoint)
+		fallback_request_id = RequestContext(
+			user=frappe.session.user, auth_mode=AuthMode.SESSION
+		).request_id
+
+		if route is None:
+			return self._render_error(NotFoundError(f"Unknown endpoint: '{endpoint}'"), fallback_request_id)
+
+		handler, requires_auth = route
+
+		try:
+			context = self._build_context(requires_auth)
+
+			if endpoint == "responses" and _wants_stream(frappe.local.form_dict):
+				payload = frappe.local.form_dict
+				agent_id = payload.get("agent_id") or payload.get("agent")
+				input_text = payload.get("input") or payload.get("input_text") or payload.get("prompt")
+				if not agent_id:
+					raise ValidationError("agent_id is required.")
+				if not input_text:
+					raise ValidationError("input is required.")
+				return handle_stream_response(
+					context,
+					agent_id=agent_id,
+					input_text=input_text,
+					conversation_id=payload.get("conversation_id"),
+				)
+
+			data = handler(context)
+			return self._render_success(data, context.request_id)
+		except ApiError as exc:
+			return self._render_error(exc, fallback_request_id)
+		except Exception as exc:
+			frappe.log_error(frappe.get_traceback(), "Huf API v1 Router Error")
+			return self._render_error(ApiError(f"Internal error: {exc}"), fallback_request_id)
+
+	def _build_context(self, requires_auth: bool) -> RequestContext:
+		"""Resolve the request's principal, or fall back to an anonymous
+		Guest context for endpoints that do not require auth."""
+		if not requires_auth:
+			try:
+				return resolve_principal(frappe.request)
+			except ApiError:
+				return RequestContext(user=frappe.session.user, auth_mode=AuthMode.SESSION)
+
+		# For auth-required endpoints, AuthenticationError propagates to the
+		# caller (render()), which supplies its own fallback request_id.
+		return resolve_principal(frappe.request)
+
+	def _render_success(self, data: dict, request_id: str):
+		body = success_response(data, request_id)
+		headers = {"Content-Type": "application/json; charset=utf-8"}
+		return self.build_response(json.dumps(body), headers=headers)
+
+	def _render_error(self, exc: ApiError, request_id: str = None):
+		body = error_response(exc, request_id=request_id)
+		headers = {"Content-Type": "application/json; charset=utf-8"}
+		return self.build_response(
+			json.dumps(body), headers=headers, http_status_code=exc.status_code
+		)

--- a/huf/api/v1/scopes.py
+++ b/huf/api/v1/scopes.py
@@ -1,0 +1,61 @@
+"""Scope and agent-restriction enforcement for the Huf public developer API (v1).
+
+The critical rule for this platform: an API key can only ever REDUCE the
+authority of the caller, never increase it. `huf.api.v1.auth._resolve_api_key`
+resolves WHO is calling and attaches the key's `credential_scopes` /
+`credential_agent_restriction` onto the `RequestContext`; this module
+enforces WHAT that key is allowed to do, on top of (never instead of) the
+normal Huf/Frappe capability and ownership checks each handler already
+performs.
+
+Session (and OAuth, once implemented) auth leaves `credential_scopes` /
+`credential_agent_restriction` as `None` on the context - those requests
+are unrestricted by credential scope, governed only by the underlying
+capability/ownership checks, same as before this module existed.
+"""
+
+from huf.api.v1.context import RequestContext
+from huf.api.v1.errors import AuthorizationError
+
+# Endpoint action -> required scope. Deliberately small and defensible:
+# every v1 handler maps to exactly one scope from `ALLOWED_SCOPES` in
+# huf.huf.doctype.huf_api_key.huf_api_key.
+ACTION_SCOPES = {
+	"agents:list": "agents:read",
+	"agents:get": "agents:read",
+	"conversations:list": "conversations:read",
+	"conversations:create": "conversations:write",
+	"conversations:get": "conversations:read",
+	"conversations:messages": "conversations:read",
+	"responses:create": "agents:run",
+	"responses:stream": "agents:run",
+	"runs:get": "conversations:read",
+}
+
+
+def require_scope(context: RequestContext, scope: str) -> None:
+	"""Raise `AuthorizationError` unless `context`'s credential permits `scope`.
+
+	Session/OAuth auth (`context.credential_scopes is None`) is unrestricted
+	by credential scope - normal capability checks elsewhere still apply.
+	"""
+	if context.credential_scopes is None:
+		return
+
+	if scope not in context.credential_scopes:
+		raise AuthorizationError(f"This API key does not have the '{scope}' scope.")
+
+
+def require_agent_allowed(context: RequestContext, agent_id: str) -> None:
+	"""Raise `AuthorizationError` unless `context`'s credential permits `agent_id`.
+
+	`context.credential_agent_restriction is None` means no restriction is
+	in effect (session/OAuth auth). Mode "all" always passes; mode
+	"selected" requires `agent_id` to be in the restricted agent list.
+	"""
+	restriction = context.credential_agent_restriction
+	if restriction is None:
+		return
+
+	if restriction.get("mode") == "selected" and agent_id not in (restriction.get("agents") or []):
+		raise AuthorizationError(f"This API key is not permitted to use agent '{agent_id}'.")

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -66,6 +66,10 @@ website_route_rules = [
     {"from_route": "/huf/stream/<path:agent_name>", "to_route": "huf/stream"},
     {"from_route": "/huf/stream", "to_route": "huf/stream"},
 
+    # Public developer API (v1) routes must come before the catch-all /huf route
+    {"from_route": "/huf/api/v1", "to_route": "huf/api/v1"},
+    {"from_route": "/huf/api/v1/<path:endpoint>", "to_route": "huf/api/v1"},
+
     # Docs routes must come before the catch-all /huf route
     {"from_route": "/huf/docs", "to_route": "huf/docs"},
     {
@@ -79,7 +83,8 @@ website_route_rules = [
 
 # Register custom page renderer for SSE streaming and docs
 page_renderer = [
-    "huf.ai.agent_stream_renderer.AgentStreamRenderer"
+    "huf.ai.agent_stream_renderer.AgentStreamRenderer",
+    "huf.api.v1.router.ApiV1Router"
 ]
 
 

--- a/huf/huf/doctype/huf_api_key/huf_api_key.json
+++ b/huf/huf/doctype/huf_api_key/huf_api_key.json
@@ -1,0 +1,152 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "field:key_id",
+ "creation": "2026-08-23 13:21:18.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "label",
+  "key_id",
+  "status",
+  "column_break_identity",
+  "expires_at",
+  "last_used_at",
+  "secret_section",
+  "hashed_secret",
+  "scope_section",
+  "scopes",
+  "column_break_scope",
+  "agent_restriction_mode",
+  "restricted_agents"
+ ],
+ "fields": [
+  {
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label",
+   "reqd": 1
+  },
+  {
+   "fieldname": "key_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Key ID",
+   "read_only": 1,
+   "unique": 1
+  },
+  {
+   "default": "Active",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Active\nRevoked",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_identity",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "expires_at",
+   "fieldtype": "Datetime",
+   "label": "Expires At"
+  },
+  {
+   "fieldname": "last_used_at",
+   "fieldtype": "Datetime",
+   "label": "Last Used At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "secret_section",
+   "fieldtype": "Section Break",
+   "label": "Secret"
+  },
+  {
+   "fieldname": "hashed_secret",
+   "fieldtype": "Data",
+   "label": "Hashed Secret",
+   "read_only": 1
+  },
+  {
+   "fieldname": "scope_section",
+   "fieldtype": "Section Break",
+   "label": "Scopes"
+  },
+  {
+   "fieldname": "scopes",
+   "fieldtype": "Small Text",
+   "label": "Scopes (JSON list)"
+  },
+  {
+   "fieldname": "column_break_scope",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "all",
+   "fieldname": "agent_restriction_mode",
+   "fieldtype": "Select",
+   "label": "Agent Restriction Mode",
+   "options": "all\nselected",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.agent_restriction_mode === 'selected'",
+   "fieldname": "restricted_agents",
+   "fieldtype": "Small Text",
+   "label": "Restricted Agents (JSON list)"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-23 13:21:18.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Huf API Key",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "select": 1,
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "select": 1,
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/huf/huf/doctype/huf_api_key/huf_api_key.py
+++ b/huf/huf/doctype/huf_api_key/huf_api_key.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+"""
+Huf API Key controller.
+
+A Huf API Key lets an external developer authenticate as a Huf user with a
+REDUCED, explicitly-scoped set of capabilities -- never elevated beyond
+whatever the owning user could already do. Only the SHA-256 hash of the
+secret is ever persisted; the raw secret is generated and returned exactly
+once, at creation time, and is unrecoverable after that.
+
+Hashing approach
+-----------------
+API keys differ from user passwords: they are already high-entropy,
+machine-generated random tokens (32 bytes of `secrets.token_urlsafe`
+output), not low-entropy human-chosen strings. There is therefore no need
+for a slow, salted KDF (bcrypt/argon2/scrypt) whose whole purpose is to
+resist offline dictionary/brute-force attacks against weak secrets -- a
+plain, fast SHA-256 digest, compared in constant time, is the standard
+approach used by GitHub, Stripe, and most API-key systems for this reason.
+`frappe.utils.password` was checked for a reusable primitive; the helpers
+there (`update_password` / `check_password` / `get_decrypted_password`)
+are wired specifically to the `User` doctype's Auth table and to a
+*reversible* Fernet-based encryption for "Password" fieldtype values --
+neither fits "store only a one-way hash of an arbitrary secret string" --
+so a hand-rolled (but standard-library, no hand-rolled crypto) SHA-256 +
+`hmac.compare_digest` scheme is used instead.
+"""
+
+import hashlib
+import hmac
+import json
+import secrets
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import now_datetime
+
+from huf.permissions import has_capability
+
+KEY_PREFIX = "huf_sk_"
+
+# V1 scope catalogue. Deliberately a small, hand-curated subset of the
+# internal Huf capability catalogue (see huf/permissions.py) -- API keys
+# must never expose the full internal capability surface.
+ALLOWED_SCOPES = frozenset(
+	[
+		"agents:read",
+		"agents:run",
+		"conversations:read",
+		"conversations:write",
+		"files:read",
+		"files:write",
+		"voice:use",
+		"ocr:use",
+	]
+)
+
+AGENT_RESTRICTION_MODES = frozenset(["all", "selected"])
+
+
+def _hash_secret(raw_secret: str) -> str:
+	"""One-way SHA-256 hex digest of a raw API key secret."""
+	return hashlib.sha256(raw_secret.encode("utf-8")).hexdigest()
+
+
+def generate_key() -> tuple[str, str]:
+	"""Generate a new (key_id, raw_secret) pair.
+
+	`raw_secret` is the only time the plaintext secret exists; callers must
+	return it to the user once and never persist it. `key_id` is a
+	non-secret, human-visible identifier used to look the key up later.
+	"""
+	raw_secret = KEY_PREFIX + secrets.token_urlsafe(32)
+	key_id = KEY_PREFIX + secrets.token_hex(8)
+	return key_id, raw_secret
+
+
+class HufAPIKey(Document):
+	def before_insert(self):
+		# `_raw_secret` is a transient attribute set by create_api_key();
+		# it is never a real field and is never persisted by Frappe.
+		raw_secret = getattr(self, "_raw_secret", None)
+		if not raw_secret:
+			frappe.throw(_("An API key cannot be created without a generated secret."))
+
+		self.hashed_secret = _hash_secret(raw_secret)
+		if not self.status:
+			self.status = "Active"
+
+	def validate(self):
+		self._validate_scopes()
+		self._validate_agent_restriction()
+
+	def has_permission(self, permission_type=None, verbose=False):
+		user = frappe.session.user
+		if "System Manager" in frappe.get_roles(user):
+			return True
+
+		if permission_type in ("create", "write", "save", "delete", "read"):
+			if has_capability(user, "developer.keys.manage"):
+				# Still limited to the caller's own keys outside System Manager.
+				return self.is_new() or self.owner == user
+			return False
+
+		return True
+
+	def _validate_scopes(self):
+		scopes = self._get_scopes_list()
+		invalid = sorted(set(scopes) - ALLOWED_SCOPES)
+		if invalid:
+			frappe.throw(_("Unknown scope(s): {0}").format(", ".join(invalid)))
+
+	def _validate_agent_restriction(self):
+		if self.agent_restriction_mode not in AGENT_RESTRICTION_MODES:
+			frappe.throw(_("Invalid agent restriction mode: {0}").format(self.agent_restriction_mode))
+
+		if self.agent_restriction_mode == "selected":
+			agents = self._get_restricted_agents_list()
+			if not agents:
+				frappe.throw(_("At least one agent must be selected when restricting by agent."))
+			for agent_name in agents:
+				if not frappe.db.exists("Agent", agent_name):
+					frappe.throw(_("Unknown agent: {0}").format(agent_name))
+
+	def _get_scopes_list(self) -> list[str]:
+		return _parse_json_list(self.scopes)
+
+	def _get_restricted_agents_list(self) -> list[str]:
+		return _parse_json_list(self.restricted_agents)
+
+
+def _parse_json_list(value) -> list[str]:
+	if not value:
+		return []
+	try:
+		parsed = json.loads(value)
+	except (TypeError, ValueError):
+		frappe.throw(_("Expected a JSON list."))
+	if not isinstance(parsed, list):
+		frappe.throw(_("Expected a JSON list."))
+	return parsed
+
+
+def verify_key(raw_key: str) -> "HufAPIKey | None":
+	"""Verify a raw API key secret presented by a caller.
+
+	Looks up candidate `Huf API Key` records by `hashed_secret` (a
+	deterministic function of the secret, so the lookup itself is exact --
+	no need to scan every row) and then re-confirms the match with a
+	constant-time comparison, so no timing signal about "how much of the
+	hash matched" ever leaks. Returns `None` (never raises) for any
+	invalid, revoked, or expired key so callers can treat "not
+	authenticated" uniformly. On success, updates `last_used_at` and
+	returns the doc.
+	"""
+	if not raw_key or not raw_key.startswith(KEY_PREFIX):
+		return None
+
+	candidate_hash = _hash_secret(raw_key)
+
+	name = frappe.db.get_value("Huf API Key", {"hashed_secret": candidate_hash}, "name")
+	if not name:
+		return None
+
+	doc = frappe.get_doc("Huf API Key", name)
+
+	if not hmac.compare_digest(doc.hashed_secret or "", candidate_hash):
+		return None
+
+	if doc.status != "Active":
+		return None
+
+	if doc.expires_at and frappe.utils.now_datetime() > frappe.utils.get_datetime(doc.expires_at):
+		return None
+
+	doc.db_set("last_used_at", now_datetime(), update_modified=False)
+	return doc
+
+
+def _require_manage_capability() -> None:
+	if not has_capability(frappe.session.user, "developer.keys.manage"):
+		frappe.throw(
+			_("You don't have permission to manage developer API keys."),
+			frappe.PermissionError,
+		)
+
+
+def _serialize_key(doc: "HufAPIKey") -> dict:
+	"""Public-safe representation of a key -- never includes hashed_secret."""
+	return {
+		"key_id": doc.key_id,
+		"label": doc.label,
+		"status": doc.status,
+		"scopes": doc._get_scopes_list(),
+		"agent_restriction_mode": doc.agent_restriction_mode,
+		"restricted_agents": doc._get_restricted_agents_list(),
+		"expires_at": doc.expires_at,
+		"last_used_at": doc.last_used_at,
+		"creation": doc.creation,
+	}
+
+
+@frappe.whitelist()
+def create_api_key(
+	label: str,
+	scopes: list | str,
+	agent_restriction_mode: str = "all",
+	restricted_agents: list | str | None = None,
+	expires_at: str | None = None,
+) -> dict:
+	"""Create a new Huf API Key for the calling user.
+
+	Returns the raw secret ONCE; it is never retrievable again after this
+	call returns. Requires the `developer.keys.manage` capability.
+	"""
+	_require_manage_capability()
+
+	if isinstance(scopes, str):
+		scopes = _parse_json_list(scopes)
+	if isinstance(restricted_agents, str):
+		restricted_agents = _parse_json_list(restricted_agents)
+
+	key_id, raw_secret = generate_key()
+
+	doc = frappe.new_doc("Huf API Key")
+	doc.key_id = key_id
+	doc.label = label
+	doc.scopes = json.dumps(scopes or [])
+	doc.agent_restriction_mode = agent_restriction_mode
+	doc.restricted_agents = json.dumps(restricted_agents or [])
+	doc.expires_at = expires_at
+	doc.status = "Active"
+	doc._raw_secret = raw_secret
+	doc.insert()
+
+	result = _serialize_key(doc)
+	result["raw_secret"] = raw_secret
+	return result
+
+
+@frappe.whitelist()
+def revoke_api_key(key_id: str) -> dict:
+	"""Revoke a Huf API Key. Requires `developer.keys.manage`; a non-System-Manager
+	caller may only revoke their own keys (enforced via has_permission on save)."""
+	_require_manage_capability()
+
+	doc = frappe.get_doc("Huf API Key", key_id)
+	if doc.owner != frappe.session.user and "System Manager" not in frappe.get_roles(frappe.session.user):
+		frappe.throw(_("You can only revoke your own API keys."), frappe.PermissionError)
+
+	doc.status = "Revoked"
+	doc.save()
+	return {"key_id": doc.key_id, "status": doc.status}
+
+
+@frappe.whitelist()
+def list_api_keys() -> list[dict]:
+	"""List the calling user's own API keys. Never includes hashed_secret."""
+	_require_manage_capability()
+
+	names = frappe.get_all(
+		"Huf API Key",
+		filters={"owner": frappe.session.user},
+		pluck="name",
+		order_by="creation desc",
+	)
+	return [_serialize_key(frappe.get_doc("Huf API Key", name)) for name in names]

--- a/huf/huf/doctype/huf_api_key/test_huf_api_key.py
+++ b/huf/huf/doctype/huf_api_key/test_huf_api_key.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, Huf and contributors
+# For license information, please see license.txt
+
+"""
+Tests for Huf API Key generation, hashing, and verification.
+
+Run with: bench --site <site> run-tests --app huf --module huf.huf.doctype.huf_api_key.test_huf_api_key
+
+NOTE: these tests require a live bench (frappe.init'd site + DB) to run;
+they could not be executed in this environment. See the implementation
+report for what still needs live verification.
+"""
+
+import unittest
+
+import frappe
+
+from huf.install import create_huf_roles
+from huf.huf.doctype.huf_api_key.huf_api_key import (
+	create_api_key,
+	revoke_api_key,
+	list_api_keys,
+	verify_key,
+	generate_key,
+	KEY_PREFIX,
+)
+
+
+class TestHufAPIKey(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		create_huf_roles()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+
+	def test_generate_key_shape(self):
+		key_id, raw_secret = generate_key()
+		self.assertTrue(key_id.startswith(KEY_PREFIX))
+		self.assertTrue(raw_secret.startswith(KEY_PREFIX))
+		self.assertNotEqual(key_id, raw_secret)
+
+	def test_create_and_verify_round_trip(self):
+		result = create_api_key(label="Test Key", scopes=["agents:read"], agent_restriction_mode="all")
+		raw_secret = result["raw_secret"]
+
+		doc = verify_key(raw_secret)
+		self.assertIsNotNone(doc)
+		self.assertEqual(doc.key_id, result["key_id"])
+
+		revoke_api_key(result["key_id"])
+		self.assertIsNone(verify_key(raw_secret))
+
+	def test_verify_key_rejects_garbage(self):
+		self.assertIsNone(verify_key("not-a-real-key"))
+		self.assertIsNone(verify_key(""))
+		self.assertIsNone(verify_key(None))
+
+	def test_list_api_keys_excludes_hashed_secret(self):
+		create_api_key(label="Listed Key", scopes=[], agent_restriction_mode="all")
+		rows = list_api_keys()
+		for row in rows:
+			self.assertNotIn("hashed_secret", row)
+			self.assertNotIn("raw_secret", row)

--- a/huf/huf/doctype/huf_role_permission/huf_role_permission.json
+++ b/huf/huf/doctype/huf_role_permission/huf_role_permission.json
@@ -14,7 +14,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Capability",
-   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.integrations.manage\nsystem.settings.manage\ndata.tables.manage\ndata.records.create\ndata.records.view_own\ndata.records.view_all\ndata.records.edit_own\ndata.records.edit_all\nusers.invite\nusers.manage\nroles.manage\nexecution_profile.manage\nnetwork_access_policy.manage\nexecution.approve\ncode_execution.run\nssh_connection.manage\nssh.run\nssh.approve\ndocker.run",
+   "options": "agent.use\nagent.create\nagent.edit\nagent.delete\nagent.view_all\nchat.use\nchat.view_own\nchat.view_all\nknowledge.use\nknowledge.create\nknowledge.manage\ntools.use\ntools.create\ntools.manage\nflows.use\nflows.create\nflows.manage\nsystem.providers.manage\nsystem.models.manage\nsystem.mcp.manage\nsystem.integrations.manage\nsystem.settings.manage\ndata.tables.manage\ndata.records.create\ndata.records.view_own\ndata.records.view_all\ndata.records.edit_own\ndata.records.edit_all\nusers.invite\nusers.manage\nroles.manage\nexecution_profile.manage\nnetwork_access_policy.manage\nexecution.approve\ncode_execution.run\nssh_connection.manage\nssh.run\nssh.approve\ndocker.run\ndeveloper.access\ndeveloper.keys.manage",
    "reqd": 1
   },
   {

--- a/huf/permissions.py
+++ b/huf/permissions.py
@@ -78,6 +78,9 @@ CAPABILITIES: dict[str, str] = {
 	"ssh.approve": "Approve SSH Executions",
 	# --- Docker Execution ---
 	"docker.run": "Run Docker Execution Tool",
+	# --- Developer Platform ---
+	"developer.access": "Access Developer Platform",
+	"developer.keys.manage": "Manage Developer API Keys",
 }
 
 # Capabilities granted to each default Huf Role.
@@ -114,6 +117,8 @@ DEFAULT_ROLE_CAPABILITIES: dict[str, list[str]] = {
 		"ssh.run",
 		"ssh.approve",
 		"docker.run",
+		"developer.access",
+		"developer.keys.manage",
 	],
 	"Huf User": [
 		"agent.use",
@@ -127,6 +132,8 @@ DEFAULT_ROLE_CAPABILITIES: dict[str, list[str]] = {
 		"data.records.edit_own",
 		"code_execution.run",
 		"ssh.run",
+		"developer.access",
+		"developer.keys.manage",
 	],
 	"Huf Viewer": [
 		"agent.use",


### PR DESCRIPTION
## Summary

Implements Phases 0–3 of the Huf Developer Platform spec (full spec: `Tracks/safwan-erooth.DeveloperSettings/GOAL.md` in the internal workspace repo, not part of this diff). Goal: a stable, versioned public API (`/huf/api/v1/...`) over Huf's existing agent runtime, plus developer-managed API credentials, so external developers can build against Huf without knowing its internal Frappe/DocType structure.

**This is a scoped subset of a 7-phase spec.** Phases 0–3 are implemented; Phases 4–7 (multimodal API, OpenAPI/SDKs/rate-limiting polish, OAuth Apps, Webhooks) are **not attempted** in this PR. See "Explicitly not done" below.

## What's in this PR

**Phase 0 — Audit** (not shipped as code; informs the design)
- Full inventory of ~130 existing whitelisted methods and 200+ frontend API call sites, synthesized into a capability matrix. Confirms every V1-scoped capability already has working runtime + an ad hoc API — this PR is adapter work, not new runtime.

**Phase 1 — API foundation** (`huf/api/v1/`)
- `/huf/api/v1/*` routing via a `BaseRenderer` (`router.py`), following the exact pattern of the existing `AgentStreamRenderer` — registered in `hooks.py` alongside it, no new routing mechanism invented.
- `RequestContext` (request id, user, auth mode), standard success/error JSON envelopes, `ApiError` hierarchy (400/401/403/404/429), an auth resolver chain (`resolve_principal`) designed so API-key/OAuth resolvers slot in without changing call sites, and a minimal OpenAPI scaffold.

**Phase 2 — Core agent API**
- `GET /v1/me`, `GET /v1/agents` (+`/{id}`), `GET/POST /v1/conversations` (+`/{id}`, `/{id}/messages`), `POST /v1/responses` (sync, queue-first — status is reported honestly as `queued`, no fabricated synchronous output), `POST /v1/responses?stream=true` (SSE — replicates the existing `run_immediately`-only streaming constraint and queued-runs ordering check exactly, does not weaken it), `GET /v1/runs/{id}`.
- Every handler is a thin wrapper reusing existing authorization primitives (`check_agent_access`, `assert_agent_access`, conversation-ownership checks) — no authorization logic is duplicated.

**Phase 3 — Credentials & Developer Settings**
- New `Huf API Key` DocType: SHA-256-hashed secret (rationale for not using a slow KDF documented in the code — these are high-entropy machine-generated tokens, not passwords), scopes (`agents:read`, `agents:run`, `conversations:read/write`, `files:read/write`, `voice:use`, `ocr:use`), agent restriction (all vs. selected), expiry, revocation. Raw secret is shown exactly once at creation and is never stored or retrievable again.
- `developer.access` / `developer.keys.manage` capabilities added to the existing Huf Role/capability system (no parallel permission system).
- API-key authentication (`Authorization: Bearer huf_sk_...`) resolves identity; **scope + agent-restriction enforcement is applied on every v1 endpoint** so a key can only ever reduce the owning user's authority, never increase it (`huf/api/v1/scopes.py`).
- **Settings → Developer** UI: Overview + a full API Keys section (create with scope/agent/expiry picker, list with status/scopes/last-used, revoke with confirmation, one-time secret reveal with copy-to-clipboard). Replaces an earlier placeholder page from this track.
- Partial: key usage updates `last_used_at`, but a real structured audit log (who/when/which endpoint) was not built — documented gap, not silently dropped.

## Explicitly not done (Phases 4–7, out of scope for this PR)
- Files/multimodal API, OCR extraction endpoint, voice session normalization under `/v1`
- Polished OpenAPI, interactive docs, TypeScript/Python SDKs, idempotency, pagination, rate limiting, usage/request logs
- OAuth Apps
- Webhooks

## How this was built / reviewed

Built with parallel sub-agents on tightly scoped, independent modules (one file per endpoint area), each given the actual existing runtime code to wrap rather than free rein to invent behavior. Every module was personally read and diff-reviewed before being wired into the shared `router.py` (the one coordination point, kept single-threaded to avoid merge conflicts across parallel agents). Full task-by-task log: `TRACKER.md` in the track directory (internal workspace repo).

## Verification status — please read before merging

**No live Frappe bench was available in the environment this was built in.** Verification was limited to:
- `ast.parse` syntax checks on every Python file
- `tsc -b --noEmit` (clean) on the frontend changes
- Manual review of every diff against the existing runtime it wraps

**Not verified end-to-end**: actual HTTP routing through `website_route_rules` (path-param extraction, route ordering), the SSE streaming path under Frappe's real async/event-loop request lifecycle, the API-key DB lookup/hash-compare under real data, and the full UI flow against a running backend. **A `bench migrate` + live smoke test of every endpoint in `TRACKER.md`'s final checklist is required before this is trustworthy in production.**

## Test plan
- [ ] `bench migrate` on a dev site to create the `Huf API Key` table
- [ ] `curl`/httpie smoke test: `GET /huf/api/v1/ping`, `GET /huf/api/v1/me` (session cookie), `GET /huf/api/v1/agents`, `POST /huf/api/v1/conversations`, `POST /huf/api/v1/responses`, `POST /huf/api/v1/responses?stream=true` against a `run_immediately` agent, `GET /huf/api/v1/runs/{id}`
- [ ] Create an API key via Settings → Developer, confirm the raw secret is shown once, then use it via `Authorization: Bearer` against a scoped endpoint and confirm both the allow and deny paths
- [ ] Revoke a key and confirm it stops authenticating
- [ ] `yarn typecheck` / `yarn lint` in `frontend/`