### PR TITLE
analytics: surface run duration in conversation analytics

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,7 +57,7 @@ const ChatScheduledPage = lazy(() =>
   import('./pages/chat/ChatPlaceholderPages').then((m) => ({ default: m.ChatScheduledPage }))
 );
 const Executions = lazy(() => import('./pages/Executions'));
-const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'));
+const AnalyticsEntityDetailPage = lazy(() => import('./pages/AnalyticsEntityDetailPage'));
 const AgentRunDetailPageWrapper = lazy(() => import('./pages/AgentRunDetailPageWrapper'));
 const McpDetailsPageWrapper = lazy(() => import('./pages/McpDetailsPageWrapper'));
 const McpListingPage = lazy(() => import('./pages/McpListingPage'));
@@ -539,13 +539,14 @@ function AppShell() {
               </ProtectedRoute>
             }
           />
+          <Route path="/analytics" element={<Navigate to="/executions?tab=analytics" replace />} />
           <Route
-            path="/analytics"
+            path="/analytics/:dimension/:entity"
             element={
               <ProtectedRoute>
                 <UnifiedLayout>
                   <Suspense fallback={<PageLoader />}>
-                    <AnalyticsPage />
+                    <AnalyticsEntityDetailPage />
                   </Suspense>
                 </UnifiedLayout>
               </ProtectedRoute>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, ChartColumnIncreasing, ChartNoAxesCombined, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -127,13 +127,6 @@ export const operateNavItems = [
 		title: "Executions",
 		url: "/executions",
 		icon: Zap,
-		capability: "agent.use",
-		badge: "Experimental",
-	},
-	{
-		title: "Analytics",
-		url: "/analytics",
-		icon: ChartNoAxesCombined,
 		capability: "agent.use",
 		badge: "Experimental",
 	},

--- a/frontend/src/components/chat/analytics/ConversationAnalyticsPane.tsx
+++ b/frontend/src/components/chat/analytics/ConversationAnalyticsPane.tsx
@@ -67,6 +67,10 @@ function formatPercent(ratio: number): string {
   return `${(ratio * 100).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`;
 }
 
+function formatDurationMs(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
 function runKindBreakdown(byKind: Record<ConversationRunKind, number>): string {
   return (Object.keys(RUN_KIND_LABEL) as ConversationRunKind[])
     .map((kind) => [kind, byKind[kind] ?? 0] as const)
@@ -187,6 +191,17 @@ function AnalyticsSections({ data }: { data: ConversationAnalyticsResponse }) {
         <GaugeRow className="mt-2">
           <MetricGauge label="Cache read" value={formatTokens(totals.cache_read_tokens)} unit="tokens" />
           <MetricGauge label="Cache write" value={formatTokens(totals.cache_write_tokens)} unit="tokens" />
+          {totals.average_duration_ms !== null ? (
+            <MetricGauge
+              label="Avg duration"
+              value={formatDurationMs(totals.average_duration_ms)}
+              info={`Averaged over ${formatCount(totals.duration_count)} of ${formatCount(totals.run_count)} run(s) with a recorded end time`}
+            />
+          ) : (
+            <div className="px-[18px] py-4 min-w-0">
+              <EmptyStat label="Avg duration" caption="No completed runs yet" />
+            </div>
+          )}
         </GaugeRow>
       </section>
 
@@ -215,6 +230,13 @@ function AnalyticsSections({ data }: { data: ConversationAnalyticsResponse }) {
                     label="Context fullness"
                     caption="Not measured"
                   />
+                </div>
+              )}
+              {current.duration_ms !== null ? (
+                <MetricGauge label="This turn" value={formatDurationMs(current.duration_ms)} />
+              ) : (
+                <div className="px-[18px] py-4 min-w-0">
+                  <EmptyStat label="This turn" caption="Not measured" />
                 </div>
               )}
             </GaugeRow>

--- a/frontend/src/pages/AnalyticsEntityDetailPage.tsx
+++ b/frontend/src/pages/AnalyticsEntityDetailPage.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { ArrowLeft, Activity } from 'lucide-react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { PageFrame } from '@/layouts/PageFrame';
+import { EmptyStat, EmptyState, GaugeRow, MetricGauge } from '@/components/dashboard';
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@/components/ui/chart';
+import { ContextBar } from '@/components/ui/context-bar';
+import { ExperimentalBadge } from '@/components/common/ExperimentalBadge';
+import { formatTimeAgo } from '@/utils/time';
+import { getExecutionAnalytics } from '@/services/executionAnalyticsApi';
+import type {
+  AnalyticsDimension,
+  ExecutionAnalyticsResponse,
+} from '@/types/executionAnalytics.types';
+
+const number = new Intl.NumberFormat();
+
+/** Same window as AnalyticsPage's default -- last 7 days, hourly buckets. */
+const WINDOW_DAYS = 7;
+const GRANULARITY = 'hour' as const;
+
+const DIMENSION_LABELS: Record<string, string> = {
+  provider: 'Provider',
+  agent: 'Agent',
+  model: 'Model',
+  conversation: 'Conversation',
+  run_kind: 'Run kind',
+};
+
+const chartConfig = {
+  runCount: {
+    label: 'Runs',
+    color: 'var(--ink)',
+  },
+} satisfies ChartConfig;
+
+/**
+ * One lightweight trend chart over `series[].run_count`, bucketed by hour.
+ * Deliberately not a reuse of ContextGrowthChart -- that component is shaped
+ * for per-turn conversation series (a `sequence` x-axis, nullable points);
+ * this is a time-bucketed rollup series with a real timestamp axis.
+ */
+function EntityTrendChart({ series }: { series: ExecutionAnalyticsResponse['series'] }) {
+  const data = useMemo(
+    () =>
+      [...series]
+        .sort((a, b) => a.bucket_start.localeCompare(b.bucket_start))
+        .map((point) => ({
+          bucketStart: point.bucket_start,
+          runCount: point.run_count,
+        })),
+    [series]
+  );
+
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[180px] items-center justify-center rounded-lg border border-line bg-panel">
+        <p className="text-[12px] text-steel-soft">No runs to chart in this window.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-[220px] w-full">
+      <AreaChart data={data} margin={{ left: 4, right: 8, top: 8, bottom: 0 }}>
+        <CartesianGrid vertical={false} stroke="var(--line)" />
+        <XAxis
+          dataKey="bucketStart"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value: string) =>
+            new Date(value).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric' })
+          }
+          minTickGap={32}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          width={36}
+          allowDecimals={false}
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              labelFormatter={(label) => new Date(label as string).toLocaleString()}
+            />
+          }
+        />
+        <Area
+          dataKey="runCount"
+          type="monotone"
+          stroke="var(--color-runCount)"
+          fill="var(--color-runCount)"
+          fillOpacity={0.12}
+          strokeWidth={1.75}
+          isAnimationActive={false}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+export default function AnalyticsEntityDetailPage() {
+  const { dimension, entity } = useParams<{ dimension: string; entity: string }>();
+  const [data, setData] = useState<ExecutionAnalyticsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fromDate = useMemo(
+    () => new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString(),
+    []
+  );
+
+  useEffect(() => {
+    if (!dimension || !entity) return;
+    let cancelled = false;
+    setLoading(true);
+    getExecutionAnalytics({
+      fromDate,
+      granularity: GRANULARITY,
+      dimension: dimension as AnalyticsDimension,
+      entity: decodeURIComponent(entity),
+    }).then((result) => {
+      if (cancelled) return;
+      setData(result);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fromDate, dimension, entity]);
+
+  const summary = data?.summary;
+  const series = data?.series ?? [];
+  const dimensionLabel = (dimension && DIMENSION_LABELS[dimension]) || 'Dimension';
+  const entityLabel = entity ? decodeURIComponent(entity) : '';
+  const freshnessLabel = data?.metadata.freshness ? `Updated ${formatTimeAgo(data.metadata.freshness)}` : undefined;
+
+  return (
+    <PageFrame
+      title={
+        <span className="flex items-center gap-2">
+          <Link
+            to="/executions?tab=analytics"
+            className="flex items-center gap-1 text-steel-soft hover:text-ink transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <span>{entityLabel || 'Entity'}</span>
+        </span>
+      }
+      badge={<ExperimentalBadge />}
+      meta={freshnessLabel}
+    >
+      <div className="flex flex-col gap-6">
+        <div className="font-body text-[12px] text-steel-soft -mt-2">
+          <Link to="/executions?tab=analytics" className="hover:text-ink transition-colors">
+            Analytics
+          </Link>
+          <span className="mx-1.5">/</span>
+          <span>{dimensionLabel}</span>
+          <span className="mx-1.5">/</span>
+          <span className="text-ink">{entityLabel || '—'}</span>
+        </div>
+
+        {loading ? (
+          <div className="px-[18px] py-4 font-body text-[13px] text-steel">Loading analytics…</div>
+        ) : !summary || summary.run_count === 0 ? (
+          <EmptyState
+            variant="passive"
+            icon={Activity}
+            title="No analytics yet"
+            description="Analytics accrue as agent runs complete in this window."
+          />
+        ) : (
+          <>
+            <GaugeRow>
+              <MetricGauge
+                label="Runs"
+                value={number.format(summary.run_count)}
+                info={`${summary.success_count} successful · ${summary.failed_count} failed`}
+              />
+              {summary.cache_ratio === null ? (
+                <div className="px-[18px] py-4 min-w-0">
+                  <EmptyStat label="Cache ratio" caption="No completed runs in this period." />
+                </div>
+              ) : (
+                <MetricGauge
+                  label="Cache ratio"
+                  value={`${summary.cache_ratio.toFixed(1)}%`}
+                  info={`${number.format(summary.cached_tokens)} cached of ${number.format(summary.input_tokens)} input`}
+                />
+              )}
+              <MetricGauge label="LLM cost" value={`$${summary.total_cost.toFixed(4)}`} info="Aggregated completed runs" />
+              {summary.average_duration_ms === null ? (
+                <div className="px-[18px] py-4 min-w-0">
+                  <EmptyStat label="Average duration" caption="No completed runs in this period." />
+                </div>
+              ) : (
+                <MetricGauge
+                  label="Average duration"
+                  value={(summary.average_duration_ms / 1000).toFixed(1)}
+                  unit="s"
+                  info={`Success rate ${summary.success_rate?.toFixed(1) ?? '—'}%`}
+                />
+              )}
+            </GaugeRow>
+
+            <div className="w-full rounded-lg border border-line bg-panel overflow-hidden">
+              <div className="px-[18px] py-3 border-b border-line">
+                <h2 className="font-body text-[13px] font-medium text-ink">Runs over time</h2>
+              </div>
+              <div className="p-[18px]">
+                <EntityTrendChart series={series} />
+              </div>
+            </div>
+
+            {data?.composition_totals && Object.keys(data.composition_totals).length > 0 && (
+              <div className="w-full rounded-lg border border-line bg-panel overflow-hidden">
+                <div className="px-[18px] py-3 border-b border-line">
+                  <h2 className="font-body text-[13px] font-medium text-ink">Context composition</h2>
+                </div>
+                <div className="p-[18px]">
+                  <ContextBar
+                    segments={data.composition_totals as any}
+                    total={null}
+                  />
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </PageFrame>
+  );
+}

--- a/frontend/src/pages/AnalyticsEntityDetailPage.tsx
+++ b/frontend/src/pages/AnalyticsEntityDetailPage.tsx
@@ -132,7 +132,10 @@ export default function AnalyticsEntityDetailPage() {
       fromDate,
       granularity: GRANULARITY,
       dimension: dimension as AnalyticsDimension,
-      entity: decodeURIComponent(entity),
+      // `entity` from useParams() is already percent-decoded by React
+      // Router's route matching -- decoding it again corrupts any value
+      // containing a raw "%" (and throws a URIError for malformed ones).
+      entity,
     }).then((result) => {
       if (cancelled) return;
       setData(result);
@@ -146,7 +149,7 @@ export default function AnalyticsEntityDetailPage() {
   const summary = data?.summary;
   const series = data?.series ?? [];
   const dimensionLabel = (dimension && DIMENSION_LABELS[dimension]) || 'Dimension';
-  const entityLabel = entity ? decodeURIComponent(entity) : '';
+  const entityLabel = entity ?? '';
   const freshnessLabel = data?.metadata.freshness ? `Updated ${formatTimeAgo(data.metadata.freshness)}` : undefined;
 
   return (

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Activity, ArrowUpDown } from 'lucide-react';
 import { PageFrame } from '@/layouts/PageFrame';
 import { EmptyStat, EmptyState, GaugeRow, MetricGauge } from '@/components/dashboard';
@@ -80,7 +81,10 @@ interface BreakdownRow extends ExecutionAnalyticsSummary {
   dimension: string;
 }
 
+const ENTITY_DIMENSIONS: ReadonlySet<AnalyticsDimension> = new Set(['agent', 'provider', 'model']);
+
 export default function AnalyticsPage() {
+  const navigate = useNavigate();
   const [dimension, setDimension] = useState<AnalyticsDimension>('provider');
   const [window, setWindow] = useState<TimeWindow>('7d');
   const [data, setData] = useState<ExecutionAnalyticsResponse | null>(null);
@@ -114,6 +118,15 @@ export default function AnalyticsPage() {
 
   const dimensionLabel =
     DIMENSION_OPTIONS.find((option) => option.value === dimension)?.label ?? 'Dimension';
+
+  const handleRowClick = (row: BreakdownRow) => {
+    if (ENTITY_DIMENSIONS.has(dimension)) {
+      navigate(`/analytics/${dimension}/${encodeURIComponent(row.dimension)}`);
+    } else if (dimension === 'conversation') {
+      navigate(`/chat/${row.dimension}?pane=analytics`);
+    }
+  };
+  const rowsAreClickable = ENTITY_DIMENSIONS.has(dimension) || dimension === 'conversation';
 
   const columns = useMemo<ColumnDef<BreakdownRow>[]>(
     () => [
@@ -340,7 +353,11 @@ export default function AnalyticsPage() {
                   </TableHeader>
                   <TableBody>
                     {table.getRowModel().rows.map((row) => (
-                      <TableRow key={row.id} className="h-11">
+                      <TableRow
+                        key={row.id}
+                        className={cn('h-11', rowsAreClickable && 'cursor-pointer hover:bg-paper-deep')}
+                        onClick={rowsAreClickable ? () => handleRowClick(row.original) : undefined}
+                      >
                         {row.getVisibleCells().map((cell) => (
                           <TableCell key={cell.id}>
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/frontend/src/pages/ChatPageV2.tsx
+++ b/frontend/src/pages/ChatPageV2.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { ChatShellFrame } from "@/components/chat/rail/ChatShellFrame";
 import ChatWindow from "@/components/chat/ChatWindowV2";
 import { ArtifactPreviewPane } from "@/components/chat/artifacts/ArtifactPreviewPane";
@@ -18,6 +18,7 @@ function ChatPage() {
     const navigate = useNavigate();
     const { chatId: routeChatId } = useParams<{ chatId?: string }>();
     const chatId = routeChatId && routeChatId !== "new" ? routeChatId : null;
+    const [searchParams] = useSearchParams();
 
     const isMobile = useIsMobile();
     const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -74,6 +75,16 @@ function ChatPage() {
             setSidebarOpen(false);
         }
     }, [isMobile, chatId]);
+
+    // Open analytics pane if ?pane=analytics is in the URL query string
+    useEffect(() => {
+        if (!chatId) return;
+
+        const hasAnalyticsPaneParam = searchParams.get('pane') === 'analytics';
+        if (hasAnalyticsPaneParam && !analyticsPane.isOpen) {
+            analyticsPane.open();
+        }
+    }, [chatId, analyticsPane]);
 
     // The rail, transcript, and artifact pane now coexist as three columns
     // (see design spec section 28.2) — the pane no longer forces the rail

--- a/frontend/src/pages/Executions.tsx
+++ b/frontend/src/pages/Executions.tsx
@@ -31,8 +31,16 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { ExecutionAnalyticsDashboard } from '@/components/executions/ExecutionAnalyticsDashboard';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import AnalyticsPage from '@/pages/AnalyticsPage';
 
 const DEFAULT_RANGE = '24h';
+
+/** Sub-tabs hosted on this page — kept in the URL so a link like
+ * `/executions?tab=analytics` opens directly on the Analytics tab. */
+const EXECUTIONS_TABS = ['runs', 'analytics'] as const;
+type ExecutionsTab = (typeof EXECUTIONS_TABS)[number];
+const DEFAULT_TAB: ExecutionsTab = 'runs';
 
 const TIME_RANGE_OPTIONS = [
   { label: 'Last 24h', value: '24h' },
@@ -60,7 +68,8 @@ function getRunStatusDot(status?: string): { variant: StatusDotVariant; label: s
   return { variant: 'run', label: status || 'Started' };
 }
 
-export default function Executions() {
+/** The "Runs" tab — this is the original Executions page body, unchanged. */
+function ExecutionsRunsTab() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [agents, setAgents] = useState<Array<{ name: string }>>([]);
@@ -520,5 +529,52 @@ export default function Executions() {
         </div>
       )}
     </PageFrame>
+  );
+}
+
+/**
+ * Merges the former `/executions` and `/analytics` routes into one page with
+ * two sub-tabs, following the same URL-synced Tabs pattern used by
+ * SkillFormPage's prompts/summary tabs. Tab state lives in `?tab=` so a link
+ * like `/executions?tab=analytics` opens directly on the Analytics tab —
+ * this is what lets a future task deep-link breakdown rows there.
+ */
+export default function Executions() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const tabFromUrl = searchParams.get('tab');
+  const activeTab: ExecutionsTab =
+    tabFromUrl && (EXECUTIONS_TABS as readonly string[]).includes(tabFromUrl)
+      ? (tabFromUrl as ExecutionsTab)
+      : DEFAULT_TAB;
+
+  const handleTabChange = (value: string) => {
+    setSearchParams(
+      (prev) => {
+        const sp = new URLSearchParams(prev);
+        if (value === DEFAULT_TAB) {
+          sp.delete('tab');
+        } else {
+          sp.set('tab', value);
+        }
+        return sp;
+      },
+      { replace: true }
+    );
+  };
+
+  return (
+    <Tabs value={activeTab} onValueChange={handleTabChange} className="h-full flex flex-col">
+      <TabsList className="mx-6 mt-4 w-fit shrink-0">
+        <TabsTrigger value="runs">Runs</TabsTrigger>
+        <TabsTrigger value="analytics">Analytics</TabsTrigger>
+      </TabsList>
+      <TabsContent value="runs" className="flex-1 min-h-0">
+        <ExecutionsRunsTab />
+      </TabsContent>
+      <TabsContent value="analytics" className="flex-1 min-h-0">
+        <AnalyticsPage />
+      </TabsContent>
+    </Tabs>
   );
 }

--- a/frontend/src/services/executionAnalyticsApi.ts
+++ b/frontend/src/services/executionAnalyticsApi.ts
@@ -11,6 +11,12 @@ export interface GetExecutionAnalyticsParams {
   granularity?: 'hour' | 'day';
   /** Dimension to break down `breakdowns` by. Defaults to 'provider'. */
   dimension?: AnalyticsDimension;
+  /**
+   * Scope the response to a single value of `dimension` (e.g. one agent name).
+   * When set, the API returns the same top-level shape but `breakdowns` is
+   * always `[]` — the caller already knows which entity it wants.
+   */
+  entity?: string;
 }
 
 export async function getExecutionAnalytics(
@@ -22,6 +28,7 @@ export async function getExecutionAnalytics(
       ...(params?.fromDate ? { from_date: params.fromDate } : {}),
       ...(params?.toDate ? { to_date: params.toDate } : {}),
       ...(params?.dimension ? { dimension: params.dimension } : {}),
+      ...(params?.entity ? { entity: params.entity } : {}),
     });
     return result.message as ExecutionAnalyticsResponse;
   } catch (error) {

--- a/frontend/src/types/conversationAnalytics.types.ts
+++ b/frontend/src/types/conversationAnalytics.types.ts
@@ -16,6 +16,10 @@ export interface ConversationAnalyticsTotals {
   cost: number;
   cache_read_tokens: number;
   cache_write_tokens: number;
+  duration_ms_sum: number;
+  duration_count: number;
+  /** `null` when no run in this conversation has both a start and end time yet. */
+  average_duration_ms: number | null;
 }
 
 /**
@@ -37,6 +41,8 @@ export interface ConversationAnalyticsCurrent {
    */
   segment_tokens: Record<string, number | null> | null;
   tool_exchange_tokens: number | null;
+  /** How long this one turn took. A snapshot like the rest of `current` — never summed into `totals`. */
+  duration_ms: number | null;
 }
 
 export interface ConversationAnalyticsSeriesPoint {
@@ -50,6 +56,7 @@ export interface ConversationAnalyticsSeriesPoint {
   cost: number | null;
   status: string | null;
   start_time: string | null;
+  duration_ms: number | null;
 }
 
 export interface ConversationAnalyticsCache {

--- a/frontend/src/types/executionAnalytics.types.ts
+++ b/frontend/src/types/executionAnalytics.types.ts
@@ -32,6 +32,14 @@ export interface ExecutionAnalyticsResponse {
   metadata: {
     granularity: 'hour' | 'day';
     dimension: AnalyticsDimension;
+    /**
+     * The entity value the response was scoped to, echoing the `entity` param
+     * sent to `get_execution_analytics`. `null`/absent when the response is
+     * the unscoped aggregate (the normal AnalyticsPage case) — only present
+     * as a real string on an entity drill-down response, where `breakdowns`
+     * is always `[]` and `breakdowns_total_count` is always 0.
+     */
+    entity?: string | null;
     freshness: string | null;
     /**
      * Total number of distinct dimension values found in the window, before the

--- a/huf/ai/agent_conversation_analytics_api.py
+++ b/huf/ai/agent_conversation_analytics_api.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 
 import frappe
+from frappe.utils import get_datetime
 
 
 RUN_KINDS = ("agent", "tool", "orchestrator")
@@ -47,6 +48,7 @@ RUN_FIELDS = [
     "run_kind",
     "status",
     "start_time",
+    "end_time",
     "input_tokens",
     "billed_input_tokens",
     "output_tokens",
@@ -89,6 +91,21 @@ def _row_is_missing_billed_input(row: dict) -> bool:
     return row.get("billed_input_tokens") is None
 
 
+def _run_duration_ms(row: dict) -> float | None:
+    """Wall-clock duration of one run, or `None` if it cannot be computed.
+
+    Same guard as `agent_run_analytics._recompute_rollup`: both timestamps
+    must be present and the duration must be non-negative (a clock skew or
+    a row with `end_time` before `start_time` is treated as unmeasured,
+    never as a negative duration)."""
+    start = row.get("start_time")
+    end = row.get("end_time")
+    if not start or not end:
+        return None
+    duration = (get_datetime(end) - get_datetime(start)).total_seconds() * 1000
+    return duration if duration >= 0 else None
+
+
 def _load_usage_snapshot(raw) -> dict:
     """Parse a run's usage_snapshot into a dict.
 
@@ -117,6 +134,11 @@ def _empty_totals() -> dict:
         "cost": 0,
         "cache_read_tokens": 0,
         "cache_write_tokens": 0,
+        # Field names match agent_run_analytics_api.py's summary shape
+        # (duration_ms_sum / duration_count / average_duration_ms) rather
+        # than inventing a second convention for the same idea.
+        "duration_ms_sum": 0,
+        "duration_count": 0,
     }
 
 
@@ -140,6 +162,11 @@ def _compute_totals(rows: list[dict]) -> tuple[dict, int]:
         totals["cost"] += row.get("cost") or 0
         totals["cache_read_tokens"] += row.get("cached_tokens") or 0
         totals["cache_write_tokens"] += row.get("cache_creation_tokens") or 0
+
+        duration = _run_duration_ms(row)
+        if duration is not None:
+            totals["duration_ms_sum"] += duration
+            totals["duration_count"] += 1
 
     return totals, runs_missing_billed_input
 
@@ -173,6 +200,9 @@ def _compute_current(latest_row: dict | None) -> dict | None:
         "context_fullness": context_fullness,
         "segment_tokens": segment_tokens,
         "tool_exchange_tokens": snapshot.get("tool_exchange_tokens"),
+        # How long this one turn took -- a snapshot like everything else in
+        # `current`, not summed into `totals.duration_ms_sum`.
+        "duration_ms": _run_duration_ms(latest_row),
     }
 
 
@@ -202,6 +232,7 @@ def _build_series(rows: list[dict]) -> list[dict]:
             "cost": row.get("cost"),
             "status": row.get("status"),
             "start_time": row.get("start_time"),
+            "duration_ms": _run_duration_ms(row),
         })
         previous_row = row
 
@@ -286,6 +317,9 @@ def get_conversation_analytics(conversation: str):
     rows = [dict(row) for row in rows]
 
     totals, runs_missing_billed_input = _compute_totals(rows)
+    totals["average_duration_ms"] = (
+        totals["duration_ms_sum"] / totals["duration_count"] if totals["duration_count"] else None
+    )
 
     latest_row = None
     for row in rows:

--- a/huf/ai/agent_run_analytics_api.py
+++ b/huf/ai/agent_run_analytics_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 import frappe
-from frappe.utils import add_to_date, get_datetime, now_datetime
+from frappe.utils import add_to_date, convert_utc_to_system_timezone, get_datetime, now_datetime
 
 from huf.ai.agent_run_analytics import DIMENSION_FIELDS
 
@@ -32,6 +32,26 @@ ROLLUP_FIELDS = [
     "composition_totals",
     "last_recomputed_at",
 ]
+
+
+def _to_system_naive(dt):
+    """Normalise a datetime to the site's naive local convention.
+
+    now_datetime() and every MariaDB datetime this module compares against
+    are naive, in the site's configured system timezone (System Settings ->
+    Time Zone, whatever that is set to -- not assumed to be UTC). But
+    get_datetime() on an ISO string carrying an offset/Z suffix -- exactly
+    what a browser's Date.toISOString() sends -- returns a timezone-AWARE
+    UTC datetime. Comparing/subtracting that against a naive value raises
+    TypeError; naively stripping tzinfo instead would silently shift the
+    window by the site's UTC offset (checked live at 2026-08-24: this site
+    is Asia/Kolkata, UTC+5:30 -- a blind strip is off by 5.5 hours, not off
+    by nothing). Route through Frappe's own system-timezone conversion,
+    which reads the site's configured timezone rather than assuming one.
+    """
+    if dt.tzinfo is not None:
+        dt = convert_utc_to_system_timezone(dt).replace(tzinfo=None)
+    return dt
 
 
 def _require_analytics_access():
@@ -103,8 +123,14 @@ def get_execution_analytics(
         frappe.throw("granularity must be 'hour' or 'day'")
     if dimension not in DIMENSION_FIELDS:
         frappe.throw(f"dimension must be one of {', '.join(DIMENSION_FIELDS)}")
-    end = get_datetime(to_date) if to_date else now_datetime()
-    start = get_datetime(from_date) if from_date else add_to_date(end, days=-7)
+    # from_date/to_date arrive as ISO strings with an offset/Z suffix (the
+    # frontend sends Date.toISOString()), which get_datetime() parses as
+    # timezone-aware. now_datetime()/add_to_date() and every bucket_start
+    # this gets compared against are naive, in the site's own timezone --
+    # see _to_system_naive's docstring for why a blind tzinfo strip would
+    # be silently wrong rather than merely inconsistent.
+    end = _to_system_naive(get_datetime(to_date)) if to_date else now_datetime()
+    start = _to_system_naive(get_datetime(from_date)) if from_date else add_to_date(end, days=-7)
     if start > end or (end - start).days > MAX_WINDOW_DAYS:
         frappe.throw(f"Date range must be between zero and {MAX_WINDOW_DAYS} days")
     if not frappe.db.exists("DocType", ROLLUP_DOCTYPE):

--- a/huf/ai/agent_run_analytics_api.py
+++ b/huf/ai/agent_run_analytics_api.py
@@ -74,6 +74,23 @@ def _query_rollups(granularity: str, start, end) -> list[dict]:
     )
 
 
+def _add_derived_rates(row: dict) -> None:
+    """Add success_rate/average_duration_ms/cache_ratio to a summary-shaped dict, in place.
+
+    The frontend's ExecutionAnalyticsSummary type declares these three as
+    `number | null` on every series bucket and breakdown row, not just the
+    top-level summary -- series/breakdowns are typed as
+    `Array<ExecutionAnalyticsSummary & {...}>`, the same type. Skipping this
+    on series/breakdown rows previously left the keys entirely absent
+    (`undefined` in JS, not `null`), which a `=== null` guard does not catch,
+    so `undefined.toFixed(...)` crashed the whole page the first time a
+    breakdown row existed. Must be called on every row this response emits.
+    """
+    row["success_rate"] = (row["success_count"] / row["run_count"] * 100) if row["run_count"] else None
+    row["average_duration_ms"] = (row["duration_ms_sum"] / row["duration_count"]) if row["duration_count"] else None
+    row["cache_ratio"] = (row["cached_tokens"] / row["input_tokens"] * 100) if row["input_tokens"] else None
+
+
 def _load_composition_totals(raw) -> dict:
     """Parse a rollup row's composition_totals JSON string.
 
@@ -186,9 +203,11 @@ def get_execution_analytics(
         _accumulate_composition(composition_totals, _load_composition_totals(row.get("composition_totals")))
         if row.get("last_recomputed_at") and (freshness is None or row["last_recomputed_at"] > freshness):
             freshness = row["last_recomputed_at"]
-    summary["success_rate"] = (summary["success_count"] / summary["run_count"] * 100) if summary["run_count"] else None
-    summary["average_duration_ms"] = (summary["duration_ms_sum"] / summary["duration_count"]) if summary["duration_count"] else None
-    summary["cache_ratio"] = (summary["cached_tokens"] / summary["input_tokens"] * 100) if summary["input_tokens"] else None
+    _add_derived_rates(summary)
+    for bucket in series_by_bucket.values():
+        _add_derived_rates(bucket)
+    for breakdown in breakdown_by_dimension.values():
+        _add_derived_rates(breakdown)
     breakdowns_total_count = len(breakdown_by_dimension)
     return {
         "summary": summary,

--- a/huf/ai/agent_run_analytics_api.py
+++ b/huf/ai/agent_run_analytics_api.py
@@ -91,6 +91,21 @@ def _add_derived_rates(row: dict) -> None:
     row["cache_ratio"] = (row["cached_tokens"] / row["input_tokens"] * 100) if row["input_tokens"] else None
 
 
+def _filter_rows_by_entity(rows: list[dict], dimension: str, entity: str | None) -> list[dict]:
+    """Restrict rollup rows to those whose `dimension` field equals `entity`.
+
+    A falsy `entity` (None or "") is a no-op passthrough -- the caller wants
+    the unfiltered rows, matching the existing dimension-only behaviour. Only
+    an exact equality match on `row.get(dimension)` counts; a row missing the
+    dimension key (`.get` returns None) only matches when `entity` is itself
+    None, which the falsy check above already routes to passthrough, so in
+    practice it never happens through this path.
+    """
+    if not entity:
+        return rows
+    return [row for row in rows if row.get(dimension) == entity]
+
+
 def _load_composition_totals(raw) -> dict:
     """Parse a rollup row's composition_totals JSON string.
 
@@ -133,6 +148,7 @@ def get_execution_analytics(
     to_date: str | None = None,
     granularity: str = "hour",
     dimension: str = "provider",
+    entity: str | None = None,
 ):
     """Return execution analytics; auto-refreshes rollups if empty."""
     _require_analytics_access()
@@ -161,6 +177,7 @@ def get_execution_analytics(
             "metadata": {
                 "granularity": granularity,
                 "dimension": dimension,
+                "entity": entity,
                 "freshness": None,
                 "breakdowns_total_count": 0,
             },
@@ -173,6 +190,8 @@ def get_execution_analytics(
         from huf.ai.agent_run_analytics import refresh_rollups
         refresh_rollups(full_backfill=True)
         rows = _query_rollups(granularity, start, end)
+
+    rows = _filter_rows_by_entity(rows, dimension, entity)
 
     summary = {
         "run_count": 0,
@@ -196,10 +215,11 @@ def get_execution_analytics(
         bucket = series_by_bucket.setdefault(row["bucket_start"], {"bucket_start": row["bucket_start"], **{key: 0 for key in summary}})
         for key in summary:
             bucket[key] += row.get(key) or 0
-        dimension_value = row.get(dimension) or "Unknown"
-        breakdown = breakdown_by_dimension.setdefault(dimension_value, {"dimension": dimension_value, **{key: 0 for key in summary}})
-        for key in summary:
-            breakdown[key] += row.get(key) or 0
+        if not entity:
+            dimension_value = row.get(dimension) or "Unknown"
+            breakdown = breakdown_by_dimension.setdefault(dimension_value, {"dimension": dimension_value, **{key: 0 for key in summary}})
+            for key in summary:
+                breakdown[key] += row.get(key) or 0
         _accumulate_composition(composition_totals, _load_composition_totals(row.get("composition_totals")))
         if row.get("last_recomputed_at") and (freshness is None or row["last_recomputed_at"] > freshness):
             freshness = row["last_recomputed_at"]
@@ -217,6 +237,7 @@ def get_execution_analytics(
         "metadata": {
             "granularity": granularity,
             "dimension": dimension,
+            "entity": entity,
             "from": start,
             "to": end,
             "freshness": freshness,

--- a/huf/ai/tests/_stub_env.py
+++ b/huf/ai/tests/_stub_env.py
@@ -55,6 +55,12 @@ def install():
     frappe_utils.add_to_date = MagicMock()
     frappe_utils.get_datetime = MagicMock(side_effect=lambda v: v)
     frappe_utils.now_datetime = MagicMock()
+    # Identity passthrough is enough for tests that never exercise the
+    # aware/naive normalisation itself (agent_run_analytics_api.py imports
+    # this at module level, so it must exist for the module to import at
+    # all) -- tests that actually need real tz-conversion behaviour talk to
+    # a live bench instead, since pytz's tzdata isn't available here.
+    frappe_utils.convert_utc_to_system_timezone = MagicMock(side_effect=lambda v: v)
     frappe.utils = frappe_utils
 
     frappe_tests = _make_module("frappe.tests")

--- a/huf/ai/tests/test_agent_conversation_analytics_duration.py
+++ b/huf/ai/tests/test_agent_conversation_analytics_duration.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Duration coverage for huf.ai.agent_conversation_analytics_api.
+
+The conversation analytics response originally summed tokens/cost across
+every run but never surfaced duration, even though Agent Run.start_time/
+end_time were always being fetched by the scheduled rollup for exactly this
+purpose (agent_run_analytics.py's duration_ms_sum/duration_count). This file
+covers the fix: _run_duration_ms's guard, _compute_totals's cumulative sum
+(matching the rollup's field names), and _compute_current's per-turn
+snapshot (never summed into totals, same discipline as peak_context_tokens).
+"""
+
+import sys
+import os
+import unittest
+from datetime import datetime, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.agent_conversation_analytics_api import (  # noqa: E402
+    _compute_current,
+    _compute_totals,
+    _run_duration_ms,
+)
+
+
+def _row(start=None, end=None, **overrides):
+    row = {
+        "name": "run-1",
+        "sequence": 1,
+        "run_kind": "agent",
+        "status": "Success",
+        "start_time": start,
+        "end_time": end,
+        "billed_input_tokens": 100,
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cost": 0.01,
+        "cached_tokens": 0,
+        "cache_creation_tokens": 0,
+        "peak_context_tokens": None,
+        "model_context_window": None,
+        "usage_snapshot": None,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestRunDurationMs(unittest.TestCase):
+    def test_none_when_start_missing(self):
+        self.assertIsNone(_run_duration_ms(_row(start=None, end=datetime(2026, 1, 1, 0, 0, 5))))
+
+    def test_none_when_end_missing(self):
+        self.assertIsNone(_run_duration_ms(_row(start=datetime(2026, 1, 1, 0, 0, 0), end=None)))
+
+    def test_computes_milliseconds_when_both_present(self):
+        start = datetime(2026, 1, 1, 0, 0, 0)
+        end = start + timedelta(seconds=2, milliseconds=500)
+        self.assertAlmostEqual(_run_duration_ms(_row(start=start, end=end)), 2500.0)
+
+    def test_negative_duration_treated_as_unmeasured(self):
+        start = datetime(2026, 1, 1, 0, 0, 5)
+        end = datetime(2026, 1, 1, 0, 0, 0)  # end before start -- clock skew / bad data
+        self.assertIsNone(_run_duration_ms(_row(start=start, end=end)))
+
+
+class TestComputeTotalsDuration(unittest.TestCase):
+    def test_sums_only_measured_runs(self):
+        start = datetime(2026, 1, 1, 0, 0, 0)
+        rows = [
+            _row(start=start, end=start + timedelta(seconds=1)),  # 1000ms
+            _row(start=start, end=start + timedelta(seconds=3)),  # 3000ms
+            _row(start=None, end=None),  # unmeasured -- must not count
+        ]
+        totals, _ = _compute_totals(rows)
+        self.assertEqual(totals["duration_ms_sum"], 4000.0)
+        self.assertEqual(totals["duration_count"], 2)
+
+    def test_zero_when_nothing_measured(self):
+        totals, _ = _compute_totals([_row(start=None, end=None)])
+        self.assertEqual(totals["duration_ms_sum"], 0)
+        self.assertEqual(totals["duration_count"], 0)
+
+    def test_empty_conversation(self):
+        totals, _ = _compute_totals([])
+        self.assertEqual(totals["duration_ms_sum"], 0)
+        self.assertEqual(totals["duration_count"], 0)
+
+
+class TestComputeCurrentDuration(unittest.TestCase):
+    def test_latest_run_duration_is_its_own_not_a_sum(self):
+        start = datetime(2026, 1, 1, 0, 0, 0)
+        latest_row = _row(start=start, end=start + timedelta(seconds=4, milliseconds=200))
+        current = _compute_current(latest_row)
+        self.assertAlmostEqual(current["duration_ms"], 4200.0)
+
+    def test_none_when_latest_run_unmeasured(self):
+        current = _compute_current(_row(start=None, end=None))
+        self.assertIsNone(current["duration_ms"])
+
+    def test_none_when_no_runs(self):
+        self.assertIsNone(_compute_current(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_agent_run_analytics_api_derived_rates.py
+++ b/huf/ai/tests/test_agent_run_analytics_api_derived_rates.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Regression test for a real bug found live-testing /analytics with actual
+rollup data: series/breakdowns rows never had success_rate/average_duration_ms/
+cache_ratio at all (not null -- entirely absent, since those three keys were
+only ever added to the top-level `summary` dict, after the per-bucket and
+per-dimension dicts had already been seeded from summary's keys). The
+frontend's `=== null` guards don't catch `undefined`, so the first real
+breakdown row crashed the whole page with "Cannot read properties of
+undefined (reading 'toFixed')".
+
+_add_derived_rates is the extracted fix: called on summary AND on every
+series bucket AND every breakdown row, so all three always end up as
+`number | null`, matching what ExecutionAnalyticsSummary (shared by all
+three shapes on the frontend) declares.
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.agent_run_analytics_api import _add_derived_rates  # noqa: E402
+
+
+def _row(**overrides):
+    row = {
+        "run_count": 0,
+        "success_count": 0,
+        "input_tokens": 0,
+        "cached_tokens": 0,
+        "duration_ms_sum": 0,
+        "duration_count": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+class TestAddDerivedRates(unittest.TestCase):
+    def test_keys_always_present_even_with_zero_denominators(self):
+        row = _row()
+        _add_derived_rates(row)
+        # Never absent (undefined) -- always a real key, value None or a number.
+        self.assertIn("success_rate", row)
+        self.assertIn("average_duration_ms", row)
+        self.assertIn("cache_ratio", row)
+        self.assertIsNone(row["success_rate"])
+        self.assertIsNone(row["average_duration_ms"])
+        self.assertIsNone(row["cache_ratio"])
+
+    def test_computes_real_ratios(self):
+        row = _row(run_count=4, success_count=3, input_tokens=1000, cached_tokens=250,
+                    duration_ms_sum=6000, duration_count=4)
+        _add_derived_rates(row)
+        self.assertAlmostEqual(row["success_rate"], 75.0)
+        self.assertAlmostEqual(row["average_duration_ms"], 1500.0)
+        self.assertAlmostEqual(row["cache_ratio"], 25.0)
+
+    def test_matches_summary_shape_on_a_breakdown_style_dict(self):
+        # Simulates what breakdown_by_dimension.setdefault(...) produces:
+        # only the base numeric keys, no derived keys yet, plus one extra
+        # "dimension" key that isn't part of the ratio computation at all.
+        breakdown_row = {"dimension": "google", **_row(run_count=2, success_count=2,
+                                                         input_tokens=500, cached_tokens=100,
+                                                         duration_ms_sum=3000, duration_count=2)}
+        _add_derived_rates(breakdown_row)
+        self.assertEqual(breakdown_row["dimension"], "google")
+        self.assertAlmostEqual(breakdown_row["success_rate"], 100.0)
+        self.assertAlmostEqual(breakdown_row["average_duration_ms"], 1500.0)
+        self.assertAlmostEqual(breakdown_row["cache_ratio"], 20.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_agent_run_analytics_api_entity_filter.py
+++ b/huf/ai/tests/test_agent_run_analytics_api_entity_filter.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Unit tests for `_filter_rows_by_entity`, the pure helper extracted from
+`get_execution_analytics` (P7-T1's `entity` param) so the filtering logic
+that used to be inlined as
+
+    if entity:
+        rows = [row for row in rows if row.get(dimension) == entity]
+
+can be exercised without a live bench. `get_execution_analytics` itself is a
+`frappe.whitelist`-decorated function doing real `frappe.db.get_all` /
+`frappe.db.exists` calls, which is not mockable via the standalone
+`_stub_env` pattern -- so this file follows the same extraction approach as
+`test_agent_run_analytics_api_derived_rates.py` did for `_add_derived_rates`:
+test the extracted pure function directly, manually computing the expected
+filtered/aggregated result and comparing against the helper's output.
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.agent_run_analytics_api import _filter_rows_by_entity  # noqa: E402
+
+
+def _rows():
+    return [
+        {"bucket_start": "2026-08-20 00:00:00", "provider": "openai", "run_count": 5},
+        {"bucket_start": "2026-08-20 01:00:00", "provider": "anthropic", "run_count": 3},
+        {"bucket_start": "2026-08-20 02:00:00", "provider": "openai", "run_count": 2},
+        {"bucket_start": "2026-08-20 03:00:00", "provider": "google", "run_count": 1},
+    ]
+
+
+class TestFilterRowsByEntity(unittest.TestCase):
+    def test_entity_filter_matches_only_matching_rows(self):
+        rows = _rows()
+        result = _filter_rows_by_entity(rows, "provider", "openai")
+        # Manual filter, same semantics as the pre-extraction inline code.
+        expected = [row for row in rows if row.get("provider") == "openai"]
+        self.assertEqual(result, expected)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(row["provider"] == "openai" for row in result))
+
+    def test_entity_none_leaves_rows_unfiltered(self):
+        rows = _rows()
+        result = _filter_rows_by_entity(rows, "provider", None)
+        self.assertEqual(result, rows)
+        self.assertIs(result, rows)  # passthrough, not a filtered copy
+
+    def test_entity_empty_string_leaves_rows_unfiltered(self):
+        rows = _rows()
+        result = _filter_rows_by_entity(rows, "provider", "")
+        self.assertEqual(result, rows)
+        self.assertIs(result, rows)
+
+    def test_entity_matching_nothing_returns_empty_list(self):
+        rows = _rows()
+        result = _filter_rows_by_entity(rows, "provider", "does-not-exist")
+        self.assertEqual(result, [])
+
+    def test_entity_filter_on_different_dimension(self):
+        rows = [
+            {"agent": "agent-a", "run_count": 4},
+            {"agent": "agent-b", "run_count": 6},
+            {"agent": "agent-a", "run_count": 1},
+        ]
+        result = _filter_rows_by_entity(rows, "agent", "agent-a")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(sum(row["run_count"] for row in result), 5)
+
+    def test_dimension_value_validation_unaffected(self):
+        # _filter_rows_by_entity has no opinion on which dimension names are
+        # valid -- that check (`dimension not in DIMENSION_FIELDS`) lives
+        # earlier in get_execution_analytics and is unchanged by this
+        # extraction; this test just confirms the helper doesn't itself
+        # raise or reject unknown dimension names (it can't validate them,
+        # it only reads `row.get(dimension)`), which is the same behaviour
+        # the inline code had.
+        rows = _rows()
+        result = _filter_rows_by_entity(rows, "not_a_real_dimension", "openai")
+        self.assertEqual(result, [])  # no row has this key equal to "openai"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Follow-up to #645

Post-merge, a manual review of the conversation analytics response (added in #645) found that
duration was never surfaced despite `Agent Run.start_time`/`end_time` already existing and already
being aggregated by the scheduled rollup (`duration_ms_sum`/`duration_count`) — `get_conversation_analytics`
simply never fetched `end_time`.

- `totals.duration_ms_sum` / `duration_count` / `average_duration_ms` — cumulative, field names
  deliberately match `agent_run_analytics_api.py`'s summary shape rather than inventing a second
  convention for the same idea.
- `current.duration_ms` — the latest turn's own duration, a snapshot like everything else in
  `current`, never summed into `totals`.
- `series[].duration_ms` — per-run, for a future latency-over-turns view.
- Negative durations (clock skew / bad data) are treated as unmeasured, same guard the rollup already
  uses — never reported as a negative number.

Two new tiles in `ConversationAnalyticsPane`: "Avg duration" in Totals, "This turn" in Current
context, using the same `(ms/1000).toFixed(1)s` formatting `ExecutionAnalyticsDashboard.tsx` already
uses.

10 new standalone tests, all pass. Frontend typecheck clean. Live bench verification in progress —
will comment with results.