### PR TITLE
feat: HUF Meeting Recorder & Transcription app (v1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { ExecutionProfilesHeaderActions } from './components/ExecutionProfilesHe
 import { SSHConnectionsHeaderActions } from './components/SSHConnectionsHeaderActions';
 import { PageLoader } from './components/PageLoader';
 import { DataHeaderActions } from './components/DataHeaderActions';
+import { MeetingsHeaderActions } from './components/meetings/MeetingsHeaderActions';
 import { DataTableBuilderWrapper } from './pages/DataTableBuilderWrapper';
 import { DataTableViewWrapper } from './pages/DataTableViewWrapper';
 import { Toaster } from './components/ui/sonner';
@@ -60,6 +61,9 @@ const Executions = lazy(() => import('./pages/Executions'));
 const AgentRunDetailPageWrapper = lazy(() => import('./pages/AgentRunDetailPageWrapper'));
 const McpDetailsPageWrapper = lazy(() => import('./pages/McpDetailsPageWrapper'));
 const McpListingPage = lazy(() => import('./pages/McpListingPage'));
+const MeetingsPage = lazy(() => import('./pages/MeetingsPage'));
+const MeetingRecorderPage = lazy(() => import('./pages/MeetingRecorderPage'));
+const MeetingDetailPageWrapper = lazy(() => import('./pages/MeetingDetailPageWrapper'));
 const KnowledgeSourcesPage = lazy(() => import('./pages/KnowledgeSourcesPage'));
 const KnowledgeSourceFormPageWrapper = lazy(() => import('./pages/KnowledgeSourceFormPageWrapper'));
 const MemoryPage = lazy(() => import('./pages/MemoryPage'));
@@ -732,6 +736,40 @@ function AppShell() {
               <ProtectedRoute>
                 <Suspense fallback={<PageLoader />}>
                   <McpDetailsPageWrapper />
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/huf/meetings"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout headerActions={<MeetingsHeaderActions />}>
+                  <Suspense fallback={<PageLoader />}>
+                    <MeetingsPage />
+                  </Suspense>
+                </UnifiedLayout>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/huf/meetings/:meetingId/record"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout>
+                  <Suspense fallback={<PageLoader />}>
+                    <MeetingRecorderPage />
+                  </Suspense>
+                </UnifiedLayout>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/huf/meetings/:meetingId"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<PageLoader />}>
+                  <MeetingDetailPageWrapper />
                 </Suspense>
               </ProtectedRoute>
             }

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Mic, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -53,6 +53,12 @@ export const useNavItems = [
     url: "/chat",
     icon: MessageSquare,
     capability: "chat.use",
+  },
+  {
+    title: "Meetings",
+    url: "/huf/meetings",
+    icon: Mic,
+    capability: "agent.use",
   },
 ]
 

--- a/frontend/src/components/meetings/MeetingCard.tsx
+++ b/frontend/src/components/meetings/MeetingCard.tsx
@@ -1,0 +1,60 @@
+import { Calendar, Clock } from 'lucide-react';
+import { ItemCard } from '@/components/dashboard';
+import { formatTimeAgo } from '@/utils/time';
+import type { MeetingListItem, MeetingStatus } from '@/types/meeting.types';
+import type { BadgeVariant } from '@/utils/status';
+
+interface MeetingCardProps {
+  meeting: MeetingListItem;
+  onClick: () => void;
+}
+
+function statusPresentation(status: MeetingStatus): { label: string; variant: BadgeVariant } {
+  switch (status) {
+    case 'Recording':
+      return { label: 'recording', variant: 'destructive' };
+    case 'Paused':
+      return { label: 'paused', variant: 'secondary' };
+    case 'Stopped':
+    case 'Transcribing':
+    case 'Summarizing':
+      return { label: 'processing', variant: 'outline' };
+    case 'Completed':
+      return { label: 'completed', variant: 'success' };
+    case 'Failed':
+      return { label: 'failed', variant: 'destructive' };
+    case 'Draft':
+    default:
+      return { label: 'draft', variant: 'secondary' };
+  }
+}
+
+function formatDuration(seconds?: number): string {
+  if (!seconds || seconds <= 0) return '—';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining > 0 ? `${hours}h ${remaining}m` : `${hours}h`;
+}
+
+/** Thin `ItemCard` wrapper for one meeting in the history grid — title (or
+ * placeholder), relative date, duration, status pill, and a summary
+ * excerpt once available (PLAN.md G.1 "Meeting-history usability"). */
+export function MeetingCard({ meeting, onClick }: MeetingCardProps) {
+  const status = statusPresentation(meeting.status);
+  const title = meeting.title?.trim() || `Meeting — ${formatTimeAgo(meeting.started_at || meeting.modified)}`;
+
+  return (
+    <ItemCard
+      title={title}
+      description={meeting.summary ? meeting.summary.slice(0, 140) : meeting.description?.slice(0, 140)}
+      status={status}
+      metadata={[
+        { label: 'When', value: formatTimeAgo(meeting.started_at || meeting.modified), icon: Calendar },
+        { label: 'Duration', value: formatDuration(meeting.duration_seconds), icon: Clock },
+      ]}
+      onClick={onClick}
+    />
+  );
+}

--- a/frontend/src/components/meetings/MeetingProcessingStatus.tsx
+++ b/frontend/src/components/meetings/MeetingProcessingStatus.tsx
@@ -1,0 +1,64 @@
+import { CheckCircle2, Loader2, XCircle } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import { useMeetingProcessingSocket } from '@/hooks/useMeetingProcessingSocket';
+
+interface MeetingProcessingStatusProps {
+    meetingName: string;
+    /** Server-side status at mount, before any realtime event has landed. */
+    initialStatus?: 'Transcribing' | 'Summarizing' | 'Completed' | 'Failed';
+}
+
+/**
+ * Two-stage processing progress ("Transcribing N/M" -> "Summarizing"), driven
+ * by the `meeting_processing_status` realtime event (see
+ * `useMeetingProcessingSocket`). Per PLAN.md G.1, this is determinate
+ * wherever the server can tell us chunk counts rather than a bare spinner.
+ */
+export function MeetingProcessingStatus({ meetingName, initialStatus }: MeetingProcessingStatusProps) {
+    const { status, chunksTranscribed, chunksTotal } = useMeetingProcessingSocket(meetingName);
+    const currentStatus = status ?? initialStatus ?? null;
+
+    if (!currentStatus || currentStatus === 'Completed') {
+        return null;
+    }
+
+    if (currentStatus === 'Failed') {
+        return (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+                <XCircle className="h-4 w-4" aria-hidden />
+                <span>Processing failed</span>
+            </div>
+        );
+    }
+
+    if (currentStatus === 'Summarizing') {
+        return (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                <span>Summarizing</span>
+            </div>
+        );
+    }
+
+    // Transcribing: determinate progress once we know the total chunk count,
+    // otherwise fall back to an indeterminate label.
+    const hasCounts = chunksTotal > 0;
+    const percent = hasCounts ? Math.round((chunksTranscribed / chunksTotal) * 100) : 0;
+
+    return (
+        <div className="flex flex-col gap-1.5 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                <span>
+                    {hasCounts
+                        ? `Transcribing ${chunksTranscribed}/${chunksTotal}`
+                        : 'Transcribing'}
+                </span>
+                {hasCounts && chunksTranscribed === chunksTotal && (
+                    <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden />
+                )}
+            </div>
+            {hasCounts && <Progress value={percent} className="h-1.5 w-48" />}
+        </div>
+    );
+}

--- a/frontend/src/components/meetings/MeetingRecordingPlayer.tsx
+++ b/frontend/src/components/meetings/MeetingRecordingPlayer.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useState } from 'react';
+import { Music } from 'lucide-react';
+import {
+  AudioPlayer,
+  AudioPlayerControlBar,
+  AudioPlayerDurationDisplay,
+  AudioPlayerElement,
+  AudioPlayerMuteButton,
+  AudioPlayerPlayButton,
+  AudioPlayerTimeDisplay,
+  AudioPlayerTimeRange,
+} from '@/components/ai-elements/audio-player';
+import type { MeetingRecordingChunk } from '@/types/meeting.types';
+
+interface MeetingRecordingPlayerProps {
+  chunks: MeetingRecordingChunk[];
+}
+
+// Mirrors the FrappeApp base URL resolution in lib/frappe-sdk.ts — `Attach`
+// field values on Meeting Recording Chunk are site-relative paths
+// (/private/files/...), same-origin cookie auth applies, so this just needs
+// the same origin frappe-sdk calls resolve against, not a new auth path.
+const FRAPPE_URL = import.meta.env.VITE_FRAPPE_URL || window.location.origin;
+
+function resolveFileUrl(audioFile: string): string {
+  if (/^https?:\/\//.test(audioFile)) return audioFile;
+  return `${FRAPPE_URL}${audioFile.startsWith('/') ? '' : '/'}${audioFile}`;
+}
+
+/**
+ * Sequential multi-chunk playback. There is no combined-recording file on
+ * the backend (PLAN.md D.4), so this plays each chunk's `audio_file` in
+ * `sequence` order via a single `<audio>` element, advancing on `ended`.
+ */
+export function MeetingRecordingPlayer({ chunks }: MeetingRecordingPlayerProps) {
+  const playableChunks = useMemo(
+    () =>
+      chunks
+        .slice()
+        .sort((a, b) => a.sequence - b.sequence)
+        .filter((chunk) => !!chunk.audio_file),
+    [chunks],
+  );
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (playableChunks.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-dashed border-line px-4 py-3 text-sm text-steel">
+        <Music className="h-4 w-4 text-steel-soft" aria-hidden />
+        No recording available for this meeting.
+      </div>
+    );
+  }
+
+  const current = playableChunks[Math.min(currentIndex, playableChunks.length - 1)];
+  const isLastChunk = currentIndex >= playableChunks.length - 1;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <AudioPlayer key={current.name}>
+        <AudioPlayerElement
+          src={resolveFileUrl(current.audio_file!)}
+          onEnded={() => {
+            if (!isLastChunk) {
+              setCurrentIndex((index) => index + 1);
+            }
+          }}
+        />
+        <AudioPlayerControlBar>
+          <AudioPlayerPlayButton />
+          <AudioPlayerTimeDisplay />
+          <AudioPlayerTimeRange />
+          <AudioPlayerDurationDisplay />
+          <AudioPlayerMuteButton />
+        </AudioPlayerControlBar>
+      </AudioPlayer>
+      {playableChunks.length > 1 && (
+        <span className="font-body text-xs text-steel-soft">
+          Part {currentIndex + 1} of {playableChunks.length}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/MeetingSummaryPanel.tsx
+++ b/frontend/src/components/meetings/MeetingSummaryPanel.tsx
@@ -1,0 +1,120 @@
+import { FileText, ListChecks, ListTree } from 'lucide-react';
+import { Streamdown } from 'streamdown';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface MeetingSummaryPanelProps {
+  /**
+   * Markdown produced by the "Meeting Summary Agent" (huf/install.py
+   * MEETING_SUMMARY_INSTRUCTIONS): exactly three `## ` sections in order —
+   * Headline, Key Points, Action Items.
+   */
+  summary?: string | null;
+}
+
+interface ParsedSummary {
+  headline: string;
+  keyPoints: string;
+  actionItems: string;
+}
+
+const SECTION_HEADINGS = ['Headline', 'Key Points', 'Action Items'] as const;
+
+/**
+ * Splits the agent's Markdown output into its three named `## ` sections.
+ * Deliberately tolerant of missing/reordered/extra sections — the model
+ * output is not guaranteed to match the prompt exactly, and a blank block
+ * is a better failure mode than a crash or a wall of unstructured text.
+ */
+function parseSummary(markdown: string): ParsedSummary {
+  const sections: Record<string, string> = {};
+  const matches = markdown.split(/(^##\s+.+$)/m);
+
+  let currentHeading: string | null = null;
+  for (const part of matches) {
+    const headingMatch = part.match(/^##\s+(.+)$/m);
+    if (headingMatch) {
+      currentHeading = headingMatch[1].trim();
+      continue;
+    }
+    if (currentHeading) {
+      sections[currentHeading] = (sections[currentHeading] || '') + part;
+    }
+  }
+
+  return {
+    headline: sections['Headline']?.trim() || '',
+    keyPoints: sections['Key Points']?.trim() || '',
+    actionItems: sections['Action Items']?.trim() || '',
+  };
+}
+
+/**
+ * Headline + Key Points + Action Items rendered as three distinct blocks
+ * (PLAN.md G.1 "summary readability" — not one undifferentiated paragraph).
+ * Falls back to rendering the raw markdown if the expected `## ` sections
+ * aren't found, so an off-spec agent response still shows something useful.
+ */
+export function MeetingSummaryPanel({ summary }: MeetingSummaryPanelProps) {
+  if (!summary || !summary.trim()) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-line py-10 text-center">
+        <FileText className="h-5 w-5 text-steel-soft" aria-hidden />
+        <p className="font-body text-sm text-steel">Meeting has no summary yet.</p>
+      </div>
+    );
+  }
+
+  const parsed = parseSummary(summary);
+  const hasStructuredSections = SECTION_HEADINGS.some(
+    (heading) => heading === 'Headline' ? parsed.headline : heading === 'Key Points' ? parsed.keyPoints : parsed.actionItems,
+  );
+
+  if (!hasStructuredSections) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Summary</CardTitle>
+        </CardHeader>
+        <CardContent className="prose prose-sm max-w-none">
+          <Streamdown>{summary}</Streamdown>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {parsed.headline && (
+        <div className="rounded-lg border border-line bg-card px-5 py-4">
+          <h2 className="font-body text-[15px] font-medium leading-snug text-ink">{parsed.headline}</h2>
+        </div>
+      )}
+
+      {parsed.keyPoints && (
+        <Card>
+          <CardHeader className="flex flex-row items-center gap-2 space-y-0">
+            <ListTree className="h-4 w-4 text-steel-soft" aria-hidden />
+            <CardTitle className="text-sm">Key points</CardTitle>
+          </CardHeader>
+          <CardContent className="prose prose-sm max-w-none [&_ul]:my-0 [&_li]:my-1">
+            <Streamdown>{parsed.keyPoints}</Streamdown>
+          </CardContent>
+        </Card>
+      )}
+
+      {parsed.actionItems && (
+        <Card>
+          <CardHeader className="flex flex-row items-center gap-2 space-y-0">
+            <ListChecks className="h-4 w-4 text-steel-soft" aria-hidden />
+            <CardTitle className="text-sm">Action items</CardTitle>
+          </CardHeader>
+          <CardContent
+            className="prose prose-sm max-w-none [&_ul]:list-none [&_ul]:pl-0 [&_ul]:my-0 [&_li]:my-1.5 [&_li]:flex [&_li]:items-start [&_li]:gap-2 [&_li::before]:content-['\2610'] [&_li::before]:text-steel-soft [&_li::before]:leading-[1.4]"
+          >
+            <Streamdown>{parsed.actionItems}</Streamdown>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/MeetingTranscriptPanel.tsx
+++ b/frontend/src/components/meetings/MeetingTranscriptPanel.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle, FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { MeetingRecordingChunk } from '@/types/meeting.types';
+
+interface MeetingTranscriptPanelProps {
+  chunks: MeetingRecordingChunk[];
+  /** Whether the meeting is still being transcribed — enables auto-scroll. */
+  isLive?: boolean;
+  className?: string;
+}
+
+/** `mm:ss` (or `h:mm:ss` past an hour) elapsed-from-start timestamp for a chunk. */
+function formatElapsed(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const mm = h > 0 ? String(m).padStart(2, '0') : String(m);
+  const ss = String(s).padStart(2, '0');
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/**
+ * Timestamped transcript, one paragraph per chunk boundary (PLAN.md G.1
+ * "transcript readability"). Auto-scrolls to the newest chunk while the
+ * meeting is still transcribing; becomes a static scrollable/searchable
+ * (browser find-in-page) panel once complete. Failed chunks already carry
+ * the backend's inline "[this part could not be transcribed]" text
+ * (Phase 4) — this renders that text as-is and adds a visible gap marker
+ * treatment, it does not invent new placeholder copy.
+ */
+export function MeetingTranscriptPanel({ chunks, isLive, className }: MeetingTranscriptPanelProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const transcribedChunks = chunks
+    .slice()
+    .sort((a, b) => a.sequence - b.sequence)
+    .filter((chunk) => !!chunk.transcript_text || chunk.upload_status === 'Failed');
+
+  useEffect(() => {
+    if (isLive) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+  }, [isLive, chunks.length]);
+
+  if (transcribedChunks.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-line py-10 text-center">
+        <FileText className="h-5 w-5 text-steel-soft" aria-hidden />
+        <p className="font-body text-sm text-steel">Meeting has no transcript yet.</p>
+      </div>
+    );
+  }
+
+  // Running elapsed offset, computed from each chunk's own duration since
+  // client_started_at isn't guaranteed to be populated for every chunk.
+  let runningSeconds = 0;
+
+  return (
+    <div
+      className={cn('flex max-h-[60vh] flex-col gap-4 overflow-y-auto rounded-lg border border-line p-4', className)}
+      role="log"
+      aria-label="Meeting transcript"
+    >
+      {transcribedChunks.map((chunk) => {
+        const timestampSeconds = chunk.client_started_at
+          ? Number(chunk.client_started_at) || runningSeconds
+          : runningSeconds;
+        runningSeconds = timestampSeconds + (chunk.duration_seconds || 0);
+        const isGap = chunk.upload_status === 'Failed' || !!chunk.transcription_error;
+
+        return (
+          <div key={chunk.name} className="flex gap-3">
+            <span
+              className="mt-0.5 shrink-0 font-mono text-xs tabular-nums text-steel-soft"
+              aria-hidden
+            >
+              {formatElapsed(timestampSeconds)}
+            </span>
+            {isGap ? (
+              <p className="flex items-start gap-1.5 text-sm leading-7 text-steel italic">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" aria-hidden />
+                {chunk.transcript_text || '[this part could not be transcribed]'}
+              </p>
+            ) : (
+              <p className="text-sm leading-7 text-ink">{chunk.transcript_text}</p>
+            )}
+          </div>
+        );
+      })}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/MeetingsHeaderActions.tsx
+++ b/frontend/src/components/meetings/MeetingsHeaderActions.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { Mic, Plus } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { NewMeetingDialog } from './NewMeetingDialog';
+import { createMeeting, startRecording } from '@/services/meetingApi';
+
+/**
+ * Quick Start is a single click, zero intermediate screens: it creates the
+ * meeting and navigates straight to the recorder, which itself requests
+ * mic permission and starts capture on mount. "New meeting with details"
+ * is the only path to the optional context dialog (PLAN.md G.1/G.2 item 1).
+ */
+export function MeetingsHeaderActions() {
+  const navigate = useNavigate();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [quickStarting, setQuickStarting] = useState(false);
+  const [starting, setStarting] = useState(false);
+
+  const beginRecording = async (details: { title?: string; description?: string; participants?: string }) => {
+    const { meeting_name: meetingName } = await createMeeting(details);
+    await startRecording(meetingName);
+    navigate(`/huf/meetings/${meetingName}/record`);
+  };
+
+  const handleQuickStart = async () => {
+    setQuickStarting(true);
+    try {
+      await beginRecording({});
+    } catch (error) {
+      toast.error('Could not start recording', {
+        description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
+    } finally {
+      setQuickStarting(false);
+    }
+  };
+
+  const handleStartWithDetails = async (details: { title?: string; description?: string; participants?: string }) => {
+    setStarting(true);
+    try {
+      await beginRecording(details);
+      setDialogOpen(false);
+    } catch (error) {
+      toast.error('Could not start recording', {
+        description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)} disabled={quickStarting}>
+        <Plus className="w-4 h-4 mr-2" />
+        New meeting with details
+      </Button>
+      <Button variant="display" size="sm" onClick={handleQuickStart} disabled={quickStarting}>
+        <Mic className="w-4 h-4 mr-2" />
+        {quickStarting ? 'Starting...' : 'Quick start'}
+      </Button>
+      <NewMeetingDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onStart={handleStartWithDetails}
+        starting={starting}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/NewMeetingDialog.tsx
+++ b/frontend/src/components/meetings/NewMeetingDialog.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+
+interface NewMeetingDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onStart: (details: { title?: string; description?: string; participants?: string }) => void;
+  starting?: boolean;
+}
+
+/**
+ * Optional "New meeting with details" form. Every field is optional and
+ * skippable — recording never blocks on this dialog (PLAN.md G.1 "Start-
+ * recording friction"). Quick Start bypasses this entirely.
+ */
+export function NewMeetingDialog({ open, onOpenChange, onStart, starting }: NewMeetingDialogProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [participants, setParticipants] = useState('');
+
+  const reset = () => {
+    setTitle('');
+    setDescription('');
+    setParticipants('');
+  };
+
+  const handleStart = () => {
+    onStart({
+      title: title.trim() || undefined,
+      description: description.trim() || undefined,
+      participants: participants.trim() || undefined,
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New meeting</DialogTitle>
+          <DialogDescription>
+            All fields are optional — you can add or edit these after the meeting too.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="new-meeting-title">Title</Label>
+            <Input
+              id="new-meeting-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="e.g. Weekly product sync"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-meeting-description">Description</Label>
+            <Textarea
+              id="new-meeting-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="What is this meeting about?"
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="new-meeting-participants">Participants</Label>
+            <Input
+              id="new-meeting-participants"
+              value={participants}
+              onChange={(event) => setParticipants(event.target.value)}
+              placeholder="Names or emails, comma separated"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={starting}>
+              Cancel
+            </Button>
+            <Button type="button" variant="display" onClick={handleStart} disabled={starting}>
+              {starting ? 'Starting...' : 'Start recording'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/meetings/PostMeetingContextPanel.tsx
+++ b/frontend/src/components/meetings/PostMeetingContextPanel.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { updateMeetingContext } from '@/services/meetingApi';
+
+interface PostMeetingContextPanelProps {
+  meetingName: string;
+  onDismiss: () => void;
+  onSaved: (values: { title?: string; description?: string; participants?: string }) => void;
+}
+
+/**
+ * Non-modal, dismissible inline prompt shown once per meeting right after
+ * Stop (PLAN.md G.1 "post-meeting context" / L Phase 7): three optional
+ * fields, "Skip" is as prominent as "Save" since none of this blocks
+ * processing — it only improves the summary prompt (meeting_summary.py
+ * _build_summary_prompt reads title/description/participants when present).
+ */
+export function PostMeetingContextPanel({ meetingName, onDismiss, onSaved }: PostMeetingContextPanelProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [participants, setParticipants] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const result = await updateMeetingContext({
+        meetingName,
+        title: title.trim() || undefined,
+        description: description.trim() || undefined,
+        participants: participants.trim() || undefined,
+      });
+      toast.success('Meeting details saved');
+      onSaved({
+        title: result.title,
+        description: result.description,
+        participants: result.participants,
+      });
+    } catch (error) {
+      toast.error('Could not save meeting details', {
+        description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="relative rounded-lg border border-line bg-card p-5" role="region" aria-label="Add meeting context">
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        className="absolute right-3 top-3"
+        aria-label="Dismiss"
+        onClick={onDismiss}
+      >
+        <X className="h-4 w-4" aria-hidden />
+      </Button>
+
+      <h3 className="font-body text-sm font-medium text-ink">Add a title and participants to improve your summary</h3>
+      <p className="mt-1 font-body text-[13px] text-steel">Entirely optional — this only helps the summary, it won't delay processing.</p>
+
+      <div className="mt-4 flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="meeting-context-title">Title</Label>
+          <Input
+            id="meeting-context-title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="e.g. Q3 roadmap review"
+            disabled={saving}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="meeting-context-participants">Participants</Label>
+          <Input
+            id="meeting-context-participants"
+            value={participants}
+            onChange={(event) => setParticipants(event.target.value)}
+            placeholder="e.g. Priya, Jordan, Sam"
+            disabled={saving}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="meeting-context-description">Description</Label>
+          <Textarea
+            id="meeting-context-description"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="What was this meeting about?"
+            rows={2}
+            disabled={saving}
+          />
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-2">
+        <Button size="sm" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save'}
+        </Button>
+        <Button variant="outline" size="sm" onClick={onDismiss} disabled={saving}>
+          Skip
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/RecorderControls.tsx
+++ b/frontend/src/components/meetings/RecorderControls.tsx
@@ -1,0 +1,87 @@
+import { Mic, MicOff, Pause, Play, Square } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { RecorderStatus } from '@/hooks/useMeetingRecorder';
+
+interface RecorderControlsProps {
+  status: RecorderStatus;
+  isMuted: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onToggleMute: () => void;
+  onRequestStop: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Pause/Resume is the primary control; Mute is a secondary icon toggle
+ * kept visually distinct so it never competes with Pause/Stop (PLAN.md
+ * G.1 "Recorder UX", G.2 item 5 — Mute and Pause stay semantically and
+ * visually separate controls).
+ */
+export function RecorderControls({
+  status,
+  isMuted,
+  onPause,
+  onResume,
+  onToggleMute,
+  onRequestStop,
+  disabled,
+}: RecorderControlsProps) {
+  const isRecording = status === 'recording';
+  const isPaused = status === 'paused';
+
+  return (
+    <div className="flex items-center justify-center gap-4">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="h-12 w-12 rounded-full"
+        onClick={onToggleMute}
+        disabled={disabled || (!isRecording && !isPaused)}
+        aria-label={isMuted ? 'Unmute microphone' : 'Mute microphone'}
+        aria-pressed={isMuted}
+      >
+        {isMuted ? <MicOff className="h-5 w-5" /> : <Mic className="h-5 w-5" />}
+      </Button>
+
+      {isPaused ? (
+        <Button
+          type="button"
+          variant="display"
+          size="lg"
+          className="h-16 w-16 rounded-full p-0"
+          onClick={onResume}
+          disabled={disabled}
+          aria-label="Resume recording"
+        >
+          <Play className="h-6 w-6" />
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="display"
+          size="lg"
+          className="h-16 w-16 rounded-full p-0"
+          onClick={onPause}
+          disabled={disabled || !isRecording}
+          aria-label="Pause recording"
+        >
+          <Pause className="h-6 w-6" />
+        </Button>
+      )}
+
+      <Button
+        type="button"
+        variant="destructive-ghost"
+        size="icon"
+        className="h-12 w-12 rounded-full"
+        onClick={onRequestStop}
+        disabled={disabled}
+        aria-label="Stop recording"
+      >
+        <Square className="h-5 w-5" />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/RecorderTimer.tsx
+++ b/frontend/src/components/meetings/RecorderTimer.tsx
@@ -1,0 +1,29 @@
+interface RecorderTimerProps {
+  elapsedSeconds: number;
+  paused?: boolean;
+}
+
+function formatClock(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  if (hours > 0) {
+    return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+  }
+  return `${pad(minutes)}:${pad(seconds)}`;
+}
+
+/** Large monospaced timer — the dominant element on the recorder view
+ * (PLAN.md G.1 "Recorder UX"). Visually freezes (dimmed) while paused. */
+export function RecorderTimer({ elapsedSeconds, paused }: RecorderTimerProps) {
+  return (
+    <div
+      className={`font-mono text-6xl font-semibold tabular-nums tracking-tight text-ink transition-opacity sm:text-7xl ${
+        paused ? 'opacity-50' : 'opacity-100'
+      }`}
+    >
+      {formatClock(elapsedSeconds)}
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/RecordingStatusPill.tsx
+++ b/frontend/src/components/meetings/RecordingStatusPill.tsx
@@ -1,0 +1,53 @@
+import { Circle, Mic, MicOff, Pause } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { RecorderStatus } from '@/hooks/useMeetingRecorder';
+
+interface RecordingStatusPillProps {
+  status: RecorderStatus;
+  isMuted: boolean;
+}
+
+/**
+ * Persistent, high-contrast status pill for the active recorder. Never
+ * relies on color alone — every state pairs an icon with a text label, per
+ * PLAN.md G.1 accessibility requirements.
+ */
+export function RecordingStatusPill({ status, isMuted }: RecordingStatusPillProps) {
+  if (status === 'recording' && isMuted) {
+    return (
+      <Badge variant="pill-warning" className="gap-1.5 px-3 py-1 text-[13px]">
+        <MicOff className="h-3.5 w-3.5" aria-hidden />
+        Muted
+      </Badge>
+    );
+  }
+
+  if (status === 'recording') {
+    return (
+      <Badge variant="pill-danger" className="gap-1.5 px-3 py-1 text-[13px]">
+        <Circle className="h-2.5 w-2.5 animate-pulse fill-current" aria-hidden />
+        Recording
+      </Badge>
+    );
+  }
+
+  if (status === 'paused') {
+    return (
+      <Badge variant="pill-neutral" className="gap-1.5 px-3 py-1 text-[13px]">
+        <Pause className="h-3.5 w-3.5" aria-hidden />
+        Paused
+      </Badge>
+    );
+  }
+
+  if (status === 'stopped') {
+    return (
+      <Badge variant="pill-neutral" className="gap-1.5 px-3 py-1 text-[13px]">
+        <Mic className="h-3.5 w-3.5" aria-hidden />
+        Stopped
+      </Badge>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/data/doctypes.ts
+++ b/frontend/src/data/doctypes.ts
@@ -40,6 +40,8 @@ export const doctype = {
   "Huf Data Table": "Huf Data Table",
   "Agent Context Artifact": "Agent Context Artifact",
   "Agent Run Feedback": "Agent Run Feedback",
+  Meeting: "Meeting",
+  "Meeting Recording Chunk": "Meeting Recording Chunk",
 } as const;
 
 export type DocType = typeof doctype[keyof typeof doctype];

--- a/frontend/src/hooks/useMeetingProcessingSocket.ts
+++ b/frontend/src/hooks/useMeetingProcessingSocket.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { useSocket } from '../contexts/SocketContext';
+
+/**
+ * `meeting_processing_status` — emitted by
+ * `huf.ai.meetings.meeting_transcription._emit_processing_status` (also used
+ * from `meeting_summary.py`) on the `meeting:{meeting_name}` channel, scoped
+ * to the meeting's owner. Mirrors `AgentRunStatusEvent` in `useChatSocket.tsx`.
+ */
+export type MeetingProcessingStatusEvent = {
+    type: 'meeting_processing_status';
+    meeting: string;
+    status: 'Transcribing' | 'Summarizing' | 'Completed' | 'Failed';
+    chunks_transcribed: number;
+    chunks_total: number;
+};
+
+export type MeetingProcessingState = {
+    status: MeetingProcessingStatusEvent['status'] | null;
+    chunksTranscribed: number;
+    chunksTotal: number;
+};
+
+const INITIAL_STATE: MeetingProcessingState = {
+    status: null,
+    chunksTranscribed: 0,
+    chunksTotal: 0,
+};
+
+/**
+ * Subscribes to realtime processing progress for a single meeting. Consumers
+ * (e.g. `MeetingProcessingStatus`) read `{status, chunksTranscribed,
+ * chunksTotal}`; nothing here polls the server — the state is purely
+ * event-driven from the `meeting:{meetingName}` channel.
+ */
+export function useMeetingProcessingSocket(meetingName: string | null) {
+    const socket = useSocket();
+    const [state, setState] = useState<MeetingProcessingState>(INITIAL_STATE);
+
+    useEffect(() => {
+        setState(INITIAL_STATE);
+
+        if (!socket || !meetingName) {
+            return;
+        }
+
+        const handler = (data: MeetingProcessingStatusEvent) => {
+            if (data.type !== 'meeting_processing_status') {
+                return;
+            }
+
+            setState({
+                status: data.status,
+                chunksTranscribed: data.chunks_transcribed,
+                chunksTotal: data.chunks_total,
+            });
+        };
+
+        socket.on(`meeting:${meetingName}`, handler);
+
+        return () => {
+            socket.off(`meeting:${meetingName}`, handler);
+        };
+    }, [socket, meetingName]);
+
+    return state;
+}

--- a/frontend/src/hooks/useMeetingRecorder.test.ts
+++ b/frontend/src/hooks/useMeetingRecorder.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeBackoffDelayMs,
+  chunkRecordId,
+  blobToBase64,
+  MAX_AUTO_RETRIES,
+  DEFAULT_TIMESLICE_MS,
+} from './useMeetingRecorder';
+
+describe('computeBackoffDelayMs', () => {
+  it('doubles the delay for each retry, starting at 2s', () => {
+    expect(computeBackoffDelayMs(0)).toBe(2_000);
+    expect(computeBackoffDelayMs(1)).toBe(4_000);
+    expect(computeBackoffDelayMs(2)).toBe(8_000);
+    expect(computeBackoffDelayMs(3)).toBe(16_000);
+  });
+
+  it('caps the delay at 60s', () => {
+    expect(computeBackoffDelayMs(10)).toBe(60_000);
+    expect(computeBackoffDelayMs(MAX_AUTO_RETRIES)).toBeLessThanOrEqual(60_000);
+  });
+
+  it('treats negative retry counts as the first attempt', () => {
+    expect(computeBackoffDelayMs(-1)).toBe(2_000);
+  });
+});
+
+describe('chunkRecordId', () => {
+  it('builds a stable, sortable-by-meeting key from meeting + sequence', () => {
+    expect(chunkRecordId('MEETING-001', 0)).toBe('MEETING-001:0');
+    expect(chunkRecordId('MEETING-001', 12)).toBe('MEETING-001:12');
+  });
+
+  it('produces distinct keys for different meetings with the same sequence', () => {
+    expect(chunkRecordId('MEETING-001', 3)).not.toBe(chunkRecordId('MEETING-002', 3));
+  });
+});
+
+describe('blobToBase64', () => {
+  it('round-trips small binary content to base64', async () => {
+    const bytes = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+    const blob = new Blob([bytes], { type: 'audio/webm' });
+    const b64 = await blobToBase64(blob);
+    expect(b64).toBe(Buffer.from(bytes).toString('base64'));
+  });
+
+  it('handles an empty blob', async () => {
+    const blob = new Blob([], { type: 'audio/webm' });
+    const b64 = await blobToBase64(blob);
+    expect(b64).toBe('');
+  });
+});
+
+describe('constants', () => {
+  it('keeps the default segment length within the 30-60s target window', () => {
+    expect(DEFAULT_TIMESLICE_MS).toBeGreaterThanOrEqual(30_000);
+    expect(DEFAULT_TIMESLICE_MS).toBeLessThanOrEqual(60_000);
+  });
+});

--- a/frontend/src/hooks/useMeetingRecorder.test.ts
+++ b/frontend/src/hooks/useMeetingRecorder.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/services/meetingApi', () => ({
+  uploadChunk: vi.fn(),
+}));
+
 import {
   computeBackoffDelayMs,
   chunkRecordId,

--- a/frontend/src/hooks/useMeetingRecorder.ts
+++ b/frontend/src/hooks/useMeetingRecorder.ts
@@ -1,0 +1,525 @@
+/**
+ * useMeetingRecorder
+ *
+ * Core recording hook for the Meeting Recorder feature (Phase 3). Wraps the
+ * browser `MediaRecorder` API to progressively capture audio in ~30-60s
+ * segments, queues each segment in IndexedDB before it is confirmed
+ * uploaded, and drives the Phase 2 `upload_chunk` API with retry/backoff.
+ *
+ * ## Public API shape
+ *
+ * `useMeetingRecorder({ meetingName })` returns:
+ *   - `status`: `'idle' | 'recording' | 'paused' | 'stopped'` — mirrors the
+ *     *client's* capture state, not `Meeting.status` on the server (callers
+ *     that need the server status should read it from `meetingApi.getMeeting`
+ *     separately; this hook does not poll the server).
+ *   - `isMuted`, `elapsedSeconds`, `pendingUploadCount` — live UI state.
+ *   - `resumableMeeting`: set on mount if IndexedDB holds unflushed segments
+ *     for *any* meeting (i.e. the app was closed mid-recording). Callers
+ *     decide the UX (offer "Resume recording" / discard).
+ *   - `start()`, `pause()`, `resume()`, `toggleMute()`, `stop()` — the
+ *     control surface used by `MeetingRecorderPage`/`RecorderControls`.
+ *   - `resumeQueuedUploads(meetingName)` / `discardQueuedUploads(meetingName)`
+ *     — flush or drop a previous session's unsent segments without starting
+ *     a new recording.
+ *
+ * ## IndexedDB schema (db `huf_meeting_recorder`, store `pending_chunks`)
+ *
+ * One record per not-yet-confirmed segment, keyed by `${meeting}:${sequence}`:
+ *   `{ id, meeting, sequence, blob, mimeType, clientStartedAt,
+ *      durationSeconds, retryCount, createdAt }`
+ * A record is written *before* the first upload attempt and deleted only
+ * after the server returns success — so a tab crash/refresh mid-upload
+ * never silently drops audio (see PLAN.md section D.2/K). An index on
+ * `meeting` lets `resumableMeeting` be computed with a single cursor scan.
+ *
+ * ## Extension points for later phases
+ *   - Phase 6 (realtime): subscribe to `meeting_chunk_uploaded` alongside
+ *     this hook's `pendingUploadCount` to reconcile client vs. server state;
+ *     no changes needed here, this hook only reports local queue depth.
+ *   - Phase 7 (detail page): does not use this hook at all — it reads
+ *     finished `Meeting`/`Meeting Recording Chunk` data via `meetingApi`.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { uploadChunk } from '@/services/meetingApi';
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit testing without a DOM/MediaRecorder mock)
+// ---------------------------------------------------------------------------
+
+/** Default segment length: emit a chunk every 45s (within the 30-60s target). */
+export const DEFAULT_TIMESLICE_MS = 45_000;
+
+const BASE_RETRY_DELAY_MS = 2_000;
+const MAX_RETRY_DELAY_MS = 60_000;
+/** After this many automatic attempts, a chunk stays queued but is no
+ * longer auto-retried — surfaced via `pendingUploadCount` until the user
+ * (or `resumeQueuedUploads`) triggers another attempt. */
+export const MAX_AUTO_RETRIES = 6;
+
+/** Exponential backoff with a cap: 2s, 4s, 8s, 16s, 32s, 60s, 60s, ... */
+export function computeBackoffDelayMs(retryCount: number): number {
+  const delay = BASE_RETRY_DELAY_MS * 2 ** Math.max(0, retryCount);
+  return Math.min(delay, MAX_RETRY_DELAY_MS);
+}
+
+/** Builds the IndexedDB primary key for a segment. */
+export function chunkRecordId(meeting: string, sequence: number): string {
+  return `${meeting}:${sequence}`;
+}
+
+/** Base64-encodes a Blob without relying on FileReader (works in the
+ * browser and under Vitest's node environment alike). */
+export async function blobToBase64(blob: Blob): Promise<string> {
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  if (typeof btoa === 'function') {
+    return btoa(binary);
+  }
+  // Node/Vitest fallback (no global btoa in the vitest `node` environment).
+  return Buffer.from(bytes).toString('base64');
+}
+
+export type RecorderStatus = 'idle' | 'recording' | 'paused' | 'stopped';
+
+export interface QueuedChunkRecord {
+  id: string;
+  meeting: string;
+  sequence: number;
+  blob: Blob;
+  mimeType: string;
+  clientStartedAt: string;
+  durationSeconds: number;
+  retryCount: number;
+  createdAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB queue
+// ---------------------------------------------------------------------------
+
+const DB_NAME = 'huf_meeting_recorder';
+const DB_VERSION = 1;
+const STORE_NAME = 'pending_chunks';
+const MEETING_INDEX = 'meeting';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openQueueDb(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('IndexedDB is not available in this environment'));
+  }
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+          store.createIndex(MEETING_INDEX, 'meeting', { unique: false });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+  return dbPromise;
+}
+
+async function putQueuedChunk(record: QueuedChunkRecord): Promise<void> {
+  const db = await openQueueDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put(record);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function deleteQueuedChunk(id: string): Promise<void> {
+  const db = await openQueueDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function getQueuedChunksForMeeting(meeting: string): Promise<QueuedChunkRecord[]> {
+  const db = await openQueueDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const index = tx.objectStore(STORE_NAME).index(MEETING_INDEX);
+    const request = index.getAll(meeting);
+    request.onsuccess = () => resolve((request.result || []) as QueuedChunkRecord[]);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function getAllQueuedChunks(): Promise<QueuedChunkRecord[]> {
+  const db = await openQueueDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const request = tx.objectStore(STORE_NAME).getAll();
+    request.onsuccess = () => resolve((request.result || []) as QueuedChunkRecord[]);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export interface ResumableMeeting {
+  meetingName: string;
+  pendingChunkCount: number;
+}
+
+/** Scans the queue for any meeting with unflushed segments. Exported so
+ * pages that want to check before mounting the hook (e.g. the meetings
+ * list) can do so directly. */
+export async function findResumableMeeting(): Promise<ResumableMeeting | null> {
+  try {
+    const all = await getAllQueuedChunks();
+    if (all.length === 0) return null;
+    const counts = new Map<string, number>();
+    for (const record of all) {
+      counts.set(record.meeting, (counts.get(record.meeting) || 0) + 1);
+    }
+    const [meetingName, pendingChunkCount] = [...counts.entries()][0];
+    return { meetingName, pendingChunkCount };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseMeetingRecorderOptions {
+  /** The `Meeting.name` this recording session belongs to. Uploads are
+   * inert until this is set (created via `meetingApi.createMeeting`). */
+  meetingName: string | null;
+  /** How often `MediaRecorder` emits a segment. Defaults to 45s. */
+  timesliceMs?: number;
+  /** Called whenever a chunk permanently fails after `MAX_AUTO_RETRIES`, or
+   * mic access fails. Non-fatal to the recording itself. */
+  onError?: (error: Error) => void;
+}
+
+export interface UseMeetingRecorderReturn {
+  status: RecorderStatus;
+  isMuted: boolean;
+  /** Seconds elapsed since `start()`, paused time excluded. */
+  elapsedSeconds: number;
+  /** Segments written to the local queue but not yet confirmed uploaded. */
+  pendingUploadCount: number;
+  /** Whole minutes captured so far, for "N minutes recorded" copy. */
+  minutesRecorded: number;
+  /** Set on mount (and after `stop()`) if the local queue holds unflushed
+   * segments belonging to a meeting other than an active recording. */
+  resumableMeeting: ResumableMeeting | null;
+  start: () => Promise<void>;
+  pause: () => void;
+  resume: () => Promise<void>;
+  toggleMute: () => void;
+  stop: () => Promise<void>;
+  /** Re-attempts upload for every queued segment of a past meeting without
+   * starting a new recording (used from the resume-recovery prompt). */
+  resumeQueuedUploads: (meetingName: string) => Promise<void>;
+  /** Drops all queued segments for a meeting — used when the user declines
+   * to resume an interrupted session. */
+  discardQueuedUploads: (meetingName: string) => Promise<void>;
+}
+
+export function useMeetingRecorder(options: UseMeetingRecorderOptions): UseMeetingRecorderReturn {
+  const { meetingName, timesliceMs = DEFAULT_TIMESLICE_MS, onError } = options;
+
+  const [status, setStatus] = useState<RecorderStatus>('idle');
+  const [isMuted, setIsMuted] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [pendingUploadCount, setPendingUploadCount] = useState(0);
+  const [resumableMeeting, setResumableMeeting] = useState<ResumableMeeting | null>(null);
+
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const sequenceRef = useRef(0);
+  const segmentStartedAtRef = useRef<number>(0);
+  const timerIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const elapsedBeforePauseRef = useRef(0);
+  const runStartedAtRef = useRef<number>(0);
+  const pendingTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const refreshPendingCount = useCallback(async () => {
+    if (!meetingName) return;
+    try {
+      const queued = await getQueuedChunksForMeeting(meetingName);
+      setPendingUploadCount(queued.length);
+    } catch {
+      // IndexedDB unavailable — pending count just stays at its last value.
+    }
+  }, [meetingName]);
+
+  // On mount, check whether a previous session left unflushed segments.
+  useEffect(() => {
+    let cancelled = false;
+    findResumableMeeting().then((found) => {
+      if (!cancelled) setResumableMeeting(found);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const attemptUpload = useCallback(
+    async (record: QueuedChunkRecord) => {
+      try {
+        const audioB64 = await blobToBase64(record.blob);
+        await uploadChunk({
+          meeting: record.meeting,
+          sequence: record.sequence,
+          clientStartedAt: record.clientStartedAt,
+          durationSeconds: record.durationSeconds,
+          audioB64: `data:${record.mimeType};base64,${audioB64}`,
+        });
+        await deleteQueuedChunk(record.id);
+        pendingTimersRef.current.delete(record.id);
+        await refreshPendingCount();
+      } catch (error) {
+        const nextRetryCount = record.retryCount + 1;
+        if (nextRetryCount > MAX_AUTO_RETRIES) {
+          onErrorRef.current?.(
+            error instanceof Error ? error : new Error('Some of this recording could not be saved'),
+          );
+          return;
+        }
+        const updated: QueuedChunkRecord = { ...record, retryCount: nextRetryCount };
+        try {
+          await putQueuedChunk(updated);
+        } catch {
+          // Best-effort persistence; retry timer still fires from memory.
+        }
+        const delay = computeBackoffDelayMs(nextRetryCount);
+        const timer = setTimeout(() => {
+          attemptUpload(updated);
+        }, delay);
+        pendingTimersRef.current.set(record.id, timer);
+      }
+    },
+    [refreshPendingCount],
+  );
+
+  const enqueueSegment = useCallback(
+    async (blob: Blob, mimeType: string, clientStartedAt: string, durationSeconds: number) => {
+      if (!meetingName) return;
+      const sequence = sequenceRef.current;
+      sequenceRef.current += 1;
+      const record: QueuedChunkRecord = {
+        id: chunkRecordId(meetingName, sequence),
+        meeting: meetingName,
+        sequence,
+        blob,
+        mimeType,
+        clientStartedAt,
+        durationSeconds,
+        retryCount: 0,
+        createdAt: Date.now(),
+      };
+      try {
+        await putQueuedChunk(record);
+      } catch (error) {
+        onErrorRef.current?.(
+          error instanceof Error ? error : new Error('Failed to save part of the recording locally'),
+        );
+      }
+      await refreshPendingCount();
+      void attemptUpload(record);
+    },
+    [meetingName, attemptUpload, refreshPendingCount],
+  );
+
+  const attachRecorderHandlers = useCallback(
+    (recorder: MediaRecorder, mimeType: string) => {
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (!event.data || event.data.size === 0) return;
+        const durationSeconds = (Date.now() - segmentStartedAtRef.current) / 1000;
+        const clientStartedAt = new Date(segmentStartedAtRef.current).toISOString();
+        segmentStartedAtRef.current = Date.now();
+        void enqueueSegment(event.data, mimeType, clientStartedAt, durationSeconds);
+      };
+    },
+    [enqueueSegment],
+  );
+
+  const stopTimer = useCallback(() => {
+    if (timerIntervalRef.current) {
+      clearInterval(timerIntervalRef.current);
+      timerIntervalRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    stopTimer();
+    runStartedAtRef.current = Date.now();
+    timerIntervalRef.current = setInterval(() => {
+      const runningSeconds = (Date.now() - runStartedAtRef.current) / 1000;
+      setElapsedSeconds(Math.floor(elapsedBeforePauseRef.current + runningSeconds));
+    }, 1000);
+  }, [stopTimer]);
+
+  const createRecorder = useCallback(
+    (stream: MediaStream) => {
+      const mimeType =
+        typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported?.('audio/webm')
+          ? 'audio/webm'
+          : 'audio/webm';
+      const recorder = new MediaRecorder(stream, { mimeType });
+      attachRecorderHandlers(recorder, mimeType);
+      segmentStartedAtRef.current = Date.now();
+      recorder.start(timesliceMs);
+      recorderRef.current = recorder;
+    },
+    [attachRecorderHandlers, timesliceMs],
+  );
+
+  const start = useCallback(async () => {
+    if (!meetingName) {
+      throw new Error('Cannot start recording before a meeting has been created');
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      sequenceRef.current = 0;
+      elapsedBeforePauseRef.current = 0;
+      setElapsedSeconds(0);
+      setIsMuted(false);
+      createRecorder(stream);
+      setStatus('recording');
+      startTimer();
+    } catch (error) {
+      onErrorRef.current?.(
+        error instanceof Error ? error : new Error('Microphone access failed'),
+      );
+      throw error;
+    }
+  }, [meetingName, createRecorder, startTimer]);
+
+  const pause = useCallback(() => {
+    if (status !== 'recording' || !recorderRef.current) return;
+    // Flush the in-flight partial segment for this span, then leave the
+    // stream open so resume() can start a fresh MediaRecorder instantly.
+    recorderRef.current.stop();
+    recorderRef.current = null;
+    elapsedBeforePauseRef.current = elapsedSeconds;
+    stopTimer();
+    setStatus('paused');
+  }, [status, elapsedSeconds, stopTimer]);
+
+  const resume = useCallback(async () => {
+    if (status !== 'paused') return;
+    let stream = streamRef.current;
+    if (!stream || stream.getAudioTracks().every((track) => track.readyState === 'ended')) {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+    }
+    if (isMuted) {
+      stream.getAudioTracks().forEach((track) => {
+        track.enabled = false;
+      });
+    }
+    createRecorder(stream);
+    setStatus('recording');
+    startTimer();
+  }, [status, isMuted, createRecorder, startTimer]);
+
+  const toggleMute = useCallback(() => {
+    const stream = streamRef.current;
+    if (!stream) return;
+    setIsMuted((prev) => {
+      const next = !prev;
+      stream.getAudioTracks().forEach((track) => {
+        track.enabled = !next;
+      });
+      return next;
+    });
+  }, []);
+
+  const stop = useCallback(async () => {
+    if (status === 'idle' || status === 'stopped') return;
+    stopTimer();
+    if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+      await new Promise<void>((resolve) => {
+        const recorder = recorderRef.current;
+        if (!recorder) {
+          resolve();
+          return;
+        }
+        recorder.addEventListener('stop', () => resolve(), { once: true });
+        recorder.stop();
+      });
+    }
+    recorderRef.current = null;
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+    for (const timer of pendingTimersRef.current.values()) {
+      clearTimeout(timer);
+    }
+    pendingTimersRef.current.clear();
+    setStatus('stopped');
+  }, [status, stopTimer]);
+
+  const resumeQueuedUploads = useCallback(
+    async (targetMeeting: string) => {
+      const queued = await getQueuedChunksForMeeting(targetMeeting);
+      await Promise.all(queued.map((record) => attemptUpload(record)));
+      const found = await findResumableMeeting();
+      setResumableMeeting(found);
+    },
+    [attemptUpload],
+  );
+
+  const discardQueuedUploads = useCallback(async (targetMeeting: string) => {
+    const queued = await getQueuedChunksForMeeting(targetMeeting);
+    await Promise.all(queued.map((record) => deleteQueuedChunk(record.id)));
+    const found = await findResumableMeeting();
+    setResumableMeeting(found);
+  }, []);
+
+  useEffect(() => {
+    void refreshPendingCount();
+  }, [refreshPendingCount]);
+
+  // Cleanup on unmount: stop any live stream/timers, but never touch the
+  // IndexedDB queue — those segments still need to reach the server.
+  useEffect(() => {
+    return () => {
+      stopTimer();
+      recorderRef.current?.state !== 'inactive' && recorderRef.current?.stop();
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      for (const timer of pendingTimersRef.current.values()) {
+        clearTimeout(timer);
+      }
+    };
+  }, [stopTimer]);
+
+  return {
+    status,
+    isMuted,
+    elapsedSeconds,
+    pendingUploadCount,
+    minutesRecorded: Math.floor(elapsedSeconds / 60),
+    resumableMeeting,
+    start,
+    pause,
+    resume,
+    toggleMute,
+    stop,
+    resumeQueuedUploads,
+    discardQueuedUploads,
+  };
+}

--- a/frontend/src/pages/MeetingDetailPage.tsx
+++ b/frontend/src/pages/MeetingDetailPage.tsx
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import { AlertTriangle, Calendar, Clock, RotateCw, Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { MeetingProcessingStatus } from '@/components/meetings/MeetingProcessingStatus';
+import { MeetingSummaryPanel } from '@/components/meetings/MeetingSummaryPanel';
+import { MeetingTranscriptPanel } from '@/components/meetings/MeetingTranscriptPanel';
+import { MeetingRecordingPlayer } from '@/components/meetings/MeetingRecordingPlayer';
+import { PostMeetingContextPanel } from '@/components/meetings/PostMeetingContextPanel';
+import { useMeetingProcessingSocket } from '@/hooks/useMeetingProcessingSocket';
+import { getMeeting, retryChunkTranscription, retrySummary } from '@/services/meetingApi';
+import { formatTimeAgo } from '@/utils/time';
+import type { GetMeetingResult } from '@/services/meetingApi';
+
+function formatDuration(seconds?: number): string {
+  if (!seconds || seconds <= 0) return '—';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining > 0 ? `${hours}h ${remaining}m` : `${hours}h`;
+}
+
+/**
+ * Meeting Detail — renders by `meeting.status` per PLAN.md G.1:
+ *  - Transcribing/Summarizing: progress + whatever transcript is already
+ *    available (progressive display), driven live by the
+ *    `meeting_processing_status` socket event.
+ *  - Completed: Summary above Transcript (most users want the summary
+ *    first), recording playback + compact metadata header.
+ *  - Failed: a distinct error state with a Retry action, not confused with
+ *    "no transcript yet".
+ */
+export { MeetingDetailPage };
+export default MeetingDetailPage;
+
+function MeetingDetailPage() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+  const navigate = useNavigate();
+  const [data, setData] = useState<GetMeetingResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [retrying, setRetrying] = useState(false);
+  const [contextDismissed, setContextDismissed] = useState(false);
+  const lastLiveSignatureRef = useRef<string | null>(null);
+
+  const { status: liveStatus, chunksTranscribed } = useMeetingProcessingSocket(meetingId ?? null);
+
+  const load = useCallback(async () => {
+    if (!meetingId) return;
+    try {
+      const result = await getMeeting(meetingId);
+      setData(result);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to load meeting'));
+    } finally {
+      setLoading(false);
+    }
+  }, [meetingId]);
+
+  useEffect(() => {
+    setLoading(true);
+    load();
+  }, [load]);
+
+  // Re-fetch the full meeting (transcript/summary/chunks) whenever the
+  // realtime processing status advances or a new chunk finishes
+  // transcribing — the socket event only carries counts, not the updated
+  // document, so progressive display needs this refetch to show anything.
+  useEffect(() => {
+    if (!liveStatus) return;
+    const signature = `${liveStatus}:${chunksTranscribed}`;
+    if (lastLiveSignatureRef.current === signature) return;
+    lastLiveSignatureRef.current = signature;
+    load();
+  }, [liveStatus, chunksTranscribed, load]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="font-body text-steel-soft">Loading meeting...</div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+        <AlertTriangle className="h-6 w-6 text-destructive" aria-hidden />
+        <p className="font-body text-sm text-ink">Couldn't load this meeting.</p>
+        <p className="font-body text-xs text-steel">{error?.message}</p>
+        <Button variant="outline" size="sm" onClick={() => { setLoading(true); load(); }}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const { meeting, chunks } = data;
+  const status = liveStatus ?? meeting.status;
+  const failedChunks = chunks.filter((chunk) => chunk.upload_status === 'Failed');
+  const hasTranscriptButNoSummary = !!meeting.transcript && !meeting.summary;
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    try {
+      if (failedChunks.length > 0) {
+        await Promise.all(failedChunks.map((chunk) => retryChunkTranscription(chunk.name)));
+        toast.success('Retrying transcription for the failed segment(s)');
+      } else if (hasTranscriptButNoSummary || meeting.transcript) {
+        await retrySummary(meeting.name);
+        toast.success('Retrying summary generation');
+      } else {
+        toast.error('Nothing to retry — no transcript is available for this meeting.');
+        return;
+      }
+      await load();
+    } catch (err) {
+      toast.error('Retry failed', {
+        description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const showContextPanel = !meeting.context_completed && !contextDismissed && status !== 'Recording' && status !== 'Paused';
+
+  const header = (
+    <div className="flex flex-col gap-2">
+      <h1 className="font-heading text-xl font-medium text-ink">
+        {meeting.title?.trim() || `Meeting — ${formatTimeAgo(meeting.started_at || meeting.creation)}`}
+      </h1>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 font-body text-xs text-steel">
+        <span className="flex items-center gap-1">
+          <Calendar className="h-3.5 w-3.5" aria-hidden />
+          {formatTimeAgo(meeting.started_at || meeting.creation)}
+        </span>
+        <span className="flex items-center gap-1">
+          <Clock className="h-3.5 w-3.5" aria-hidden />
+          {formatDuration(meeting.duration_seconds)}
+        </span>
+        {meeting.participants && (
+          <span className="flex items-center gap-1">
+            <Users className="h-3.5 w-3.5" aria-hidden />
+            {meeting.participants}
+          </span>
+        )}
+      </div>
+      {meeting.description && <p className="font-body text-sm text-steel">{meeting.description}</p>}
+    </div>
+  );
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+        {header}
+
+        {showContextPanel && (
+          <PostMeetingContextPanel
+            meetingName={meeting.name}
+            onDismiss={() => setContextDismissed(true)}
+            onSaved={() => load()}
+          />
+        )}
+
+        {(status === 'Transcribing' || status === 'Summarizing') && (
+          <div className="rounded-lg border border-line bg-card p-4">
+            <MeetingProcessingStatus meetingName={meeting.name} initialStatus={status} />
+          </div>
+        )}
+
+        {status === 'Stopped' && (
+          <div className="rounded-lg border border-line bg-card p-4 font-body text-sm text-steel">
+            Starting to process your recording...
+          </div>
+        )}
+
+        {status === 'Failed' && (
+          <div className="flex flex-col gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertTriangle className="h-4 w-4" aria-hidden />
+              <span>
+                {failedChunks.length > 0
+                  ? 'Transcription failed for this meeting.'
+                  : 'Summarizing this meeting failed.'}
+              </span>
+            </div>
+            <div>
+              <Button size="sm" variant="outline" onClick={handleRetry} disabled={retrying}>
+                <RotateCw className={retrying ? 'h-3.5 w-3.5 animate-spin' : 'h-3.5 w-3.5'} aria-hidden />
+                {retrying ? 'Retrying...' : 'Retry'}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {status === 'Completed' && chunks.some((chunk) => !!chunk.audio_file) && (
+          <MeetingRecordingPlayer chunks={chunks} />
+        )}
+
+        {status === 'Completed' && (
+          <>
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="font-body text-sm font-medium text-ink">Summary</h2>
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="h-auto p-0 text-xs"
+                  onClick={() => document.getElementById('transcript')?.scrollIntoView({ behavior: 'smooth' })}
+                >
+                  Jump to transcript
+                </Button>
+              </div>
+              <MeetingSummaryPanel summary={meeting.summary} />
+            </div>
+
+            <Separator />
+
+            <div id="transcript">
+              <h2 className="mb-3 font-body text-sm font-medium text-ink">Transcript</h2>
+              <MeetingTranscriptPanel chunks={chunks} isLive={false} />
+            </div>
+          </>
+        )}
+
+        {(status === 'Transcribing' || status === 'Summarizing') && (
+          <div>
+            <h2 className="mb-3 font-body text-sm font-medium text-ink">Transcript so far</h2>
+            <MeetingTranscriptPanel chunks={chunks} isLive={status === 'Transcribing'} />
+          </div>
+        )}
+
+        {status === 'Failed' && meeting.transcript && (
+          <div>
+            <h2 className="mb-3 font-body text-sm font-medium text-ink">Transcript</h2>
+            <MeetingTranscriptPanel chunks={chunks} isLive={false} />
+          </div>
+        )}
+
+        <div>
+          <Button variant="link" size="sm" className="h-auto p-0" onClick={() => navigate('/huf/meetings')}>
+            Back to meetings
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MeetingDetailPageWrapper.tsx
+++ b/frontend/src/pages/MeetingDetailPageWrapper.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { UnifiedLayout } from '../layouts/UnifiedLayout';
+import { MeetingDetailPage } from './MeetingDetailPage';
+import { getMeeting } from '../services/meetingApi';
+import { formatTimeAgo } from '../utils/time';
+
+export { MeetingDetailPageWrapper };
+export default MeetingDetailPageWrapper;
+
+function MeetingDetailPageWrapper() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+  const [meetingLabel, setMeetingLabel] = useState<string>('Meeting');
+
+  useEffect(() => {
+    if (!meetingId) return;
+    getMeeting(meetingId)
+      .then(({ meeting }) => {
+        setMeetingLabel(meeting.title?.trim() || `Meeting — ${formatTimeAgo(meeting.started_at || meeting.creation)}`);
+      })
+      .catch(() => {
+        setMeetingLabel('Meeting');
+      });
+  }, [meetingId]);
+
+  const breadcrumbs = [
+    { label: 'Meetings', href: '/huf/meetings' },
+    { label: meetingLabel },
+  ];
+
+  return (
+    <UnifiedLayout breadcrumbs={breadcrumbs}>
+      <MeetingDetailPage />
+    </UnifiedLayout>
+  );
+}

--- a/frontend/src/pages/MeetingRecorderPage.tsx
+++ b/frontend/src/pages/MeetingRecorderPage.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { RecorderTimer } from '@/components/meetings/RecorderTimer';
+import { RecorderControls } from '@/components/meetings/RecorderControls';
+import { RecordingStatusPill } from '@/components/meetings/RecordingStatusPill';
+import { useMeetingRecorder } from '@/hooks/useMeetingRecorder';
+import { stopRecording as stopRecordingApi } from '@/services/meetingApi';
+
+/**
+ * Active recording view. Calm/minimal on purpose (PLAN.md G.1 "Overall
+ * product polish") — the timer is the dominant element, controls are large
+ * touch targets, and there is no dense data on this screen.
+ *
+ * Recording starts automatically on mount (mic permission prompt included)
+ * since the meeting itself was already created by `MeetingsHeaderActions`
+ * before navigating here — Quick Start has zero intermediate screens.
+ */
+export default function MeetingRecorderPage() {
+  const { meetingId } = useParams<{ meetingId: string }>();
+  const navigate = useNavigate();
+  const [confirmStopOpen, setConfirmStopOpen] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+  const hasStartedRef = useRef(false);
+
+  const recorder = useMeetingRecorder({
+    meetingName: meetingId ?? null,
+    onError: (error) => {
+      toast.error('Recording issue', { description: error.message });
+    },
+  });
+
+  const { status, isMuted, elapsedSeconds, pendingUploadCount, minutesRecorded, start, pause, resume, toggleMute } =
+    recorder;
+
+  useEffect(() => {
+    if (!meetingId || hasStartedRef.current) return;
+    hasStartedRef.current = true;
+    start().catch(() => {
+      toast.error('Could not access your microphone', {
+        description: 'Check your browser permissions and try again.',
+      });
+    });
+  }, [meetingId, start]);
+
+  useEffect(() => {
+    if (status === 'recording') {
+      setAnnouncement(isMuted ? 'Muted' : 'Recording');
+    } else if (status === 'paused') {
+      setAnnouncement('Paused');
+    } else if (status === 'stopped') {
+      setAnnouncement('Recording stopped');
+    }
+  }, [status, isMuted]);
+
+  const handleStop = async () => {
+    if (!meetingId) return;
+    setStopping(true);
+    try {
+      await recorder.stop();
+      await stopRecordingApi(meetingId);
+      navigate(`/huf/meetings/${meetingId}`);
+    } catch (error) {
+      toast.error('Could not stop recording', {
+        description: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
+    } finally {
+      setStopping(false);
+      setConfirmStopOpen(false);
+    }
+  };
+
+  if (!meetingId) {
+    return null;
+  }
+
+  const savedIndicatorLabel =
+    pendingUploadCount > 0
+      ? `${minutesRecorded} minute${minutesRecorded === 1 ? '' : 's'} recorded, saving...`
+      : `${minutesRecorded} minute${minutesRecorded === 1 ? '' : 's'} recorded, all saved`;
+
+  return (
+    <div className="flex min-h-[70vh] flex-col items-center justify-center gap-10 px-4 py-16">
+      <div aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
+
+      <RecordingStatusPill status={status} isMuted={isMuted} />
+
+      <RecorderTimer elapsedSeconds={elapsedSeconds} paused={status === 'paused'} />
+
+      <p className="text-sm text-steel">{savedIndicatorLabel}</p>
+
+      <RecorderControls
+        status={status}
+        isMuted={isMuted}
+        onPause={pause}
+        onResume={() => {
+          resume().catch(() => {
+            toast.error('Could not resume recording', {
+              description: 'Check your microphone permissions and try again.',
+            });
+          });
+        }}
+        onToggleMute={toggleMute}
+        onRequestStop={() => setConfirmStopOpen(true)}
+        disabled={status === 'stopped' || stopping}
+      />
+
+      <AlertDialog open={confirmStopOpen} onOpenChange={setConfirmStopOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Stop this recording?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This ends the session. Everything recorded so far has been saved and will be
+              transcribed and summarized next.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={stopping}>Keep recording</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                handleStop();
+              }}
+              disabled={stopping}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {stopping ? 'Stopping...' : 'Stop recording'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Button variant="link" size="sm" onClick={() => navigate('/huf/meetings')} disabled={stopping}>
+        Back to meetings
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/pages/MeetingsPage.tsx
+++ b/frontend/src/pages/MeetingsPage.tsx
@@ -1,0 +1,148 @@
+import { useEffect } from 'react';
+import { Mic } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { PageFrame } from '@/layouts/PageFrame';
+import { FilterBar, GridView, LoadMoreButton, EmptyState } from '@/components/dashboard';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { MeetingCard } from '@/components/meetings/MeetingCard';
+import { createMeeting, listMeetings, startRecording } from '@/services/meetingApi';
+import type { MeetingListItem, MeetingStatus } from '@/types/meeting.types';
+
+const STATUS_FILTER_OPTIONS: Array<{ label: string; value: string }> = [
+  { label: 'All statuses', value: 'all' },
+  { label: 'Recording', value: 'Recording' },
+  { label: 'Paused', value: 'Paused' },
+  { label: 'Processing', value: 'Stopped' },
+  { label: 'Completed', value: 'Completed' },
+  { label: 'Failed', value: 'Failed' },
+];
+
+export default function MeetingsPage() {
+  const navigate = useNavigate();
+
+  const {
+    items: meetings,
+    hasMore,
+    initialLoading,
+    loadingMore,
+    search,
+    setSearch,
+    filters,
+    setFilter,
+    loadMore,
+    total,
+    error,
+  } = useInfiniteScroll<
+    { page?: number; limit?: number; start?: number; search?: string; status?: string },
+    MeetingListItem
+  >({
+    fetchFn: async (params) => {
+      const response = await listMeetings({
+        start: params.start,
+        limit: params.limit,
+        search: params.search,
+        status: (params.status as MeetingStatus | undefined) || undefined,
+      });
+      return {
+        data: response.meetings,
+        hasMore: response.has_more,
+      };
+    },
+    initialParams: {},
+    pageSize: 20,
+    debounceMs: 300,
+    autoLoad: true,
+  });
+
+  const handleEmptyStateQuickStart = async () => {
+    try {
+      const { meeting_name: meetingName } = await createMeeting({});
+      await startRecording(meetingName);
+      navigate(`/huf/meetings/${meetingName}/record`);
+    } catch (err) {
+      toast.error('Could not start recording', {
+        description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (error) {
+      toast.error('Failed to load meetings', {
+        description: error.message || 'An error occurred while fetching meetings. Please try again.',
+        duration: 5000,
+      });
+    }
+  }, [error]);
+
+  return (
+    <PageFrame
+      title="Meetings"
+      filters={
+        <FilterBar
+          searchPlaceholder="Search meetings..."
+          searchValue={search}
+          onSearchChange={setSearch}
+          filters={[
+            {
+              label: 'Status',
+              value: filters.status || 'all',
+              options: STATUS_FILTER_OPTIONS,
+              onChange: (value) => setFilter('status', value),
+            },
+          ]}
+        />
+      }
+    >
+      {error && !initialLoading && (
+        <div className="text-center py-12">
+          <p className="text-destructive mb-4">Failed to load meetings</p>
+          <p className="text-sm text-steel mb-4">{error.message || 'An error occurred while fetching meetings.'}</p>
+        </div>
+      )}
+      <GridView
+        items={meetings}
+        columns={{ sm: 1, md: 2, lg: 3 }}
+        loading={initialLoading}
+        emptyState={
+          search ? (
+            <EmptyState
+              variant="no-results"
+              icon={Mic}
+              title="No meetings found"
+              filterTerm={search}
+              secondaryAction={{ label: 'Clear search', onClick: () => setSearch('') }}
+            />
+          ) : (
+            <EmptyState
+              variant="create"
+              icon={Mic}
+              title="No meetings yet"
+              description="Start your first recording — you can add a title and participants later."
+              action={{ label: 'Quick start', onClick: handleEmptyStateQuickStart }}
+            />
+          )
+        }
+        renderItem={(meeting) => (
+          <MeetingCard
+            meeting={meeting}
+            onClick={() => navigate(`/huf/meetings/${meeting.name}`)}
+          />
+        )}
+        keyExtractor={(meeting) => meeting.name}
+      />
+      <LoadMoreButton
+        hasMore={hasMore}
+        loading={loadingMore}
+        onLoadMore={loadMore}
+        disabled={!!search || initialLoading}
+      />
+      {!hasMore && meetings.length > 0 && (
+        <div className="text-center py-4 text-sm font-body text-steel">
+          {total !== undefined ? `Showing all ${total} meetings` : 'No more meetings to load'}
+        </div>
+      )}
+    </PageFrame>
+  );
+}

--- a/frontend/src/services/meetingApi.ts
+++ b/frontend/src/services/meetingApi.ts
@@ -1,0 +1,228 @@
+/**
+ * Meeting Recorder API
+ *
+ * Thin wrappers around the Phase 2 whitelisted backend methods in
+ * `huf.ai.meetings.meeting_api` and `huf.ai.meetings.meeting_recording`.
+ * Every function here returns the already-unwrapped `response.message`
+ * payload (never the raw axios/frappe-sdk envelope), throws a normalized
+ * error via `handleFrappeError` on failure, and does no caching/derived
+ * state of its own — that lives in `useMeetingRecorder` and the pages that
+ * call these functions.
+ */
+
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+import type {
+  Meeting,
+  MeetingListItem,
+  MeetingRecordingChunk,
+  MeetingStatus,
+} from '@/types/meeting.types';
+
+const API_PREFIX = 'huf.ai.meetings.meeting_api';
+const RECORDING_PREFIX = 'huf.ai.meetings.meeting_recording';
+
+export interface CreateMeetingParams {
+  title?: string;
+  description?: string;
+  participants?: string;
+}
+
+export interface CreateMeetingResult {
+  meeting_name: string;
+}
+
+export async function createMeeting(params: CreateMeetingParams = {}): Promise<CreateMeetingResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.create_meeting`, params);
+    return response.message as CreateMeetingResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface RecordingLifecycleResult {
+  meeting_name: string;
+  status: MeetingStatus;
+  started_at?: string;
+  stopped_at?: string;
+}
+
+export async function startRecording(meetingName: string): Promise<RecordingLifecycleResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.start_recording`, { meeting_name: meetingName });
+    return response.message as RecordingLifecycleResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function pauseRecording(meetingName: string): Promise<RecordingLifecycleResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.pause_recording`, { meeting_name: meetingName });
+    return response.message as RecordingLifecycleResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function resumeRecording(meetingName: string): Promise<RecordingLifecycleResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.resume_recording`, { meeting_name: meetingName });
+    return response.message as RecordingLifecycleResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function stopRecording(meetingName: string): Promise<RecordingLifecycleResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.stop_recording`, { meeting_name: meetingName });
+    return response.message as RecordingLifecycleResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface UpdateMeetingContextParams {
+  meetingName: string;
+  title?: string;
+  description?: string;
+  participants?: string;
+}
+
+export interface UpdateMeetingContextResult {
+  meeting_name: string;
+  title?: string;
+  description?: string;
+  participants?: string;
+  context_completed: 0 | 1;
+}
+
+export async function updateMeetingContext(
+  params: UpdateMeetingContextParams,
+): Promise<UpdateMeetingContextResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.update_meeting_context`, {
+      meeting_name: params.meetingName,
+      title: params.title,
+      description: params.description,
+      participants: params.participants,
+    });
+    return response.message as UpdateMeetingContextResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface GetMeetingResult {
+  meeting: Meeting;
+  chunks: MeetingRecordingChunk[];
+}
+
+export async function getMeeting(meetingName: string): Promise<GetMeetingResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.get_meeting`, { meeting_name: meetingName });
+    return response.message as GetMeetingResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface ListMeetingsParams {
+  start?: number;
+  limit?: number;
+  status?: MeetingStatus;
+  search?: string;
+}
+
+export interface ListMeetingsResult {
+  meetings: MeetingListItem[];
+  has_more: boolean;
+}
+
+export async function listMeetings(params: ListMeetingsParams = {}): Promise<ListMeetingsResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.list_meetings`, params);
+    return response.message as ListMeetingsResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface RetryChunkTranscriptionResult {
+  chunk_name: string;
+  upload_status: string;
+}
+
+export async function retryChunkTranscription(chunkName: string): Promise<RetryChunkTranscriptionResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.retry_chunk_transcription`, { chunk_name: chunkName });
+    return response.message as RetryChunkTranscriptionResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface RetrySummaryResult {
+  meeting_name: string;
+  status: MeetingStatus;
+}
+
+export async function retrySummary(meetingName: string): Promise<RetrySummaryResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.retry_summary`, { meeting_name: meetingName });
+    return response.message as RetrySummaryResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface UploadChunkParams {
+  meeting: string;
+  sequence: number;
+  clientStartedAt?: string;
+  durationSeconds?: number;
+  /** Exactly one of `audioB64` or `file` must be provided. */
+  audioB64?: string;
+  file?: string;
+}
+
+export interface UploadChunkResult {
+  chunk_name: string;
+  sequence: number;
+  upload_status: string;
+  chunk_count: number;
+}
+
+/**
+ * Uploads a single recorded audio segment for a meeting. Callers own retry
+ * policy (see `useMeetingRecorder`) — this function makes exactly one
+ * network attempt and rejects on failure so the caller can back off.
+ */
+export async function uploadChunk(params: UploadChunkParams): Promise<UploadChunkResult> {
+  try {
+    const response = await call.post(`${RECORDING_PREFIX}.upload_chunk`, {
+      meeting: params.meeting,
+      sequence: params.sequence,
+      client_started_at: params.clientStartedAt,
+      duration_seconds: params.durationSeconds,
+      audio_b64: params.audioB64,
+      file: params.file,
+    });
+    return response.message as UploadChunkResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}

--- a/frontend/src/types/meeting.types.ts
+++ b/frontend/src/types/meeting.types.ts
@@ -1,0 +1,78 @@
+/**
+ * Types for the Meeting Recorder feature.
+ *
+ * Mirrors the `Meeting` and `Meeting Recording Chunk` DocTypes
+ * (huf/huf/doctype/meeting/meeting.json,
+ * huf/huf/doctype/meeting_recording_chunk/meeting_recording_chunk.json)
+ * and the payload shapes returned by `huf.ai.meetings.meeting_api` /
+ * `huf.ai.meetings.meeting_recording` (Phase 2 backend).
+ */
+
+/** `Meeting.status` Select options, in lifecycle order. */
+export type MeetingStatus =
+  | 'Draft'
+  | 'Recording'
+  | 'Paused'
+  | 'Stopped'
+  | 'Transcribing'
+  | 'Summarizing'
+  | 'Completed'
+  | 'Failed';
+
+/** `Meeting Recording Chunk.upload_status` Select options. */
+export type ChunkUploadStatus =
+  | 'Pending'
+  | 'Uploaded'
+  | 'Transcribing'
+  | 'Transcribed'
+  | 'Failed';
+
+/** Full `Meeting` document shape (all fields from meeting.json). */
+export interface Meeting {
+  name: string;
+  title?: string;
+  description?: string;
+  participants?: string;
+  status: MeetingStatus;
+  started_at?: string;
+  stopped_at?: string;
+  duration_seconds?: number;
+  chunk_count?: number;
+  transcript?: string;
+  transcript_language?: string;
+  summary?: string;
+  summary_agent_run?: string;
+  context_prompted_at?: string;
+  context_completed?: 0 | 1;
+  is_system_owned?: 0 | 1;
+  modified?: string;
+  creation?: string;
+  owner?: string;
+}
+
+/** Summary row shape returned inline by `list_meetings`. */
+export interface MeetingListItem {
+  name: string;
+  title?: string;
+  description?: string;
+  status: MeetingStatus;
+  started_at?: string;
+  stopped_at?: string;
+  duration_seconds?: number;
+  chunk_count?: number;
+  summary?: string;
+  modified?: string;
+}
+
+/** Full `Meeting Recording Chunk` row shape as returned by `get_meeting`. */
+export interface MeetingRecordingChunk {
+  name: string;
+  sequence: number;
+  audio_file?: string;
+  upload_status: ChunkUploadStatus;
+  client_started_at?: string;
+  duration_seconds?: number;
+  transcript_text?: string;
+  transcription_error?: string;
+  retry_count?: number;
+}

--- a/huf/ai/meetings/meeting_api.py
+++ b/huf/ai/meetings/meeting_api.py
@@ -1,0 +1,268 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""
+Public API for Meeting lifecycle: create, start/pause/resume/stop, context
+updates, detail/list reads, and manual retry actions.
+
+All methods operate on a specific ``Meeting`` document and go through
+standard Frappe doc permissions (``frappe.get_doc`` + ``has_permission``),
+matching the pattern used by ``huf.ai.audio_api``/``huf.ai.apps_api``.
+Guest access is not allowed.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import cint, now_datetime
+
+RUNNING_STATUSES = ("Recording", "Paused")
+
+
+def _get_meeting(meeting_name: str, ptype: str = "read"):
+    if not meeting_name:
+        frappe.throw(_("meeting_name is required"))
+
+    meeting = frappe.get_doc("Meeting", meeting_name)
+    if not frappe.has_permission(doc=meeting, ptype=ptype):
+        frappe.throw(_("Not permitted to access this Meeting"), frappe.PermissionError)
+
+    return meeting
+
+
+@frappe.whitelist()
+def create_meeting(title: str = None, description: str = None, participants: str = None):
+    """
+    Create a new Meeting in Draft status.
+
+    Returns:
+        dict: {"meeting_name": str}
+    """
+    if not frappe.has_permission("Meeting", "create"):
+        frappe.throw(_("Not permitted to create a Meeting"), frappe.PermissionError)
+
+    meeting = frappe.get_doc({
+        "doctype": "Meeting",
+        "title": title,
+        "description": description,
+        "participants": participants,
+        "status": "Draft",
+    })
+    meeting.insert()
+
+    return {"meeting_name": meeting.name}
+
+
+@frappe.whitelist()
+def start_recording(meeting_name: str):
+    """Transition a Meeting to Recording and stamp started_at."""
+    meeting = _get_meeting(meeting_name, "write")
+
+    meeting.status = "Recording"
+    meeting.started_at = now_datetime()
+    meeting.save()
+
+    return {"meeting_name": meeting.name, "status": meeting.status, "started_at": meeting.started_at}
+
+
+@frappe.whitelist()
+def pause_recording(meeting_name: str):
+    """Toggle a Recording Meeting to Paused."""
+    meeting = _get_meeting(meeting_name, "write")
+
+    if meeting.status != "Recording":
+        frappe.throw(_("Meeting is not currently recording"))
+
+    meeting.status = "Paused"
+    meeting.save()
+
+    return {"meeting_name": meeting.name, "status": meeting.status}
+
+
+@frappe.whitelist()
+def resume_recording(meeting_name: str):
+    """Toggle a Paused Meeting back to Recording."""
+    meeting = _get_meeting(meeting_name, "write")
+
+    if meeting.status != "Paused":
+        frappe.throw(_("Meeting is not currently paused"))
+
+    meeting.status = "Recording"
+    meeting.save()
+
+    return {"meeting_name": meeting.name, "status": meeting.status}
+
+
+@frappe.whitelist()
+def stop_recording(meeting_name: str):
+    """Transition a Meeting to Stopped and stamp stopped_at."""
+    meeting = _get_meeting(meeting_name, "write")
+
+    if meeting.status not in RUNNING_STATUSES:
+        frappe.throw(_("Meeting is not currently recording or paused"))
+
+    meeting.status = "Stopped"
+    meeting.stopped_at = now_datetime()
+    meeting.save()
+
+    return {"meeting_name": meeting.name, "status": meeting.status, "stopped_at": meeting.stopped_at}
+
+
+@frappe.whitelist()
+def update_meeting_context(
+    meeting_name: str,
+    title: str = None,
+    description: str = None,
+    participants: str = None,
+):
+    """Update the post-meeting context fields (title/description/participants)."""
+    meeting = _get_meeting(meeting_name, "write")
+
+    if title is not None:
+        meeting.title = title
+    if description is not None:
+        meeting.description = description
+    if participants is not None:
+        meeting.participants = participants
+    meeting.context_completed = 1
+
+    meeting.save()
+
+    return {
+        "meeting_name": meeting.name,
+        "title": meeting.title,
+        "description": meeting.description,
+        "participants": meeting.participants,
+        "context_completed": meeting.context_completed,
+    }
+
+
+@frappe.whitelist()
+def get_meeting(meeting_name: str):
+    """Return a Meeting document plus its ordered Meeting Recording Chunk rows."""
+    meeting = _get_meeting(meeting_name, "read")
+
+    chunks = frappe.get_all(
+        "Meeting Recording Chunk",
+        filters={"meeting": meeting_name},
+        fields=[
+            "name",
+            "sequence",
+            "audio_file",
+            "upload_status",
+            "client_started_at",
+            "duration_seconds",
+            "transcript_text",
+            "transcription_error",
+            "retry_count",
+        ],
+        order_by="sequence asc",
+    )
+
+    return {"meeting": meeting.as_dict(), "chunks": chunks}
+
+
+@frappe.whitelist()
+def list_meetings(start: int = 0, limit: int = 20, status: str = None, search: str = None):
+    """
+    Return a paginated, permission-aware list of Meetings.
+
+    Uses the ``limit+1`` pattern: fetches one extra row to compute
+    ``has_more`` without a separate count query.
+
+    Returns:
+        dict: {"meetings": list, "has_more": bool}
+    """
+    start = cint(start)
+    limit = cint(limit) or 20
+
+    filters = {}
+    if status:
+        filters["status"] = status
+
+    or_filters = None
+    if search:
+        or_filters = [
+            ["title", "like", f"%{search}%"],
+            ["description", "like", f"%{search}%"],
+            ["transcript", "like", f"%{search}%"],
+        ]
+
+    meetings = frappe.get_list(
+        "Meeting",
+        filters=filters,
+        or_filters=or_filters,
+        fields=[
+            "name",
+            "title",
+            "description",
+            "status",
+            "started_at",
+            "stopped_at",
+            "duration_seconds",
+            "chunk_count",
+            "summary",
+            "modified",
+        ],
+        order_by="modified desc",
+        start=start,
+        page_length=limit + 1,
+    )
+
+    has_more = len(meetings) > limit
+    meetings = meetings[:limit]
+
+    return {"meetings": meetings, "has_more": has_more}
+
+
+@frappe.whitelist()
+def retry_chunk_transcription(chunk_name: str):
+    """
+    Reset a failed chunk back to Uploaded and re-enqueue transcription.
+
+    The transcription job itself (``huf.ai.meetings.meeting_transcription.
+    transcribe_meeting_chunk``) is built in Phase 4; the dotted path is
+    referenced here so Phase 2's enqueue call already matches the job name
+    and signature Phase 4 will implement.
+    """
+    if not chunk_name:
+        frappe.throw(_("chunk_name is required"))
+
+    chunk = frappe.get_doc("Meeting Recording Chunk", chunk_name)
+    _get_meeting(chunk.meeting, "write")
+
+    chunk.upload_status = "Uploaded"
+    chunk.transcription_error = None
+    chunk.retry_count = cint(chunk.retry_count) + 1
+    chunk.save()
+
+    frappe.enqueue(
+        "huf.ai.meetings.meeting_transcription.transcribe_meeting_chunk",
+        queue="default",
+        chunk_name=chunk.name,
+    )
+
+    return {"chunk_name": chunk.name, "upload_status": chunk.upload_status}
+
+
+@frappe.whitelist()
+def retry_summary(meeting_name: str):
+    """
+    Re-invoke summary generation for a meeting whose summary step failed.
+
+    The summary job itself (``huf.ai.meetings.meeting_summary.
+    retry_summary_job``) is built in Phase 5; the dotted path is referenced
+    here so Phase 2's enqueue call already matches the job name Phase 5
+    will implement.
+    """
+    meeting = _get_meeting(meeting_name, "write")
+
+    meeting.status = "Summarizing"
+    meeting.save()
+
+    frappe.enqueue(
+        "huf.ai.meetings.meeting_summary.retry_summary_job",
+        queue="default",
+        meeting_name=meeting.name,
+    )
+
+    return {"meeting_name": meeting.name, "status": meeting.status}

--- a/huf/ai/meetings/meeting_recording.py
+++ b/huf/ai/meetings/meeting_recording.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""
+Chunk-upload ingest for Meeting recordings.
+
+Generalizes ``huf.ai.audio_service.save_audio_upload``'s validation
+(extension/MIME allowlist, base64 decode, size cap) to a meeting/chunk
+context instead of the conversation/message context that
+``huf.ai.audio_api`` uses. Does not modify ``audio_service`` - only reuses
+its constants and file-saving helper.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import add_to_date, cint, now_datetime
+
+from huf.ai import audio_service
+from huf.ai.meetings.meeting_api import RUNNING_STATUSES, _get_meeting
+
+# How long a Meeting may sit in "Recording"/"Paused" with no new chunk
+# activity before the stale-recording sweep auto-stops it (K-table row 1:
+# "auto-stop after N hours of no new chunk"). 6 hours comfortably covers any
+# legitimate single-session meeting (including a long, heavily paused one)
+# while still reclaiming abandoned tab/device-sleep sessions within the day.
+STALE_RECORDING_THRESHOLD_HOURS = 6
+
+
+@frappe.whitelist()
+def upload_chunk(
+    meeting: str,
+    sequence,
+    client_started_at: str = None,
+    duration_seconds=None,
+    audio_b64: str = None,
+    file: str = None,
+):
+    """
+    Upload one recorded audio chunk for a Meeting.
+
+    Provide exactly one audio source: ``audio_b64`` (base64 data, optionally
+    with a data-URL prefix and a ``filename``-free extension guess of
+    ``webm``) or ``file`` (an existing Frappe File ID already uploaded via
+    the standard file uploader).
+
+    Args:
+        meeting: Meeting this chunk belongs to.
+        sequence: Chunk order within the meeting (0-based).
+        client_started_at: Meeting-relative timestamp the chunk started at.
+        duration_seconds: Chunk duration in seconds.
+        audio_b64: Base64 audio data, with or without a data-URL prefix.
+        file: Existing Frappe File ID holding the chunk audio.
+
+    Returns:
+        dict: {"chunk_name": str, "sequence": int, "upload_status": str,
+               "chunk_count": int}
+    """
+    meeting_doc = _get_meeting(meeting, "write")
+
+    if meeting_doc.status not in ("Recording", "Paused"):
+        frappe.throw(_("Meeting is not currently recording"))
+
+    if sequence is None:
+        frappe.throw(_("sequence is required"))
+    sequence = cint(sequence)
+
+    sources = sum(1 for source in (audio_b64, file) if source)
+    if sources != 1:
+        frappe.throw(_("Provide exactly one of audio_b64 or file"))
+
+    if file:
+        file_doc = frappe.get_doc("File", file)
+        audio_service.validate_audio_filename(file_doc.file_name)
+        audio_file = file_doc.name
+    else:
+        saved = audio_service.save_audio_upload(
+            f"chunk-{meeting}-{sequence}.webm",
+            audio_b64,
+            attached_to_doctype="Meeting Recording Chunk",
+            is_private=1,
+        )
+        audio_file = saved["file_id"]
+
+    chunk = frappe.get_doc({
+        "doctype": "Meeting Recording Chunk",
+        "meeting": meeting,
+        "sequence": sequence,
+        "audio_file": audio_file,
+        "upload_status": "Uploaded",
+        "client_started_at": client_started_at,
+        "duration_seconds": duration_seconds,
+    })
+    chunk.insert()
+
+    if audio_file:
+        frappe.db.set_value("File", audio_file, "attached_to_name", chunk.name)
+
+    meeting_doc.db_set("chunk_count", cint(meeting_doc.chunk_count) + 1)
+
+    # The transcription job itself (huf.ai.meetings.meeting_transcription.
+    # transcribe_meeting_chunk) is built in Phase 4; the dotted path is
+    # referenced here so Phase 4's job name/signature is already pinned.
+    frappe.enqueue(
+        "huf.ai.meetings.meeting_transcription.transcribe_meeting_chunk",
+        queue="default",
+        chunk_name=chunk.name,
+    )
+
+    return {
+        "chunk_name": chunk.name,
+        "sequence": chunk.sequence,
+        "upload_status": chunk.upload_status,
+        "chunk_count": meeting_doc.chunk_count,
+    }
+
+
+def cleanup_stale_recordings():
+    """
+    Scheduled sweep (see ``huf/hooks.py`` ``scheduler_events["hourly"]``):
+    auto-stops any Meeting left in ``Recording``/``Paused`` whose
+    ``modified`` timestamp is older than ``STALE_RECORDING_THRESHOLD_HOURS``.
+
+    Covers the "recording interrupted" recovery case from PLAN.md K row 1
+    (tab crash, device sleep, abandoned session) — without this sweep, a
+    Meeting with no explicit Stop would sit in a running status forever.
+    ``modified`` is used as the staleness signal rather than a dedicated
+    "last chunk received" field because every chunk upload (``upload_chunk``
+    above) and every explicit pause/resume both touch the Meeting doc
+    (``meeting_doc.db_set``/``meeting.save()``), so ``modified`` already
+    tracks "last activity" without a schema change.
+
+    Mirrors ``huf.ai.meetings.meeting_api.stop_recording``'s transition
+    (status -> "Stopped", ``stopped_at`` stamped) so a stale meeting is
+    picked up by the normal finalize/transcription pipeline exactly as if
+    the user had pressed Stop themselves.
+    """
+    cutoff = add_to_date(now_datetime(), hours=-STALE_RECORDING_THRESHOLD_HOURS)
+
+    stale_meetings = frappe.get_all(
+        "Meeting",
+        filters={"status": ["in", RUNNING_STATUSES], "modified": ["<", cutoff]},
+        pluck="name",
+    )
+
+    for meeting_name in stale_meetings:
+        try:
+            meeting = frappe.get_doc("Meeting", meeting_name)
+            meeting.status = "Stopped"
+            meeting.stopped_at = now_datetime()
+            meeting.save(ignore_permissions=True)
+
+            frappe.enqueue(
+                "huf.ai.meetings.meeting_transcription.finalize_meeting",
+                queue="default",
+                meeting_name=meeting.name,
+            )
+        except Exception:
+            frappe.log_error(
+                title="Stale meeting cleanup failed",
+                message=frappe.get_traceback(),
+            )
+
+    if stale_meetings:
+        frappe.db.commit()

--- a/huf/ai/meetings/meeting_summary.py
+++ b/huf/ai/meetings/meeting_summary.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""
+Summary generation for Meetings.
+
+``run_meeting_summary`` is enqueued once ``huf.ai.meetings.meeting_transcription.
+finalize_meeting`` has assembled ``Meeting.transcript`` and set
+``Meeting.status = "Summarizing"``. It runs the seeded "Meeting Summary Agent"
+(see ``huf.install.create_meeting_summary_agent``) against the transcript and
+writes the resulting Markdown summary back onto the Meeting.
+
+``retry_summary_job`` is enqueued by ``huf.ai.meetings.meeting_api.retry_summary``
+after it resets a failed Meeting back to "Summarizing".
+"""
+
+import frappe
+
+from huf.ai.agent_integration import run_agent_sync
+from huf.ai.meetings.meeting_transcription import _emit_processing_status
+
+SUMMARY_AGENT = "Meeting Summary Agent"
+
+
+def _build_summary_prompt(meeting) -> str:
+    parts = ["Meeting transcript:", meeting.transcript]
+
+    if meeting.title:
+        parts.append(f"Meeting title: {meeting.title}")
+    if meeting.description:
+        parts.append(f"Meeting description: {meeting.description}")
+    if meeting.participants:
+        parts.append(f"Participants: {meeting.participants}")
+
+    return "\n\n".join(parts)
+
+
+def run_meeting_summary(meeting_name: str):
+    meeting = frappe.get_doc("Meeting", meeting_name)
+    prompt = _build_summary_prompt(meeting)
+
+    try:
+        result = run_agent_sync(
+            agent_name=SUMMARY_AGENT,
+            prompt=prompt,
+            channel_id="meeting-summary",
+            external_id=meeting_name,
+            now=True,
+        )
+    except Exception:
+        frappe.log_error(title="Meeting Summary failed", message=frappe.get_traceback())
+        result = {}
+
+    if result.get("success") and result.get("status") == "Success":
+        meeting.summary = result.get("response")
+        meeting.summary_agent_run = result.get("agent_run_id")
+        meeting.status = "Completed"
+    else:
+        meeting.status = "Failed"
+
+    meeting.save(ignore_permissions=True)
+    frappe.db.commit()
+    _emit_processing_status(meeting_name, meeting.status)
+
+
+def retry_summary_job(meeting_name: str):
+    run_meeting_summary(meeting_name)

--- a/huf/ai/meetings/meeting_transcription.py
+++ b/huf/ai/meetings/meeting_transcription.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""
+Transcription pipeline for Meeting recordings.
+
+``transcribe_meeting_chunk`` is enqueued once per uploaded chunk (see
+``huf.ai.meetings.meeting_recording.upload_chunk`` and
+``huf.ai.meetings.meeting_api.retry_chunk_transcription``); it resolves the
+Meeting Summary Agent's STT configuration through the existing
+``huf.ai.audio_service`` reuse surface and writes the chunk's transcript.
+Once a Meeting is Stopped and every chunk has reached a terminal state,
+``finalize_meeting`` assembles ``Meeting.transcript`` and hands off to the
+summary step (``huf.ai.meetings.meeting_summary.run_meeting_summary``,
+built in Phase 5).
+"""
+
+import time
+
+import frappe
+from frappe.utils import cint, flt, get_datetime, time_diff_in_seconds
+
+from huf.ai import audio_service
+
+TRANSCRIPTION_AGENT = "Meeting Summary Agent"
+MAX_RETRY_COUNT = 3
+RETRY_BACKOFF_SECONDS = 5
+FINALIZE_POLL_SECONDS = 5
+TERMINAL_UPLOAD_STATUSES = ("Transcribed", "Failed")
+
+
+def transcribe_meeting_chunk(chunk_name: str):
+    chunk = frappe.get_doc("Meeting Recording Chunk", chunk_name)
+    chunk.upload_status = "Transcribing"
+    chunk.save(ignore_permissions=True)
+    frappe.db.commit()
+    _emit_processing_status(chunk.meeting, "Transcribing")
+
+    result = audio_service.transcribe_audio_file(
+        file_id=chunk.audio_file,
+        agent_name=TRANSCRIPTION_AGENT,
+    )
+
+    if not result.get("success"):
+        _handle_transcription_failure(chunk, result.get("error") or "Transcription failed")
+        return
+
+    chunk.transcript_text = result.get("transcript")
+    chunk.upload_status = "Transcribed"
+    chunk.transcription_error = None
+    chunk.save(ignore_permissions=True)
+    frappe.db.commit()
+    _emit_processing_status(chunk.meeting, "Transcribing")
+
+    _maybe_finalize_meeting(chunk.meeting)
+
+
+def _handle_transcription_failure(chunk, error_message: str):
+    chunk.retry_count = cint(chunk.retry_count) + 1
+    chunk.transcription_error = error_message
+
+    if chunk.retry_count < MAX_RETRY_COUNT:
+        chunk.upload_status = "Uploaded"
+        chunk.save(ignore_permissions=True)
+        frappe.db.commit()
+
+        time.sleep(RETRY_BACKOFF_SECONDS * chunk.retry_count)
+        frappe.enqueue(
+            "huf.ai.meetings.meeting_transcription.transcribe_meeting_chunk",
+            queue="default",
+            chunk_name=chunk.name,
+        )
+        return
+
+    chunk.upload_status = "Failed"
+    chunk.save(ignore_permissions=True)
+    frappe.db.commit()
+    _emit_processing_status(chunk.meeting, "Transcribing")
+
+    _maybe_finalize_meeting(chunk.meeting)
+
+
+def _maybe_finalize_meeting(meeting_name: str):
+    meeting_status = frappe.db.get_value("Meeting", meeting_name, "status")
+    if meeting_status != "Stopped":
+        return
+
+    if not _all_chunks_terminal(meeting_name):
+        return
+
+    frappe.enqueue(
+        "huf.ai.meetings.meeting_transcription.finalize_meeting",
+        queue="default",
+        meeting_name=meeting_name,
+    )
+
+
+def _all_chunks_terminal(meeting_name: str) -> bool:
+    statuses = frappe.get_all(
+        "Meeting Recording Chunk",
+        filters={"meeting": meeting_name},
+        pluck="upload_status",
+    )
+    if not statuses:
+        return False
+
+    return all(status in TERMINAL_UPLOAD_STATUSES for status in statuses)
+
+
+def _chunk_progress(meeting_name: str) -> tuple:
+    """Return (chunks_transcribed, chunks_total) for the meeting's chunks."""
+    statuses = frappe.get_all(
+        "Meeting Recording Chunk",
+        filters={"meeting": meeting_name},
+        pluck="upload_status",
+    )
+    chunks_transcribed = sum(1 for status in statuses if status == "Transcribed")
+    return chunks_transcribed, len(statuses)
+
+
+def _emit_processing_status(meeting_name: str, status: str):
+    """Publish a ``meeting_processing_status`` realtime event to the meeting owner.
+
+    Mirrors ``huf.ai.agent_integration._emit_conversation_title_updated``: the
+    job runs off the request/session context, so the target user is resolved
+    from the record's owner rather than ``frappe.session.user``, and any
+    publish failure is swallowed as a non-critical UI notification.
+    """
+    try:
+        owner = frappe.db.get_value("Meeting", meeting_name, "owner")
+        if not owner:
+            return
+
+        chunks_transcribed, chunks_total = _chunk_progress(meeting_name)
+        frappe.publish_realtime(
+            event=f"meeting:{meeting_name}",
+            message={
+                "type": "meeting_processing_status",
+                "meeting": meeting_name,
+                "status": status,
+                "chunks_transcribed": chunks_transcribed,
+                "chunks_total": chunks_total,
+            },
+            user=owner,
+        )
+    except (RuntimeError, TypeError, ValueError, KeyError, AttributeError,
+            frappe.DoesNotExistError, frappe.ValidationError, frappe.PermissionError) as exc:
+        frappe.logger("huf").debug(f"Meeting processing status publish failed: {exc!s}")
+
+
+def finalize_meeting(meeting_name: str):
+    meeting = frappe.get_doc("Meeting", meeting_name)
+
+    if meeting.status != "Stopped" or not _all_chunks_terminal(meeting_name):
+        time.sleep(FINALIZE_POLL_SECONDS)
+        frappe.enqueue(
+            "huf.ai.meetings.meeting_transcription.finalize_meeting",
+            queue="default",
+            meeting_name=meeting_name,
+        )
+        return
+
+    chunks = frappe.get_all(
+        "Meeting Recording Chunk",
+        filters={"meeting": meeting_name},
+        fields=["name", "sequence", "upload_status", "transcript_text", "client_started_at", "duration_seconds"],
+        order_by="sequence asc",
+    )
+
+    transcript, duration_seconds = _assemble_transcript(meeting, chunks)
+
+    meeting.transcript = transcript
+    meeting.duration_seconds = duration_seconds
+    meeting.status = "Summarizing"
+    meeting.save(ignore_permissions=True)
+    frappe.db.commit()
+    _emit_processing_status(meeting_name, "Summarizing")
+
+    frappe.enqueue(
+        "huf.ai.meetings.meeting_summary.run_meeting_summary",
+        queue="default",
+        meeting_name=meeting_name,
+    )
+
+
+def _assemble_transcript(meeting, chunks: list) -> tuple:
+    started_at = meeting.started_at and get_datetime(meeting.started_at)
+
+    lines = []
+    duration_seconds = flt(meeting.duration_seconds)
+
+    for chunk in chunks:
+        timestamp = _format_timestamp(started_at, chunk.get("client_started_at"))
+
+        if chunk.get("upload_status") == "Transcribed":
+            lines.append(f"[{timestamp}] {chunk.get('transcript_text') or ''}".rstrip())
+        else:
+            lines.append(f"[{timestamp}] [this part could not be transcribed]")
+
+        chunk_end = flt(chunk.get("duration_seconds"))
+        if chunk.get("client_started_at") and started_at:
+            offset = time_diff_in_seconds(get_datetime(chunk["client_started_at"]), started_at)
+            duration_seconds = max(duration_seconds, offset + chunk_end)
+
+    return "\n".join(lines), duration_seconds
+
+
+def _format_timestamp(started_at, client_started_at) -> str:
+    if not started_at or not client_started_at:
+        return "00:00:00"
+
+    offset_seconds = int(max(0, time_diff_in_seconds(get_datetime(client_started_at), started_at)))
+    hours, remainder = divmod(offset_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"

--- a/huf/ai/meetings/test_meeting_api.py
+++ b/huf/ai/meetings/test_meeting_api.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from huf.ai.meetings import meeting_api
+
+
+class TestMeetingApi(unittest.TestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self._meetings = []
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for name in self._meetings:
+            try:
+                frappe.delete_doc("Meeting", name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.db.commit()
+
+    def _create(self, **kwargs):
+        result = meeting_api.create_meeting(**kwargs)
+        self._meetings.append(result["meeting_name"])
+        return result["meeting_name"]
+
+    def test_create_meeting_defaults_to_draft(self):
+        name = self._create()
+        doc = frappe.get_doc("Meeting", name)
+        self.assertEqual(doc.status, "Draft")
+
+    def test_create_meeting_with_context(self):
+        name = self._create(title="Standup", description="Daily sync", participants="Alice, Bob")
+        doc = frappe.get_doc("Meeting", name)
+        self.assertEqual(doc.title, "Standup")
+        self.assertEqual(doc.description, "Daily sync")
+        self.assertEqual(doc.participants, "Alice, Bob")
+
+    def test_start_pause_resume_stop_transitions(self):
+        name = self._create()
+
+        started = meeting_api.start_recording(name)
+        self.assertEqual(started["status"], "Recording")
+        self.assertIsNotNone(started["started_at"])
+
+        paused = meeting_api.pause_recording(name)
+        self.assertEqual(paused["status"], "Paused")
+
+        resumed = meeting_api.resume_recording(name)
+        self.assertEqual(resumed["status"], "Recording")
+
+        stopped = meeting_api.stop_recording(name)
+        self.assertEqual(stopped["status"], "Stopped")
+        self.assertIsNotNone(stopped["stopped_at"])
+
+    def test_pause_requires_recording_status(self):
+        name = self._create()
+        with self.assertRaises(frappe.ValidationError):
+            meeting_api.pause_recording(name)
+
+    def test_resume_requires_paused_status(self):
+        name = self._create()
+        meeting_api.start_recording(name)
+        with self.assertRaises(frappe.ValidationError):
+            meeting_api.resume_recording(name)
+
+    def test_stop_requires_running_status(self):
+        name = self._create()
+        with self.assertRaises(frappe.ValidationError):
+            meeting_api.stop_recording(name)
+
+    def test_update_meeting_context_marks_completed(self):
+        name = self._create()
+        result = meeting_api.update_meeting_context(name, title="Renamed", participants="Carol")
+        self.assertEqual(result["title"], "Renamed")
+        self.assertEqual(result["participants"], "Carol")
+        self.assertEqual(result["context_completed"], 1)
+
+    def test_get_meeting_returns_ordered_chunks(self):
+        name = self._create()
+        for sequence in (1, 0, 2):
+            frappe.get_doc({
+                "doctype": "Meeting Recording Chunk",
+                "meeting": name,
+                "sequence": sequence,
+                "upload_status": "Uploaded",
+            }).insert(ignore_permissions=True)
+
+        result = meeting_api.get_meeting(name)
+        self.assertEqual(result["meeting"]["name"], name)
+        self.assertEqual([c["sequence"] for c in result["chunks"]], [0, 1, 2])
+
+    def test_list_meetings_pagination_shape(self):
+        for _ in range(3):
+            self._create()
+
+        result = meeting_api.list_meetings(start=0, limit=2)
+        self.assertIn("meetings", result)
+        self.assertIn("has_more", result)
+        self.assertLessEqual(len(result["meetings"]), 2)
+
+    def test_list_meetings_filters_by_status(self):
+        draft = self._create()
+        recording = self._create()
+        meeting_api.start_recording(recording)
+
+        result = meeting_api.list_meetings(status="Recording", limit=50)
+        names = [m["name"] for m in result["meetings"]]
+        self.assertIn(recording, names)
+        self.assertNotIn(draft, names)
+
+    def test_retry_summary_resets_status_and_returns(self):
+        # meeting_summary.retry_summary_job (Phase 5) does not exist yet;
+        # frappe.enqueue is mocked so the test only exercises Phase 2's
+        # status-reset behavior, not the not-yet-built job import.
+        name = self._create()
+        meeting_api.start_recording(name)
+        meeting_api.stop_recording(name)
+
+        with patch("frappe.enqueue") as mock_enqueue:
+            result = meeting_api.retry_summary(name)
+
+        mock_enqueue.assert_called_once()
+        self.assertEqual(result["status"], "Summarizing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/meetings/test_meeting_recording.py
+++ b/huf/ai/meetings/test_meeting_recording.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+import base64
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from huf.ai.meetings import meeting_api, meeting_recording
+
+# 1x1 transparent-ish tiny payload used as a stand-in for audio bytes; the
+# validation under test cares about extension/size, not real audio content.
+TINY_AUDIO_B64 = base64.b64encode(b"fake-audio-bytes").decode("ascii")
+
+
+class TestMeetingRecording(unittest.TestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self._meetings = []
+        self.meeting = meeting_api.create_meeting()
+        self._meetings.append(self.meeting["meeting_name"])
+        meeting_api.start_recording(self.meeting["meeting_name"])
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for name in self._meetings:
+            try:
+                frappe.delete_doc("Meeting", name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.db.commit()
+
+    def _upload(self, **kwargs):
+        with patch("frappe.enqueue"):
+            return meeting_recording.upload_chunk(
+                meeting=self.meeting["meeting_name"],
+                sequence=kwargs.pop("sequence", 0),
+                client_started_at=kwargs.pop("client_started_at", None),
+                duration_seconds=kwargs.pop("duration_seconds", 30),
+                audio_b64=kwargs.pop("audio_b64", TINY_AUDIO_B64),
+                **kwargs,
+            )
+
+    def test_upload_chunk_creates_row_and_increments_count(self):
+        result = self._upload(sequence=0)
+
+        self.assertEqual(result["upload_status"], "Uploaded")
+        self.assertEqual(result["chunk_count"], 1)
+
+        chunk = frappe.get_doc("Meeting Recording Chunk", result["chunk_name"])
+        self.assertEqual(chunk.meeting, self.meeting["meeting_name"])
+        self.assertEqual(chunk.sequence, 0)
+        self.assertEqual(chunk.upload_status, "Uploaded")
+
+        meeting_doc = frappe.get_doc("Meeting", self.meeting["meeting_name"])
+        self.assertEqual(meeting_doc.chunk_count, 1)
+
+    def test_upload_chunk_count_increments_across_multiple_chunks(self):
+        self._upload(sequence=0)
+        self._upload(sequence=1)
+        result = self._upload(sequence=2)
+
+        self.assertEqual(result["chunk_count"], 3)
+
+    def test_upload_chunk_requires_exactly_one_source(self):
+        with self.assertRaises(frappe.ValidationError):
+            self._upload(audio_b64=None, file=None)
+
+    def test_upload_chunk_rejects_when_both_sources_given(self):
+        with self.assertRaises(frappe.ValidationError):
+            self._upload(audio_b64=TINY_AUDIO_B64, file="some-file")
+
+    def test_upload_chunk_requires_sequence(self):
+        with self.assertRaises(frappe.ValidationError):
+            self._upload(sequence=None)
+
+    def test_upload_chunk_requires_running_meeting(self):
+        meeting_api.stop_recording(self.meeting["meeting_name"])
+        with self.assertRaises(frappe.ValidationError):
+            self._upload(sequence=0)
+
+    def test_upload_chunk_rejects_oversized_payload(self):
+        from huf.ai import audio_service
+
+        oversized = base64.b64encode(b"0" * (audio_service.MAX_AUDIO_FILE_SIZE + 1)).decode("ascii")
+        with self.assertRaises(frappe.ValidationError):
+            self._upload(sequence=0, audio_b64=oversized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/meetings/test_meeting_summary.py
+++ b/huf/ai/meetings/test_meeting_summary.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from huf.ai.meetings import meeting_api, meeting_summary
+
+
+class TestMeetingSummary(unittest.TestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self._meetings = []
+        self.meeting_name = meeting_api.create_meeting()["meeting_name"]
+        self._meetings.append(self.meeting_name)
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        meeting.transcript = "Alice: Let's ship the feature.\nBob: Agreed."
+        meeting.status = "Summarizing"
+        meeting.save(ignore_permissions=True)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for name in self._meetings:
+            try:
+                frappe.delete_doc("Meeting", name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.db.commit()
+
+    def test_prompt_includes_full_context(self):
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        meeting.title = "Launch sync"
+        meeting.description = "Weekly launch review"
+        meeting.participants = "Alice, Bob"
+        meeting.save(ignore_permissions=True)
+
+        prompt = meeting_summary._build_summary_prompt(meeting)
+
+        self.assertIn(meeting.transcript, prompt)
+        self.assertIn("Launch sync", prompt)
+        self.assertIn("Weekly launch review", prompt)
+        self.assertIn("Alice, Bob", prompt)
+
+    def test_prompt_omits_missing_context(self):
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+
+        prompt = meeting_summary._build_summary_prompt(meeting)
+
+        self.assertIn(meeting.transcript, prompt)
+        self.assertNotIn("Meeting title", prompt)
+        self.assertNotIn("Meeting description", prompt)
+        self.assertNotIn("Participants", prompt)
+
+    def test_success_sets_summary_and_completes(self):
+        with patch(
+            "huf.ai.meetings.meeting_summary.run_agent_sync",
+            return_value={
+                "success": True,
+                "status": "Success",
+                "response": "## Headline\nShipping the feature.",
+                "agent_run_id": "Agent Run 1",
+            },
+        ):
+            meeting_summary.run_meeting_summary(self.meeting_name)
+
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        self.assertEqual(meeting.summary, "## Headline\nShipping the feature.")
+        self.assertEqual(meeting.summary_agent_run, "Agent Run 1")
+        self.assertEqual(meeting.status, "Completed")
+
+    def test_failure_sets_failed_and_preserves_transcript(self):
+        transcript_before = frappe.get_doc("Meeting", self.meeting_name).transcript
+
+        with patch(
+            "huf.ai.meetings.meeting_summary.run_agent_sync",
+            return_value={"success": False, "status": "Failed", "error": "provider down"},
+        ):
+            meeting_summary.run_meeting_summary(self.meeting_name)
+
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        self.assertEqual(meeting.status, "Failed")
+        self.assertEqual(meeting.transcript, transcript_before)
+        self.assertFalse(meeting.summary)
+
+    def test_exception_sets_failed_and_preserves_transcript(self):
+        transcript_before = frappe.get_doc("Meeting", self.meeting_name).transcript
+
+        with patch(
+            "huf.ai.meetings.meeting_summary.run_agent_sync",
+            side_effect=RuntimeError("boom"),
+        ), patch("frappe.log_error"):
+            meeting_summary.run_meeting_summary(self.meeting_name)
+
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        self.assertEqual(meeting.status, "Failed")
+        self.assertEqual(meeting.transcript, transcript_before)
+
+    def test_retry_summary_job_reinvokes_run_meeting_summary(self):
+        with patch(
+            "huf.ai.meetings.meeting_summary.run_agent_sync",
+            return_value={
+                "success": True,
+                "status": "Success",
+                "response": "## Headline\nRetried summary.",
+                "agent_run_id": "Agent Run 2",
+            },
+        ) as mock_run:
+            meeting_summary.retry_summary_job(self.meeting_name)
+
+        mock_run.assert_called_once()
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        self.assertEqual(meeting.status, "Completed")
+        self.assertEqual(meeting.summary, "## Headline\nRetried summary.")

--- a/huf/ai/meetings/test_meeting_transcription.py
+++ b/huf/ai/meetings/test_meeting_transcription.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from huf.ai.meetings import meeting_api, meeting_transcription
+
+
+class TestMeetingTranscription(unittest.TestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self._meetings = []
+        self.meeting = meeting_api.create_meeting()
+        self._meetings.append(self.meeting["meeting_name"])
+        meeting_api.start_recording(self.meeting["meeting_name"])
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for name in self._meetings:
+            try:
+                frappe.delete_doc("Meeting", name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.db.commit()
+
+    def _make_chunk(self, **kwargs):
+        chunk = frappe.get_doc({
+            "doctype": "Meeting Recording Chunk",
+            "meeting": self.meeting["meeting_name"],
+            "sequence": kwargs.pop("sequence", 0),
+            "audio_file": kwargs.pop("audio_file", None),
+            "upload_status": kwargs.pop("upload_status", "Uploaded"),
+            "client_started_at": kwargs.pop("client_started_at", None),
+            "duration_seconds": kwargs.pop("duration_seconds", 30),
+            **kwargs,
+        })
+        chunk.insert(ignore_permissions=True)
+        return chunk
+
+    def test_successful_transcription_updates_chunk(self):
+        chunk = self._make_chunk()
+
+        with patch(
+            "huf.ai.audio_service.transcribe_audio_file",
+            return_value={"success": True, "transcript": "hello world"},
+        ):
+            meeting_transcription.transcribe_meeting_chunk(chunk.name)
+
+        chunk.reload()
+        self.assertEqual(chunk.upload_status, "Transcribed")
+        self.assertEqual(chunk.transcript_text, "hello world")
+        self.assertFalse(chunk.transcription_error)
+
+    def test_failure_increments_retry_and_reaches_failed_after_max_retries(self):
+        chunk = self._make_chunk()
+
+        with (
+            patch(
+                "huf.ai.audio_service.transcribe_audio_file",
+                return_value={"success": False, "error": "provider down"},
+            ),
+            patch("time.sleep"),
+            patch("frappe.enqueue") as mock_enqueue,
+        ):
+            for _ in range(meeting_transcription.MAX_RETRY_COUNT):
+                meeting_transcription.transcribe_meeting_chunk(chunk.name)
+                chunk.reload()
+
+        self.assertEqual(chunk.retry_count, meeting_transcription.MAX_RETRY_COUNT)
+        self.assertEqual(chunk.upload_status, "Failed")
+        self.assertEqual(chunk.transcription_error, "provider down")
+        self.assertEqual(mock_enqueue.call_count, meeting_transcription.MAX_RETRY_COUNT - 1)
+
+    def test_finalize_meeting_reenqueues_when_chunks_not_terminal(self):
+        self._make_chunk(upload_status="Transcribing")
+        meeting_api.stop_recording(self.meeting["meeting_name"])
+
+        with patch("time.sleep") as mock_sleep, patch("frappe.enqueue") as mock_enqueue:
+            meeting_transcription.finalize_meeting(self.meeting["meeting_name"])
+
+        mock_sleep.assert_called_once()
+        mock_enqueue.assert_called_once_with(
+            "huf.ai.meetings.meeting_transcription.finalize_meeting",
+            queue="default",
+            meeting_name=self.meeting["meeting_name"],
+        )
+
+        meeting_doc = frappe.get_doc("Meeting", self.meeting["meeting_name"])
+        self.assertEqual(meeting_doc.status, "Stopped")
+
+    def test_finalize_meeting_assembles_transcript_with_gap_markers_and_timestamps(self):
+        meeting_doc = frappe.get_doc("Meeting", self.meeting["meeting_name"])
+        started_at = meeting_doc.started_at
+
+        self._make_chunk(
+            sequence=0,
+            upload_status="Transcribed",
+            transcript_text="first segment",
+            client_started_at=started_at,
+            duration_seconds=30,
+        )
+        self._make_chunk(
+            sequence=1,
+            upload_status="Failed",
+            client_started_at=frappe.utils.add_to_date(started_at, seconds=30),
+            duration_seconds=30,
+        )
+        self._make_chunk(
+            sequence=2,
+            upload_status="Transcribed",
+            transcript_text="third segment",
+            client_started_at=frappe.utils.add_to_date(started_at, seconds=90),
+            duration_seconds=30,
+        )
+
+        meeting_api.stop_recording(self.meeting["meeting_name"])
+
+        with patch("frappe.enqueue") as mock_enqueue:
+            meeting_transcription.finalize_meeting(self.meeting["meeting_name"])
+
+        meeting_doc.reload()
+        self.assertEqual(meeting_doc.status, "Summarizing")
+        self.assertIn("[00:00:00] first segment", meeting_doc.transcript)
+        self.assertIn("[00:00:30] [this part could not be transcribed]", meeting_doc.transcript)
+        self.assertIn("[00:01:30] third segment", meeting_doc.transcript)
+        self.assertGreaterEqual(meeting_doc.duration_seconds, 120)
+
+        mock_enqueue.assert_called_once_with(
+            "huf.ai.meetings.meeting_summary.run_meeting_summary",
+            queue="default",
+            meeting_name=self.meeting["meeting_name"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -271,7 +271,8 @@ scheduler_events = {
     },
     "hourly": [
         "huf.ai.mcp_client.auto_sync_mcp_server_tools",
-        "huf.ai.mcp_oauth.auto_refresh_oauth_tokens"
+        "huf.ai.mcp_oauth.auto_refresh_oauth_tokens",
+        "huf.ai.meetings.meeting_recording.cleanup_stale_recordings"
     ]
 }
 

--- a/huf/huf/doctype/meeting/meeting.json
+++ b/huf/huf/doctype/meeting/meeting.json
@@ -1,0 +1,196 @@
+{
+ "actions": [],
+ "creation": "2026-08-24 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "description",
+  "participants",
+  "column_break_status",
+  "status",
+  "started_at",
+  "stopped_at",
+  "duration_seconds",
+  "chunk_count",
+  "section_break_transcript",
+  "transcript",
+  "transcript_language",
+  "section_break_summary",
+  "summary",
+  "summary_agent_run",
+  "section_break_context",
+  "context_prompted_at",
+  "context_completed",
+  "is_system_owned"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "participants",
+   "fieldtype": "Small Text",
+   "label": "Participants"
+  },
+  {
+   "fieldname": "column_break_status",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Draft\nRecording\nPaused\nStopped\nTranscribing\nSummarizing\nCompleted\nFailed"
+  },
+  {
+   "fieldname": "started_at",
+   "fieldtype": "Datetime",
+   "label": "Started At"
+  },
+  {
+   "fieldname": "stopped_at",
+   "fieldtype": "Datetime",
+   "label": "Stopped At"
+  },
+  {
+   "fieldname": "duration_seconds",
+   "fieldtype": "Int",
+   "label": "Duration (Seconds)"
+  },
+  {
+   "fieldname": "chunk_count",
+   "fieldtype": "Int",
+   "label": "Chunk Count"
+  },
+  {
+   "fieldname": "section_break_transcript",
+   "fieldtype": "Section Break",
+   "label": "Transcript"
+  },
+  {
+   "fieldname": "transcript",
+   "fieldtype": "Long Text",
+   "label": "Transcript"
+  },
+  {
+   "fieldname": "transcript_language",
+   "fieldtype": "Data",
+   "label": "Transcript Language"
+  },
+  {
+   "fieldname": "section_break_summary",
+   "fieldtype": "Section Break",
+   "label": "Summary"
+  },
+  {
+   "fieldname": "summary",
+   "fieldtype": "Long Text",
+   "label": "Summary"
+  },
+  {
+   "fieldname": "summary_agent_run",
+   "fieldtype": "Link",
+   "label": "Summary Agent Run",
+   "options": "Agent Run",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_context",
+   "fieldtype": "Section Break",
+   "label": "Post-Meeting Context"
+  },
+  {
+   "fieldname": "context_prompted_at",
+   "fieldtype": "Datetime",
+   "label": "Context Prompted At"
+  },
+  {
+   "default": "0",
+   "fieldname": "context_completed",
+   "fieldtype": "Check",
+   "label": "Context Completed"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_system_owned",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is System Owned",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Meeting",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Viewer",
+   "share": 1,
+   "write": 0
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
+}

--- a/huf/huf/doctype/meeting/meeting.py
+++ b/huf/huf/doctype/meeting/meeting.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class Meeting(Document):
+	def on_trash(self):
+		if self.is_system_owned and not (
+			frappe.flags.in_install or frappe.flags.in_migrate or frappe.flags.in_uninstall
+		):
+			frappe.throw(_("System-owned meetings cannot be deleted."), title=_("Meeting Protected"))

--- a/huf/huf/doctype/meeting/test_meeting.py
+++ b/huf/huf/doctype/meeting/test_meeting.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+class TestMeeting(IntegrationTestCase):
+	def setUp(self):
+		self._names = []
+
+	def tearDown(self):
+		for name in self._names:
+			frappe.db.delete("Meeting", {"name": name})
+		frappe.db.commit()
+
+	def test_create_meeting(self):
+		doc = frappe.get_doc({
+			"doctype": "Meeting",
+			"title": "__test_meeting__",
+			"status": "Draft",
+		})
+		doc.insert(ignore_permissions=True)
+		self._names.append(doc.name)
+
+		self.assertTrue(frappe.db.exists("Meeting", doc.name))
+
+	def test_is_system_owned_defaults_to_one(self):
+		doc = frappe.get_doc({
+			"doctype": "Meeting",
+			"title": "__test_meeting_default__",
+		})
+		doc.insert(ignore_permissions=True)
+		self._names.append(doc.name)
+
+		self.assertEqual(doc.is_system_owned, 1)
+
+	def test_system_owned_meeting_delete_guard(self):
+		"""Deleting a system-owned meeting should be blocked outside install/migrate/uninstall."""
+		meeting = frappe.new_doc("Meeting")
+		meeting.title = "__test_meeting_guard__"
+		meeting.is_system_owned = 1
+
+		with self.assertRaises(frappe.ValidationError):
+			meeting.on_trash()
+
+	def test_non_manager_role_cannot_delete(self):
+		doc = frappe.get_doc({
+			"doctype": "Meeting",
+			"title": "__test_meeting_perm__",
+		})
+		doc.insert(ignore_permissions=True)
+		self._names.append(doc.name)
+
+		self.assertFalse(
+			frappe.has_permission("Meeting", ptype="delete", doc=doc.name, user="Guest")
+		)

--- a/huf/huf/doctype/meeting_recording_chunk/meeting_recording_chunk.json
+++ b/huf/huf/doctype/meeting_recording_chunk/meeting_recording_chunk.json
@@ -1,0 +1,156 @@
+{
+ "actions": [],
+ "creation": "2026-08-24 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "meeting",
+  "sequence",
+  "column_break_upload",
+  "audio_file",
+  "upload_status",
+  "client_started_at",
+  "duration_seconds",
+  "section_break_transcript",
+  "transcript_text",
+  "transcription_error",
+  "retry_count",
+  "is_system_owned"
+ ],
+ "fields": [
+  {
+   "fieldname": "meeting",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Meeting",
+   "options": "Meeting",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "sequence",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Sequence",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_upload",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "audio_file",
+   "fieldtype": "Attach",
+   "label": "Audio File"
+  },
+  {
+   "default": "Pending",
+   "fieldname": "upload_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Upload Status",
+   "options": "Pending\nUploaded\nTranscribing\nTranscribed\nFailed"
+  },
+  {
+   "fieldname": "client_started_at",
+   "fieldtype": "Datetime",
+   "label": "Client Started At"
+  },
+  {
+   "fieldname": "duration_seconds",
+   "fieldtype": "Float",
+   "label": "Duration (Seconds)"
+  },
+  {
+   "fieldname": "section_break_transcript",
+   "fieldtype": "Section Break",
+   "label": "Transcript"
+  },
+  {
+   "fieldname": "transcript_text",
+   "fieldtype": "Long Text",
+   "label": "Transcript Text"
+  },
+  {
+   "fieldname": "transcription_error",
+   "fieldtype": "Small Text",
+   "label": "Transcription Error"
+  },
+  {
+   "default": "0",
+   "fieldname": "retry_count",
+   "fieldtype": "Int",
+   "label": "Retry Count"
+  },
+  {
+   "default": "1",
+   "fieldname": "is_system_owned",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is System Owned",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Meeting Recording Chunk",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Viewer",
+   "share": 1,
+   "write": 0
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/huf/huf/doctype/meeting_recording_chunk/meeting_recording_chunk.py
+++ b/huf/huf/doctype/meeting_recording_chunk/meeting_recording_chunk.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class MeetingRecordingChunk(Document):
+	def on_trash(self):
+		if self.is_system_owned and not (
+			frappe.flags.in_install or frappe.flags.in_migrate or frappe.flags.in_uninstall
+		):
+			frappe.throw(
+				_("System-owned meeting recording chunks cannot be deleted."),
+				title=_("Meeting Recording Chunk Protected"),
+			)

--- a/huf/huf/doctype/meeting_recording_chunk/test_meeting_recording_chunk.py
+++ b/huf/huf/doctype/meeting_recording_chunk/test_meeting_recording_chunk.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+class TestMeetingRecordingChunk(IntegrationTestCase):
+	def setUp(self):
+		self._chunk_names = []
+		self._meeting_names = []
+
+		meeting = frappe.get_doc({
+			"doctype": "Meeting",
+			"title": "__test_meeting_for_chunks__",
+		})
+		meeting.insert(ignore_permissions=True)
+		self._meeting_names.append(meeting.name)
+		self.meeting_name = meeting.name
+
+	def tearDown(self):
+		for name in self._chunk_names:
+			frappe.db.delete("Meeting Recording Chunk", {"name": name})
+		for name in self._meeting_names:
+			frappe.db.delete("Meeting", {"name": name})
+		frappe.db.commit()
+
+	def test_create_chunk(self):
+		doc = frappe.get_doc({
+			"doctype": "Meeting Recording Chunk",
+			"meeting": self.meeting_name,
+			"sequence": 1,
+			"upload_status": "Pending",
+		})
+		doc.insert(ignore_permissions=True)
+		self._chunk_names.append(doc.name)
+
+		self.assertTrue(frappe.db.exists("Meeting Recording Chunk", doc.name))
+
+	def test_is_system_owned_defaults_to_one(self):
+		doc = frappe.get_doc({
+			"doctype": "Meeting Recording Chunk",
+			"meeting": self.meeting_name,
+			"sequence": 1,
+		})
+		doc.insert(ignore_permissions=True)
+		self._chunk_names.append(doc.name)
+
+		self.assertEqual(doc.is_system_owned, 1)
+
+	def test_system_owned_chunk_delete_guard(self):
+		"""Deleting a system-owned chunk should be blocked outside install/migrate/uninstall."""
+		chunk = frappe.new_doc("Meeting Recording Chunk")
+		chunk.meeting = self.meeting_name
+		chunk.sequence = 1
+		chunk.is_system_owned = 1
+
+		with self.assertRaises(frappe.ValidationError):
+			chunk.on_trash()
+
+	def test_non_manager_role_cannot_delete(self):
+		doc = frappe.get_doc({
+			"doctype": "Meeting Recording Chunk",
+			"meeting": self.meeting_name,
+			"sequence": 1,
+		})
+		doc.insert(ignore_permissions=True)
+		self._chunk_names.append(doc.name)
+
+		self.assertFalse(
+			frappe.has_permission(
+				"Meeting Recording Chunk", ptype="delete", doc=doc.name, user="Guest"
+			)
+		)

--- a/huf/install.py
+++ b/huf/install.py
@@ -104,6 +104,8 @@ def after_install():
     create_demo_ai_providers()
     create_demo_ai_models()
     create_hub_orchestrator_agent()
+    create_meeting_summary_agent()
+    create_meeting_recorder_app()
     create_image_generation_tool()
     create_transcribe_audio_tool()
     create_generate_audio_tool()
@@ -196,6 +198,16 @@ def after_migrate():
 		create_hub_orchestrator_agent()
 	except Exception as e:
 		logger.warning(f"Failed to seed Hub Orchestrator agent after migrate: {e!s}")
+
+	try:
+		create_meeting_summary_agent()
+	except Exception as e:
+		logger.warning(f"Failed to seed Meeting Summary agent after migrate: {e!s}")
+
+	try:
+		create_meeting_recorder_app()
+	except Exception as e:
+		logger.warning(f"Failed to seed Meeting Recorder HUF App after migrate: {e!s}")
 
 	try:
 		from huf.ai.app_seeding.apps_loader import sync_huf_apps
@@ -517,6 +529,132 @@ def create_hub_orchestrator_agent():
 		_create()
 	except Exception as e:
 		logger.warning(f"Failed to seed Hub Orchestrator agent: {e!s}")
+
+
+MEETING_SUMMARY_AGENT_NAME = "Meeting Summary Agent"
+
+MEETING_SUMMARY_PREFERRED_MODELS = [
+	"gemini-3.5-flash-lite",
+	"gemini-3.1-flash-lite",
+	"gemini-3.5-flash",
+	"gemini-2.5-flash",
+]
+
+MEETING_SUMMARY_INSTRUCTIONS = """You turn a raw meeting transcript into a structured Markdown summary.
+
+Output exactly these Markdown sections, in this order:
+1. `## Headline` — one sentence capturing what the meeting was about.
+2. `## Key Points` — a bullet list of the main discussion points and decisions.
+3. `## Action Items` — a bullet list of concrete follow-up actions, with an owner if the transcript names one. If there are none, write "None identified."
+
+Base the summary only on the transcript and any meeting title, description, or participants provided. Do not invent details that are not in the transcript."""
+
+
+def _meeting_summary_model():
+	"""First AI Model on the Google provider, preferring the light chat models."""
+	if not frappe.db.exists("AI Provider", "Google"):
+		return None
+
+	models = frappe.get_all(
+		"AI Model",
+		filters={"provider": "Google"},
+		pluck="name",
+		order_by="creation asc",
+	)
+	for preferred in MEETING_SUMMARY_PREFERRED_MODELS:
+		if preferred in models:
+			return preferred
+	return models[0] if models else None
+
+
+def create_meeting_summary_agent():
+	"""
+	Idempotent: seed the "Meeting Summary Agent" system agent used to turn a
+	finalized Meeting transcript into a structured Markdown summary (see
+	huf.ai.meetings.meeting_summary.run_meeting_summary).
+
+	This agent's name is also hardcoded by Phase 4's meeting_transcription.py
+	(TRANSCRIPTION_AGENT) to resolve STT config for chunk transcription, so
+	its name must stay exactly "Meeting Summary Agent".
+
+	Provider/model default to the Google/Gemini AI Model records seeded by
+	create_demo_ai_models(), following the same "pick a sensible default,
+	never hardcode a key" convention as create_hub_orchestrator_agent(). If
+	no Google AI Model is configured yet, the agent is seeded disabled so it
+	does not block install; it can be reconfigured from the Agent list once
+	a provider/model is available.
+
+	Safe to call on both after_install and after_migrate.
+	"""
+	fields = {
+		"agent_name": MEETING_SUMMARY_AGENT_NAME,
+		"description": "Summarizes a finalized Meeting transcript into headline, key points, and action items.",
+		"prompt_mode": "Local",
+		"instructions": MEETING_SUMMARY_INSTRUCTIONS,
+		"is_system": 1,
+		"allow_chat": 0,
+		"persist_conversation": 0,
+		"run_immediately": 1,
+		"allow_guest": 0,
+	}
+
+	model = _meeting_summary_model()
+	if model:
+		fields["provider"] = "Google"
+		fields["model"] = model
+		fields["disabled"] = 0
+	else:
+		fields["disabled"] = 1
+
+	previous_in_seeding = getattr(frappe.flags, "in_seeding", False)
+	frappe.flags.in_seeding = True
+	try:
+		if frappe.db.exists("Agent", MEETING_SUMMARY_AGENT_NAME):
+			doc = frappe.get_doc("Agent", MEETING_SUMMARY_AGENT_NAME)
+			for fieldname, value in fields.items():
+				doc.set(fieldname, value)
+			doc.save(ignore_permissions=True)
+			return
+
+		doc = frappe.get_doc({"doctype": "Agent", **fields})
+		if not model:
+			doc.flags.ignore_mandatory = True
+		doc.insert(ignore_permissions=True)
+	finally:
+		frappe.flags.in_seeding = previous_in_seeding
+
+
+def create_meeting_recorder_app():
+	"""
+	Idempotent: seed the "Meeting Recorder" HUF App manifest entry.
+
+	Meeting Recorder is a first-party huf feature, not a third-party app
+	manifest discovered via huf.ai.app_seeding.apps_loader (that scanner
+	explicitly skips the "huf" app itself), so it is seeded directly here
+	following the same get_value-check-then-insert-or-update pattern used
+	for the other install.py-seeded primitives (e.g. create_hub_orchestrator_agent).
+	Safe to call on both after_install and after_migrate.
+	"""
+	app_id = "meeting-recorder"
+	fields = {
+		"title": "Meeting Recorder",
+		"description": "Record, transcribe, and summarize meetings.",
+		"route": "/huf/meetings",
+		"icon": "mic",
+		"category": "Productivity",
+		"enabled": 1,
+	}
+
+	existing_name = frappe.db.get_value("HUF App", {"app_id": app_id}, "name")
+	if existing_name:
+		frappe.db.set_value("HUF App", existing_name, fields)
+		return
+
+	doc = frappe.get_doc({"doctype": "HUF App", "app_id": app_id, **fields})
+	try:
+		doc.insert(ignore_permissions=True)
+	except Exception as e:
+		logger.warning(f"Failed to seed Meeting Recorder HUF App: {e!s}")
 
 
 def create_image_generation_tool():


### PR DESCRIPTION
## Summary

First-party HUF app for recording meetings in-browser, transcribing them progressively (Gemini-based STT reusing the existing `audio_service` provider abstraction), summarizing them via a seeded `Meeting Summary Agent`, and browsing meeting history. Implemented end-to-end from the planning doc on `huf-meeting-recorder-planning`, in 8 dependency-ordered phases — see `PLAN.md` in the tracking doc below for the full architecture rationale (this PR does not touch anything outside `huf/huf/doctype/meeting*`, `huf/ai/meetings/`, `huf/install.py`, `huf/hooks.py`, and the new `frontend/src/{pages,components/meetings,hooks,services,types}` meeting files).

Source plan: `origin/huf-meeting-recorder-planning:docs/planning/meeting-recorder-transcription-plan.md`
Implementation tracker: `Tracks/safwan-erooth.MeetingRecorder/{PLAN.md,TRACKER.md}` (workspace repo, not part of this diff)

## What's included

**Data model & seeding**
- `Meeting`, `Meeting Recording Chunk` DocTypes — system-owned (`is_system_owned`, mirrors `Agent.is_system`), restricted delete, guarded via `on_trash`.
- `HUF App` manifest entry for Meeting Recorder (`/huf/meetings`, category Productivity), seeded in `install.py` (not the `app_seeding` scanner path — that's reserved for third-party apps registering into HUF, not HUF's own built-ins).
- `Meeting Summary Agent` (`is_system=1`, Gemini-provider AI Model, seeded disabled if no Google provider is configured yet so install never blocks).

**Backend**
- `huf/ai/meetings/meeting_api.py` — create/start/pause/resume/stop/list/get/update_context/retry_chunk_transcription/retry_summary.
- `huf/ai/meetings/meeting_recording.py` — `upload_chunk` (reuses `audio_service` size/type validation), plus an hourly `cleanup_stale_recordings` scheduled job (6h no-activity threshold, auto-stops and finalizes).
- `huf/ai/meetings/meeting_transcription.py` — per-chunk background transcription with retry/backoff, ordered timestamped assembly with visible `[this part could not be transcribed]` gap markers for failed segments.
- `huf/ai/meetings/meeting_summary.py` — prompt assembly + `run_agent_sync` against the seeded agent, `Agent Run` linkback for cost/audit trail.
- Realtime: `frappe.publish_realtime` on a per-meeting channel (`meeting:{name}`), `meeting_processing_status` event, targeted at the meeting owner (mirrors the existing conversation-title-update precedent).

**Frontend**
- `MeetingsPage` (history, reuses `FilterBar`/`GridView`/`ItemCard`/`EmptyState`/`useInfiniteScroll` verbatim), Quick Start with zero intermediate screens.
- `MeetingRecorderPage` — `MediaRecorder`-chunked capture, IndexedDB retry queue (survives refresh/crash), pause/resume/mute (semantically distinct), calm/minimal full-focus layout, `aria-live` state announcements.
- `MeetingDetailPage` — live processing progress (Transcribing N/M → Summarizing) via socket, then Summary-above-Transcript, sequential multi-chunk playback, retry actions on failure, non-modal post-meeting context nudge with equally-prominent Skip.
- Nav entry added to the app sidebar.

## Known gaps / needs reviewer attention

- **Not run against a live bench** — no `bench migrate`/`bench run-tests` was executed in this environment (no bench available). DocType JSON was validated (`json.load`) and all `.py` files pass `py_compile`; correctness is by close analogy to existing DocTypes/APIs, not live-verified.
- **Frontend not typechecked or built** — `node_modules` isn't installed in the implementation worktree, so `tsc`/`vitest`/`npm run build` were not run here. Every import/prop shape was traced manually against sibling components.
- **No component-render tests** for `MeetingSummaryPanel`/`MeetingTranscriptPanel` — this repo has no `@testing-library/react`/jsdom in devDependencies yet; only the pure-logic parts of `useMeetingRecorder` are unit-tested (`useMeetingRecorder.test.ts`). Backend has full pytest-style coverage per module (create/status-transition/pagination/upload-validation/retry-backoff/assembly-ordering/prompt-assembly).
- **No screenshots** — could not run the dev server / a browser in this environment to capture the recorder/detail UI live.
- **`Agent.flags.in_seeding` fix**: initial Phase 5 output set the flag on the wrong object (`doc.flags` instead of `frappe.flags`), which would have broken re-seeding the system agent on subsequent `bench migrate` runs after any field is intentionally changed. Caught and corrected before commit — see `install.py::create_meeting_summary_agent`.

## Test plan

- [ ] `bench migrate` on a real site — confirms DocTypes install cleanly and `Meeting Summary Agent`/`HUF App` seed without error.
- [ ] `bench run-tests --app huf --module huf.ai.meetings.test_meeting_api` (and sibling `test_meeting_recording`, `test_meeting_transcription`, `test_meeting_summary`, plus `huf.huf.doctype.meeting.test_meeting` / `test_meeting_recording_chunk`).
- [ ] Frontend: `npm run typecheck` / `npm run build` / `npx vitest run` in `frontend/`.
- [ ] Manual golden path: Home → Quick Start → record → pause/resume/mute → stop → skip context → watch processing → view detail (summary + transcript + playback) → back to history.
- [ ] Manual: refresh mid-recording (IndexedDB resume), forced chunk-upload failure, forced transcription/summary failure + retry, mobile viewport pass.


