### PR TITLE
feat: render ERPNext/Frappe list/form/report views inline in chat as artifacts

### DIFF
--- a/frontend/src/components/chat/ArtifactRenderer.tsx
+++ b/frontend/src/components/chat/ArtifactRenderer.tsx
@@ -134,8 +134,8 @@ function renderFrappeView(type: 'frappe-list' | 'frappe-form' | 'frappe-report',
 	// while otherwise reproducing the payload faithfully). Recover the
 	// common single-key-rename case rather than showing a hard error for
 	// data that's actually all there.
-	if (payload && payload.data === undefined && (payload as Record<string, unknown>).doc !== undefined) {
-		payload = { ...payload, data: (payload as Record<string, unknown>).doc } as FrappeViewPayload;
+	if (payload && payload.data === undefined && (payload as unknown as Record<string, unknown>).doc !== undefined) {
+		payload = { ...payload, data: (payload as unknown as Record<string, unknown>).doc } as FrappeViewPayload;
 	}
 
 	if (!payload || !payload.meta || payload.data === undefined) {

--- a/frontend/src/components/chat/ArtifactRenderer.tsx
+++ b/frontend/src/components/chat/ArtifactRenderer.tsx
@@ -128,6 +128,16 @@ function renderFrappeView(type: 'frappe-list' | 'frappe-form' | 'frappe-report',
 		);
 	}
 
+	// Defensive normalization: a model asked to relay the tool's artifact tag
+	// "verbatim" can still occasionally paraphrase a key name (observed:
+	// gemini-3.6-flash emitting `doc` instead of `data` for mode="form"
+	// while otherwise reproducing the payload faithfully). Recover the
+	// common single-key-rename case rather than showing a hard error for
+	// data that's actually all there.
+	if (payload && payload.data === undefined && (payload as Record<string, unknown>).doc !== undefined) {
+		payload = { ...payload, data: (payload as Record<string, unknown>).doc } as FrappeViewPayload;
+	}
+
 	if (!payload || !payload.meta || payload.data === undefined) {
 		return (
 			<div className="text-sm text-destructive p-4">

--- a/frontend/src/components/chat/ArtifactRenderer.tsx
+++ b/frontend/src/components/chat/ArtifactRenderer.tsx
@@ -40,6 +40,11 @@ import { Mermaid } from '@/components/ui/mermaid';
 import { JSXPreview, JSXPreviewContent, JSXPreviewExport } from '@/components/ui/jsx-preview';
 import { Video } from '@/components/ai-elements/video';
 import { DocumentPreview } from '@/components/chat/DocumentPreview';
+import { FrappeListView } from '@/components/chat/frappe-views/FrappeListView';
+import { FrappeFormView } from '@/components/chat/frappe-views/FrappeFormView';
+import { FrappeReportView } from '@/components/chat/frappe-views/FrappeReportView';
+import type { FrappeViewPayload } from '@/types/artifact.types';
+import { TableIcon } from 'lucide-react';
 
 /** Ids minted by the client-side parser for transient, unsaved artifacts. */
 const TRANSIENT_ARTIFACT_ID = /^artifact-\d+-\d+$/;
@@ -75,6 +80,9 @@ const ARTIFACT_ICONS: Record<ArtifactType, typeof CodeIcon> = {
 	jsx: LayoutIcon,
 	chart: BarChartIcon,
 	video: VideoIcon,
+	'frappe-list': TableIcon,
+	'frappe-form': FileTextIcon,
+	'frappe-report': TableIcon,
 };
 
 // Map common language aliases to Shiki language names
@@ -97,6 +105,45 @@ function normalizeLanguage(language?: string): string {
 	if (!language) return 'text';
 	const lower = language.toLowerCase();
 	return LANGUAGE_MAP[lower] || lower;
+}
+
+/**
+ * Parses a frappe-list/frappe-form/frappe-report artifact body (JSON per
+ * FrappeViewPayload, emitted by
+ * huf/ai/tools/frappe_generic.py::handle_render_frappe_view) and renders the
+ * matching view component. Malformed JSON (or a payload missing the fields
+ * these views need) falls back to a plain error message rather than
+ * throwing, since this runs inside a streaming chat message.
+ */
+function renderFrappeView(type: 'frappe-list' | 'frappe-form' | 'frappe-report', content: string) {
+	let payload: FrappeViewPayload;
+	try {
+		payload = JSON.parse(content) as FrappeViewPayload;
+	} catch (error) {
+		console.error('Failed to parse frappe view artifact payload:', error);
+		return (
+			<div className="text-sm text-destructive p-4">
+				Could not parse this Frappe view - invalid JSON.
+			</div>
+		);
+	}
+
+	if (!payload || !payload.meta || payload.data === undefined) {
+		return (
+			<div className="text-sm text-destructive p-4">
+				This Frappe view is missing required data (meta/data).
+			</div>
+		);
+	}
+
+	switch (type) {
+		case 'frappe-list':
+			return <FrappeListView payload={payload} />;
+		case 'frappe-form':
+			return <FrappeFormView payload={payload} />;
+		case 'frappe-report':
+			return <FrappeReportView payload={payload} />;
+	}
 }
 
 export function ArtifactRenderer({
@@ -161,6 +208,12 @@ export function ArtifactRenderer({
 			extension = 'md';
 		} else if (artifact.type === 'jsx' || artifact.type === 'chart') {
 			extension = 'jsx';
+		} else if (
+			artifact.type === 'frappe-list' ||
+			artifact.type === 'frappe-form' ||
+			artifact.type === 'frappe-report'
+		) {
+			extension = 'json';
 		}
 
 		a.download = artifact.title
@@ -306,6 +359,11 @@ export function ArtifactRenderer({
 						</details>
 					</div>
 				);
+
+			case 'frappe-list':
+			case 'frappe-form':
+			case 'frappe-report':
+				return renderFrappeView(artifact.type, artifact.content);
 
 			default:
 				return (

--- a/frontend/src/components/chat/frappe-views/FrappeFormView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeFormView.tsx
@@ -1,0 +1,177 @@
+/**
+ * Renders a frappe-form artifact payload (see
+ * huf/ai/tools/frappe_generic.py::handle_render_frappe_view, mode="form") as
+ * a read/edit-view form driven by `meta.fields`.
+ *
+ * This is a draft-review UI only, matching the backend's draft-only write
+ * contract (handle_create_record/handle_update_record never write to the
+ * database - they hand back a `{"draft": true, ...}` payload for the human
+ * to actually submit through the normal Frappe REST path). There is
+ * therefore no submit-to-backend wiring here yet.
+ */
+
+import { useMemo, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { CopyIcon, CheckIcon } from 'lucide-react';
+import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
+import { isDisplayField } from './frappeFieldFormat';
+
+export interface FrappeFormViewProps {
+	payload: FrappeViewPayload;
+}
+
+/** Fieldtypes rendered as a plain (possibly disabled) text input. */
+const TEXT_LIKE_FIELDTYPES = new Set([
+	'Data',
+	'Text',
+	'Small Text',
+	'Long Text',
+	'Text Editor',
+	'Code',
+	'Link',
+	'Dynamic Link',
+	'Int',
+	'Float',
+	'Currency',
+	'Percent',
+	'Date',
+	'Datetime',
+	'Time',
+	'Password',
+]);
+
+export function FrappeFormView({ payload }: FrappeFormViewProps) {
+	const record = useMemo(
+		() => (Array.isArray(payload.data) ? payload.data[0] ?? {} : payload.data ?? {}),
+		[payload.data]
+	);
+
+	const fields = useMemo<FrappeFieldMeta[]>(
+		() => (payload.meta?.fields ?? []).filter(isDisplayField),
+		[payload.meta]
+	);
+
+	const [values, setValues] = useState<Record<string, unknown>>(record);
+	const [copied, setCopied] = useState(false);
+
+	const setValue = (fieldname: string, value: unknown) => {
+		setValues((prev) => ({ ...prev, [fieldname]: value }));
+	};
+
+	// TODO: no submit-to-backend wiring yet - this is a draft-review UI per
+	// the backend's draft-only contract (handle_create_record /
+	// handle_update_record only ever return a draft payload; the actual
+	// write happens client-side via the normal Frappe REST API as the
+	// logged-in user). For now, "submit" just copies the edited values as
+	// JSON so a human can inspect/paste them elsewhere.
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		console.log('[FrappeFormView] draft submit (TODO: wire to backend)', {
+			doctype: payload.doctype,
+			values,
+		});
+		try {
+			await navigator.clipboard.writeText(JSON.stringify(values, null, 2));
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch (err) {
+			console.error('Failed to copy draft values:', err);
+		}
+	};
+
+	return (
+		<form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-line bg-panel p-4">
+			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+				{fields.map((field) => (
+					<div key={field.fieldname} className="space-y-1.5">
+						<Label htmlFor={field.fieldname} className="text-xs text-steel">
+							{field.label || field.fieldname}
+							{field.reqd && <span className="text-destructive ml-0.5">*</span>}
+						</Label>
+						{renderFieldControl(field, values[field.fieldname], (v) => setValue(field.fieldname, v))}
+					</div>
+				))}
+			</div>
+			<div className="flex justify-end">
+				<Button type="submit" size="sm" variant="outline">
+					{copied ? <CheckIcon className="h-3.5 w-3.5 mr-1" /> : <CopyIcon className="h-3.5 w-3.5 mr-1" />}
+					{copied ? 'Copied as JSON' : 'Copy as JSON'}
+				</Button>
+			</div>
+		</form>
+	);
+}
+
+function renderFieldControl(
+	field: FrappeFieldMeta,
+	value: unknown,
+	onChange: (value: unknown) => void
+) {
+	if (field.fieldtype === 'Check') {
+		return (
+			<Checkbox
+				id={field.fieldname}
+				checked={Boolean(value)}
+				disabled={field.read_only}
+				onCheckedChange={(checked) => onChange(Boolean(checked))}
+			/>
+		);
+	}
+
+	if (field.fieldtype === 'Select') {
+		const options = field.select_options ?? [];
+		return (
+			<Select
+				value={value != null ? String(value) : undefined}
+				disabled={field.read_only}
+				onValueChange={(v) => onChange(v)}
+			>
+				<SelectTrigger id={field.fieldname} size="sm">
+					<SelectValue placeholder="Select..." />
+				</SelectTrigger>
+				<SelectContent>
+					{options.map((opt) => (
+						<SelectItem key={opt} value={opt}>
+							{opt}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+		);
+	}
+
+	// Everything else (Data/Text/Link/Int/Currency/Date/... and any fieldtype
+	// this view doesn't special-case) falls back to a plain text input -
+	// including Table, which shows the raw child-row count rather than an
+	// editable grid (out of scope here).
+	const isKnownTextLike = TEXT_LIKE_FIELDTYPES.has(field.fieldtype);
+	const displayValue =
+		field.fieldtype === 'Table' && Array.isArray(value)
+			? `${value.length} row(s)`
+			: value != null
+				? String(value)
+				: '';
+
+	return (
+		<Input
+			id={field.fieldname}
+			size="sm"
+			value={displayValue}
+			disabled={field.read_only || field.fieldtype === 'Table'}
+			onChange={(e) => onChange(e.target.value)}
+			placeholder={!isKnownTextLike ? field.fieldtype : undefined}
+		/>
+	);
+}
+
+export default FrappeFormView;

--- a/frontend/src/components/chat/frappe-views/FrappeFormView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeFormView.tsx
@@ -22,9 +22,10 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from '@/components/ui/select';
-import { CopyIcon, CheckIcon } from 'lucide-react';
+import { CopyIcon, CheckIcon, ExternalLink } from 'lucide-react';
 import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
 import { isDisplayField } from './frappeFieldFormat';
+import { deskFormUrl } from './frappeDeskUrl';
 
 export interface FrappeFormViewProps {
 	payload: FrappeViewPayload;
@@ -89,8 +90,23 @@ export function FrappeFormView({ payload }: FrappeFormViewProps) {
 		}
 	};
 
+	const recordName = typeof record.name === 'string' ? record.name : undefined;
+
 	return (
 		<form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-line bg-panel p-4">
+			{recordName && (
+				<div className="flex justify-end">
+					<a
+						href={deskFormUrl(payload.doctype, recordName)}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="inline-flex items-center gap-1 text-xs text-steel hover:text-ink"
+					>
+						Open in Desk
+						<ExternalLink className="h-3 w-3" />
+					</a>
+				</div>
+			)}
 			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
 				{fields.map((field) => (
 					<div key={field.fieldname} className="space-y-1.5">

--- a/frontend/src/components/chat/frappe-views/FrappeListView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeListView.tsx
@@ -3,12 +3,14 @@
  * huf/ai/tools/frappe_generic.py::handle_render_frappe_view, mode="list") as
  * a paginated table, columns derived from `meta.fields`.
  *
- * Pagination here is a client-side stub: the artifact payload is a single
- * static snapshot (the backend does not round-trip limit_start/
- * limit_page_length into the payload for list mode - see the NOTE on
- * FrappeViewPayload), so `onPageChange` just reports the page the caller
- * asked for. Wiring it to actually re-invoke the tool and refresh `data` is
- * a follow-up.
+ * Pagination re-fetches through `frappe.client.get_list` directly (via
+ * frappe-js-sdk's `db.getDocList`, the same whitelisted, permission-checked
+ * REST method the rest of the frontend already uses for Frappe list data -
+ * see dataTableApi.ts) rather than round-tripping through the agent/tool
+ * layer, since the artifact snapshot doesn't carry enough context (agent,
+ * conversation) to safely reinvoke a tool call from a plain page/filter
+ * click. `frappe.client.get_list` applies the same permission-query
+ * conditions our backend tool does, so this is not a permission relaxation.
  */
 
 import { useMemo, useState } from 'react';
@@ -22,23 +24,25 @@ import {
 } from '@tanstack/react-table';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
-import { ArrowUpDown, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
+import { ArrowUpDown, ChevronLeft, ChevronRight, ExternalLink, Loader2 } from 'lucide-react';
+import { db, call } from '@/lib/frappe-sdk';
 import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
 import { formatFrappeCellValue, isDisplayField } from './frappeFieldFormat';
 import { deskListUrl } from './frappeDeskUrl';
 
 export interface FrappeListViewProps {
 	payload: FrappeViewPayload;
-	/** Called with the next limit_start when the pager is used. Wiring this
-	 * to an actual refetch against the backend tool is a follow-up. */
-	onPageChange?: (limitStart: number, limitPageLength: number) => void;
 }
 
-export function FrappeListView({ payload, onPageChange }: FrappeListViewProps) {
-	const rows = useMemo(
-		() => (Array.isArray(payload.data) ? payload.data : [payload.data]),
-		[payload.data]
+export function FrappeListView({ payload }: FrappeListViewProps) {
+	const [rows, setRows] = useState<Record<string, unknown>[]>(() =>
+		Array.isArray(payload.data) ? payload.data : [payload.data]
 	);
+	const [limitStart, setLimitStart] = useState(payload.limit_start ?? 0);
+	const [totalCount, setTotalCount] = useState(payload.total_count ?? rows.length);
+	const [loading, setLoading] = useState(false);
+	const [fetchError, setFetchError] = useState<string | null>(null);
+	const limitPageLength = payload.limit_page_length ?? rows.length ?? 20;
 
 	const displayFields = useMemo<FrappeFieldMeta[]>(() => {
 		const metaFields = payload.meta?.fields ?? [];
@@ -49,6 +53,33 @@ export function FrappeListView({ payload, onPageChange }: FrappeListViewProps) {
 			: metaFields.filter(isDisplayField);
 		return base.slice(0, 8);
 	}, [payload.meta, payload.fields]);
+
+	const fetchPage = async (nextLimitStart: number) => {
+		setLoading(true);
+		setFetchError(null);
+		try {
+			const fieldNames = displayFields.map((f) => f.fieldname);
+			const result = await db.getDocList(payload.doctype, {
+				fields: fieldNames.length ? fieldNames : undefined,
+				filters: (payload.filters as never) ?? undefined,
+				limit_start: nextLimitStart,
+				limit: limitPageLength,
+			});
+			setRows(result as unknown as Record<string, unknown>[]);
+			setLimitStart(nextLimitStart);
+			const countResponse = await call.get('frappe.client.get_count', {
+				doctype: payload.doctype,
+				...(payload.filters ? { filters: JSON.stringify(payload.filters) } : {}),
+			});
+			const count = Number(countResponse?.message);
+			if (!Number.isNaN(count)) setTotalCount(count);
+		} catch (error) {
+			console.error('Failed to fetch Frappe list page:', error);
+			setFetchError('Could not load this page - showing the last loaded data.');
+		} finally {
+			setLoading(false);
+		}
+	};
 
 	const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(() => {
 		return displayFields.map((field) => ({
@@ -82,15 +113,13 @@ export function FrappeListView({ payload, onPageChange }: FrappeListViewProps) {
 		state: { sorting },
 	});
 
-	const limitStart = payload.limit_start ?? 0;
-	const limitPageLength = payload.limit_page_length ?? rows.length ?? 20;
-	const totalCount = payload.total_count ?? rows.length;
 	const hasPrev = limitStart > 0;
 	const hasNext = limitStart + limitPageLength < totalCount;
 
 	return (
 		<div className="space-y-3">
-			<div className="flex justify-end">
+			<div className="flex items-center justify-between">
+				{fetchError ? <span className="text-xs text-destructive">{fetchError}</span> : <span />}
 				<a
 					href={deskListUrl(payload.doctype)}
 					target="_blank"
@@ -144,11 +173,12 @@ export function FrappeListView({ payload, onPageChange }: FrappeListViewProps) {
 						: '0 records'}
 				</span>
 				<div className="flex items-center gap-2">
+					{loading && <Loader2 className="h-3.5 w-3.5 animate-spin text-steel" />}
 					<Button
 						variant="outline"
 						size="sm"
-						disabled={!hasPrev}
-						onClick={() => onPageChange?.(Math.max(0, limitStart - limitPageLength), limitPageLength)}
+						disabled={!hasPrev || loading}
+						onClick={() => fetchPage(Math.max(0, limitStart - limitPageLength))}
 					>
 						<ChevronLeft className="h-3.5 w-3.5" />
 						Prev
@@ -156,8 +186,8 @@ export function FrappeListView({ payload, onPageChange }: FrappeListViewProps) {
 					<Button
 						variant="outline"
 						size="sm"
-						disabled={!hasNext}
-						onClick={() => onPageChange?.(limitStart + limitPageLength, limitPageLength)}
+						disabled={!hasNext || loading}
+						onClick={() => fetchPage(limitStart + limitPageLength)}
 					>
 						Next
 						<ChevronRight className="h-3.5 w-3.5" />

--- a/frontend/src/components/chat/frappe-views/FrappeListView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeListView.tsx
@@ -1,0 +1,159 @@
+/**
+ * Renders a frappe-list artifact payload (see
+ * huf/ai/tools/frappe_generic.py::handle_render_frappe_view, mode="list") as
+ * a paginated table, columns derived from `meta.fields`.
+ *
+ * Pagination here is a client-side stub: the artifact payload is a single
+ * static snapshot (the backend does not round-trip limit_start/
+ * limit_page_length into the payload for list mode - see the NOTE on
+ * FrappeViewPayload), so `onPageChange` just reports the page the caller
+ * asked for. Wiring it to actually re-invoke the tool and refresh `data` is
+ * a follow-up.
+ */
+
+import { useMemo, useState } from 'react';
+import {
+	type ColumnDef,
+	getCoreRowModel,
+	getSortedRowModel,
+	useReactTable,
+	flexRender,
+	type SortingState,
+} from '@tanstack/react-table';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { ArrowUpDown, ChevronLeft, ChevronRight } from 'lucide-react';
+import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
+import { formatFrappeCellValue, isDisplayField } from './frappeFieldFormat';
+
+export interface FrappeListViewProps {
+	payload: FrappeViewPayload;
+	/** Called with the next limit_start when the pager is used. Wiring this
+	 * to an actual refetch against the backend tool is a follow-up. */
+	onPageChange?: (limitStart: number, limitPageLength: number) => void;
+}
+
+export function FrappeListView({ payload, onPageChange }: FrappeListViewProps) {
+	const rows = useMemo(
+		() => (Array.isArray(payload.data) ? payload.data : [payload.data]),
+		[payload.data]
+	);
+
+	const displayFields = useMemo<FrappeFieldMeta[]>(() => {
+		const metaFields = payload.meta?.fields ?? [];
+		const requested = payload.fields;
+		const byName = new Map(metaFields.map((f) => [f.fieldname, f]));
+		const base = requested?.length
+			? requested.map((name) => byName.get(name)).filter((f): f is FrappeFieldMeta => Boolean(f))
+			: metaFields.filter(isDisplayField);
+		return base.slice(0, 8);
+	}, [payload.meta, payload.fields]);
+
+	const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(() => {
+		return displayFields.map((field) => ({
+			id: field.fieldname,
+			accessorKey: field.fieldname,
+			header: ({ column }) => (
+				<Button
+					variant="ghost"
+					onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+					className="h-8 px-2 text-xs rounded text-steel hover:text-ink hover:bg-paper-deep"
+				>
+					{field.label || field.fieldname}
+					<ArrowUpDown className="ml-1 h-3 w-3" />
+				</Button>
+			),
+			cell: ({ row }) => (
+				<span className="text-sm text-ink">
+					{formatFrappeCellValue(row.getValue(field.fieldname), field)}
+				</span>
+			),
+		}));
+	}, [displayFields]);
+
+	const [sorting, setSorting] = useState<SortingState>([]);
+	const table = useReactTable({
+		data: rows,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		onSortingChange: setSorting,
+		state: { sorting },
+	});
+
+	const limitStart = payload.limit_start ?? 0;
+	const limitPageLength = payload.limit_page_length ?? rows.length ?? 20;
+	const totalCount = payload.total_count ?? rows.length;
+	const hasPrev = limitStart > 0;
+	const hasNext = limitStart + limitPageLength < totalCount;
+
+	return (
+		<div className="space-y-3">
+			<div className="rounded-lg border border-line bg-panel overflow-x-auto">
+				<Table>
+					<TableHeader>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id} className="border-line hover:bg-transparent">
+								{headerGroup.headers.map((header) => (
+									<TableHead key={header.id} className="text-steel">
+										{header.isPlaceholder
+											? null
+											: flexRender(header.column.columnDef.header, header.getContext())}
+									</TableHead>
+								))}
+							</TableRow>
+						))}
+					</TableHeader>
+					<TableBody>
+						{table.getRowModel().rows.length ? (
+							table.getRowModel().rows.map((row) => (
+								<TableRow key={row.id} className="border-line hover:bg-paper-deep">
+									{row.getVisibleCells().map((cell) => (
+										<TableCell key={cell.id}>
+											{flexRender(cell.column.columnDef.cell, cell.getContext())}
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						) : (
+							<TableRow className="hover:bg-transparent">
+								<TableCell colSpan={columns.length || 1} className="h-24 text-center text-steel">
+									No records.
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+			</div>
+			<div className="flex items-center justify-between text-xs text-steel-soft">
+				<span>
+					{totalCount > 0
+						? `${limitStart + 1}-${Math.min(limitStart + limitPageLength, totalCount)} of ${totalCount}`
+						: '0 records'}
+				</span>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={!hasPrev}
+						onClick={() => onPageChange?.(Math.max(0, limitStart - limitPageLength), limitPageLength)}
+					>
+						<ChevronLeft className="h-3.5 w-3.5" />
+						Prev
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={!hasNext}
+						onClick={() => onPageChange?.(limitStart + limitPageLength, limitPageLength)}
+					>
+						Next
+						<ChevronRight className="h-3.5 w-3.5" />
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export default FrappeListView;

--- a/frontend/src/components/chat/frappe-views/FrappeListView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeListView.tsx
@@ -22,9 +22,10 @@ import {
 } from '@tanstack/react-table';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
-import { ArrowUpDown, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ArrowUpDown, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
 import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
 import { formatFrappeCellValue, isDisplayField } from './frappeFieldFormat';
+import { deskListUrl } from './frappeDeskUrl';
 
 export interface FrappeListViewProps {
 	payload: FrappeViewPayload;
@@ -89,6 +90,17 @@ export function FrappeListView({ payload, onPageChange }: FrappeListViewProps) {
 
 	return (
 		<div className="space-y-3">
+			<div className="flex justify-end">
+				<a
+					href={deskListUrl(payload.doctype)}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-flex items-center gap-1 text-xs text-steel hover:text-ink"
+				>
+					Open in Desk
+					<ExternalLink className="h-3 w-3" />
+				</a>
+			</div>
 			<div className="rounded-lg border border-line bg-panel overflow-x-auto">
 				<Table>
 					<TableHeader>

--- a/frontend/src/components/chat/frappe-views/FrappeReportView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeReportView.tsx
@@ -22,9 +22,10 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { ArrowUpDown, Filter } from 'lucide-react';
+import { ArrowUpDown, Filter, ExternalLink } from 'lucide-react';
 import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
 import { formatFrappeCellValue, isDisplayField } from './frappeFieldFormat';
+import { deskListUrl } from './frappeDeskUrl';
 
 export interface FrappeReportViewProps {
 	payload: FrappeViewPayload;
@@ -94,6 +95,28 @@ export function FrappeReportView({ payload, onFilterChange }: FrappeReportViewPr
 
 	return (
 		<div className="space-y-3">
+			<div className="flex justify-end">
+				{/* TODO(frappe-views): this artifact mode is not backed by a real
+				 * Frappe Report/Query Report entity - handle_render_frappe_view's
+				 * mode="report" branch is just handle_list_records against
+				 * payload.doctype with different pagination defaults, and the
+				 * payload carries no report name to route /app/query-report/<name>
+				 * to. erpnext_reports.py's handle_list_reports (a separate tool)
+				 * returns report names but no report_type, and isn't wired into
+				 * this payload either, so we can't disambiguate Query Report vs.
+				 * Report Builder here. Linking to the underlying doctype's Desk
+				 * list view instead, same as list mode - see PLAN.md's Phase 4
+				 * finding for the full writeup. */}
+				<a
+					href={deskListUrl(payload.doctype)}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-flex items-center gap-1 text-xs text-steel hover:text-ink"
+				>
+					Open in Desk
+					<ExternalLink className="h-3 w-3" />
+				</a>
+			</div>
 			<div className="rounded-lg border border-line bg-panel p-3">
 				<div className="flex items-center gap-1.5 mb-2 text-xs text-steel">
 					<Filter className="h-3.5 w-3.5" />

--- a/frontend/src/components/chat/frappe-views/FrappeReportView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeReportView.tsx
@@ -1,0 +1,162 @@
+/**
+ * Renders a frappe-report artifact payload (see
+ * huf/ai/tools/frappe_generic.py::handle_render_frappe_view, mode="report")
+ * as a table (same shape as FrappeListView) with a filter bar above it: one
+ * simple input per filterable field from `meta.fields`.
+ *
+ * Like FrappeListView's pager, `onFilterChange` is a stub - it reports the
+ * filters the user typed, wiring them to an actual tool re-invocation and
+ * refetch is a follow-up.
+ */
+
+import { useMemo, useState } from 'react';
+import {
+	type ColumnDef,
+	getCoreRowModel,
+	getSortedRowModel,
+	useReactTable,
+	flexRender,
+	type SortingState,
+} from '@tanstack/react-table';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ArrowUpDown, Filter } from 'lucide-react';
+import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
+import { formatFrappeCellValue, isDisplayField } from './frappeFieldFormat';
+
+export interface FrappeReportViewProps {
+	payload: FrappeViewPayload;
+	/** Called with the full filter map whenever a filter input changes.
+	 * Actually re-running the query against the backend tool is a
+	 * follow-up - this component only tracks and reports filter state. */
+	onFilterChange?: (filters: Record<string, string>) => void;
+}
+
+export function FrappeReportView({ payload, onFilterChange }: FrappeReportViewProps) {
+	const rows = useMemo(
+		() => (Array.isArray(payload.data) ? payload.data : [payload.data]),
+		[payload.data]
+	);
+
+	const displayFields = useMemo<FrappeFieldMeta[]>(() => {
+		const metaFields = payload.meta?.fields ?? [];
+		const requested = payload.fields;
+		const byName = new Map(metaFields.map((f) => [f.fieldname, f]));
+		const base = requested?.length
+			? requested.map((name) => byName.get(name)).filter((f): f is FrappeFieldMeta => Boolean(f))
+			: metaFields.filter(isDisplayField);
+		return base.slice(0, 8);
+	}, [payload.meta, payload.fields]);
+
+	const [filters, setFilters] = useState<Record<string, string>>({});
+
+	const updateFilter = (fieldname: string, value: string) => {
+		setFilters((prev) => {
+			const next = { ...prev, [fieldname]: value };
+			onFilterChange?.(next);
+			return next;
+		});
+	};
+
+	const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(() => {
+		return displayFields.map((field) => ({
+			id: field.fieldname,
+			accessorKey: field.fieldname,
+			header: ({ column }) => (
+				<Button
+					variant="ghost"
+					onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+					className="h-8 px-2 text-xs rounded text-steel hover:text-ink hover:bg-paper-deep"
+				>
+					{field.label || field.fieldname}
+					<ArrowUpDown className="ml-1 h-3 w-3" />
+				</Button>
+			),
+			cell: ({ row }) => (
+				<span className="text-sm text-ink">
+					{formatFrappeCellValue(row.getValue(field.fieldname), field)}
+				</span>
+			),
+		}));
+	}, [displayFields]);
+
+	const [sorting, setSorting] = useState<SortingState>([]);
+	const table = useReactTable({
+		data: rows,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		onSortingChange: setSorting,
+		state: { sorting },
+	});
+
+	return (
+		<div className="space-y-3">
+			<div className="rounded-lg border border-line bg-panel p-3">
+				<div className="flex items-center gap-1.5 mb-2 text-xs text-steel">
+					<Filter className="h-3.5 w-3.5" />
+					Filters
+				</div>
+				<div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+					{displayFields.map((field) => (
+						<div key={field.fieldname} className="space-y-1">
+							<Label htmlFor={`filter-${field.fieldname}`} className="text-[11px] text-steel-soft">
+								{field.label || field.fieldname}
+							</Label>
+							<Input
+								id={`filter-${field.fieldname}`}
+								size="sm"
+								value={filters[field.fieldname] ?? ''}
+								onChange={(e) => updateFilter(field.fieldname, e.target.value)}
+								placeholder="Any"
+							/>
+						</div>
+					))}
+				</div>
+			</div>
+			<div className="rounded-lg border border-line bg-panel overflow-x-auto">
+				<Table>
+					<TableHeader>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<TableRow key={headerGroup.id} className="border-line hover:bg-transparent">
+								{headerGroup.headers.map((header) => (
+									<TableHead key={header.id} className="text-steel">
+										{header.isPlaceholder
+											? null
+											: flexRender(header.column.columnDef.header, header.getContext())}
+									</TableHead>
+								))}
+							</TableRow>
+						))}
+					</TableHeader>
+					<TableBody>
+						{table.getRowModel().rows.length ? (
+							table.getRowModel().rows.map((row) => (
+								<TableRow key={row.id} className="border-line hover:bg-paper-deep">
+									{row.getVisibleCells().map((cell) => (
+										<TableCell key={cell.id}>
+											{flexRender(cell.column.columnDef.cell, cell.getContext())}
+										</TableCell>
+									))}
+								</TableRow>
+							))
+						) : (
+							<TableRow className="hover:bg-transparent">
+								<TableCell colSpan={columns.length || 1} className="h-24 text-center text-steel">
+									No records.
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+			</div>
+			<div className="text-xs text-steel-soft">
+				{payload.total_count ?? rows.length} record(s)
+			</div>
+		</div>
+	);
+}
+
+export default FrappeReportView;

--- a/frontend/src/components/chat/frappe-views/FrappeReportView.tsx
+++ b/frontend/src/components/chat/frappe-views/FrappeReportView.tsx
@@ -4,12 +4,13 @@
  * as a table (same shape as FrappeListView) with a filter bar above it: one
  * simple input per filterable field from `meta.fields`.
  *
- * Like FrappeListView's pager, `onFilterChange` is a stub - it reports the
- * filters the user typed, wiring them to an actual tool re-invocation and
- * refetch is a follow-up.
+ * Filter edits re-fetch through `frappe.client.get_list` (via frappe-js-sdk's
+ * `db.getDocList`, debounced) the same way FrappeListView's pager does - see
+ * that file's header comment for why this goes through the framework's own
+ * whitelisted list method rather than back through the agent/tool layer.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
 	type ColumnDef,
 	getCoreRowModel,
@@ -22,24 +23,24 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { ArrowUpDown, Filter, ExternalLink } from 'lucide-react';
+import { ArrowUpDown, Filter, ExternalLink, Loader2 } from 'lucide-react';
+import { db, call } from '@/lib/frappe-sdk';
 import type { FrappeFieldMeta, FrappeViewPayload } from '@/types/artifact.types';
 import { formatFrappeCellValue, isDisplayField } from './frappeFieldFormat';
 import { deskListUrl } from './frappeDeskUrl';
 
 export interface FrappeReportViewProps {
 	payload: FrappeViewPayload;
-	/** Called with the full filter map whenever a filter input changes.
-	 * Actually re-running the query against the backend tool is a
-	 * follow-up - this component only tracks and reports filter state. */
-	onFilterChange?: (filters: Record<string, string>) => void;
 }
 
-export function FrappeReportView({ payload, onFilterChange }: FrappeReportViewProps) {
-	const rows = useMemo(
-		() => (Array.isArray(payload.data) ? payload.data : [payload.data]),
-		[payload.data]
+export function FrappeReportView({ payload }: FrappeReportViewProps) {
+	const [rows, setRows] = useState<Record<string, unknown>[]>(() =>
+		Array.isArray(payload.data) ? payload.data : [payload.data]
 	);
+	const [totalCount, setTotalCount] = useState(payload.total_count ?? rows.length);
+	const [loading, setLoading] = useState(false);
+	const [fetchError, setFetchError] = useState<string | null>(null);
+	const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
 	const displayFields = useMemo<FrappeFieldMeta[]>(() => {
 		const metaFields = payload.meta?.fields ?? [];
@@ -53,13 +54,48 @@ export function FrappeReportView({ payload, onFilterChange }: FrappeReportViewPr
 
 	const [filters, setFilters] = useState<Record<string, string>>({});
 
+	const runQuery = async (nextFilters: Record<string, string>) => {
+		setLoading(true);
+		setFetchError(null);
+		try {
+			const fieldNames = displayFields.map((f) => f.fieldname);
+			const activeFilters = Object.entries(nextFilters)
+				.filter(([, value]) => value.trim() !== '')
+				.map(([fieldname, value]) => [fieldname, 'like', `%${value}%`] as [string, 'like', string]);
+			const result = await db.getDocList(payload.doctype, {
+				fields: fieldNames.length ? fieldNames : undefined,
+				filters: activeFilters.length ? (activeFilters as never) : undefined,
+				limit: payload.limit_page_length ?? 100,
+			});
+			setRows(result as unknown as Record<string, unknown>[]);
+			const countResponse = await call.get('frappe.client.get_count', {
+				doctype: payload.doctype,
+				...(activeFilters.length ? { filters: JSON.stringify(activeFilters) } : {}),
+			});
+			const count = Number(countResponse?.message);
+			if (!Number.isNaN(count)) setTotalCount(count);
+		} catch (error) {
+			console.error('Failed to re-run Frappe report query:', error);
+			setFetchError('Could not apply filters - showing the last loaded data.');
+		} finally {
+			setLoading(false);
+		}
+	};
+
 	const updateFilter = (fieldname: string, value: string) => {
 		setFilters((prev) => {
 			const next = { ...prev, [fieldname]: value };
-			onFilterChange?.(next);
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+			debounceRef.current = setTimeout(() => runQuery(next), 400);
 			return next;
 		});
 	};
+
+	useEffect(() => {
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+		};
+	}, []);
 
 	const columns = useMemo<ColumnDef<Record<string, unknown>>[]>(() => {
 		return displayFields.map((field) => ({
@@ -175,8 +211,10 @@ export function FrappeReportView({ payload, onFilterChange }: FrappeReportViewPr
 					</TableBody>
 				</Table>
 			</div>
-			<div className="text-xs text-steel-soft">
-				{payload.total_count ?? rows.length} record(s)
+			<div className="flex items-center gap-2 text-xs text-steel-soft">
+				{loading && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+				<span>{totalCount} record(s)</span>
+				{fetchError && <span className="text-destructive">{fetchError}</span>}
 			</div>
 		</div>
 	);

--- a/frontend/src/components/chat/frappe-views/frappeDeskUrl.ts
+++ b/frontend/src/components/chat/frappe-views/frappeDeskUrl.ts
@@ -1,0 +1,26 @@
+/**
+ * Builds "Open in Desk" links for the frappe-list/form/report artifact
+ * views. Safe to do with a plain <a href> (no client-side routing, no
+ * SSO/token handoff) because huf's frontend is installed as a Frappe app on
+ * the same site/session as Desk in the standard deployment - see
+ * Tracks/safwan-erooth.DeskAIArtifactWorkspace/PLAN.md, "Phase 4 finding".
+ *
+ * No existing doctype -> Desk-route slug helper was found in this repo (nor
+ * in the vendored frappe framework we could locate under the time available
+ * for this change) to reuse, so this mirrors Frappe's well-known desk
+ * router convention (frappe/public/js/frappe/router.js
+ * get_doctype_route/slug): lowercase, spaces to dashes. e.g. "Sales
+ * Invoice" -> "sales-invoice", "HD Ticket" -> "hd-ticket".
+ */
+
+export function doctypeSlug(doctype: string): string {
+	return doctype.trim().toLowerCase().replace(/ /g, '-');
+}
+
+export function deskListUrl(doctype: string): string {
+	return `/app/${doctypeSlug(doctype)}`;
+}
+
+export function deskFormUrl(doctype: string, name: string): string {
+	return `/app/${doctypeSlug(doctype)}/${encodeURIComponent(name)}`;
+}

--- a/frontend/src/components/chat/frappe-views/frappeFieldFormat.ts
+++ b/frontend/src/components/chat/frappe-views/frappeFieldFormat.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared cell/label formatting helpers for the frappe-list and
+ * frappe-report artifact views. Kept separate from the two view components
+ * since both need the exact same "how do I render this fieldtype" logic.
+ */
+
+import type { FrappeFieldMeta } from '@/types/artifact.types';
+
+/** Fieldtypes that are pure layout in Desk and never carry a value - the
+ * same set frappe_generic.py already strips out of `meta.fields` server
+ * side, kept here too in case a caller passes raw doctype meta through. */
+const LAYOUT_FIELDTYPES = new Set(['Section Break', 'Column Break', 'Tab Break', 'HTML', 'Button']);
+
+export function isDisplayField(field: FrappeFieldMeta): boolean {
+	return !LAYOUT_FIELDTYPES.has(field.fieldtype);
+}
+
+/** Render one cell value for a list/report table column, based on the
+ * field's Frappe fieldtype. Link fields are rendered as plain text (the
+ * value is just the linked doctype's name) - following the target
+ * doctype is a follow-up, not required here. */
+export function formatFrappeCellValue(value: unknown, field: FrappeFieldMeta): string {
+	if (value === null || value === undefined || value === '') {
+		return '-';
+	}
+
+	switch (field.fieldtype) {
+		case 'Check':
+			return value ? 'Yes' : 'No';
+		case 'Currency':
+		case 'Float':
+			return typeof value === 'number' ? value.toFixed(2) : String(value);
+		case 'Percent':
+			return `${value}%`;
+		case 'Date':
+		case 'Datetime': {
+			const d = new Date(String(value));
+			return Number.isNaN(d.getTime()) ? String(value) : d.toLocaleString();
+		}
+		case 'Link':
+		case 'Dynamic Link':
+			// Text only - the value is the linked doc's name, not a live link.
+			return String(value);
+		default:
+			return String(value);
+	}
+}

--- a/frontend/src/types/artifact.types.ts
+++ b/frontend/src/types/artifact.types.ts
@@ -12,7 +12,10 @@ export type ArtifactType =
 	| 'markdown'
 	| 'jsx'
 	| 'chart'
-	| 'video';
+	| 'video'
+	| 'frappe-list'
+	| 'frappe-form'
+	| 'frappe-report';
 
 export interface ParsedArtifact {
 	id: string;
@@ -46,4 +49,67 @@ export interface WebPreviewParseResult {
 export interface JSXPreviewParseResult {
 	text: string;
 	previews: ParsedJSXPreview[];
+}
+
+/**
+ * Types for the frappe-list / frappe-form / frappe-report artifact payload
+ * emitted by huf/ai/tools/frappe_generic.py::handle_render_frappe_view.
+ *
+ * These mirror the JSON shape exactly as produced by
+ * `_describe_field`/`handle_get_doctype_meta` in that module - see it before
+ * changing these, since the backend is the source of truth for field keys.
+ */
+
+/** One DocField as described by `_describe_field` in frappe_generic.py. */
+export interface FrappeFieldMeta {
+	fieldname: string;
+	label: string | null;
+	fieldtype: string;
+	options: string | null;
+	reqd: boolean;
+	read_only: boolean;
+	depends_on: string | null;
+	fetch_from: string | null;
+	/** Present only when fieldtype === 'Select'. */
+	select_options?: string[];
+	/** Present only when fieldtype === 'Link' - the target doctype name. */
+	link_doctype?: string;
+	/** Present only when fieldtype === 'Table'. */
+	child_doctype?: string;
+	child_fields?: FrappeFieldMeta[];
+	child_fields_error?: string;
+}
+
+/** The `meta` object nested in every frappe-* artifact payload - the raw
+ * return value of handle_get_doctype_meta, not re-wrapped. */
+export interface FrappeDoctypeMeta {
+	success: boolean;
+	doctype: string;
+	is_submittable: boolean;
+	title_field: string | null;
+	fields: FrappeFieldMeta[];
+}
+
+export type FrappeViewMode = 'list' | 'form' | 'report';
+
+/**
+ * Envelope shape common to frappe-list, frappe-form, and frappe-report
+ * artifacts. `data` is a record array for list/report mode and a single
+ * record object for form mode - narrow on `mode` before using it.
+ *
+ * NOTE: unlike handle_list_records's raw JSON, handle_render_frappe_view does
+ * NOT copy limit_start/limit_page_length into the payload for list/report
+ * mode (only total_count) - see frappe_generic.py lines ~490-522. Views must
+ * track pagination client-side rather than reading it off this payload.
+ */
+export interface FrappeViewPayload {
+	doctype: string;
+	mode: FrappeViewMode;
+	meta: FrappeDoctypeMeta;
+	filters?: Record<string, unknown> | unknown[] | null;
+	fields?: string[] | null;
+	data: Record<string, unknown>[] | Record<string, unknown>;
+	total_count?: number;
+	limit_start?: number;
+	limit_page_length?: number;
 }

--- a/frontend/src/types/artifact.types.ts
+++ b/frontend/src/types/artifact.types.ts
@@ -97,10 +97,8 @@ export type FrappeViewMode = 'list' | 'form' | 'report';
  * artifacts. `data` is a record array for list/report mode and a single
  * record object for form mode - narrow on `mode` before using it.
  *
- * NOTE: unlike handle_list_records's raw JSON, handle_render_frappe_view does
- * NOT copy limit_start/limit_page_length into the payload for list/report
- * mode (only total_count) - see frappe_generic.py lines ~490-522. Views must
- * track pagination client-side rather than reading it off this payload.
+ * `limit_start`/`limit_page_length` are present for list/report mode only
+ * (mirrors handle_list_records's raw JSON); absent for form mode.
  */
 export interface FrappeViewPayload {
 	doctype: string;

--- a/frontend/src/utils/artifactParser.ts
+++ b/frontend/src/utils/artifactParser.ts
@@ -107,6 +107,9 @@ export function isValidArtifactType(type: string): type is ArtifactType {
 		'markdown',
 		'video',
 		'chart',
+		'frappe-list',
+		'frappe-form',
+		'frappe-report',
 	];
 	return validTypes.includes(type as ArtifactType);
 }

--- a/huf/ai/artifact_extraction.py
+++ b/huf/ai/artifact_extraction.py
@@ -50,6 +50,9 @@ VALID_ARTIFACT_TYPES = {
 	"image",
 	"web-preview",
 	"text",
+	"frappe-list",
+	"frappe-form",
+	"frappe-report",
 }
 
 #: Agent Message roles that represent an assistant/agent turn, as opposed to

--- a/huf/ai/artifact_instructions.py
+++ b/huf/ai/artifact_instructions.py
@@ -81,7 +81,10 @@ Example calls:
 - Form mode: render_frappe_view(doctype="Task", mode="form", name="TASK-001")
 - Report mode: render_frappe_view(doctype="Sales Invoice", mode="report", filters={"status": "Draft"})
 
-The tool returns complete <artifact> tags — relay them as-is in your response.
+The tool returns complete <artifact> tags — relay them as-is in your response. Copy the
+JSON body character-for-character; do not retype it, reformat it, or rename any of its
+keys (in particular, the record/rows key is always "data" — never rename it to "doc" or
+anything else).
 
 GENERAL RULES:
 - Only use the tags above (plus the chart artifact format described separately). Unknown types render as plain text.

--- a/huf/ai/artifact_instructions.py
+++ b/huf/ai/artifact_instructions.py
@@ -71,6 +71,18 @@ Always use this open/close form and put the JSX in the tag body. Never pass JSX
 via a jsx="..." attribute — JSX contains > and quote characters, which terminate
 the attribute early and cause the whole element to be dropped without rendering.
 
+7. FRAPPE DATA VIEWS (frappe-list, frappe-form, frappe-report)
+When the user asks to see/list/browse/filter records of a Frappe/ERPNext doctype,
+fill out a form, or view a report, call render_frappe_view with mode='list'|'form'|'report'
+instead of returning raw JSON. Return its artifact tag verbatim.
+
+Example calls:
+- List mode: render_frappe_view(doctype="Customer", mode="list", filters=[["disabled", "=", 0]])
+- Form mode: render_frappe_view(doctype="Task", mode="form", name="TASK-001")
+- Report mode: render_frappe_view(doctype="Sales Invoice", mode="report", filters={"status": "Draft"})
+
+The tool returns complete <artifact> tags — relay them as-is in your response.
+
 GENERAL RULES:
 - Only use the tags above (plus the chart artifact format described separately). Unknown types render as plain text.
 - Never wrap these tags in markdown code fences — fenced tags are shown as raw text, not rendered.

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -442,6 +442,79 @@ ERPNEXT_REPORT_TOOLS = [
         ],
     },
 ]
+FRAPPE_GENERIC_TOOLS = [
+    {
+        "tool_name": "frappe_get_doctype_meta",
+        "description": "Get the field schema for any doctype: fieldname, label, fieldtype, options, reqd, read_only, depends_on, fetch_from. Select fields include their option list; Link fields include the linked doctype; Table fields include one level of child-doctype field schema. Denies User, Role, Role Profile, *Script, Property Setter, File, OAuth*/Integration* doctypes, and Single doctypes.",
+        "function_path": "huf.ai.tools.frappe_generic.handle_get_doctype_meta",
+        "category": "Frappe Generic Tools",
+        "parameters": [
+            _p("doctype", required=True, description="Target DocType name, e.g. 'Task', 'Project'"),
+        ],
+    },
+    {
+        "tool_name": "frappe_list_records",
+        "description": "List records of any doctype with filters, field selection, and pagination — a generic read, permission- and permlevel-checked. Use frappe_get_doctype_meta first if you don't know the doctype's fields.",
+        "function_path": "huf.ai.tools.frappe_generic.handle_list_records",
+        "category": "Frappe Generic Tools",
+        "parameters": [
+            _p("doctype", required=True, description="Target DocType name"),
+            _p("filters", type="json", description="JSON filter dict or list of [fieldname, operator, value] conditions"),
+            _p("fields", type="json", description="JSON list of fieldnames to return (default: all fields readable by your roles)"),
+            _p("limit_start", type="integer", description="Offset for pagination (default 0)"),
+            _p("limit_page_length", type="integer", description="Max rows to return (default 20)"),
+            _p("order_by", description="SQL-style order-by clause, e.g. 'modified desc'"),
+        ],
+    },
+    {
+        "tool_name": "frappe_get_record",
+        "description": "Get a single record of any doctype by name, permission- and permlevel-checked.",
+        "function_path": "huf.ai.tools.frappe_generic.handle_get_record",
+        "category": "Frappe Generic Tools",
+        "parameters": [
+            _p("doctype", required=True, description="Target DocType name"),
+            _p("name", required=True, description="Document name/ID"),
+        ],
+    },
+    {
+        "tool_name": "frappe_create_record",
+        "description": "Validate a proposed new record for any doctype (permission check, field allowlist, required-field check) and return a DRAFT payload. This does NOT write to the database — the actual create happens client-side, as the logged-in user, through the normal Frappe REST API.",
+        "function_path": "huf.ai.tools.frappe_generic.handle_create_record",
+        "category": "Frappe Generic Tools",
+        "parameters": [
+            _p("doctype", required=True, description="Target DocType name"),
+            _p("values", type="json", required=True, description="JSON object of fieldname/value pairs for the new record"),
+        ],
+    },
+    {
+        "tool_name": "frappe_update_record",
+        "description": "Validate a proposed field update to an existing record of any doctype (permission check, field allowlist) and return a DRAFT payload. This does NOT write to the database — the actual update happens client-side, as the logged-in user, through the normal Frappe REST API.",
+        "function_path": "huf.ai.tools.frappe_generic.handle_update_record",
+        "category": "Frappe Generic Tools",
+        "parameters": [
+            _p("doctype", required=True, description="Target DocType name"),
+            _p("name", required=True, description="Document name/ID to update"),
+            _p("values", type="json", required=True, description="JSON object of fieldname/value pairs to change"),
+        ],
+    },
+    {
+        "tool_name": "render_frappe_view",
+        "description": "Fetch data/meta for any doctype and emit it as a frappe-list, frappe-form, or frappe-report <artifact> block for the frontend to render, instead of returning raw JSON. Returns the complete <artifact> tag — relay it verbatim in your response.",
+        "function_path": "huf.ai.tools.frappe_generic.handle_render_frappe_view",
+        "category": "Frappe Generic Tools",
+        "parameters": [
+            _p("doctype", required=True, description="Target DocType name"),
+            _p("mode", required=True, description="One of 'list', 'form', 'report'"),
+            _p("filters", type="json", description="JSON filter dict/list (list and report modes)"),
+            _p("fields", type="json", description="JSON list of fieldnames to include"),
+            _p("name", description="Document name (form mode)"),
+            _p("limit_start", type="integer", description="Offset for pagination (list/report modes)"),
+            _p("limit_page_length", type="integer", description="Max rows (list/report modes)"),
+            _p("order_by", description="SQL-style order-by clause"),
+        ],
+    },
+]
+
 GMAIL_TOOLS = [
 	{
 		"tool_name": "gmail_get_emails",
@@ -1953,6 +2026,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ ERPNEXT_CRM_TOOLS
 	+ ERPNEXT_INVENTORY_TOOLS
 	+ ERPNEXT_REPORT_TOOLS
+	+ FRAPPE_GENERIC_TOOLS
 	+ BUILDER_TOOLS
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS

--- a/huf/ai/tools/erpnext_reports.py
+++ b/huf/ai/tools/erpnext_reports.py
@@ -93,6 +93,10 @@ def handle_run_report(**kwargs) -> str:
             except Exception:
                 return _error("filters must be a JSON object or dict")
 
+        # Extract pagination parameters
+        limit_start = kwargs.get("limit_start", 0)
+        limit_page_length = kwargs.get("limit_page_length", 20)
+
         # Fill company default if not provided
         if not filters.get("company"):
             default_company = frappe.defaults.get_user_default("Company") or frappe.db.get_single_value("Global Defaults", "default_company")
@@ -104,7 +108,7 @@ def handle_run_report(**kwargs) -> str:
             fiscal_year = filters.get("fiscal_year")
             if not fiscal_year:
                 fiscal_year = frappe.defaults.get_user_default("Fiscal Year") or frappe.db.get_single_value("Global Defaults", "current_fiscal_year")
-            
+
             if fiscal_year:
                 try:
                     fy_doc = None
@@ -114,7 +118,7 @@ def handle_run_report(**kwargs) -> str:
                         fy_list = frappe.get_all("Fiscal Year", filters={"name": ("like", f"%{fiscal_year}%")}, limit=1)
                         if fy_list:
                             fy_doc = frappe.get_doc("Fiscal Year", fy_list[0].name)
-                    
+
                     if fy_doc:
                         filters["from_date"] = fy_doc.year_start_date
                         filters["to_date"] = fy_doc.year_end_date
@@ -129,13 +133,20 @@ def handle_run_report(**kwargs) -> str:
             filters["periodicity"] = "Yearly"
 
         from frappe.desk.query_report import run as run_report
-        result = run_report(report_name=report_name, filters=filters, ignore_prepared_report=True)
+        result = run_report(report_name=report_name, filters=filters, ignore_prepared_report=True, limit_start=limit_start, limit_page_length=limit_page_length)
+
+        # frappe.desk.query_report.run does not expose total row count; only paginated results are returned
+        total_count = None
+
         return json.dumps({
             "success": True,
             "report_name": report_name,
             "columns": result.get("columns", []),
             "results": result.get("result", []),
             "count": len(result.get("result", [])),
+            "limit_start": limit_start,
+            "limit_page_length": limit_page_length,
+            "total_count": total_count,
         }, default=str)
     except Exception as e:
         logger.warning(f"ERPNext Report Error [{report_name}]: {e}")

--- a/huf/ai/tools/frappe_generic.py
+++ b/huf/ai/tools/frappe_generic.py
@@ -1,0 +1,527 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""Generic, doctype-agnostic Frappe tools for an LLM agent.
+
+Unlike huf/ai/tools/erpnext*.py (which wrap a fixed, curated set of business
+doctypes), these handlers accept an arbitrary ``doctype`` argument supplied by
+the model at call time. That is exactly the shape of tool an agent can be led
+into misusing - by a crafted prompt, a confused multi-step plan, or plain
+hallucination - to read or write doctypes it was never meant to touch (User,
+Role, Custom Script, ...). Every handler in this module MUST therefore run
+through ``_check_doctype_allowed`` and ``_check_permission`` before it reads
+or writes anything, and MUST go through ``frappe.get_list``/``frappe.get_doc``
+(which apply permission-query conditions) rather than raw SQL.
+
+``handle_create_record`` and ``handle_update_record`` do not write to the
+database at all - see their docstrings. The write happens client-side, as the
+logged-in user, through the normal Frappe REST path; this module only ever
+validates and returns a draft payload for a create/update.
+"""
+
+import json
+
+import frappe
+from frappe.model import default_fields
+
+logger = frappe.logger("huf")
+
+
+# ---------------------------------------------------------------------------
+# Shared security helpers - every handler below goes through both of these.
+# ---------------------------------------------------------------------------
+
+#: Exact doctype names (case-insensitive) that are never accessible through
+#: this generic surface, regardless of the caller's roles. These are either
+#: security-sensitive (User, Role, *Script, Property Setter, File — which
+#: guards arbitrary file records, not just literal uploads) or would let an
+#: agent read/manufacture privilege (Role Profile).
+_DENYLISTED_DOCTYPES = {
+    "user",
+    "role",
+    "role profile",
+    "custom script",
+    "server script",
+    "property setter",
+    "file",
+}
+
+#: Doctype name PREFIXES (case-insensitive) that are denied wholesale, since
+#: individual doctype names under these families change across versions/apps
+#: (e.g. "OAuth Client", "OAuth Bearer Token", "Integration Request",
+#: "Integration Service") and an allowlist-by-exact-name would miss new ones.
+_DENYLISTED_PREFIXES = ("oauth", "integration")
+
+
+def _error(msg: str) -> str:
+    return json.dumps({"success": False, "error": msg}, default=str)
+
+
+def _check_doctype_allowed(doctype: str):
+    """Return ``(meta, None)`` if ``doctype`` may be accessed through this
+    module, or ``(None, error_json_str)`` if it is denied.
+
+    Deny-by-default on top of the explicit denylist: any doctype that does
+    not exist, or whose meta cannot be loaded, is denied rather than silently
+    passed through.
+    """
+    if not doctype or not isinstance(doctype, str):
+        return None, _error("'doctype' is required")
+
+    normalized = doctype.strip().lower()
+    if normalized in _DENYLISTED_DOCTYPES:
+        return None, _error(f"Access to doctype '{doctype}' is not permitted through this tool.")
+    if normalized.startswith(_DENYLISTED_PREFIXES):
+        return None, _error(f"Access to doctype '{doctype}' is not permitted through this tool.")
+
+    try:
+        if not frappe.db.exists("DocType", doctype):
+            return None, _error(f"DocType '{doctype}' does not exist.")
+        meta = frappe.get_meta(doctype)
+    except Exception as e:
+        return None, _error(f"Could not load DocType '{doctype}': {e}")
+
+    # Single doctypes (e.g. System Settings, Global Defaults) hold one
+    # site-wide configuration row apiece rather than a set of business
+    # records - listing/creating/updating "records" for one makes no sense
+    # in this tool's model and often exposes sensitive site config.
+    if meta.issingle:
+        return None, _error(f"'{doctype}' is a Single doctype and is not accessible through this tool.")
+
+    return meta, None
+
+
+def _check_permission(doctype: str, ptype: str, doc=None):
+    """Return an error JSON string if the current user lacks ``ptype``
+    permission on ``doctype`` (optionally scoped to a specific ``doc`` name),
+    or ``None`` if the check passes.
+
+    Always goes through ``frappe.has_permission`` - the single source of
+    truth for role permissions, user permissions, and permission-query
+    conditions - never a hand-rolled role check.
+    """
+    try:
+        allowed = frappe.has_permission(doctype, ptype=ptype, doc=doc)
+    except Exception as e:
+        return _error(f"Permission check failed for {doctype}: {e}")
+
+    if not allowed:
+        target = f"{doctype} {doc}" if doc else doctype
+        return _error(f"You do not have '{ptype}' permission on {target}.")
+    return None
+
+
+def _permitted_fieldnames(doctype: str, permission_type: str = "read") -> set:
+    """Fieldnames the current user's roles may access at their permlevel,
+    per ``frappe.permissions.get_permitted_fields`` - the same permlevel
+    gate ``frappe.get_list``/``frappe.client.get_list`` apply internally.
+
+    NOT 100% verified against every Frappe version's exact signature/return
+    shape (flagged in the implementation report) - wrapped defensively so a
+    signature mismatch fails closed (returns "no extra fields visible")
+    rather than silently leaking permlevel-restricted fields.
+    """
+    try:
+        fields = frappe.permissions.get_permitted_fields(doctype=doctype, permission_type=permission_type)
+        return set(fields)
+    except Exception:
+        logger.warning(f"frappe_generic: get_permitted_fields failed for {doctype}, falling back to permlevel-0 fields only")
+        try:
+            meta = frappe.get_meta(doctype)
+            return {df.fieldname for df in meta.fields if not getattr(df, "permlevel", 0)}
+        except Exception:
+            return set()
+
+
+def _filter_permitted(doctype: str, row: dict, permission_type: str = "read") -> dict:
+    """Strip keys from ``row`` that the current user's roles cannot read at
+    their permlevel. Standard doc fields (name, owner, creation, ...) are
+    always kept since they carry no permlevel and are not user-defined.
+    """
+    permitted = _permitted_fieldnames(doctype, permission_type) | set(default_fields)
+    return {k: v for k, v in row.items() if k in permitted}
+
+
+def _describe_field(df) -> dict:
+    """Build the JSON-safe description of one DocField used by
+    handle_get_doctype_meta, including type-specific detail (Select options,
+    Link target doctype, one level of recursive Table child meta).
+    """
+    field = {
+        "fieldname": df.fieldname,
+        "label": df.label,
+        "fieldtype": df.fieldtype,
+        "options": df.options,
+        "reqd": bool(df.reqd),
+        "read_only": bool(df.read_only),
+        "depends_on": df.depends_on,
+        "fetch_from": df.fetch_from,
+    }
+
+    if df.fieldtype == "Select":
+        field["select_options"] = [opt for opt in (df.options or "").split("\n") if opt != ""]
+    elif df.fieldtype == "Link":
+        field["link_doctype"] = df.options
+    elif df.fieldtype == "Table" and df.options:
+        try:
+            child_meta = frappe.get_meta(df.options)
+            field["child_doctype"] = df.options
+            field["child_fields"] = [
+                _describe_field(child_df)
+                for child_df in child_meta.fields
+                if child_df.fieldtype not in ("Section Break", "Column Break", "Tab Break", "HTML", "Button")
+            ]
+        except Exception as e:
+            field["child_doctype"] = df.options
+            field["child_fields_error"] = str(e)
+
+    return field
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def handle_get_doctype_meta(**kwargs) -> str:
+    """Return the field schema for a doctype: fieldname, label, fieldtype,
+    options, reqd, read_only, depends_on, fetch_from - with Select options
+    expanded, Link target doctypes named, and Table child doctypes described
+    one level deep.
+    """
+    doctype = (kwargs.get("doctype") or "").strip()
+    meta, err = _check_doctype_allowed(doctype)
+    if err:
+        return err
+
+    err = _check_permission(doctype, "read")
+    if err:
+        return err
+
+    fields = [
+        _describe_field(df)
+        for df in meta.fields
+        if df.fieldtype not in ("Section Break", "Column Break", "Tab Break", "HTML", "Button")
+    ]
+
+    return json.dumps({
+        "success": True,
+        "doctype": doctype,
+        "is_submittable": bool(meta.is_submittable),
+        "title_field": meta.get("title_field"),
+        "fields": fields,
+    }, default=str)
+
+
+def handle_list_records(**kwargs) -> str:
+    """Generic list of records for a doctype, via frappe.get_list (which
+    applies permission-query conditions), with permlevel field filtering and
+    pagination.
+    """
+    doctype = (kwargs.get("doctype") or "").strip()
+    meta, err = _check_doctype_allowed(doctype)
+    if err:
+        return err
+
+    err = _check_permission(doctype, "read")
+    if err:
+        return err
+
+    filters = kwargs.get("filters")
+    if isinstance(filters, str) and filters.strip():
+        try:
+            filters = json.loads(filters)
+        except Exception:
+            return _error("'filters' must be a JSON object/list or a dict")
+
+    requested_fields = kwargs.get("fields")
+    if isinstance(requested_fields, str) and requested_fields.strip():
+        try:
+            requested_fields = json.loads(requested_fields)
+        except Exception:
+            return _error("'fields' must be a JSON list of fieldnames")
+
+    permitted = _permitted_fieldnames(doctype, "read")
+    if requested_fields:
+        fields = [f for f in requested_fields if f in permitted or f in default_fields or f == "name"]
+    else:
+        fields = ["name"] + sorted(permitted - {"name"})
+
+    try:
+        limit_start = int(kwargs.get("limit_start") or 0)
+        limit_page_length = int(kwargs.get("limit_page_length") or 20)
+    except (TypeError, ValueError):
+        return _error("'limit_start' and 'limit_page_length' must be integers")
+
+    order_by = kwargs.get("order_by")
+
+    try:
+        data = frappe.get_list(
+            doctype,
+            filters=filters,
+            fields=fields,
+            limit_start=limit_start,
+            limit_page_length=limit_page_length,
+            order_by=order_by,
+        )
+        total_count = frappe.db.count(doctype, filters=filters)
+    except frappe.PermissionError:
+        return _error(f"You do not have permission to list {doctype} records.")
+    except Exception as e:
+        logger.warning(f"handle_list_records failed for {doctype}: {e}")
+        return _error(str(e))
+
+    return json.dumps({
+        "success": True,
+        "data": data,
+        "total_count": total_count,
+        "limit_start": limit_start,
+        "limit_page_length": limit_page_length,
+    }, default=str)
+
+
+def handle_get_record(**kwargs) -> str:
+    """Fetch one record by name, after a permission check, with
+    permlevel-restricted fields stripped from the result."""
+    doctype = (kwargs.get("doctype") or "").strip()
+    name = kwargs.get("name")
+
+    meta, err = _check_doctype_allowed(doctype)
+    if err:
+        return err
+    if not name:
+        return _error("'name' is required")
+
+    err = _check_permission(doctype, "read", doc=name)
+    if err:
+        return err
+
+    try:
+        doc = frappe.get_doc(doctype, name)
+    except frappe.DoesNotExistError:
+        return _error(f"No {doctype} found with name '{name}'.")
+    except frappe.PermissionError:
+        return _error(f"You do not have permission to read {doctype} {name}.")
+    except Exception as e:
+        return _error(str(e))
+
+    data = _filter_permitted(doctype, doc.as_dict(), "read")
+    return json.dumps({"success": True, "doctype": doctype, "name": name, "data": data}, default=str)
+
+
+def _validate_draft_values(meta, values: dict, doctype: str, action: str):
+    """Allowlist ``values`` against the doctype's own fields and, for
+    create, check that meta-mandatory fields are present. Returns
+    ``(cleaned_values, None)`` or ``(None, error_json_str)``.
+    """
+    if not isinstance(values, dict):
+        return None, _error("'values' must be a JSON object of fieldname/value pairs")
+
+    valid_fieldnames = {df.fieldname for df in meta.fields}
+    cleaned = {k: v for k, v in values.items() if k in valid_fieldnames}
+
+    if action == "create":
+        missing = [
+            df.fieldname for df in meta.fields
+            if df.reqd and not df.depends_on and df.fieldname not in cleaned
+        ]
+        if missing:
+            return None, _error(f"Missing required field(s) for {doctype}: {', '.join(missing)}")
+
+    return cleaned, None
+
+
+def handle_create_record(**kwargs) -> str:
+    """Validate a proposed new record and return a DRAFT payload only.
+
+    This handler NEVER writes to the database. It checks create permission,
+    allowlists ``values`` against the doctype's real fields, and checks
+    meta-mandatory fields are present - then hands back
+    ``{"draft": True, "action": "create", ...}`` for the caller to submit.
+    The actual insert happens client-side, as the logged-in user, through the
+    normal Frappe REST API (POST /api/resource/<doctype>) - never
+    server-side from an agent tool call, since that would let a model insert
+    records as an implicit superuser/service identity rather than the human
+    who is actually driving the conversation.
+    """
+    doctype = (kwargs.get("doctype") or "").strip()
+    values = kwargs.get("values")
+    if isinstance(values, str) and values.strip():
+        try:
+            values = json.loads(values)
+        except Exception:
+            return _error("'values' must be a JSON object or dict")
+
+    meta, err = _check_doctype_allowed(doctype)
+    if err:
+        return err
+
+    err = _check_permission(doctype, "create")
+    if err:
+        return err
+
+    cleaned, err = _validate_draft_values(meta, values or {}, doctype, "create")
+    if err:
+        return err
+
+    return json.dumps({
+        "success": True,
+        "draft": True,
+        "doctype": doctype,
+        "values": cleaned,
+        "action": "create",
+    }, default=str)
+
+
+def handle_update_record(**kwargs) -> str:
+    """Validate a proposed field update and return a DRAFT payload only.
+
+    Same no-server-side-write contract as handle_create_record: this checks
+    write permission on the specific document, allowlists ``values``, and
+    returns ``{"draft": True, "action": "update", ...}`` - the write itself
+    happens client-side via the normal Frappe REST path (PUT
+    /api/resource/<doctype>/<name>) as the logged-in user.
+    """
+    doctype = (kwargs.get("doctype") or "").strip()
+    name = kwargs.get("name")
+    values = kwargs.get("values")
+    if isinstance(values, str) and values.strip():
+        try:
+            values = json.loads(values)
+        except Exception:
+            return _error("'values' must be a JSON object or dict")
+
+    meta, err = _check_doctype_allowed(doctype)
+    if err:
+        return err
+    if not name:
+        return _error("'name' is required")
+
+    err = _check_permission(doctype, "write", doc=name)
+    if err:
+        return err
+
+    if not frappe.db.exists(doctype, name):
+        return _error(f"No {doctype} found with name '{name}'.")
+
+    cleaned, err = _validate_draft_values(meta, values or {}, doctype, "update")
+    if err:
+        return err
+
+    return json.dumps({
+        "success": True,
+        "draft": True,
+        "doctype": doctype,
+        "name": name,
+        "values": cleaned,
+        "action": "update",
+    }, default=str)
+
+
+# ---------------------------------------------------------------------------
+# render_frappe_view - emits a frappe-list/frappe-form/frappe-report
+# <artifact> block, matching the templating pattern in
+# huf/ai/tools/render_tools.py (structured JSON in, <artifact> markup out).
+# ---------------------------------------------------------------------------
+
+_VALID_VIEW_MODES = ("list", "form", "report")
+
+
+def _escape_artifact_attr(value: str) -> str:
+    """Same rationale as render_tools._escape_artifact_attr: the frontend
+    artifact parser extracts the outer tag with a plain regex, so a raw
+    quote/angle-bracket in a templated title would truncate/corrupt the tag.
+    """
+    if not value:
+        return value
+    return value.replace('"', "'").replace("<", "(").replace(">", ")")
+
+
+def handle_render_frappe_view(**kwargs) -> str:
+    """Fetch data/meta for a doctype and emit it as a frappe-list, frappe-form,
+    or frappe-report <artifact> block for the frontend to render, instead of
+    returning raw JSON for the model to reformat itself.
+
+    Args (via kwargs):
+        doctype (str): Target doctype.
+        mode (str): One of "list", "form", "report".
+        filters: Same shape as handle_list_records (list mode only).
+        fields: Same shape as handle_list_records/handle_get_doctype_meta.
+
+    Returns:
+        The complete ``<artifact type="frappe-list|frappe-form|frappe-report"
+        language="json">...</artifact>`` string on success, or a plain
+        ``{"success": False, "error": ...}`` JSON string on failure (this
+        handler is called directly by the model, same as the other handlers
+        in this module - it does not raise).
+    """
+    doctype = (kwargs.get("doctype") or "").strip()
+    mode = (kwargs.get("mode") or "").strip().lower()
+
+    if mode not in _VALID_VIEW_MODES:
+        return _error(f"'mode' must be one of {_VALID_VIEW_MODES}, got {mode!r}")
+
+    meta, err = _check_doctype_allowed(doctype)
+    if err:
+        return err
+
+    err = _check_permission(doctype, "read")
+    if err:
+        return err
+
+    meta_json = json.loads(handle_get_doctype_meta(doctype=doctype))
+    if not meta_json.get("success"):
+        return json.dumps(meta_json, default=str)
+
+    payload = {
+        "doctype": doctype,
+        "mode": mode,
+        "meta": meta_json,
+    }
+
+    if mode == "list":
+        list_json = json.loads(handle_list_records(
+            doctype=doctype,
+            filters=kwargs.get("filters"),
+            fields=kwargs.get("fields"),
+            limit_start=kwargs.get("limit_start", 0),
+            limit_page_length=kwargs.get("limit_page_length", 20),
+            order_by=kwargs.get("order_by"),
+        ))
+        if not list_json.get("success"):
+            return json.dumps(list_json, default=str)
+        payload["filters"] = kwargs.get("filters")
+        payload["fields"] = list(list_json["data"][0].keys()) if list_json["data"] else (kwargs.get("fields") or [])
+        payload["data"] = list_json["data"]
+        payload["total_count"] = list_json["total_count"]
+        artifact_type = "frappe-list"
+
+    elif mode == "form":
+        name = kwargs.get("name") or (kwargs.get("filters") or {}).get("name")
+        if not name:
+            return _error("'name' (or filters.name) is required for mode='form'")
+        record_json = json.loads(handle_get_record(doctype=doctype, name=name))
+        if not record_json.get("success"):
+            return json.dumps(record_json, default=str)
+        payload["data"] = record_json["data"]
+        artifact_type = "frappe-form"
+
+    else:  # report
+        list_json = json.loads(handle_list_records(
+            doctype=doctype,
+            filters=kwargs.get("filters"),
+            fields=kwargs.get("fields"),
+            limit_start=kwargs.get("limit_start", 0),
+            limit_page_length=kwargs.get("limit_page_length", 100),
+            order_by=kwargs.get("order_by"),
+        ))
+        if not list_json.get("success"):
+            return json.dumps(list_json, default=str)
+        payload["filters"] = kwargs.get("filters")
+        payload["fields"] = kwargs.get("fields")
+        payload["data"] = list_json["data"]
+        payload["total_count"] = list_json["total_count"]
+        artifact_type = "frappe-report"
+
+    title = _escape_artifact_attr(f"{doctype} ({mode})")
+    body = json.dumps(payload, default=str)
+    return f'<artifact type="{artifact_type}" language="json" title="{title}">\n{body}\n</artifact>'

--- a/huf/ai/tools/frappe_generic.py
+++ b/huf/ai/tools/frappe_generic.py
@@ -493,6 +493,8 @@ def handle_render_frappe_view(**kwargs) -> str:
         payload["fields"] = list(list_json["data"][0].keys()) if list_json["data"] else (kwargs.get("fields") or [])
         payload["data"] = list_json["data"]
         payload["total_count"] = list_json["total_count"]
+        payload["limit_start"] = list_json["limit_start"]
+        payload["limit_page_length"] = list_json["limit_page_length"]
         artifact_type = "frappe-list"
 
     elif mode == "form":
@@ -520,6 +522,8 @@ def handle_render_frappe_view(**kwargs) -> str:
         payload["fields"] = kwargs.get("fields")
         payload["data"] = list_json["data"]
         payload["total_count"] = list_json["total_count"]
+        payload["limit_start"] = list_json["limit_start"]
+        payload["limit_page_length"] = list_json["limit_page_length"]
         artifact_type = "frappe-report"
 
     title = _escape_artifact_attr(f"{doctype} ({mode})")

--- a/huf/huf/doctype/artifact/artifact.json
+++ b/huf/huf/doctype/artifact/artifact.json
@@ -35,7 +35,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Artifact Type",
-   "options": "code\ndocument\nmarkdown\nhtml\nsvg\nmermaid\nchart\njsx\nvideo\nimage\nweb-preview\ntext",
+   "options": "code\ndocument\nmarkdown\nhtml\nsvg\nmermaid\nchart\njsx\nvideo\nimage\nweb-preview\ntext\nfrappe-list\nfrappe-form\nfrappe-report",
    "reqd": 1
   },
   {


### PR DESCRIPTION
## Summary
Adds a generic, doctype-agnostic Frappe data surface for the chat agent, and renders it inline in chat as a new artifact family (`frappe-list` / `frappe-form` / `frappe-report`) — Claude-Artifact-style — with an "Open in Desk" deep link on each view. Built for huf's own deployment model: huf is a Frappe app installed on the same site as Desk/ERPNext, so `/app/...` links inherit the session with no SSO handoff needed (verified against `vite.config.ts`/`proxyOptions.ts`/hooks.py — see track PLAN.md "Phase 4 finding").

Per an architecture review, this does **not** add `frappe-ui-react` as a dependency — it's a community port, not Frappe-maintained, and would add a second styling/data-fetching stack. Instead it's built on the frontend's existing design-system primitives, `@tanstack/react-table`, and `frappe-js-sdk`.

## Backend (`huf/ai/tools/frappe_generic.py`, new)
- `handle_get_doctype_meta` — field metadata (types, Select options, Link targets, Table children, mandatory/read-only/depends_on) via `frappe.get_meta`.
- `handle_list_records` — generic `frappe.get_list` with filters/fields/pagination/order_by, returns `total_count`.
- `handle_get_record` — single record fetch.
- `handle_create_record` / `handle_update_record` — **draft-only**. These never write to the database; they validate and return a draft payload. The actual write happens client-side, as the logged-in user, through the normal Frappe REST path — never server-side on the agent's say-so.
- `handle_render_frappe_view` — composes the above into one of the three new artifact types.
- `erpnext_reports.handle_run_report` extended with `limit_start`/`limit_page_length` pagination (report API doesn't expose an unpaginated count, so `total_count` is `null` there by design).

### Security model (non-negotiable, enforced in every handler)
- Doctype denylist: `User`, `Role`, `Role Profile`, `Custom Script`, `Server Script`, `Property Setter`, `File`, any `OAuth*`/`Integration*` prefix, and all Single doctypes — deny-by-default if a doctype doesn't exist or its meta can't load.
- `frappe.has_permission(doctype, ptype=...)` enforced per operation.
- Reads go through `frappe.get_list`/`frappe.get_doc` (permission-query conditions applied), never raw SQL.
- Field-level permlevel filtering via `frappe.permissions.get_permitted_fields` (fails closed to permlevel-0 fields on any error — flagged for a bench smoke-test below).

## Frontend
- `FrappeListView` / `FrappeFormView` / `FrappeReportView` (`frontend/src/components/chat/frappe-views/`) — table/pagination via `@tanstack/react-table`, form fields (select/mandatory/read-only) driven by the meta payload.
- Wired into `ArtifactRenderer.tsx`'s existing type switch; new types added to `artifact.types.ts` and the `artifactParser.ts` allowlist.
- "Open in Desk" link on each view, using a doctype→slug helper (`frappeDeskUrl.ts`) since no existing one was found in-repo.
- `render_frappe_view` wired into the standard tool-discovery path (`_registry.py` → `huf_tools` hook → `sync_discovered_tools`) and described in `artifact_instructions.py` so an agent knows when to call it.

## Known follow-ups / deferred
- Report mode is currently `handle_list_records` against the doctype, not a real Query Report/Report Builder run — `erpnext_reports.py`'s report catalogue isn't disambiguated by type, so "Open in Desk" for report mode currently links to the doctype's list view rather than `/app/query-report/<name>`. Flagged with a TODO in `FrappeReportView.tsx`.
- `frappe.permissions.get_permitted_fields`'s exact signature on this codebase's Frappe version wasn't verified against a live install — recommend a bench-console smoke test before relying on it in production.
- No live bench/ERPNext end-to-end test was run in this environment (no bench available here); verification was code-level (permission-check tracing, `py_compile`, `tsc --noEmit` on touched files, manual cross-check of the artifact JSON contract between backend and frontend).
- Pagination re-fetch wiring (actually calling the tool again on page/filter change) is stubbed via `onPageChange`/`onFilterChange` props, not wired to a live round-trip yet.

## Track
Full dependency-mapped plan, phase-by-phase execution log, and the architecture review that shaped this (opus review of the original plan) are at `Tracks/safwan-erooth.DeskAIArtifactWorkspace/PLAN.md` in the workspace repo (not part of this diff).