### PR TITLE
sync: merge pre-dev into pre-develop

### DIFF
--- a/docs/PLAYGROUND_MULTIMODAL_ROADMAP.md
+++ b/docs/PLAYGROUND_MULTIMODAL_ROADMAP.md
@@ -1,0 +1,422 @@
+# Huf Playground — Multimodal Roadmap (Plan Stub)
+
+Status: plan seed / RFC. No implementation. Written against the `huf` worktree at
+`Tracks/safwan-erooth.PlaygroundMediaRoadmap/worktrees/huf` (branch `main`).
+
+---
+
+## Overview
+
+Huf's Playground (`/playground`, `frontend/src/pages/PlaygroundPage.tsx`) is today a
+**text-only prompt bench**: pick an agent *or* a raw provider+model, type a prompt, set
+temperature / max tokens, hit Run, compare two columns side by side, keep a local run ledger.
+
+Meanwhile the *agent runtime underneath it already speaks five other modalities*. Image
+generation, TTS, STT, OCR/document understanding and full realtime voice all exist as
+whitelisted backend handlers, DocType fields and — for voice — a separate ASGI sidecar
+process. None of it is reachable from the Playground. A developer wanting to answer
+"does `eleven_flash_v2_5` sound better than `eleven_turbo_v2_5` for this line?" or
+"does `gpt-image-1-mini` hold up against `gpt-image-1` for this prompt?" has no bench:
+they have to build an agent, wire a tool, and go through chat.
+
+The goal of this track is to close that gap — turn the Playground from a text bench into a
+**modality bench**, reusing the media plumbing that already exists rather than building a
+parallel stack.
+
+The headline finding from the code read: **this is mostly a frontend and thin-API-shim
+problem, with exactly one genuinely hard architectural piece (realtime voice transport).**
+
+---
+
+## Current State (What Huf Already Has)
+
+### Playground frontend — the surface we are extending
+
+| File | Role |
+| --- | --- |
+| `frontend/src/pages/PlaygroundPage.tsx` (216 L) | Page shell; loads agents + providers; owns `mode`, per-slot config state, run ledger |
+| `frontend/src/components/playground/PlaygroundShell.tsx` | `WorkSurfaceFrame` wrapper; **tabs are already a first-class concept** — `[{value:'playground',label:'Single'},{value:'compare',label:'Compare'}]` |
+| `frontend/src/components/playground/types.ts` | `PlaygroundConfig` (agentName, provider, model, prompt, evaluationCriteria, temperature, maxTokens), `RunOutcome`, `SlotState` |
+| `frontend/src/components/playground/ConfigStrip.tsx` | Agent / provider / model / params selector; loads models via `getModels(provider)` |
+| `frontend/src/components/playground/runExecutor.ts` | `executeRun(config)` → `runAgentSync` or `runPromptSync`, plus Agent Run telemetry enrichment |
+| `frontend/src/components/playground/{PromptPanel,ResponsePanel,TraceRail,RunLedger,ledgerStorage}.tsx/ts` | Input, output, trace rail, localStorage ledger (50 entries) |
+| `frontend/src/services/consoleApi.ts` | Only four backend calls, all text: `huf.ai.console_api.{run_prompt_sync, generate_prompt, evaluate_run, save_prompt_template}` |
+
+Architecturally this is a good base: the shell already renders a tab bar, config is a plain
+serializable object, and `executeRun` is a single dispatch point. A modality axis slots in
+naturally.
+
+### Backend media handlers — already whitelisted, already working
+
+`huf/ai/handlers/media.py` (924 L) exposes four `@frappe.whitelist() async def` handlers:
+
+| Handler | Signature highlights |
+| --- | --- |
+| `handle_generate_image` | `prompt, size="1024x1024", quality="standard", n=1, agent_name, conversation_id` — LiteLLM `image_generation()`; model from `Agent.image_generation_model` or provider auto-detect (`_get_default_image_model`) |
+| `handle_generate_audio` | `input, voice, model, speed=1.0, response_format="mp3", agent_name, conversation_id` — LiteLLM `speech()`; `_resolve_tts_config` / `_get_default_voice` / `_get_default_tts_model` |
+| `handle_transcribe_audio` | `file_id, file_url, file_path, language, model, agent_name` — pure tool, delegates to the audio service, deliberately creates **no** Agent Message |
+| `handle_ocr_document` | `file_id, file_url, pages, include_images, model, agent_name, conversation_id, create_message=True` — PDFs / images / office docs |
+
+Supporting modules:
+
+- `huf/ai/audio_service.py` (803 L) — canonical STT service: `save_audio_upload`,
+  `import_local_audio`, `resolve_local_audio_path` (allow-listed import dirs),
+  `resolve_stt_config`, `transcribe_audio_file`, `_call_stt_provider`,
+  `create_audio_user_message`.
+- `huf/ai/audio_api.py` (132 L) — clean public `transcribe()` endpoint: accepts exactly one of
+  `file_id` / `b64data`+`filename` / `file_path` (System Manager only), optional
+  `create_message`. **This is already very close to what a transcription playground tab needs.**
+- `huf/ai/ocr_engine.py` — strategy selection (`_determine_strategy`: local extractor vs LiteLLM
+  OCR endpoint vs vision model), local extractors, file hashing, `_default_model(provider, strategy)`.
+- `huf/ai/transcription_handler.py` — `execute_provider_capability`, `handle_speech_to_text`.
+
+### Voice / realtime — a control plane exists, a client does not
+
+`huf/ai/voice/` is a complete, documented session-broker layer (`huf/ai/voice/README.md` is
+unusually candid and worth reading before any work here):
+
+- `api.py` — `list_engines`, `get_config_schema`, `get_capabilities`, `list_voices`,
+  `start_session(agent, conversation_id)`, `end_session`, `send_to_session`,
+  `start_public_session(publishable_key, agent)` (guest, HMAC-safe key + Origin allowlist).
+- `engines/elevenlabs.py` (`elevenlabs_convai`) — returns a **signed WebSocket URL**; threading of
+  `huf_conversation_id` is client-cooperative (Huf cannot enforce it); persistence via post-call
+  webhook only.
+- `engines/litellm_realtime.py` — returns `{session_id, sidecar_ws_path: "/voice/realtime/<id>"}`;
+  stashes `{agent, model, api_key_provider, conversation_id}` in `frappe.cache()` under
+  `huf:voice:realtime:session:{session_id}`, TTL 300 s.
+- `sidecar/app.py` — **standalone FastAPI + uvicorn ASGI process**, separate from the gunicorn
+  bench workers, because (quoting the module docstring's reasoning) WSGI cannot hold a long-lived
+  duplex WebSocket. Run as `FRAPPE_SITE=<site> REALTIME_SIDECAR_PORT=8091 python -m
+  huf.ai.voice.sidecar.app`. Optional dependency group `realtime = ["fastapi", "uvicorn[standard]"]`
+  in `pyproject.toml`. Proxies raw OpenAI Realtime frames; close codes 4404 / 4500 / 4502.
+- `persistence.py` — `get_or_create_voice_conversation` (channel `realtime_voice`), `record_voice_turn`.
+- DocType `Voice Engine`: `engine_key`, `label`, `kind` (**`composed` | `realtime`**), `provider`, `enabled`.
+
+Known gaps already documented by the team (do not rediscover these):
+`send_to_session` raises `NotImplementedError` on **both** engines; realtime persists **agent turns
+only** (user speech is captured nowhere); ElevenLabs persistence has a single point of failure in the
+webhook; and `huf/public/js/huf-voice.md` states outright that opening the actual audio connection
+"is not yet implemented by this bundle". **There is no live voice UI anywhere in Huf today** —
+`frontend/src/components/agent/VoiceTab.tsx` and `components/settings/VoiceSettingsTab.tsx` are
+configuration forms, not clients.
+
+### Data model — mostly ready
+
+`Agent Message` (`huf/huf/doctype/agent_message/agent_message.json`) already carries:
+
+- `kind` Select: `Message, Tool Call, Tool Result, Status, Error, **Image, Audio, Video**`
+- `generated_image` (Attach Image), `generated_audio` (Attach), **`generated_video` (Attach)**
+- `tts_model`, `tts_voice`, `stt_model` (Links to AI Model), `voice_message` (Attach)
+- `content_type` Select includes `Image`
+
+Notably `generated_video` and `kind: Video` **already exist** — the "missing video field" the task
+brief hypothesized is not missing. There is no generation handler behind it yet, which is the
+opposite gap.
+
+`AI Model.modalities` (Data field, comma-joined) options:
+`Text, Image, Text-to-Speech, Transcription, Embeddings, Vision, OCR, Speech-to-Speech`.
+Seeded in `huf/install.py`: `eleven_multilingual_v2` / `eleven_turbo_v2_5` / `eleven_flash_v2_5`
+(TTS), `gpt-image-2` / `gpt-image-1` / `gpt-image-1-mini` / `chatgpt-image-latest` (Image, both
+OpenAI and OpenRouter-prefixed), `tts-1` / `tts-1-hd`, `whisper-1`, `gpt-realtime-whisper` (STT).
+`Speech-to-Speech` is a valid option that **no seeded model claims** — realtime models are not
+modelled as AI Model rows at all today.
+
+`Agent` carries `image_generation_model`, `tts_model`, `tts_voice`, `stt_model`, `enable_ocr`, and a
+whole `voice_tab` (`voice_enabled`, `voice_engine`, `voice_config`, `voice_greeting`).
+`AI Provider` has **no realtime-capable flag** — realtime capability lives only on `Voice Engine.kind`.
+
+### Frontend media libraries already installed
+
+From `frontend/package.json`:
+
+- `media-chrome@^4.18.0` — themeable `<media-controller>` audio/video player elements. **Already
+  there; use it for TTS/audio playback rather than adding a new player.**
+- `socket.io-client@^4.7.5` — existing chat streaming transport.
+- `ai@^6.0.116` (Vercel AI SDK), `streamdown`, `tokenlens`.
+- **Not present:** any waveform library (wavesurfer/peaks), any WebRTC helper, any audio-worklet
+  PCM resampler. These are the real net-new frontend dependencies.
+
+Also already built: `frontend/src/components/ai-elements/speech-input.tsx` — a dual-mode mic button
+that uses the Web Speech API when available and falls back to `MediaRecorder` +
+`navigator.mediaDevices.getUserMedia`, uploading to
+`huf.ai.agent_chat.upload_audio_and_transcribe_web`. **Phase 2 should lift capture logic from here,
+not reinvent it.**
+
+---
+
+## Reference Patterns (OpenAI / ElevenLabs / Anthropic)
+
+### OpenAI Playground
+
+- **Modality as a top-level mode selector**, not a hidden setting. Chat / Realtime / Assistants /
+  TTS / Transcription are distinct surfaces sharing one model+params rail.
+- **Realtime tab**: a session-oriented UI, not a request/response one. Press-to-connect →
+  persistent session → mic capture with a live input level meter → streaming interleaved transcript
+  (user turns and assistant turns as they arrive, not on completion) → barge-in supported →
+  explicit End session. Session config (voice, VAD threshold, turn detection mode, instructions) is
+  set *before* connect and partially mutable mid-session.
+- **Transcription**: file drop zone + language hint + model picker → transcript with optional
+  timestamps/segments.
+- **Image**: prompt + size + quality + n → grid of results, each downloadable, each carrying its
+  generation params so a result can be re-run or forked.
+- Everything writes into a shared run history with cost/latency per run.
+
+### ElevenLabs
+
+- **TTS playground**: text box + voice picker (with per-voice preview) + model picker
+  (flash/turbo/multilingual, framed as a latency↔quality tradeoff) + stability/similarity sliders →
+  generate → inline player with waveform scrub, plus a persistent history of generations.
+  The *voice picker is the primary control*, ahead of the model picker — a UX detail Huf's
+  agent-centric `ConfigStrip` currently has no slot for.
+- **Conversational AI (agent) testing**: an in-dashboard "Test AI agent" widget — click to talk,
+  live transcript pane on one side, a latency/turn breakdown on the other, post-call the
+  conversation appears in a call history with full transcript and per-turn timing.
+- Model comparison is done by re-generating the same text on a different model and A/B-ing the two
+  audio clips from history — exactly the shape Huf's existing Compare mode already implements for text.
+
+### Anthropic Console
+
+- Deliberately narrower: a **Workbench** with system prompt / messages / params, plus file and image
+  attachment for vision, and an Evaluate tab that runs a prompt across a test-case table.
+- Key transferable idea: **attachment as a first-class part of the prompt input**, not a separate
+  tab. Vision/document understanding is not its own mode — it is the text mode with a file attached.
+
+### Mapping to Huf
+
+| Pattern | Fit for Huf |
+| --- | --- |
+| Modality as top-level tab | Direct fit — `PlaygroundShell` already renders `WorkSurfaceTab[]`. Extend `PlaygroundMode` from `'playground' \| 'compare'` to a modality × layout matrix. |
+| Request/response modalities (image, TTS, STT, OCR) | Direct fit — plain `frappe.call` POST against the existing `handlers/media.py` endpoints. Same `executeRun` dispatch shape, just a wider `RunOutcome`. |
+| Compare-two-columns | Direct fit and arguably *more* valuable for media than for text (two TTS voices, two image models side by side). Reuse `CompareView` with a modality-specific result renderer. |
+| Run ledger / history | Direct fit, with one caveat: `ledgerStorage.ts` is `localStorage`, capped at 50 entries. Audio/image results cannot be stored inline — the ledger must hold **file URLs**, and generated files need a retention story. |
+| Realtime session UI | **No fit with the current transport.** See Risks. Needs the sidecar, a browser WS client, and PCM capture — none of which exist. |
+| Attachment-in-prompt (Anthropic style) | Good fit for OCR/vision: rather than a separate OCR tab, allow a file attachment in the existing text prompt panel that routes through `handle_ocr_document` and prepends the extraction. Consider offering **both** (dedicated tab for isolating the OCR step, attachment for end-to-end). |
+
+---
+
+## Proposed Phases
+
+Ordering principle: **highest ratio of (developer value) to (new architecture) first.** Phases 1–3
+are essentially UI on top of endpoints that already work. Phase 4 is where the real engineering is.
+
+### Phase 0 — Foundation (prerequisite for everything below)
+
+Small, unglamorous, and it unblocks all later phases.
+
+**Backend**
+
+1. **Modality-aware model listing.** `ConfigStrip` calls `getModels(provider)` and shows everything.
+   Add a modality filter so a TTS tab offers only `Text-to-Speech` models. `AI Model.modalities`
+   already holds the data and `providerApi.getModalityOptions()` already reads the Select options
+   from the DocType meta — this is a filter parameter, not a schema change.
+2. **A console-layer shim per modality.** `handlers/media.py` handlers are *agent tools*: they take
+   `agent_name` and (for image/audio/OCR) write Agent Messages into a `conversation_id`. The
+   Playground wants **agentless, provider+model-direct, no-persistence** runs, mirroring how
+   `console_api.run_prompt_sync` relates to `run_agent_sync`. Add
+   `huf.ai.console_api.{run_image_sync, run_tts_sync, run_stt_sync, run_ocr_sync}` that accept an
+   explicit provider+model, bypass Agent resolution, skip message creation, and return uniform
+   telemetry (`latency_ms`, `cost`, `model`, plus artifact URL). Do **not** re-implement generation —
+   these call the same underlying services.
+3. **Generated-artifact retention policy.** Playground runs will produce orphan files (images, mp3s)
+   attached to no Agent Message. Decide now: private `File` records tagged with a
+   `playground` source + a scheduled cleanup, vs. ephemeral in-memory/base64 returns for small
+   results. Getting this wrong fills the site's file store with unreferenced blobs.
+4. **Cost/telemetry for non-token modalities.** `RunOutcome` assumes input/output tokens. Image and
+   TTS bill per image / per character. Either widen the ledger's notion of cost units or accept
+   `cost` only.
+
+**Frontend**
+
+5. **Widen the type layer.** `PlaygroundConfig` gains a `modality` discriminant and a
+   modality-specific params bag; `RunOutcome` gains optional `artifactUrl`, `artifactKind`,
+   `transcript`, `extractedText`. Keep it a discriminated union so `executeRun` stays a single
+   exhaustive switch.
+6. **Widen the shell.** Decide the tab taxonomy (see Open Questions) and extend
+   `PlaygroundShell`'s tab list; keep Single/Compare as a sub-toggle rather than flattening
+   modality × layout into one tab row.
+7. **A `MediaResultPanel`** sibling to `ResponsePanel`, rendering per artifact kind (image grid,
+   `media-chrome` audio player, transcript block, extracted-text block).
+
+*Deliverable:* nothing user-visible changes; every later phase becomes a mostly-declarative addition.
+
+---
+
+### Phase 1 — Image Generation Tab (highest value / lowest risk)
+
+Backend already complete (`handle_generate_image`, models seeded). Purely additive.
+
+- **Backend:** `run_image_sync(provider, model, prompt, size, quality, n)` shim from Phase 0.
+- **Frontend:** `ImageConfigStrip` (model filtered to `Image`, size, quality, n) + prompt panel reuse +
+  result grid with download and "open full size". Compare mode = same prompt against two models
+  (`gpt-image-1` vs `gpt-image-1-mini` is the obvious first demo).
+- **Reused:** prompt panel, run ledger, compare layout, trace rail.
+- **Net new:** image grid component, size/quality controls.
+- Risk: latency (10–60 s per image) — the existing synchronous run path may exceed gunicorn/proxy
+  timeouts for `n>1`. Consider capping `n` or routing through the existing background-job path.
+
+### Phase 2 — Audio Generation (TTS) Tab
+
+Backend already complete (`handle_generate_audio`, `_resolve_tts_config`, ElevenLabs models seeded).
+
+- **Backend:** `run_tts_sync(provider, model, input, voice, speed, response_format)`. Also expose a
+  **voice catalogue** — `huf.ai.voice.api.list_voices(agent)` exists but is agent-scoped; the
+  Playground needs a provider-scoped variant, otherwise the voice field is a free-text `Data` box
+  (which is what `Agent.tts_voice` is today).
+- **Frontend:** text input + voice picker (with preview) + model picker (`eleven_flash_v2_5` /
+  `eleven_turbo_v2_5` / `eleven_multilingual_v2` / `tts-1*`) + speed slider + format selector →
+  `media-chrome` player. Compare = same text, two voices or two models, two players.
+- **Net new:** voice picker component; optional waveform (defer — a plain player is enough for v1).
+- Risk: the voice-catalogue endpoint is the only real backend work; ElevenLabs and OpenAI voice
+  lists have different shapes and need normalising.
+
+### Phase 3 — Transcription (STT) + OCR / Document Understanding Tabs
+
+Grouped because they share one interaction: **drop a file, get text back.**
+
+- **Backend:** `run_stt_sync` is close to a rename of `huf.ai.audio_api.transcribe` with
+  `create_message=False` and a provider+model override; `run_ocr_sync` wraps `handle_ocr_document`
+  without message creation. `ocr_engine._determine_strategy` should surface *which* strategy it
+  chose (local extractor / OCR endpoint / vision model) in the result — that is exactly the debug
+  signal a playground exists to give.
+- **Frontend:** a shared `FileDropPanel` (drag-drop + picker, respecting `audio_service.is_audio_file`
+  and the OCR engine's supported types) → result pane with the transcript / extracted text, plus a
+  metadata rail (model used, strategy, language, page count, duration).
+- **Reused:** `speech-input.tsx` capture logic for a "record instead of upload" affordance in the STT tab.
+- **Net new:** drop zone, strategy/metadata rail.
+- Risk: file size limits and Frappe's upload path; private-file access control for the resulting `File`.
+
+### Phase 4 — Realtime / Conversational Voice Tab (the hard one)
+
+This is a different kind of work from Phases 1–3 and should not be scheduled as if it were the same.
+
+**What exists:** the entire server-side control plane (session minting, engine abstraction,
+credential brokering, Redis session stash, ASGI sidecar, persistence hooks).
+**What does not exist:** *any* browser client. No PCM capture, no playback queue, no WS client, no
+transcript UI, no session state machine. `huf-voice.md` says so explicitly.
+
+- **Backend / ops:**
+  - Make the sidecar a first-class, documented part of the dev and deploy story (Procfile entry or
+    compose service; today it is an opt-in `pip install -e ".[realtime]"` + manual `python -m`).
+  - Reverse-proxy config so `/voice/realtime/<session_id>` reaches port 8091 with WS upgrade intact.
+  - Close the documented gaps that a playground will immediately expose: **user speech turns are not
+    persisted** (a transcript pane showing only the agent's half is not a usable bench), and
+    `send_to_session` raises on both engines (needed for "type a message into a live voice session",
+    which both OpenAI and ElevenLabs playgrounds offer).
+  - Decide whether realtime models become `AI Model` rows with modality `Speech-to-Speech`, or stay
+    exclusively under `Voice Engine`. The Playground's model picker assumes the former.
+- **Frontend:**
+  - Mic capture at the provider's required PCM format (OpenAI Realtime wants PCM16 @ 24 kHz) —
+    `MediaRecorder` alone is insufficient; needs `AudioWorklet` + a resampler. This is the single
+    largest net-new frontend component.
+  - Playback queue with barge-in (interrupt-on-user-speech) — both engines advertise
+    `barge_in: True`, so the client must honour it.
+  - Session state machine: idle → minting → connecting → live → ending → ended, with the sidecar's
+    close codes (4404 expired session / 4500 misconfigured / 4502 upstream) surfaced as human errors.
+  - Two client paths, because the two engines differ fundamentally: ElevenLabs gives a **signed URL
+    to their servers** (and requires the client to echo `huf_conversation_id` as a dynamic variable —
+    Huf cannot enforce this) while litellm_realtime gives a **path to Huf's own sidecar**. Abstract
+    behind one `VoiceSession` interface with two transports; do not let engine specifics leak into
+    the tab component.
+  - Live interleaved transcript + input/output level meters + turn latency readout.
+
+### Phase 5 (speculative) — Video, and cross-modality chaining
+
+- `Agent Message.generated_video` and `kind: Video` already exist with no handler behind them.
+  A `handle_generate_video` would complete the set, but there is no seeded video model and no
+  provider story yet — park it until one exists.
+- Chaining (image → OCR → prompt; prompt → TTS → STT round-trip as a quality check) is a natural
+  playground superpower once each modality is individually benched. Explicitly **out of scope**
+  until Phases 1–4 land.
+
+---
+
+## Open Questions & Risks
+
+### Architectural risks
+
+1. **Realtime transport is a different animal (biggest risk).** Frappe's chat streaming is
+   REST + Socket.IO — server-push over a Node process, request/response for input. Realtime voice
+   needs **duplex binary streaming with sub-200 ms budgets**. The team already concluded WSGI/gunicorn
+   cannot host it and built a separate uvicorn sidecar, which means realtime voice introduces a
+   **second long-lived server process, a second port, a second proxy rule, and a second failure
+   mode** into every environment that wants the feature. That is an operational commitment, not a
+   feature flag. Phase 4 should be gated on an explicit decision to own that.
+2. **Two incompatible realtime engines.** ElevenLabs connects the browser *directly to ElevenLabs*
+   (Huf sees nothing but the post-call webhook); litellm_realtime proxies through Huf's sidecar
+   (Huf sees every frame). Observability, persistence, cost accounting and failure behaviour differ
+   completely between them. A single "Realtime" playground tab that silently behaves differently per
+   engine will confuse more than it reveals — surface the engine's `get_capabilities()` in the UI.
+3. **Persistence asymmetry.** Realtime persists agent turns only; ElevenLabs persists nothing if the
+   webhook misses. A playground built on top of this will intermittently show incomplete
+   transcripts, and users will read that as a playground bug.
+4. **Synchronous long-running generation.** Image generation and long TTS can exceed typical
+   gunicorn worker / proxy timeouts. The text playground never hit this. Decide per modality:
+   raise timeouts, or route through the existing background-job + Socket.IO completion pattern
+   that chat already uses.
+5. **`send_to_session` is dead code on every engine.** Anything in the plan that assumes mid-session
+   text injection is currently unimplementable.
+
+### Product / scope questions
+
+6. **Tab taxonomy.** Modality × layout is a 2-D space (6 modalities × Single/Compare). Options:
+   (a) modality tabs with a Single/Compare sub-toggle, (b) flat tab list, (c) modality as a
+   `ConfigStrip` field with the tabs staying Single/Compare. (a) is recommended — it keeps the
+   existing shell semantics and doesn't explode the tab row.
+7. **Agent-mode vs direct-mode for media.** Text playground supports both ("run through this agent"
+   vs "run this provider+model raw"). For media, agent-mode means the agent's
+   `image_generation_model` / `tts_model` / `stt_model` is used and messages get persisted to a
+   conversation. Is agent-mode in scope for media tabs, or is direct-mode enough for v1?
+   Recommendation: direct-mode only for Phases 1–3; agent-mode is unavoidable for Phase 4 because
+   voice sessions are minted *from* an Agent.
+8. **Generated-artifact lifetime.** Do playground images/audio persist as `File` records the user can
+   find later, or vanish on reload? Affects the run ledger (localStorage cannot hold blobs) and the
+   site's disk usage. Needs a decision in Phase 0.
+9. **Cost visibility.** Per-image and per-character pricing is not modelled — `AI Model` has
+   `input_cost_per_1m_tokens` / `output_cost_per_1m_tokens` / `cached_input_cost_per_1m_tokens` only.
+   Either extend the pricing fields or show latency-only for media runs.
+10. **Voice catalogue ownership.** `Agent.tts_voice` is free-text `Data`. A picker needs a
+    provider-scoped, cached voice list. Where does it live — a new `AI Voice` DocType, a cached
+    provider call, or a hardcoded map per `provider_brand`?
+11. **Permissions.** `audio_api.transcribe` gates `file_path` behind System Manager. What role gates
+    playground media generation — is running image generation from the Playground a
+    capability, and does it respect the same access checks agents do?
+12. **Compare semantics for media.** Word-diff (`wordDiff.ts`) is meaningless for an image or an mp3.
+    Compare for media is "put them next to each other and let the human judge" — which means the
+    existing `evaluate_run` LLM-judge path also does not transfer without a vision/audio judge.
+
+---
+
+## Rough Effort Sizing
+
+Deliberately coarse. Assumes one developer familiar with both the Frappe app and the React frontend.
+"Weeks" are calendar-ish, not padded.
+
+| Phase | Backend | Frontend | Total | Confidence |
+| --- | --- | --- | --- | --- |
+| **0 — Foundation** | Model-modality filter, 4 console shims, retention policy | Type widening, shell tabs, `MediaResultPanel` | **1–1.5 wk** | High — well-understood, no unknowns |
+| **1 — Image** | Thin (shim only) | Config strip + result grid | **3–5 d** | High |
+| **2 — TTS** | Voice catalogue endpoint (the real work) | Voice picker + player (media-chrome already installed) | **4–6 d** | Medium-high — voice list normalisation across providers is the unknown |
+| **3 — STT + OCR** | Two shims + surface OCR strategy in result | Shared file-drop panel + metadata rail | **1 wk** | Medium-high |
+| **4 — Realtime voice** | Sidecar productionisation, proxy/WS ops, user-turn persistence, `send_to_session`, realtime model modelling | PCM capture via AudioWorklet, playback queue + barge-in, session state machine, two transports, live transcript | **3–5 wk** | **Low** — the frontend audio pipeline and the two-engine split are both genuinely hard, and the ops story is unwritten |
+| **5 — Video / chaining** | Unknown (no provider story) | — | Not sized | Speculative |
+
+**Total for Phases 0–3 (all request/response modalities): ~3–4 weeks**, delivering image, TTS, STT
+and OCR benches on top of infrastructure that already works.
+**Phase 4 alone is comparable to or larger than Phases 0–3 combined**, and carries an operational
+commitment (a second server process) that the others do not.
+
+Recommended sequencing decision: ship 0→3 as one coherent release ("the Playground now covers every
+modality Huf can do in a single request"), and treat Phase 4 as its own track with its own go/no-go,
+rather than as the last item on this one.
+
+---
+
+## Appendix — Files to read first, in order
+
+1. `huf/ai/voice/README.md` — the most honest document in the repo about what realtime does and does not do.
+2. `huf/ai/handlers/media.py` — the four handlers all of Phases 1–3 wrap.
+3. `huf/ai/voice/sidecar/app.py` (docstring, lines 1–60) — why the transport is what it is.
+4. `frontend/src/components/playground/{types.ts,runExecutor.ts,PlaygroundShell.tsx}` — the three
+   files every frontend phase touches.
+5. `huf/ai/audio_api.py` — the template for what a clean console-layer media shim looks like.
+6. `huf/install.py` (~lines 261–470) — the seeded model/modality ground truth.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,7 @@ const ChatScheduledPage = lazy(() =>
   import('./pages/chat/ChatPlaceholderPages').then((m) => ({ default: m.ChatScheduledPage }))
 );
 const Executions = lazy(() => import('./pages/Executions'));
+const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'));
 const AgentRunDetailPageWrapper = lazy(() => import('./pages/AgentRunDetailPageWrapper'));
 const McpDetailsPageWrapper = lazy(() => import('./pages/McpDetailsPageWrapper'));
 const McpListingPage = lazy(() => import('./pages/McpListingPage'));
@@ -533,6 +534,18 @@ function AppShell() {
                 <UnifiedLayout>
                   <Suspense fallback={<PageLoader />}>
                     <Executions />
+                  </Suspense>
+                </UnifiedLayout>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/analytics"
+            element={
+              <ProtectedRoute>
+                <UnifiedLayout>
+                  <Suspense fallback={<PageLoader />}>
+                    <AnalyticsPage />
                   </Suspense>
                 </UnifiedLayout>
               </ProtectedRoute>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, ChartNoAxesCombined, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"
@@ -127,6 +127,13 @@ export const operateNavItems = [
 		title: "Executions",
 		url: "/executions",
 		icon: Zap,
+		capability: "agent.use",
+		badge: "Experimental",
+	},
+	{
+		title: "Analytics",
+		url: "/analytics",
+		icon: ChartNoAxesCombined,
 		capability: "agent.use",
 		badge: "Experimental",
 	},

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useImperativeHandle, forwardRef } from "react";
 import { toast } from "sonner";
-import { ArrowUp, Plus, Square } from "lucide-react";
+import { ArrowUp, Mic, MicOff, Phone, PhoneOff, Plus, Square } from "lucide-react";
 import { Button } from "../ui/button";
 import {
   sendMessage,
@@ -18,6 +18,8 @@ import { cn } from "@/lib/utils";
 import type { MessageType } from './types';
 import { cacheReasoning } from './chatMessageList.mappers';
 import { cacheAgentNameForChat } from './useChatAgentIdentity';
+import { useVoiceCall } from '@/hooks/useVoiceCall';
+import { VoiceCallOverlay } from './VoiceCallOverlay';
 
 export type LoadingType = 'default' | 'transcribing';
 
@@ -106,6 +108,47 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
         status: 'uploading' | 'ready' | 'error';
         error?: string;
     } | null>(null);
+
+    // "Talk to this agent" voice call. The Agent object available here is
+    // just `agentName` (no `voice_enabled`/`voice_engine` — plumbing that in
+    // would require changes to how agent data flows into ChatInput), so the
+    // call button is always shown and relies on `start_session` throwing a
+    // clear backend error for agents without a voice engine configured,
+    // surfaced below via the same toast convention as the rest of this file.
+    const voiceCall = useVoiceCall(agentName, chatId ?? undefined);
+    const voiceCallErrorRef = useRef<string | null>(null);
+    useEffect(() => {
+        if (voiceCall.status === 'error' && voiceCall.error && voiceCall.error !== voiceCallErrorRef.current) {
+            voiceCallErrorRef.current = voiceCall.error;
+            toast.error(voiceCall.error);
+        }
+        if (voiceCall.status !== 'error') {
+            voiceCallErrorRef.current = null;
+        }
+    }, [voiceCall.status, voiceCall.error]);
+
+    const handleStartVoiceCall = useCallback(() => {
+        void voiceCall.start();
+    }, [voiceCall]);
+
+    const handleEndVoiceCall = useCallback(() => {
+        void voiceCall.stop();
+    }, [voiceCall]);
+
+    // Which view represents a live/connecting call: the full-viewport
+    // overlay (default) or the collapsed compact bar. Purely a UI
+    // preference — unrelated to useVoiceCall's own state machine — so it
+    // lives here rather than inside the hook. Each new call defaults back
+    // to the prominent overlay, so a "minimized" choice from a previous
+    // call never carries over.
+    const [isVoiceOverlayMinimized, setIsVoiceOverlayMinimized] = useState(false);
+    const prevVoiceStatusRef = useRef(voiceCall.status);
+    useEffect(() => {
+        if (prevVoiceStatusRef.current === 'idle' && voiceCall.status === 'connecting') {
+            setIsVoiceOverlayMinimized(false);
+        }
+        prevVoiceStatusRef.current = voiceCall.status;
+    }, [voiceCall.status]);
 
     const clearRunTimeout = useCallback(() => {
         if (runTimeoutRef.current) {
@@ -913,8 +956,98 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
         return null;
     }
 
+    // 'connecting'/'live' default to the prominent full-viewport overlay —
+    // this is the "just started a call" moment where a takeover view matters
+    // most. 'error'/'ended' are terminal/transient and stay on the compact
+    // bar below (a full-screen takeover for an error is overkill). Minimizing
+    // the overlay also falls back to the compact bar without ending the call.
+    if ((voiceCall.status === 'connecting' || voiceCall.status === 'live') && !isVoiceOverlayMinimized) {
+        return (
+            <VoiceCallOverlay
+                voiceCall={voiceCall}
+                agentName={agentName}
+                onEndCall={handleEndVoiceCall}
+                onStartCall={handleStartVoiceCall}
+                onMinimize={() => setIsVoiceOverlayMinimized(true)}
+            />
+        );
+    }
+
+    if (voiceCall.status !== 'idle') {
+        const statusLabel =
+            voiceCall.status === 'connecting'
+                ? 'Connecting…'
+                : voiceCall.status === 'live'
+                    ? (voiceCall.isMuted ? 'Muted' : 'Live')
+                    : voiceCall.status === 'error'
+                        ? (voiceCall.error || 'Call error')
+                        : 'Call ended';
+
+        return (
+            <div className="flex-none px-[26px] pb-4 animate-drop motion-reduce:animate-none">
+                <div
+                    key={voiceCall.status}
+                    className="flex items-center gap-2.5 rounded-chat-bubble border border-input bg-panel px-[13px] py-[11px] transition-colors duration-300 animate-drop motion-reduce:animate-none"
+                >
+                    {/* Orb: glows/pulses while the agent's audio is live and unmuted,
+                        a subtler idle pulse while connecting, and a static muted/idle
+                        look otherwise — mirrors the loading-state visual language in
+                        MessageLoadingState.tsx (icon + shimmer) at a glance-able size. */}
+                    <span className="relative flex size-7 shrink-0 items-center justify-center">
+                        {voiceCall.status === 'live' && !voiceCall.isMuted && (
+                            <span className="absolute inset-0 rounded-full bg-destructive/40 animate-ping motion-reduce:animate-none" />
+                        )}
+                        <span
+                            className={cn(
+                                "relative rounded-full transition-all duration-300 ease-out",
+                                voiceCall.status === 'live' && !voiceCall.isMuted && "size-3.5 bg-destructive shadow-md",
+                                voiceCall.status === 'live' && voiceCall.isMuted && "size-2.5 bg-steel-soft opacity-70",
+                                voiceCall.status === 'connecting' && "size-2.5 bg-steel-soft animate-pulse motion-reduce:animate-none",
+                                (voiceCall.status === 'error' || voiceCall.status === 'ended') && "size-2 bg-steel-soft"
+                            )}
+                        />
+                    </span>
+                    <span className="flex-1 text-[13px] text-ui-text truncate">{statusLabel}</span>
+                    {voiceCall.status === 'live' && (
+                        <button
+                            type="button"
+                            onClick={voiceCall.isMuted ? voiceCall.unmute : voiceCall.mute}
+                            className="shrink-0 text-steel hover:text-ink"
+                            aria-label={voiceCall.isMuted ? "Unmute microphone" : "Mute microphone"}
+                            title={voiceCall.isMuted ? "Unmute microphone" : "Mute microphone"}
+                        >
+                            {voiceCall.isMuted ? <MicOff className="size-[17px]" /> : <Mic className="size-[17px]" />}
+                        </button>
+                    )}
+                    {(voiceCall.status === 'live' || voiceCall.status === 'connecting') && (
+                        <Button
+                            type="button"
+                            onClick={handleEndVoiceCall}
+                            className="shrink-0 !h-[26px] !w-[26px] !p-0 rounded-chat-send bg-destructive hover:bg-destructive/90 text-destructive-foreground"
+                            aria-label="End call"
+                            title="End call"
+                        >
+                            <PhoneOff className="size-3.5" />
+                        </Button>
+                    )}
+                    {(voiceCall.status === 'error' || voiceCall.status === 'ended') && (
+                        <Button
+                            type="button"
+                            onClick={handleStartVoiceCall}
+                            className="shrink-0 !h-[26px] !w-[26px] !p-0 rounded-chat-send bg-ink hover:bg-ink/90 text-white"
+                            aria-label="Talk to this agent"
+                            title="Talk to this agent"
+                        >
+                            <Phone className="size-3.5" />
+                        </Button>
+                    )}
+                </div>
+            </div>
+        );
+    }
+
     return (
-        <div className="flex-none px-[26px] pb-4">
+        <div className="flex-none px-[26px] pb-4 animate-drop motion-reduce:animate-none">
             <form onSubmit={handleSubmit}>
                 <div className={cn(
                     "rounded-chat-bubble border border-input bg-panel",
@@ -993,6 +1126,20 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
                                     // control reads as the bare glyph spec 28.1 draws.
                                     className="shrink-0"
                                 />
+                            )}
+                            {!message.trim() && !pendingFile && voiceCall.status === 'idle' && (
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={handleStartVoiceCall}
+                                    disabled={isSubmitting}
+                                    className="shrink-0 bg-transparent text-steel hover:bg-transparent hover:text-ink"
+                                    aria-label="Talk to this agent"
+                                    title="Talk to this agent"
+                                >
+                                    <Phone className="size-[17px]" />
+                                </Button>
                             )}
                             {isStreamingResponse ? (
                                 <Button

--- a/frontend/src/components/chat/ChatWindowHeader.tsx
+++ b/frontend/src/components/chat/ChatWindowHeader.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import {
     ArrowLeft,
+    BarChart3,
     Check,
     ChevronDown,
     MoreVertical,
@@ -39,6 +40,12 @@ interface ChatWindowHeaderProps {
     /** Toggles the artifact preview pane. The toggle button only renders when
      * this is provided, so the control is never present-but-inert. */
     onToggleArtifactPane?: () => void;
+    /** Whether the right-docked conversation analytics pane is currently open.
+     * Sibling of artifactPaneOpen - drives the analytics toggle's fill state. */
+    analyticsPaneOpen?: boolean;
+    /** Toggles the analytics pane. Sibling of onToggleArtifactPane: the
+     * toggle button only renders when this is provided. */
+    onToggleAnalyticsPane?: () => void;
     /** Whether the left rail is collapsed. When true, the header gains a
      * leading icon cluster (expand rail, Dashboard, New, divider) in place
      * of the plain sidebar-open button (spec 28.5). */
@@ -53,6 +60,8 @@ export function ChatWindowHeader({
     onToggleSidebar,
     artifactPaneOpen,
     onToggleArtifactPane,
+    analyticsPaneOpen,
+    onToggleAnalyticsPane,
     railCollapsed,
     onExpandRail,
 }: ChatWindowHeaderProps) {
@@ -207,21 +216,23 @@ export function ChatWindowHeader({
                     </button>
                 </AgentSwitcher>
                 <span className="flex-1" />
+                <AnalyticsPaneToggle open={analyticsPaneOpen} onToggle={onToggleAnalyticsPane} />
                 <ArtifactPaneToggle open={artifactPaneOpen} onToggle={onToggleArtifactPane} />
             </header>
         );
     }
 
-    // Spec 28.2: with the artifact pane open, the header simplifies down to
-    // the title, a flex spacer, and the artifact toggle — the picker
-    // chevron, model text, and overflow dots all drop out.
-    if (artifactPaneOpen) {
+    // Spec 28.2: with the artifact pane (or the sibling analytics pane) open,
+    // the header simplifies down to the title, a flex spacer, and the pane
+    // toggles — the picker chevron, model text, and overflow dots all drop out.
+    if (artifactPaneOpen || analyticsPaneOpen) {
         return (
             <header className={headerClassName}>
                 <span className="truncate text-[14px] font-[590] tracking-[-0.01em] text-ink">
                     {conversationTitle || agent.agent_name}
                 </span>
                 <span className="flex-1" />
+                <AnalyticsPaneToggle open={analyticsPaneOpen} onToggle={onToggleAnalyticsPane} />
                 <ArtifactPaneToggle open={artifactPaneOpen} onToggle={onToggleArtifactPane} />
             </header>
         );
@@ -325,6 +336,7 @@ export function ChatWindowHeader({
                 />
             )}
 
+            <AnalyticsPaneToggle open={analyticsPaneOpen} onToggle={onToggleAnalyticsPane} />
             <ArtifactPaneToggle open={artifactPaneOpen} onToggle={onToggleArtifactPane} />
         </header>
     );
@@ -421,6 +433,34 @@ function ArtifactPaneToggle({ open, onToggle }: ArtifactPaneToggleProps) {
                 )}
             </svg>
             <span className="sr-only">{open ? "Hide artifacts" : "Show artifacts"}</span>
+        </Button>
+    );
+}
+
+interface AnalyticsPaneToggleProps {
+    open?: boolean;
+    onToggle?: () => void;
+}
+
+/**
+ * Sibling of `ArtifactPaneToggle`, following its exact shape: ghost icon
+ * button, `h-8 w-8`, `text-steel hover:text-ink` when closed / `text-ink`
+ * when open, rendered only when `onToggle` is provided so a conversation
+ * with no analytics available never shows an inert control.
+ */
+function AnalyticsPaneToggle({ open, onToggle }: AnalyticsPaneToggleProps) {
+    if (!onToggle) return null;
+
+    return (
+        <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={open ? "h-8 w-8 text-ink hover:text-ink" : "h-8 w-8 text-steel hover:text-ink"}
+            onClick={onToggle}
+        >
+            <BarChart3 className="size-[17px]" strokeWidth={open ? 2.25 : 2} aria-hidden="true" />
+            <span className="sr-only">{open ? "Hide analytics" : "Show analytics"}</span>
         </Button>
     );
 }

--- a/frontend/src/components/chat/ChatWindowV2.tsx
+++ b/frontend/src/components/chat/ChatWindowV2.tsx
@@ -19,6 +19,11 @@ interface ChatWindowProps {
     artifacts?: ArtifactListItem[];
     onOpenArtifact?: (target: ArtifactPaneTarget) => void;
     activeArtifactName?: string;
+    /** Whether the right-docked conversation analytics pane is currently open. */
+    analyticsPaneOpen?: boolean;
+    /** Toggles the analytics pane. Sibling of onToggleArtifactPane - the
+     * header only renders its toggle button when this is provided. */
+    onToggleAnalyticsPane?: () => void;
 }
 
 export default function ChatWindow({
@@ -32,6 +37,8 @@ export default function ChatWindow({
     artifacts,
     onOpenArtifact,
     activeArtifactName,
+    analyticsPaneOpen,
+    onToggleAnalyticsPane,
 }: ChatWindowProps) {
     return (
         <div className="w-full h-full flex flex-col overflow-hidden bg-background">
@@ -42,6 +49,8 @@ export default function ChatWindow({
                 onExpandRail={onExpandRail}
                 artifactPaneOpen={artifactPaneOpen}
                 onToggleArtifactPane={onToggleArtifactPane}
+                analyticsPaneOpen={analyticsPaneOpen}
+                onToggleAnalyticsPane={onToggleAnalyticsPane}
             />
             <ChatMessageList
                 chatId={chatIdProp}

--- a/frontend/src/components/chat/VoiceCallOverlay.tsx
+++ b/frontend/src/components/chat/VoiceCallOverlay.tsx
@@ -1,0 +1,123 @@
+import { ChevronDown, Mic, MicOff, Phone, PhoneOff } from "lucide-react";
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "../ui/dialog";
+import { Button } from "../ui/button";
+import { cn } from "@/lib/utils";
+import type { UseVoiceCallResult } from "@/hooks/useVoiceCall";
+
+interface VoiceCallOverlayProps {
+    voiceCall: UseVoiceCallResult;
+    agentName: string;
+    /** Ends the call — same handler the compact bar wires to `voiceCall.stop`. */
+    onEndCall: () => void;
+    /** Restarts a call after an error/end state — same handler as the compact bar. */
+    onStartCall: () => void;
+    /** Collapses this overlay back to the compact bar. Does NOT end the call. */
+    onMinimize: () => void;
+}
+
+/**
+ * Full-viewport "in call" takeover, shown while a voice call is connecting
+ * or live — mirrors the elevated call UI in ChatGPT Advanced Voice Mode /
+ * Claude voice mode. This is purely a view on top of useVoiceCall's state
+ * machine: minimizing swaps back to the compact bar in ChatInput.tsx
+ * without touching the call itself.
+ *
+ * Reuses the same Dialog/Portal primitives as every other full-screen
+ * surface in this codebase (see components/modals/*) rather than inventing
+ * a bespoke `fixed inset-0` overlay.
+ */
+export function VoiceCallOverlay({ voiceCall, agentName, onEndCall, onStartCall, onMinimize }: VoiceCallOverlayProps) {
+    const statusLabel =
+        voiceCall.status === 'connecting'
+            ? 'Connecting…'
+            : voiceCall.status === 'live'
+                ? (voiceCall.isMuted ? 'Muted' : 'Live')
+                : voiceCall.status === 'error'
+                    ? (voiceCall.error || 'Call error')
+                    : 'Call ended';
+
+    return (
+        <Dialog open onOpenChange={(open) => { if (!open) onMinimize(); }}>
+            <DialogContent
+                className="flex flex-col items-center justify-center gap-8 !rounded-none border-0 bg-background p-8 sm:!rounded-none sm:max-w-[100vw] sm:h-[100dvh] sm:translate-x-0 sm:translate-y-0 sm:left-0 sm:top-0"
+                onEscapeKeyDown={(event) => {
+                    // Escape minimizes the overlay — it must never end a live call.
+                    event.preventDefault();
+                    onMinimize();
+                }}
+                onInteractOutside={(event) => event.preventDefault()}
+            >
+                <DialogTitle className="sr-only">Voice call with {agentName}</DialogTitle>
+                <DialogDescription className="sr-only">{statusLabel}</DialogDescription>
+
+                <button
+                    type="button"
+                    onClick={onMinimize}
+                    className="absolute left-4 top-4 flex size-9 items-center justify-center rounded-full text-steel hover:bg-panel hover:text-ink"
+                    aria-label="Minimize call"
+                    title="Minimize call"
+                >
+                    <ChevronDown className="size-5" />
+                </button>
+
+                {/* Orb: same visual language as the compact bar's orb in
+                    ChatInput.tsx, scaled up for a dedicated takeover view. */}
+                <span className="relative flex size-36 shrink-0 items-center justify-center">
+                    {voiceCall.status === 'live' && !voiceCall.isMuted && (
+                        <span className="absolute inset-0 rounded-full bg-destructive/40 animate-ping motion-reduce:animate-none" />
+                    )}
+                    <span
+                        className={cn(
+                            "relative rounded-full transition-all duration-300 ease-out",
+                            voiceCall.status === 'live' && !voiceCall.isMuted && "size-32 bg-destructive shadow-xl",
+                            voiceCall.status === 'live' && voiceCall.isMuted && "size-24 bg-steel-soft opacity-70",
+                            voiceCall.status === 'connecting' && "size-24 bg-steel-soft animate-pulse motion-reduce:animate-none",
+                            (voiceCall.status === 'error' || voiceCall.status === 'ended') && "size-20 bg-steel-soft"
+                        )}
+                    />
+                </span>
+
+                <div className="flex flex-col items-center gap-2 text-center">
+                    <span className="text-lg font-medium text-ink">{agentName}</span>
+                    <span className="text-sm text-steel">{statusLabel}</span>
+                </div>
+
+                <div className="flex items-center gap-6">
+                    {voiceCall.status === 'live' && (
+                        <button
+                            type="button"
+                            onClick={voiceCall.isMuted ? voiceCall.unmute : voiceCall.mute}
+                            className="flex size-16 items-center justify-center rounded-full border border-input bg-panel text-ink hover:bg-panel/80"
+                            aria-label={voiceCall.isMuted ? "Unmute microphone" : "Mute microphone"}
+                            title={voiceCall.isMuted ? "Unmute microphone" : "Mute microphone"}
+                        >
+                            {voiceCall.isMuted ? <MicOff className="size-6" /> : <Mic className="size-6" />}
+                        </button>
+                    )}
+                    {(voiceCall.status === 'live' || voiceCall.status === 'connecting') && (
+                        <Button
+                            type="button"
+                            onClick={onEndCall}
+                            className="flex !size-16 items-center justify-center !rounded-full bg-destructive p-0 text-destructive-foreground hover:bg-destructive/90"
+                            aria-label="End call"
+                            title="End call"
+                        >
+                            <PhoneOff className="size-6" />
+                        </Button>
+                    )}
+                    {(voiceCall.status === 'error' || voiceCall.status === 'ended') && (
+                        <Button
+                            type="button"
+                            onClick={onStartCall}
+                            className="flex !size-16 items-center justify-center !rounded-full bg-ink p-0 text-white hover:bg-ink/90"
+                            aria-label="Talk to this agent"
+                            title="Talk to this agent"
+                        >
+                            <Phone className="size-6" />
+                        </Button>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/components/chat/VoiceCallOverlay.tsx
+++ b/frontend/src/components/chat/VoiceCallOverlay.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, Mic, MicOff, Phone, PhoneOff } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "../ui/dialog";
 import { Button } from "../ui/button";
 import { cn } from "@/lib/utils";
@@ -27,6 +28,16 @@ interface VoiceCallOverlayProps {
  * a bespoke `fixed inset-0` overlay.
  */
 export function VoiceCallOverlay({ voiceCall, agentName, onEndCall, onStartCall, onMinimize }: VoiceCallOverlayProps) {
+    const transcriptRef = useRef<HTMLDivElement>(null);
+
+    // Auto-scroll the caption list to the newest turn as the transcript grows.
+    useEffect(() => {
+        const el = transcriptRef.current;
+        if (el) {
+            el.scrollTop = el.scrollHeight;
+        }
+    }, [voiceCall.transcript]);
+
     const statusLabel =
         voiceCall.status === 'connecting'
             ? 'Connecting…'
@@ -81,6 +92,29 @@ export function VoiceCallOverlay({ voiceCall, agentName, onEndCall, onStartCall,
                     <span className="text-lg font-medium text-ink">{agentName}</span>
                     <span className="text-sm text-steel">{statusLabel}</span>
                 </div>
+
+                {voiceCall.transcript.length > 0 && (
+                    <div
+                        ref={transcriptRef}
+                        className="flex w-full max-w-md flex-col gap-2 overflow-y-auto px-2 text-sm"
+                        style={{ maxHeight: '30vh' }}
+                        aria-live="polite"
+                    >
+                        {voiceCall.transcript.map((turn) => (
+                            <p
+                                key={turn.id}
+                                className={cn(
+                                    "leading-snug",
+                                    turn.role === 'agent' ? "text-ink" : "text-steel",
+                                    !turn.final && "opacity-70",
+                                )}
+                            >
+                                <span className="font-medium">{turn.role === 'agent' ? agentName : 'You'}: </span>
+                                {turn.text}
+                            </p>
+                        ))}
+                    </div>
+                )}
 
                 <div className="flex items-center gap-6">
                     {voiceCall.status === 'live' && (

--- a/frontend/src/components/chat/analytics/ContextGrowthChart.tsx
+++ b/frontend/src/components/chat/analytics/ContextGrowthChart.tsx
@@ -1,0 +1,109 @@
+/**
+ * ContextGrowthChart — the ONE chart on the conversation analytics pane
+ * (see ConversationAnalyticsPane.tsx for why exactly one chart is allowed
+ * here). Plots `series[].peak_context_tokens` against `series[].sequence`:
+ * context growth over turns is a shape over an axis, which is the one
+ * question the tile-based sections on this pane genuinely cannot answer.
+ *
+ * `peak_context_tokens` is `null` for any run whose context size could not
+ * be measured (see conversationAnalytics.types.ts). A `null` is NOT zero —
+ * plotting it as 0 would draw a fake cliff back to the origin. Instead each
+ * null point is kept in the data (so its turn still occupies an x position)
+ * but carries `value: null`, and the line is drawn with `connectNulls={false}`
+ * so Recharts breaks the line across that gap instead of interpolating
+ * through it or drawing it as zero.
+ */
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@/components/ui/chart';
+import type { ConversationAnalyticsSeriesPoint } from '@/types/conversationAnalytics.types';
+
+const chartConfig = {
+  contextTokens: {
+    label: 'Context size',
+    color: 'var(--ink)',
+  },
+} satisfies ChartConfig;
+
+export interface ContextGrowthChartProps {
+  series: ConversationAnalyticsSeriesPoint[];
+}
+
+interface ChartDatum {
+  sequence: number;
+  contextTokens: number | null;
+}
+
+export function ContextGrowthChart({ series }: ContextGrowthChartProps) {
+  const data: ChartDatum[] = series.map((point) => ({
+    sequence: point.sequence,
+    // Kept as `null`, not defaulted to 0 — see file header comment.
+    contextTokens: point.peak_context_tokens,
+  }));
+
+  const hasAnyMeasurement = data.some((d) => d.contextTokens !== null);
+
+  if (data.length === 0 || !hasAnyMeasurement) {
+    return (
+      <div className="flex h-[160px] items-center justify-center rounded-lg border border-line bg-panel">
+        <p className="text-[12px] text-steel-soft">No measured turns to chart yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-[180px] w-full">
+      <LineChart data={data} margin={{ left: 4, right: 8, top: 8, bottom: 0 }}>
+        <CartesianGrid vertical={false} stroke="var(--line)" />
+        <XAxis
+          dataKey="sequence"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          label={{ value: 'Turn', position: 'insideBottom', offset: -4, fontSize: 11 }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          width={48}
+          tickFormatter={(value: number) =>
+            value >= 1000 ? `${(value / 1000).toFixed(0)}k` : String(value)
+          }
+        />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              labelFormatter={(label) => `Turn ${label}`}
+              // No custom `formatter`: the default renderer already shows the
+              // series label, and simply omits a value when it is `null` —
+              // which is the correct "not measured" reading for this data,
+              // never a fabricated 0.
+            />
+          }
+        />
+        <Line
+          dataKey="contextTokens"
+          type="monotone"
+          stroke="var(--color-contextTokens)"
+          strokeWidth={1.75}
+          dot={{ r: 2.5 }}
+          connectNulls={false}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}
+
+export default ContextGrowthChart;

--- a/frontend/src/components/chat/analytics/ConversationAnalyticsPane.tsx
+++ b/frontend/src/components/chat/analytics/ConversationAnalyticsPane.tsx
@@ -1,0 +1,360 @@
+/**
+ * ConversationAnalyticsPane — right-docked pane showing token/cost/context
+ * analytics for the open conversation, fetched from
+ * `getConversationAnalytics` (see conversationAnalyticsApi.ts).
+ *
+ * Chrome (border-l, fixed px width, header row, drag-to-resize handle on the
+ * left edge, scrollable body) intentionally mirrors ArtifactPreviewPane.tsx
+ * rather than sharing code with it: ArtifactPreviewPane is owned by another
+ * concurrent work stream and is off-limits to edit here, so duplicating its
+ * ~15 lines of resize-drag plumbing is the least invasive way to get a
+ * visually consistent second pane. Both panes read and write the same
+ * `width`/`onWidthChange` pair (owned by `useArtifactPane` in ChatPageV2.tsx)
+ * so the slot keeps one remembered size regardless of which tab is showing.
+ *
+ * THE CENTRAL INVARIANT: `totals` (cumulative, summed across every run) and
+ * `current` (a snapshot of only the latest run) describe different kinds of
+ * quantities — a running sum vs. one point in time. This component renders
+ * them as two visually and textually separate sections and never divides
+ * one by the other or otherwise combines them into a single "share"/percent
+ * figure. Do not "simplify" them together — that is the exact misleading
+ * aggregation this pane exists to prevent. See conversationAnalytics.types.ts.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { getConversationAnalytics } from '@/services/conversationAnalyticsApi';
+import type {
+  ConversationAnalyticsResponse,
+  ConversationRunKind,
+} from '@/types/conversationAnalytics.types';
+import { GaugeRow, MetricGauge } from '@/components/dashboard/cards/MetricGauge';
+import { EmptyStat } from '@/components/dashboard/views/EmptyState';
+import { ContextGrowthChart } from './ContextGrowthChart';
+
+export interface ConversationAnalyticsPaneProps {
+  /** Conversation to show analytics for, or null when the pane should render nothing. */
+  conversationId: string | null;
+  onClose: () => void;
+  /** Current pane width in px, shared with the artifact pane (see file header). */
+  width: number;
+  onWidthChange: (px: number) => void;
+}
+
+const RUN_KIND_LABEL: Record<ConversationRunKind, string> = {
+  agent: 'agent',
+  tool: 'tool',
+  orchestrator: 'orchestrator',
+};
+
+function formatCount(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatCost(n: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(n);
+}
+
+function formatPercent(ratio: number): string {
+  return `${(ratio * 100).toLocaleString(undefined, { maximumFractionDigits: 1 })}%`;
+}
+
+function runKindBreakdown(byKind: Record<ConversationRunKind, number>): string {
+  return (Object.keys(RUN_KIND_LABEL) as ConversationRunKind[])
+    .map((kind) => [kind, byKind[kind] ?? 0] as const)
+    .filter(([, count]) => count > 0)
+    .map(([kind, count]) => `${count} ${RUN_KIND_LABEL[kind]}`)
+    .join(' · ');
+}
+
+export function ConversationAnalyticsPane({
+  conversationId,
+  onClose,
+  width,
+  onWidthChange,
+}: ConversationAnalyticsPaneProps) {
+  const [isResizing, setIsResizing] = useState(false);
+  const [data, setData] = useState<ConversationAnalyticsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!conversationId) {
+      setData(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    getConversationAnalytics(conversationId).then((result) => {
+      if (cancelled) return;
+      setData(result);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsResizing(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isResizing) return;
+    const handleMouseMove = (e: MouseEvent) => {
+      onWidthChange(window.innerWidth - e.clientX);
+    };
+    const handleMouseUp = () => setIsResizing(false);
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.body.style.userSelect = previousUserSelect;
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isResizing, onWidthChange]);
+
+  if (!conversationId) {
+    return null;
+  }
+
+  return (
+    <div
+      className="relative flex h-full shrink-0 flex-col border-l border-line bg-paper"
+      style={{ width }}
+    >
+      <div
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/50 transition-colors"
+        onMouseDown={handleMouseDown}
+      />
+
+      <div className="flex h-chat-header flex-none items-center gap-2.5 border-b border-line px-3.5">
+        <h2 className="min-w-0 flex-1 truncate text-[13px] font-medium">Analytics</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close analytics"
+          className="text-steel hover:text-ink"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-3.5 py-4">
+        {loading && !data && (
+          <p className="text-[12px] text-steel-soft">Loading analytics...</p>
+        )}
+        {!loading && !data && (
+          <p className="text-[12px] text-steel-soft">
+            Analytics are not available for this conversation.
+          </p>
+        )}
+        {data && <AnalyticsSections data={data} />}
+      </div>
+    </div>
+  );
+}
+
+function AnalyticsSections({ data }: { data: ConversationAnalyticsResponse }) {
+  const { totals, current, series, cache, measurement } = data;
+  const breakdown = runKindBreakdown(totals.run_count_by_kind);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* --- Cumulative: a running sum over every run so far. --- */}
+      <section>
+        <SectionHeading title="Totals" caption="Summed across every run in this conversation" />
+        <GaugeRow className="mt-2">
+          <MetricGauge
+            label="Runs"
+            value={formatCount(totals.run_count)}
+            unit={breakdown || undefined}
+          />
+          <MetricGauge label="Billed input" value={formatTokens(totals.billed_input_tokens)} unit="tokens" />
+          <MetricGauge label="Output" value={formatTokens(totals.output_tokens)} unit="tokens" />
+          <MetricGauge label="Cost" value={formatCost(totals.cost)} />
+        </GaugeRow>
+        <GaugeRow className="mt-2">
+          <MetricGauge label="Cache read" value={formatTokens(totals.cache_read_tokens)} unit="tokens" />
+          <MetricGauge label="Cache write" value={formatTokens(totals.cache_write_tokens)} unit="tokens" />
+        </GaugeRow>
+      </section>
+
+      {/* --- Current: a snapshot of the latest run only, never summed. --- */}
+      <section>
+        <SectionHeading title="Current context" caption="Snapshot of the latest turn — not a total" />
+        {current ? (
+          <div className="mt-2 flex flex-col gap-2">
+            <GaugeRow>
+              <MetricGauge
+                label="Largest turn"
+                value={current.peak_context_tokens !== null ? formatTokens(current.peak_context_tokens) : '—'}
+                unit={current.peak_context_tokens !== null ? 'tokens' : undefined}
+                info="Peak context size measured on the most recent run."
+              />
+              <MetricGauge
+                label="Context window"
+                value={current.model_context_window !== null ? formatTokens(current.model_context_window) : '—'}
+                unit={current.model_context_window !== null ? 'tokens' : undefined}
+              />
+              {current.context_fullness !== null ? (
+                <MetricGauge label="Context fullness" value={formatPercent(current.context_fullness)} />
+              ) : (
+                <div className="px-[18px] py-4 min-w-0">
+                  <EmptyStat
+                    label="Context fullness"
+                    caption="Not measured"
+                  />
+                </div>
+              )}
+            </GaugeRow>
+            <CompositionList
+              segmentTokens={current.segment_tokens}
+              toolExchangeTokens={current.tool_exchange_tokens}
+            />
+          </div>
+        ) : (
+          <p className="mt-2 text-[12px] text-steel-soft">No runs recorded yet for this conversation.</p>
+        )}
+      </section>
+
+      {/* --- Cache effectiveness --- */}
+      <section>
+        <SectionHeading title="Cache effectiveness" />
+        <GaugeRow className="mt-2">
+          {cache.effectiveness !== null ? (
+            <MetricGauge
+              label="Effectiveness"
+              value={formatPercent(cache.effectiveness)}
+              info="An indicator of prompt-prefix stability across runs, not a measurement confirmed by the provider."
+            />
+          ) : (
+            <div className="px-[18px] py-4 min-w-0">
+              <EmptyStat label="Effectiveness" caption="No billed input to measure against" />
+            </div>
+          )}
+          <MetricGauge label="Uncached input" value={formatTokens(cache.uncached_input_tokens)} unit="tokens" />
+        </GaugeRow>
+        <p className="mt-2 text-[11px] leading-relaxed text-steel-soft">
+          Cache effectiveness is an indicator of prompt-prefix stability, not a value the provider
+          confirms directly.
+        </p>
+      </section>
+
+      {/* --- Measurement disclosure --- */}
+      <MeasurementDisclosure measurement={measurement} />
+
+      {/* --- The one chart on this pane: context growth over turns. --- */}
+      <section>
+        <SectionHeading title="Context growth" caption="Largest context size measured per turn" />
+        <div className="mt-2">
+          <ContextGrowthChart series={series} />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function SectionHeading({ title, caption }: { title: string; caption?: string }) {
+  return (
+    <div>
+      <h3 className="text-[12px] font-semibold uppercase tracking-wide text-ink">{title}</h3>
+      {caption && <p className="text-[11px] text-steel-soft">{caption}</p>}
+    </div>
+  );
+}
+
+function CompositionList({
+  segmentTokens,
+  toolExchangeTokens,
+}: {
+  segmentTokens: Record<string, number | null> | null;
+  toolExchangeTokens: number | null;
+}) {
+  const hasSegments = segmentTokens !== null && Object.keys(segmentTokens).length > 0;
+
+  if (!hasSegments && toolExchangeTokens === null) {
+    return <p className="text-[11px] text-steel-soft">Composition not measured for the latest turn.</p>;
+  }
+
+  return (
+    <div className="rounded-lg border border-line bg-panel px-3.5 py-3">
+      <div className="text-[11px] font-medium text-steel-soft">Composition</div>
+      <dl className="mt-1.5 flex flex-col gap-1">
+        {hasSegments &&
+          Object.entries(segmentTokens).map(([segment, value]) => (
+            <div key={segment} className="flex items-center justify-between text-[12px]">
+              <dt className="capitalize text-steel">{segment.replace(/_/g, ' ')}</dt>
+              <dd className="font-mono tabular-nums text-ink">
+                {value !== null ? `${formatTokens(value)} tokens` : 'not measured'}
+              </dd>
+            </div>
+          ))}
+        <div className="flex items-center justify-between text-[12px]">
+          <dt className="text-steel">Tool exchange</dt>
+          <dd className="font-mono tabular-nums text-ink">
+            {toolExchangeTokens !== null ? `${formatTokens(toolExchangeTokens)} tokens` : 'not measured'}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+function MeasurementDisclosure({
+  measurement,
+}: {
+  measurement: ConversationAnalyticsResponse['measurement'];
+}) {
+  const { runs_missing_billed_input, runs_missing_peak_context, tool_runs_without_conversation_note } =
+    measurement;
+  const hasAnyGap =
+    runs_missing_billed_input > 0 || runs_missing_peak_context > 0 || tool_runs_without_conversation_note > 0;
+
+  return (
+    <section>
+      <SectionHeading title="Measurement notes" />
+      {!hasAnyGap ? (
+        <p className="mt-2 text-[11px] text-steel-soft">
+          Every run in this conversation was fully measured.
+        </p>
+      ) : (
+        <div className="mt-2 flex flex-col gap-2">
+          {runs_missing_billed_input > 0 && (
+            <p className="text-[11px] leading-relaxed text-steel">
+              {formatCount(runs_missing_billed_input)} run(s) fall back to legacy token counts — billed
+              input was not separately measured for them.
+            </p>
+          )}
+          {runs_missing_peak_context > 0 && (
+            <p className="text-[11px] leading-relaxed text-steel">
+              {formatCount(runs_missing_peak_context)} run(s) have no recorded peak context size.
+            </p>
+          )}
+          {tool_runs_without_conversation_note > 0 && (
+            <div className="flex gap-2 rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5">
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-warning" />
+              <p className="text-[11px] leading-relaxed text-ink">
+                {formatCount(tool_runs_without_conversation_note)} older tool run(s) were created before
+                conversation linking existed and cannot be retro-linked. The totals above under-report
+                this conversation's real usage by that amount.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default ConversationAnalyticsPane;

--- a/frontend/src/components/chat/analytics/RightPaneTabStrip.tsx
+++ b/frontend/src/components/chat/analytics/RightPaneTabStrip.tsx
@@ -1,0 +1,51 @@
+/**
+ * RightPaneTabStrip — the "Artifact / Analytics" switcher for the shared
+ * right-docked pane slot (see ChatPageV2.tsx). The slot previously hosted
+ * only `ArtifactPreviewPane`; this pane adds a second, independent tenant
+ * (`ConversationAnalyticsPane`) that can be open at the same time. Rather
+ * than merging the two panes' chrome (their headers, close buttons, and
+ * resize handles stay exactly as each pane already renders them), this is a
+ * thin strip mounted above whichever pane is currently visible, purely to
+ * switch which one shows. The caller only mounts this component when BOTH
+ * tabs have something to show — a single remaining tab is rendered as no
+ * strip at all, not a one-item strip.
+ */
+import { cn } from '@/lib/utils';
+
+export type RightPaneTab = 'artifact' | 'analytics';
+
+export interface RightPaneTabStripProps {
+  active: RightPaneTab;
+  onSelect: (tab: RightPaneTab) => void;
+  width: number;
+}
+
+const TABS: { key: RightPaneTab; label: string }[] = [
+  { key: 'artifact', label: 'Artifact' },
+  { key: 'analytics', label: 'Analytics' },
+];
+
+export function RightPaneTabStrip({ active, onSelect, width }: RightPaneTabStripProps) {
+  return (
+    <div
+      className="flex h-8 flex-none items-center gap-1 border-b border-l border-line bg-paper px-2.5"
+      style={{ width }}
+    >
+      {TABS.map((tab) => (
+        <button
+          key={tab.key}
+          type="button"
+          onClick={() => onSelect(tab.key)}
+          className={cn(
+            'rounded-md px-2 py-1 text-[11px] font-medium transition-colors',
+            active === tab.key ? 'bg-paper-deep text-ink' : 'text-steel-soft hover:text-steel'
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default RightPaneTabStrip;

--- a/frontend/src/components/chat/analytics/useConversationAnalyticsPane.ts
+++ b/frontend/src/components/chat/analytics/useConversationAnalyticsPane.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react';
+
+export interface UseConversationAnalyticsPaneResult {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+/**
+ * State for the right-docked conversation analytics pane. Modelled on
+ * `useArtifactPane` (see useArtifactPane.ts), but deliberately smaller:
+ * there is no "current target" to track — the pane always shows analytics
+ * for whichever conversation is open — and no width state of its own,
+ * because the analytics pane shares the same right-pane slot (and its
+ * persisted width) with the artifact preview pane. The slot's width is
+ * owned by `useArtifactPane`; callers pass it through to
+ * `ConversationAnalyticsPane` so both tabs agree on one size.
+ */
+export function useConversationAnalyticsPane(): UseConversationAnalyticsPaneResult {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return { isOpen, open, close };
+}

--- a/frontend/src/components/knowledge/GeneralTab.tsx
+++ b/frontend/src/components/knowledge/GeneralTab.tsx
@@ -565,6 +565,58 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
         </Card>
       )}
 
+      {watchKnowledgeType === 'sqlite_hybrid' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>SQLite Hybrid settings</CardTitle>
+            <CardDescription>
+              Combines SQLite FTS keyword search with SQLite Vec similarity search (reciprocal rank fusion)
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
+      {watchKnowledgeType === 'weaviate' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Weaviate connection settings</CardTitle>
+            <CardDescription>Connect HUF Knowledge to a Weaviate vector database</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
+      {watchKnowledgeType === 'faiss' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>FAISS settings</CardTitle>
+            <CardDescription>
+              Embedded similarity search index — runs in-process, stores to a local file
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
+      {watchKnowledgeType === 'pinecone' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Pinecone connection settings</CardTitle>
+            <CardDescription>Connect HUF Knowledge to a Pinecone vector database</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
+          </CardContent>
+        </Card>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle>Chunking settings</CardTitle>

--- a/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
+++ b/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
@@ -13,10 +13,12 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { Progress } from '@/components/ui/progress';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
-import { Plus, Trash2, RefreshCw, FileText, Link, Type, Loader2, Upload } from 'lucide-react';
+import { Plus, Trash2, RefreshCw, FileText, Link, Type, Loader2, Upload, X, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
 import { knowledgeInputTypes } from '@/data/knowledge';
 import type { KnowledgeInputDoc, KnowledgeInputType } from '@/types/knowledge.types';
 import {
@@ -26,6 +28,14 @@ import {
   reprocessInput,
 } from '@/services/knowledgeApi';
 import { file as frappeFile } from '@/lib/frappe-sdk';
+
+interface QueuedUpload {
+  id: string;
+  fileName: string;
+  progress: number;
+  status: 'uploading' | 'creating' | 'error';
+  error?: string;
+}
 
 interface KnowledgeInputsModalProps {
   open: boolean;
@@ -81,13 +91,11 @@ export function KnowledgeInputsModal({
   const [loading, setLoading] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState(0);
+  const [dragOver, setDragOver] = useState(false);
+  const [uploadQueue, setUploadQueue] = useState<QueuedUpload[]>([]);
 
   // Create form state
   const [inputType, setInputType] = useState<KnowledgeInputType>('File');
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [uploadedFileUrl, setUploadedFileUrl] = useState('');
   const [text, setText] = useState('');
   const [url, setUrl] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -112,55 +120,76 @@ export function KnowledgeInputsModal({
 
   const resetForm = () => {
     setInputType('File');
-    setSelectedFile(null);
-    setUploadedFileUrl('');
     setText('');
     setUrl('');
-    setUploading(false);
-    setUploadProgress(0);
     setShowCreate(false);
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0];
-    if (f) {
-      setSelectedFile(f);
-      setUploadedFileUrl('');
-    }
+  const uploadOneFile = useCallback(
+    async (file: File) => {
+      const id = `${file.name}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      setUploadQueue((q) => [...q, { id, fileName: file.name, progress: 0, status: 'uploading' }]);
+      try {
+        const response = await frappeFile.uploadFile(
+          file,
+          {
+            isPrivate: true,
+            doctype: 'Knowledge Input',
+          },
+          (completed, total) => {
+            if (total) {
+              const progress = Math.round((completed / total) * 100);
+              setUploadQueue((q) => q.map((item) => (item.id === id ? { ...item, progress } : item)));
+            }
+          },
+        );
+        const res = response as { data?: { message?: { file_url?: string } } };
+        const fileUrl = res?.data?.message?.file_url;
+        if (!fileUrl) throw new Error('No file URL returned');
+
+        setUploadQueue((q) => q.map((item) => (item.id === id ? { ...item, status: 'creating' } : item)));
+        await createKnowledgeInput({
+          knowledge_source: knowledgeSource,
+          input_type: 'File',
+          file: fileUrl,
+        });
+        setUploadQueue((q) => q.filter((item) => item.id !== id));
+        await loadInputs();
+        onSourceChanged();
+      } catch {
+        setUploadQueue((q) =>
+          q.map((item) => (item.id === id ? { ...item, status: 'error', error: 'Upload failed' } : item)),
+        );
+        toast.error(`Failed to upload ${file.name}`);
+      }
+    },
+    [knowledgeSource, loadInputs, onSourceChanged],
+  );
+
+  const handleFilesSelected = useCallback(
+    (files: FileList | File[] | null) => {
+      if (!files || files.length === 0) return;
+      Array.from(files).forEach((file) => {
+        void uploadOneFile(file);
+      });
+    },
+    [uploadOneFile],
+  );
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFilesSelected(e.target.files);
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleUploadFile = async () => {
-    if (!selectedFile) {
-      toast.error('Please select a file first');
-      return;
-    }
-    setUploading(true);
-    setUploadProgress(0);
-    try {
-      const response = await frappeFile.uploadFile(
-        selectedFile,
-        {
-          isPrivate: true,
-          doctype: 'Knowledge Input',
-        },
-        (completed, total) => {
-          if (total) setUploadProgress(Math.round((completed / total) * 100));
-        },
-      );
-      const res = response as { data?: { message?: { file_url?: string } } };
-      const fileUrl = res?.data?.message?.file_url;
-      if (fileUrl) {
-        setUploadedFileUrl(fileUrl);
-        toast.success('File uploaded');
-      } else {
-        toast.error('Upload succeeded but no file URL returned');
-      }
-    } catch {
-      toast.error('Failed to upload file');
-    } finally {
-      setUploading(false);
-    }
+  const handleDropzoneDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    handleFilesSelected(e.dataTransfer.files);
+  };
+
+  const dismissQueuedUpload = (id: string) => {
+    setUploadQueue((q) => q.filter((item) => item.id !== id));
   };
 
   const handleCreate = async () => {
@@ -169,10 +198,6 @@ export function KnowledgeInputsModal({
       input_type: inputType,
     };
 
-    if (inputType === 'File' && !uploadedFileUrl) {
-      toast.error('Please upload a file first');
-      return;
-    }
     if (inputType === 'Text' && !text.trim()) {
       toast.error('Text content is required');
       return;
@@ -182,7 +207,6 @@ export function KnowledgeInputsModal({
       return;
     }
 
-    if (inputType === 'File') data.file = uploadedFileUrl;
     if (inputType === 'Text') data.text = text;
     if (inputType === 'URL') data.url = url;
 
@@ -267,34 +291,67 @@ export function KnowledgeInputsModal({
 
               {inputType === 'File' && (
                 <div className="space-y-3">
-                  <Label>File</Label>
-                  <div className="flex items-center gap-2">
+                  <Label>Files</Label>
+                  <div
+                    className={cn(
+                      'flex flex-col items-center justify-center gap-2 rounded-md border border-dashed p-6 text-center transition-colors cursor-pointer',
+                      dragOver ? 'border-primary bg-primary/5' : 'border-input',
+                    )}
+                    onClick={() => fileInputRef.current?.click()}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setDragOver(true);
+                    }}
+                    onDragLeave={() => setDragOver(false)}
+                    onDrop={handleDropzoneDrop}
+                  >
+                    <Upload className="w-6 h-6 text-steel-soft" />
+                    <p className="text-sm">Drag and drop files here, or click to browse</p>
+                    <p className="text-xs text-steel-soft">Select multiple files to upload them all at once</p>
                     <Input
                       ref={fileInputRef}
                       type="file"
-                      onChange={handleFileSelect}
-                      className="flex-1"
-                      disabled={uploading}
+                      multiple
+                      onChange={handleFileInputChange}
+                      className="hidden"
                     />
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={handleUploadFile}
-                      disabled={!selectedFile || uploading || !!uploadedFileUrl}
-                    >
-                      {uploading ? (
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      ) : (
-                        <Upload className="w-4 h-4 mr-2" />
-                      )}
-                      {uploading ? `${uploadProgress}%` : 'Upload'}
-                    </Button>
                   </div>
-                  {uploadedFileUrl && (
-                    <p className="text-xs text-steel-soft">
-                      Uploaded: <span className="font-mono">{uploadedFileUrl}</span>
-                    </p>
+
+                  {uploadQueue.length > 0 && (
+                    <div className="space-y-2">
+                      {uploadQueue.map((item) => (
+                        <div key={item.id} className="flex items-center gap-3 rounded-md border p-2.5">
+                          {item.status === 'error' ? (
+                            <AlertCircle className="w-4 h-4 text-destructive flex-shrink-0" />
+                          ) : (
+                            <Loader2 className="w-4 h-4 animate-spin text-steel-soft flex-shrink-0" />
+                          )}
+                          <div className="flex-1 min-w-0">
+                            <p className="text-sm truncate">{item.fileName}</p>
+                            {item.status === 'error' ? (
+                              <p className="text-xs text-destructive">{item.error}</p>
+                            ) : (
+                              <>
+                                <p className="text-xs text-steel-soft">
+                                  {item.status === 'uploading' ? `Uploading... ${item.progress}%` : 'Creating input...'}
+                                </p>
+                                <Progress value={item.status === 'uploading' ? item.progress : 100} className="h-1 mt-1" />
+                              </>
+                            )}
+                          </div>
+                          {item.status === 'error' && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => dismissQueuedUpload(item.id)}
+                            >
+                              <X className="w-3.5 h-3.5" />
+                            </Button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
                   )}
                 </div>
               )}
@@ -324,16 +381,14 @@ export function KnowledgeInputsModal({
 
               <div className="flex justify-end gap-2">
                 <Button variant="outline" size="sm" onClick={resetForm}>
-                  Cancel
+                  {inputType === 'File' ? 'Done' : 'Cancel'}
                 </Button>
-                <Button
-                  size="sm"
-                  onClick={handleCreate}
-                  disabled={creating || uploading || (inputType === 'File' && !uploadedFileUrl)}
-                >
-                  {creating && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-                  Create
-                </Button>
+                {inputType !== 'File' && (
+                  <Button size="sm" onClick={handleCreate} disabled={creating}>
+                    {creating && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    Create
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/frontend/src/components/knowledge/types.ts
+++ b/frontend/src/components/knowledge/types.ts
@@ -4,10 +4,23 @@ import { isVectorKnowledgeType } from '@/data/knowledge';
 export const knowledgeSourceFormSchema = z.object({
 	source_name: z.string().min(1, 'Source name is required'),
 	description: z.string().optional(),
-	knowledge_type: z.enum(['sqlite_fts', 'sqlite_vec', 'chroma', 'pgvector', 'redis', 'zvec'], {
-
-		required_error: 'Knowledge type is required',
-	}),
+	knowledge_type: z.enum(
+		[
+			'sqlite_fts',
+			'sqlite_vec',
+			'sqlite_hybrid',
+			'chroma',
+			'pgvector',
+			'redis',
+			'zvec',
+			'weaviate',
+			'faiss',
+			'pinecone',
+		],
+		{
+			required_error: 'Knowledge type is required',
+		},
+	),
 	scope: z.enum(['Site', 'Workspace', 'Agent', 'Global']).default('Site'),
 	storage_mode: z.string().default('Frappe File'),
 	chunk_size: z.number().int().min(100, 'Minimum chunk size is 100').default(512),

--- a/frontend/src/components/playground/CompareView.tsx
+++ b/frontend/src/components/playground/CompareView.tsx
@@ -3,12 +3,21 @@ import { ArrowRightLeft, Copy, GitCompare, Pencil } from 'lucide-react';
 import type { AgentDoc, AIProvider } from '@/types/agent.types';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ShortcutKey } from '@/components/ui/shortcut-key';
+import { useKeyboardShortcut } from '@/lib/shortcuts/useKeyboardShortcut';
+import { formatBinding } from '@/lib/shortcuts/registry';
+import { usePlatform } from '@/lib/shortcuts/platform';
 import { ConfigStrip } from './ConfigStrip';
 import { PromptPanel } from './PromptPanel';
 import { ResponsePanel } from './ResponsePanel';
 import { RunLedger, type RunLedgerProps } from './RunLedger';
 import { wordDiff } from './wordDiff';
 import type { PlaygroundConfig, SlotState } from './types';
+
+const COPY_A_TO_B_BINDING = { key: 'c', mod: true, shift: true } as const;
+const SWAP_BINDING = { key: 'x', mod: true, shift: true } as const;
+const TOGGLE_DIFF_BINDING = { key: 'd', mod: true, shift: true } as const;
 
 interface CompareViewProps {
   agents: AgentDoc[];
@@ -105,6 +114,7 @@ export function CompareView({
   const [labelA, setLabelA] = useState('Baseline');
   const [labelB, setLabelB] = useState('Challenger');
   const [diffEnabled, setDiffEnabled] = useState(true);
+  const platform = usePlatform();
 
   const diff = useMemo(() => {
     if (!diffEnabled) return null;
@@ -131,61 +141,22 @@ export function CompareView({
     setLabelB(nextLabelB);
   };
 
+  const toggleDiff = () => setDiffEnabled((on) => !on);
+
+  useKeyboardShortcut(COPY_A_TO_B_BINDING, handleCopyAtoB, { allowInEditable: true });
+  useKeyboardShortcut(SWAP_BINDING, handleSwap, { allowInEditable: true });
+  useKeyboardShortcut(TOGGLE_DIFF_BINDING, toggleDiff, { allowInEditable: true });
+
   return (
     <div className="flex h-full min-h-0 flex-col overflow-y-auto">
-      {/* Control row */}
-      <div className="flex items-center justify-between px-5 pt-3">
+      <div className="flex items-center px-5 pt-3">
         <div className="flex items-center gap-2 font-mono text-eyebrow uppercase text-steel-soft">
           Two configurations
         </div>
-        <div className="flex items-center gap-4">
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={handleCopyAtoB}
-            className="h-auto gap-1.5 p-0 text-[12.5px] font-normal text-steel hover:bg-transparent hover:text-ink"
-          >
-            <Copy className="h-3.5 w-3.5" strokeWidth={1.8} />
-            Copy A → B
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={handleSwap}
-            className="h-auto gap-1.5 p-0 text-[12.5px] font-normal text-steel hover:bg-transparent hover:text-ink"
-          >
-            <ArrowRightLeft className="h-3.5 w-3.5" strokeWidth={1.8} />
-            Swap
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            role="switch"
-            aria-checked={diffEnabled}
-            onClick={() => setDiffEnabled((on) => !on)}
-            className="h-auto gap-1.5 p-0 text-[12.5px] font-normal text-ink hover:bg-transparent"
-          >
-            <GitCompare className="h-3.5 w-3.5 text-steel" strokeWidth={1.8} />
-            Diff responses
-            <span
-              className={cn(
-                'relative inline-flex h-[19px] w-[32px] shrink-0 items-center rounded-full p-[2px] transition-colors',
-                diffEnabled ? 'bg-signal' : 'bg-steel-soft',
-              )}
-            >
-              <span
-                className={cn(
-                  'block h-[15px] w-[15px] rounded-full bg-panel shadow-sm transition-transform',
-                  diffEnabled ? 'translate-x-[13px]' : 'translate-x-0',
-                )}
-              />
-            </span>
-          </Button>
-        </div>
       </div>
 
-      {/* Columns */}
-      <div className="grid flex-1 grid-cols-1 gap-4 p-5 lg:grid-cols-2">
+      {/* Columns, with a center console acting on both */}
+      <div className="grid flex-1 grid-cols-1 gap-4 p-5 lg:grid-cols-[1fr_auto_1fr] lg:items-stretch">
         <div>
           <EditableLabel glyph="A" label={labelA} onLabelChange={setLabelA} />
           <ConfigStrip
@@ -210,6 +181,72 @@ export function CompareView({
             onRun={onRunA}
             className="mt-4 min-h-[170px]"
           />
+        </div>
+
+        <div className="flex flex-row items-center justify-center gap-3 border-y border-line py-2 lg:h-full lg:w-14 lg:flex-col lg:justify-center lg:gap-4 lg:border-x lg:border-y-0 lg:py-4">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={handleCopyAtoB}
+                aria-label="Copy A to B"
+                className="text-steel hover:bg-paper-deep hover:text-ink"
+              >
+                <Copy className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="flex items-center gap-2">
+              <span>Copy A → B</span>
+              <ShortcutKey keys={formatBinding(COPY_A_TO_B_BINDING, platform)} size="sm" />
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={handleSwap}
+                aria-label="Swap A and B"
+                className="text-steel hover:bg-paper-deep hover:text-ink"
+              >
+                <ArrowRightLeft className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="flex items-center gap-2">
+              <span>Swap A and B</span>
+              <ShortcutKey keys={formatBinding(SWAP_BINDING, platform)} size="sm" />
+            </TooltipContent>
+          </Tooltip>
+
+          <div className="h-6 w-px bg-line lg:h-px lg:w-6" />
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                role="switch"
+                aria-checked={diffEnabled}
+                aria-label="Toggle diff responses"
+                onClick={toggleDiff}
+                className={cn(
+                  'hover:bg-paper-deep',
+                  diffEnabled ? 'text-signal' : 'text-steel',
+                )}
+              >
+                <GitCompare className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right" className="flex items-center gap-2">
+              <span>Diff responses: {diffEnabled ? 'on' : 'off'}</span>
+              <ShortcutKey keys={formatBinding(TOGGLE_DIFF_BINDING, platform)} size="sm" />
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <div>

--- a/frontend/src/components/playground/PromptPanel.tsx
+++ b/frontend/src/components/playground/PromptPanel.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { ChevronRight, Loader2, Pencil } from 'lucide-react';
+import { toast } from 'sonner';
+import { ChevronRight, Loader2, Pencil, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import { improvePrompt } from '@/services/consoleApi';
+import { wordDiff } from './wordDiff';
 import type { PlaygroundConfig } from './types';
 
 interface PromptPanelProps {
@@ -21,6 +24,8 @@ export function PromptPanel({
   className,
 }: PromptPanelProps) {
   const [criteriaOpen, setCriteriaOpen] = useState(() => !!config.evaluationCriteria.trim());
+  const [improving, setImproving] = useState(false);
+  const [improvedPrompt, setImprovedPrompt] = useState<string | null>(null);
 
   // Auto-expand the disclosure when criteria arrive from outside (e.g. a
   // restored ledger entry or a loaded template).
@@ -31,34 +36,127 @@ export function PromptPanel({
     hadCriteria.current = has;
   }, [config.evaluationCriteria]);
 
+  const handleImprove = async () => {
+    if (!config.prompt.trim()) {
+      toast.info('Write a prompt first, then use Improve prompt.');
+      return;
+    }
+    setImproving(true);
+    try {
+      const result = await improvePrompt({
+        prompt_body: config.prompt,
+        provider: config.provider || undefined,
+        model: config.model || undefined,
+      });
+      setImprovedPrompt(result.prompt);
+    } catch {
+      // The service already surfaces the error toast.
+    } finally {
+      setImproving(false);
+    }
+  };
+
+  const handleAcceptImprovement = () => {
+    if (improvedPrompt === null) return;
+    onConfigChange({ ...config, prompt: improvedPrompt });
+    setImprovedPrompt(null);
+    toast.success('Improved prompt applied');
+  };
+
+  const handleDiscardImprovement = () => setImprovedPrompt(null);
+
+  const diff = improvedPrompt !== null ? wordDiff(config.prompt, improvedPrompt) : null;
+
   return (
     <div className={cn('flex min-h-[260px] flex-col rounded border border-line bg-panel', className)}>
       <div className="flex items-center justify-between border-b border-line px-3.5 py-2.5">
         <span className="font-mono text-eyebrow font-medium uppercase text-steel">Prompt</span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          onClick={onDraft}
-          title="Draft prompt"
-          aria-label="Draft prompt"
-          className="h-auto w-auto p-0 text-steel hover:bg-transparent hover:text-ink disabled:opacity-40"
-          disabled={generating}
-        >
-          {generating ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Pencil className="h-4 w-4" strokeWidth={1.8} />
-          )}
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleImprove}
+            title="Improve prompt"
+            aria-label="Improve prompt"
+            className="h-auto w-auto p-0 text-steel hover:bg-transparent hover:text-ink disabled:opacity-40"
+            disabled={improving || improvedPrompt !== null}
+          >
+            {improving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" strokeWidth={1.8} />
+            )}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onDraft}
+            title="Draft prompt"
+            aria-label="Draft prompt"
+            className="h-auto w-auto p-0 text-steel hover:bg-transparent hover:text-ink disabled:opacity-40"
+            disabled={generating}
+          >
+            {generating ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Pencil className="h-4 w-4" strokeWidth={1.8} />
+            )}
+          </Button>
+        </div>
       </div>
 
-      <Textarea
-        value={config.prompt}
-        onChange={(e) => onConfigChange({ ...config, prompt: e.target.value })}
-        placeholder="Type a prompt to send to the agent…"
-        className="min-h-0 flex-1 resize-none rounded border-0 px-3.5 py-3 font-sans text-[13.5px] leading-relaxed shadow-sm placeholder:text-steel focus-visible:ring-0"
-      />
+      {improvedPrompt !== null && diff ? (
+        <div className="flex min-h-0 flex-1 flex-col divide-y divide-line overflow-y-auto">
+          <div className="px-3.5 py-2.5">
+            <div className="mb-1 font-mono text-[11px] uppercase text-steel-soft">Current</div>
+            <p className="whitespace-pre-wrap text-[12.5px] leading-relaxed">
+              {diff.a.map((segment, index) => (
+                <span
+                  key={index}
+                  className={cn(
+                    segment.type === 'removed' && 'bg-red-100 text-red-900 line-through decoration-red-400',
+                  )}
+                >
+                  {segment.text}
+                </span>
+              ))}
+            </p>
+          </div>
+          <div className="px-3.5 py-2.5">
+            <div className="mb-1 font-mono text-[11px] uppercase text-steel-soft">Improved</div>
+            <p className="whitespace-pre-wrap text-[12.5px] leading-relaxed">
+              {diff.b.map((segment, index) => (
+                <span
+                  key={index}
+                  className={cn(segment.type === 'added' && 'bg-emerald-100 text-emerald-900')}
+                >
+                  {segment.text}
+                </span>
+              ))}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <Textarea
+          value={config.prompt}
+          onChange={(e) => onConfigChange({ ...config, prompt: e.target.value })}
+          placeholder="Type a prompt to send to the agent…"
+          className="min-h-0 flex-1 resize-none rounded border-0 px-3.5 py-3 font-sans text-[13.5px] leading-relaxed shadow-sm placeholder:text-steel focus-visible:ring-0"
+        />
+      )}
+
+      {improvedPrompt !== null && (
+        <div className="flex items-center justify-end gap-2 border-t border-line px-3.5 py-2">
+          <Button type="button" variant="outline" size="sm" onClick={handleDiscardImprovement}>
+            Discard
+          </Button>
+          <Button type="button" size="sm" onClick={handleAcceptImprovement}>
+            Accept
+          </Button>
+        </div>
+      )}
 
       <div className="border-t border-line px-3.5 py-2.5">
         <Button

--- a/frontend/src/components/playground/SaveTemplateDialog.tsx
+++ b/frontend/src/components/playground/SaveTemplateDialog.tsx
@@ -19,23 +19,43 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { savePromptTemplate, type SavePromptTemplateResult } from '@/services/consoleApi';
+import {
+  updateAgentPrompt,
+  createAgentPromptNewVersion,
+  forkAgentPrompt,
+  type AgentPromptDoc,
+} from '@/services/agentPromptApi';
 import { getCategories, type CategoryDoc } from '@/services/categoryApi';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
+
+type SaveMode = 'new' | 'update' | 'version' | 'fork';
+
+export interface SaveTemplateResult {
+  mode: SaveMode;
+  name: string;
+  title?: string;
+  version?: number;
+}
 
 interface SaveTemplateDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   promptBody: string;
-  onSaved?: (result: SavePromptTemplateResult) => void;
+  /** The Agent Prompt currently loaded into the bench, if any — enables update/version/fork. */
+  loadedTemplate?: Pick<AgentPromptDoc, 'name' | 'title' | 'version'> | null;
+  onSaved?: (result: SaveTemplateResult) => void;
 }
 
 export function SaveTemplateDialog({
   open,
   onOpenChange,
   promptBody,
+  loadedTemplate,
   onSaved,
 }: SaveTemplateDialogProps) {
+  const [mode, setMode] = useState<SaveMode>('new');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [visibility, setVisibility] = useState<'Public' | 'App' | 'Private'>('Private');
@@ -61,31 +81,55 @@ export function SaveTemplateDialog({
 
   useEffect(() => {
     if (open) {
+      setMode(loadedTemplate ? 'version' : 'new');
       setTitle('');
       setDescription('');
       setVisibility('Private');
       setCategory('');
       setTags('');
     }
-  }, [open]);
+  }, [open, loadedTemplate]);
 
   const handleSave = async () => {
-    if (!title.trim()) {
+    if (mode === 'new' && !title.trim()) {
       toast.error('Title is required');
       return;
     }
     setSaving(true);
     try {
-      const result = await savePromptTemplate({
-        prompt_body: promptBody,
-        title: title.trim(),
-        description: description.trim() || undefined,
-        visibility,
-        category: category || undefined,
-        tags: tags.trim() || undefined,
-      });
-      toast.success('Prompt saved as template');
-      onSaved?.(result);
+      if (mode === 'new') {
+        const result: SavePromptTemplateResult = await savePromptTemplate({
+          prompt_body: promptBody,
+          title: title.trim(),
+          description: description.trim() || undefined,
+          visibility,
+          category: category || undefined,
+          tags: tags.trim() || undefined,
+        });
+        toast.success('Prompt saved as template');
+        onSaved?.({ mode, name: result.name, title: title.trim(), version: result.version });
+      } else if (mode === 'update' && loadedTemplate) {
+        const result = await updateAgentPrompt(loadedTemplate.name, {
+          prompt_body: promptBody,
+          ...(title.trim() && { title: title.trim() }),
+          ...(description.trim() && { description: description.trim() }),
+        });
+        toast.success('Template updated');
+        onSaved?.({ mode, name: result.name, title: result.title, version: result.version });
+      } else if (mode === 'version' && loadedTemplate) {
+        const result = await createAgentPromptNewVersion(
+          loadedTemplate.name,
+          promptBody,
+          title.trim() || undefined,
+          description.trim() || undefined,
+        );
+        toast.success(`Saved as version ${result.version}`);
+        onSaved?.({ mode, name: result.name, title: title.trim() || loadedTemplate.title, version: result.version });
+      } else if (mode === 'fork' && loadedTemplate) {
+        const result = await forkAgentPrompt(loadedTemplate.name, title.trim() || undefined);
+        toast.success('Forked as a new template');
+        onSaved?.({ mode, name: result.name, title: title.trim() || undefined, version: result.version });
+      }
       onOpenChange(false);
     } catch (error) {
       toast.error(`Failed to save template: ${getFrappeErrorMessage(error)}`);
@@ -94,80 +138,146 @@ export function SaveTemplateDialog({
     }
   };
 
+  const saveLabel =
+    mode === 'update'
+      ? 'Update template'
+      : mode === 'version'
+        ? 'Save as new version'
+        : mode === 'fork'
+          ? 'Fork template'
+          : 'Save template';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Save as template</DialogTitle>
-          <DialogDescription>Save the current prompt as a reusable Agent Prompt template.</DialogDescription>
+          <DialogDescription>
+            {loadedTemplate
+              ? `"${loadedTemplate.title}" is currently loaded. Choose how to save your changes.`
+              : 'Save the current prompt as a reusable Agent Prompt template.'}
+          </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-2">
+          {loadedTemplate && (
+            <RadioGroup
+              value={mode}
+              onValueChange={(v) => setMode(v as SaveMode)}
+              className="gap-2.5"
+            >
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="update" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Update this template</span>
+                  <span className="block text-xs text-steel">
+                    Overwrite “{loadedTemplate.title}” in place.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="version" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Save as new version</span>
+                  <span className="block text-xs text-steel">
+                    Keep the current version and publish a new one in its place.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="fork" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Fork as new template</span>
+                  <span className="block text-xs text-steel">
+                    Create an independent copy, unlinked from “{loadedTemplate.title}”.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 text-sm">
+                <RadioGroupItem value="new" className="mt-0.5" />
+                <span>
+                  <span className="font-medium">Save as new template</span>
+                  <span className="block text-xs text-steel">Start an unrelated template.</span>
+                </span>
+              </label>
+            </RadioGroup>
+          )}
+
           <div className="space-y-2">
             <Label htmlFor="template-title">Title</Label>
             <Input
               id="template-title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="e.g. Customer support greeting"
+              placeholder={
+                mode === 'new' || !loadedTemplate
+                  ? 'e.g. Customer support greeting'
+                  : `Defaults to "${loadedTemplate.title}"`
+              }
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="template-description">Description</Label>
-            <Textarea
-              id="template-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="What is this prompt for?"
-              rows={2}
-            />
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2">
+          {mode !== 'fork' && (
             <div className="space-y-2">
-              <Label>Visibility</Label>
-              <Select value={visibility} onValueChange={(v) => setVisibility(v as typeof visibility)}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="Private">Private</SelectItem>
-                  <SelectItem value="App">App</SelectItem>
-                  <SelectItem value="Public">Public</SelectItem>
-                </SelectContent>
-              </Select>
+              <Label htmlFor="template-description">Description</Label>
+              <Textarea
+                id="template-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What is this prompt for?"
+                rows={2}
+              />
             </div>
-            <div className="space-y-2">
-              <Label>Category</Label>
-              <Select value={category} onValueChange={setCategory}>
-                <SelectTrigger>
-                  <SelectValue placeholder="None" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">None</SelectItem>
-                  {categories.map((c) => (
-                    <SelectItem key={c.name} value={c.name}>
-                      {c.category_name || c.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="template-tags">Tags</Label>
-            <Input
-              id="template-tags"
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
-              placeholder="Comma-separated tags"
-            />
-          </div>
+          )}
+          {mode === 'new' && (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Visibility</Label>
+                  <Select value={visibility} onValueChange={(v) => setVisibility(v as typeof visibility)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="Private">Private</SelectItem>
+                      <SelectItem value="App">App</SelectItem>
+                      <SelectItem value="Public">Public</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Category</Label>
+                  <Select value={category} onValueChange={setCategory}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="None" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">None</SelectItem>
+                      {categories.map((c) => (
+                        <SelectItem key={c.name} value={c.name}>
+                          {c.category_name || c.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="template-tags">Tags</Label>
+                <Input
+                  id="template-tags"
+                  value={tags}
+                  onChange={(e) => setTags(e.target.value)}
+                  placeholder="Comma-separated tags"
+                />
+              </div>
+            </>
+          )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={saving || !title.trim()}>
-            {saving ? 'Saving...' : 'Save template'}
+          <Button onClick={handleSave} disabled={saving || (mode === 'new' && !title.trim())}>
+            {saving ? 'Saving...' : saveLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/shortcuts/KeyboardShortcutsDialog.tsx
+++ b/frontend/src/components/shortcuts/KeyboardShortcutsDialog.tsx
@@ -9,7 +9,7 @@ import { ShortcutKey } from '@/components/ui/shortcut-key';
 import { SHORTCUTS, formatBinding, type ShortcutScope } from '@/lib/shortcuts/registry';
 import { usePlatform } from '@/lib/shortcuts/platform';
 
-const SCOPE_ORDER: ShortcutScope[] = ['Global', 'Chat', 'Sidebar'];
+const SCOPE_ORDER: ShortcutScope[] = ['Global', 'Chat', 'Playground', 'Sidebar'];
 
 interface KeyboardShortcutsDialogProps {
   open: boolean;

--- a/frontend/src/components/ui/context-bar.tsx
+++ b/frontend/src/components/ui/context-bar.tsx
@@ -10,7 +10,14 @@ export interface ContextBarCacheState {
 export interface ContextBarProps {
   segments: SegmentTokens;
   cacheState?: ContextBarCacheState;
-  total: number;
+  /**
+   * The model's context window, in tokens. Null when the window is
+   * unknown (unresolvable model metadata) — in that case the composition
+   * strip is rendered proportionally against the sum of known segments
+   * instead of a guessed denominator, and no headroom is drawn, so the
+   * user is never shown a made-up "free space" figure.
+   */
+  total: number | null;
   size?: 'sm' | 'md';
   /** Render a visible swatch legend below the bars (run detail context panel). */
   showLegend?: boolean;
@@ -37,6 +44,9 @@ const SEGMENT_ORDER: Array<{ key: keyof SegmentTokens; label: string; color: str
   { key: 'knowledge', label: 'Knowledge', color: 'bg-good' },
   { key: 'history', label: 'History', color: 'bg-warning' },
   { key: 'message', label: 'Message', color: 'bg-signal' },
+  // Neutral tone (shared with cache-write below): red is reserved for
+  // failure states, so tool exchange gets steel rather than a new hue.
+  { key: 'tool_exchange', label: 'Tool exchange', color: 'bg-steel' },
 ];
 
 /**
@@ -56,7 +66,13 @@ export function ContextBar({
 }: ContextBarProps) {
   const height = size === 'sm' ? 'h-1' : 'h-2';
   const known = SEGMENT_ORDER.reduce((sum, { key }) => sum + (segments[key] ?? 0), 0);
-  const headroom = total > known ? total - known : 0;
+  const hasWindow = typeof total === 'number' && total > 0;
+  // With no known window, fall back to the sum of known segments as the
+  // denominator so the composition strip always fills 100% of what was
+  // actually measured, instead of drawing a headroom sliver against a
+  // fabricated total.
+  const denominator = hasWindow ? (total as number) : known;
+  const headroom = hasWindow && (total as number) > known ? (total as number) - known : 0;
 
   const cacheTotal = cacheState ? cacheState.cacheRead + cacheState.cacheWrite + cacheState.uncached : 0;
 
@@ -68,11 +84,14 @@ export function ContextBar({
       onClick={onClick}
       type={onClick ? 'button' : undefined}
     >
-      <div className={cn('flex w-full overflow-hidden rounded-full bg-muted', height)}>
+      <div
+        className={cn('flex w-full overflow-hidden rounded-full bg-muted', height)}
+        title={!hasWindow ? 'Context window size is not known for this run — showing measured composition only.' : undefined}
+      >
         {SEGMENT_ORDER.map(({ key, label, color }) => {
           const value = segments[key];
           if (!value) return null;
-          const pct = total > 0 ? (value / total) * 100 : 0;
+          const pct = denominator > 0 ? (value / denominator) * 100 : 0;
           return (
             <div
               key={key}
@@ -85,11 +104,14 @@ export function ContextBar({
         {headroom > 0 && (
           <div
             className="bg-transparent"
-            style={{ width: `${(headroom / total) * 100}%` }}
+            style={{ width: `${(headroom / denominator) * 100}%` }}
             title={`Headroom: ${headroom.toLocaleString()} tokens`}
           />
         )}
       </div>
+      {!hasWindow && (
+        <span className="text-[11px] text-steel">Context window not measured — showing known composition only.</span>
+      )}
 
       {cacheState && cacheTotal > 0 && (
         <div className={cn('flex w-full overflow-hidden rounded-full bg-muted', height)}>
@@ -127,10 +149,12 @@ export function ContextBar({
             <LegendSwatch color={UNCACHED_COLOR} />
             Fresh input {formatPct(cacheState.uncached / cacheTotal)}
           </span>
-          <span className="flex items-center gap-1.5">
-            <LegendSwatch color={cn(FREE_COLOR, 'border border-line')} />
-            Window free {total > 0 ? formatPct(headroom / total) : '0%'}
-          </span>
+          {hasWindow && (
+            <span className="flex items-center gap-1.5">
+              <LegendSwatch color={cn(FREE_COLOR, 'border border-line')} />
+              Window free {formatPct(headroom / denominator)}
+            </span>
+          )}
         </div>
       )}
     </Wrapper>

--- a/frontend/src/data/knowledge.ts
+++ b/frontend/src/data/knowledge.ts
@@ -6,16 +6,30 @@
 export const knowledgeTypes = [
 	{ label: 'SQLite FTS', value: 'sqlite_fts' },
 	{ label: 'SQLite Vec', value: 'sqlite_vec' },
+	{ label: 'SQLite Hybrid (FTS + Vec)', value: 'sqlite_hybrid' },
 	{ label: 'ChromaDB', value: 'chroma' },
 	{ label: 'PGVector', value: 'pgvector' },
 	{ label: 'zvec (Embedded)', value: 'zvec' },
 	{ label: 'Redis', value: 'redis' },
+	{ label: 'Weaviate', value: 'weaviate' },
+	{ label: 'FAISS', value: 'faiss' },
+	{ label: 'Pinecone', value: 'pinecone' },
 
 ] as const;
 
 export type KnowledgeTypeOption = (typeof knowledgeTypes)[number]['value'];
 
-export const VECTOR_KNOWLEDGE_TYPES = ['sqlite_vec', 'chroma', 'pgvector', 'redis', 'zvec'] as const;
+export const VECTOR_KNOWLEDGE_TYPES = [
+	'sqlite_vec',
+	'sqlite_hybrid',
+	'chroma',
+	'pgvector',
+	'redis',
+	'zvec',
+	'weaviate',
+	'faiss',
+	'pinecone',
+] as const;
 
 
 export function isVectorKnowledgeType(type: string): boolean {
@@ -25,10 +39,14 @@ export function isVectorKnowledgeType(type: string): boolean {
 export const knowledgeTypeLabels: Record<string, string> = {
 	sqlite_fts: 'FTS',
 	sqlite_vec: 'Vec',
+	sqlite_hybrid: 'Hybrid',
 	chroma: 'Chroma',
 	pgvector: 'PGVector',
 	zvec: 'zvec',
 	redis: 'Redis',
+	weaviate: 'Weaviate',
+	faiss: 'FAISS',
+	pinecone: 'Pinecone',
 
 };
 

--- a/frontend/src/hooks/useVoiceCall.ts
+++ b/frontend/src/hooks/useVoiceCall.ts
@@ -4,6 +4,14 @@ import { getFrappeErrorMessage } from '@/lib/frappe-error';
 
 export type VoiceCallStatus = 'idle' | 'connecting' | 'live' | 'error' | 'ended';
 
+export interface TranscriptTurn {
+  id: string;
+  role: 'user' | 'agent';
+  text: string;
+  /** True once the turn is known-final (no more deltas will arrive for it). */
+  final: boolean;
+}
+
 export interface UseVoiceCallResult {
   status: VoiceCallStatus;
   error: string | null;
@@ -12,6 +20,7 @@ export interface UseVoiceCallResult {
   mute: () => void;
   unmute: () => void;
   isMuted: boolean;
+  transcript: TranscriptTurn[];
 }
 
 /**
@@ -58,6 +67,14 @@ function floatTo16kPcm16(input: Float32Array, inputSampleRate: number): ArrayBuf
   return out.buffer;
 }
 
+let transcriptIdCounter = 0;
+
+/** Dependency-free id generator — good enough for keying local transcript turns. */
+function nextTranscriptId(): string {
+  transcriptIdCounter += 1;
+  return `turn-${Date.now()}-${transcriptIdCounter}`;
+}
+
 function base64FromArrayBuffer(buffer: ArrayBuffer): string {
   let binary = '';
   const bytes = new Uint8Array(buffer);
@@ -88,6 +105,25 @@ function base64FromArrayBuffer(buffer: ArrayBuffer): string {
  *   `wss://<current host><sidecar_ws_path>`. No frontend env var for a
  *   sidecar base URL was found in this repo at implementation time — if one
  *   is added later (e.g. VITE_REALTIME_WS_BASE), this should read it first.
+ *
+ * Transcript event shapes (NOT re-verified against live provider docs in
+ * this pass — same "flagged, not silently guessed" convention as above):
+ * - ElevenLabs: `{type: "user_transcript", user_transcription_event:
+ *   {user_transcript}}` for recognized user speech, and `{type:
+ *   "agent_response", agent_response_event: {agent_response}}` for the
+ *   agent's spoken response — both arrive as single, already-final frames
+ *   (no delta/done split, per ElevenLabs' documented Conversational AI
+ *   WebSocket event shapes). An `interruption` event type likely also
+ *   exists but was not observed in this pass, so it is not handled.
+ * - litellm_realtime: `response.audio_transcript.delta` (`{delta}`, partial)
+ *   and `response.audio_transcript.done` (`{transcript}`, final) for the
+ *   agent's spoken text — this matches exactly what the sidecar itself
+ *   parses in `_try_persist_agent_turn` (huf/ai/voice/sidecar/app.py), so
+ *   confidence here is high. User-side transcription
+ *   (`conversation.item.input_audio_transcription.completed`) is NOT
+ *   implemented: the sidecar never sends a `session.update` enabling input
+ *   transcription, so there is no evidence the provider ever emits it for
+ *   these sessions — left as a documented gap rather than fabricated.
  */
 export function useVoiceCall(
   agentName: string,
@@ -96,6 +132,7 @@ export function useVoiceCall(
   const [status, setStatus] = useState<VoiceCallStatus>('idle');
   const [error, setError] = useState<string | null>(null);
   const [isMuted, setIsMuted] = useState(false);
+  const [transcript, setTranscript] = useState<TranscriptTurn[]>([]);
 
   const wsRef = useRef<WebSocket | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
@@ -110,6 +147,11 @@ export function useVoiceCall(
   // Tracks the latest status so close/error listeners registered at start()
   // time can check "were we actually live" without stale closures.
   const statusRef = useRef(status);
+  // litellm_realtime streams the agent's transcript as delta/done events
+  // with no turn id of its own to key off — this tracks the in-progress
+  // turn's locally-generated id so successive deltas update the same entry,
+  // and is cleared on "done" so the next response starts a fresh turn.
+  const streamingAgentTurnIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     isMutedRef.current = isMuted;
@@ -181,6 +223,27 @@ export function useVoiceCall(
     source.start(startAt);
     playbackTimeRef.current = startAt + audioBuffer.duration;
   }, []);
+
+  /**
+   * Insert or update one transcript turn by id. `append: true` concatenates
+   * onto the existing turn's text (streaming deltas); otherwise `text`
+   * replaces it outright (a final/complete transcript).
+   */
+  const upsertTranscriptTurn = useCallback(
+    (id: string, role: TranscriptTurn['role'], text: string, final: boolean, append = false) => {
+      setTranscript((prev) => {
+        const index = prev.findIndex((turn) => turn.id === id);
+        if (index === -1) {
+          return [...prev, { id, role, text, final }];
+        }
+        const next = [...prev];
+        const existing = next[index];
+        next[index] = { ...existing, text: append ? existing.text + text : text, final };
+        return next;
+      });
+    },
+    [],
+  );
 
   const startMicCapture = useCallback(
     async (onFrame: (pcm16: ArrayBuffer) => void) => {
@@ -266,6 +329,8 @@ export function useVoiceCall(
     }
     setError(null);
     setStatus('connecting');
+    setTranscript([]);
+    streamingAgentTurnIdRef.current = null;
 
     let result: StartSessionResult;
     try {
@@ -328,6 +393,8 @@ export function useVoiceCall(
             const parsed = JSON.parse(event.data) as {
               type?: string;
               audio_event?: { audio_base_64?: string };
+              user_transcription_event?: { user_transcript?: string };
+              agent_response_event?: { agent_response?: string };
             };
             const base64Audio = parsed?.audio_event?.audio_base_64;
             if (parsed?.type === 'audio' && base64Audio) {
@@ -337,10 +404,21 @@ export function useVoiceCall(
                 bytes[i] = binary.charCodeAt(i);
               }
               playIncomingPcm16(bytes.buffer);
+            } else if (parsed?.type === 'user_transcript') {
+              const text = parsed.user_transcription_event?.user_transcript;
+              if (text) {
+                upsertTranscriptTurn(nextTranscriptId(), 'user', text, true);
+              }
+            } else if (parsed?.type === 'agent_response') {
+              const text = parsed.agent_response_event?.agent_response;
+              if (text) {
+                upsertTranscriptTurn(nextTranscriptId(), 'agent', text, true);
+              }
             }
+            // Other control frames (interruption, ping, etc.) are still
+            // ignored — this hook only handles audio + transcript text.
           } catch {
-            // Non-audio control frames (interruption, ping, etc.) are
-            // ignored — this hook only handles the audio path.
+            // Malformed/non-JSON frames are ignored.
           }
         });
 
@@ -384,9 +462,42 @@ export function useVoiceCall(
           }
           if (event.data instanceof Blob) {
             void event.data.arrayBuffer().then((buffer) => playIncomingPcm16(buffer));
+            return;
           }
-          // String frames (JSON control/status messages from the sidecar)
-          // are intentionally ignored here — this hook only handles audio.
+          if (typeof event.data !== 'string') {
+            return;
+          }
+          // String frames are JSON control/status/transcript messages
+          // relayed from the OpenAI Realtime API by the sidecar (see
+          // huf/ai/voice/sidecar/app.py's own `_try_persist_agent_turn`,
+          // which parses this same wire format for `response.audio_
+          // transcript.done`). Defensive try/catch: a parse failure here
+          // must never affect the live audio path above.
+          try {
+            const parsed = JSON.parse(event.data) as {
+              type?: string;
+              delta?: string;
+              transcript?: string;
+              item_id?: string;
+              response_id?: string;
+            };
+            if (parsed?.type === 'response.audio_transcript.delta' && parsed.delta) {
+              const id = streamingAgentTurnIdRef.current ?? parsed.item_id ?? parsed.response_id ?? nextTranscriptId();
+              streamingAgentTurnIdRef.current = id;
+              upsertTranscriptTurn(id, 'agent', parsed.delta, false, true);
+            } else if (parsed?.type === 'response.audio_transcript.done') {
+              const id = streamingAgentTurnIdRef.current ?? parsed.item_id ?? parsed.response_id ?? nextTranscriptId();
+              upsertTranscriptTurn(id, 'agent', parsed.transcript ?? '', true, false);
+              streamingAgentTurnIdRef.current = null;
+            }
+            // `conversation.item.input_audio_transcription.completed` (user
+            // speech) is deliberately NOT handled here — the sidecar never
+            // sends a session.update enabling input transcription, so there
+            // is no evidence the provider emits it for these sessions. Left
+            // as a documented gap rather than fabricated.
+          } catch {
+            // Non-JSON/malformed string frames are ignored.
+          }
         });
 
         ws.addEventListener('close', () => {
@@ -402,7 +513,7 @@ export function useVoiceCall(
       handleTransportError(err instanceof Error ? err.message : 'Failed to open voice call');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentName, conversationId, status, startMicCapture, playIncomingPcm16, handleTransportError]);
+  }, [agentName, conversationId, status, startMicCapture, playIncomingPcm16, handleTransportError, upsertTranscriptTurn]);
 
   const mute = useCallback(() => setIsMuted(true), []);
   const unmute = useCallback(() => setIsMuted(false), []);
@@ -415,5 +526,5 @@ export function useVoiceCall(
     [closeSocket, teardownAudio],
   );
 
-  return { status, error, start, stop, mute, unmute, isMuted };
+  return { status, error, start, stop, mute, unmute, isMuted, transcript };
 }

--- a/frontend/src/hooks/useVoiceCall.ts
+++ b/frontend/src/hooks/useVoiceCall.ts
@@ -1,0 +1,419 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { call } from '@/lib/frappe-sdk';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+
+export type VoiceCallStatus = 'idle' | 'connecting' | 'live' | 'error' | 'ended';
+
+export interface UseVoiceCallResult {
+  status: VoiceCallStatus;
+  error: string | null;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  mute: () => void;
+  unmute: () => void;
+  isMuted: boolean;
+}
+
+/**
+ * Real response shapes returned by `huf.ai.voice.api.start_session`
+ * (see huf/ai/voice/README.md — this is the frozen contract).
+ */
+interface ElevenLabsStartSessionResult {
+  engine: 'elevenlabs_convai';
+  signed_url: string;
+  agent_id: string;
+  conversation_id?: string;
+  dynamic_variables?: Record<string, string>;
+}
+
+interface LitellmRealtimeStartSessionResult {
+  engine: 'litellm_realtime';
+  session_id: string;
+  sidecar_ws_path: string;
+  conversation_id?: string;
+}
+
+type StartSessionResult = ElevenLabsStartSessionResult | LitellmRealtimeStartSessionResult;
+
+// PCM16 mono @ 16kHz is ElevenLabs' documented default input format for the
+// browser Conversational AI WebSocket path. If a deployment overrides the
+// agent's input audio format, this capture rate would need to follow suit.
+const CAPTURE_SAMPLE_RATE = 16000;
+
+/**
+ * Downsample/convert a Float32 audio buffer (native AudioContext sample rate)
+ * into 16-bit PCM at CAPTURE_SAMPLE_RATE, little-endian, mono. Conservative,
+ * dependency-free implementation — good enough for a mic capture path, not a
+ * general-purpose resampler.
+ */
+function floatTo16kPcm16(input: Float32Array, inputSampleRate: number): ArrayBuffer {
+  const ratio = inputSampleRate / CAPTURE_SAMPLE_RATE;
+  const outLength = Math.floor(input.length / ratio);
+  const out = new Int16Array(outLength);
+  for (let i = 0; i < outLength; i += 1) {
+    const srcIndex = Math.floor(i * ratio);
+    const sample = Math.max(-1, Math.min(1, input[srcIndex]));
+    out[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+  }
+  return out.buffer;
+}
+
+function base64FromArrayBuffer(buffer: ArrayBuffer): string {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * useVoiceCall — opens a live voice call against an Agent's configured voice
+ * engine, per the contract in huf/ai/voice/api.py and huf/ai/voice/README.md.
+ *
+ * Deliberately framework-agnostic in its internals (no JSX): this is meant to
+ * be a clean reference for the wire protocol even for callers that don't use
+ * React.
+ *
+ * Known assumptions (flagged, not silently guessed):
+ * - ElevenLabs: sends `conversation_initiation_client_data` as the first
+ *   WebSocket message when `dynamic_variables` are present, per ElevenLabs'
+ *   documented Conversational AI WebSocket client-data message shape.
+ * - ElevenLabs: captures mic audio as PCM16 mono @ 16kHz, base64-encoded into
+ *   `{"user_audio_chunk": "<base64>"}` messages — ElevenLabs' documented
+ *   default input format for the browser client path.
+ * - litellm_realtime: the sidecar is assumed reverse-proxied at the SAME
+ *   origin as the frontend under `sidecar_ws_path`. If no separate sidecar
+ *   origin is configured for a given deployment, this constructs
+ *   `wss://<current host><sidecar_ws_path>`. No frontend env var for a
+ *   sidecar base URL was found in this repo at implementation time — if one
+ *   is added later (e.g. VITE_REALTIME_WS_BASE), this should read it first.
+ */
+export function useVoiceCall(
+  agentName: string,
+  conversationId: string | undefined,
+): UseVoiceCallResult {
+  const [status, setStatus] = useState<VoiceCallStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [isMuted, setIsMuted] = useState(false);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const playbackContextRef = useRef<AudioContext | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const sourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const engineRef = useRef<StartSessionResult['engine'] | null>(null);
+  const isMutedRef = useRef(false);
+  const playbackTimeRef = useRef(0);
+  // Tracks the latest status so close/error listeners registered at start()
+  // time can check "were we actually live" without stale closures.
+  const statusRef = useRef(status);
+
+  useEffect(() => {
+    isMutedRef.current = isMuted;
+  }, [isMuted]);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  const teardownAudio = useCallback(() => {
+    if (processorRef.current) {
+      processorRef.current.disconnect();
+      processorRef.current.onaudioprocess = null;
+      processorRef.current = null;
+    }
+    if (sourceNodeRef.current) {
+      sourceNodeRef.current.disconnect();
+      sourceNodeRef.current = null;
+    }
+    if (mediaStreamRef.current) {
+      for (const track of mediaStreamRef.current.getTracks()) {
+        track.stop();
+      }
+      mediaStreamRef.current = null;
+    }
+    if (audioContextRef.current) {
+      void audioContextRef.current.close().catch(() => undefined);
+      audioContextRef.current = null;
+    }
+    if (playbackContextRef.current) {
+      void playbackContextRef.current.close().catch(() => undefined);
+      playbackContextRef.current = null;
+    }
+    playbackTimeRef.current = 0;
+  }, []);
+
+  const closeSocket = useCallback(() => {
+    if (wsRef.current) {
+      const ws = wsRef.current;
+      wsRef.current = null;
+      // Avoid firing onclose/onerror handlers after a deliberate stop().
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.onmessage = null;
+      try {
+        ws.close();
+      } catch {
+        // Already closed/closing — nothing to do.
+      }
+    }
+  }, []);
+
+  const playIncomingPcm16 = useCallback((buffer: ArrayBuffer, sampleRate = CAPTURE_SAMPLE_RATE) => {
+    if (!playbackContextRef.current) {
+      return;
+    }
+    const ctx = playbackContextRef.current;
+    const pcm16 = new Int16Array(buffer);
+    const float32 = new Float32Array(pcm16.length);
+    for (let i = 0; i < pcm16.length; i += 1) {
+      float32[i] = pcm16[i] / 0x8000;
+    }
+    const audioBuffer = ctx.createBuffer(1, float32.length, sampleRate);
+    audioBuffer.copyToChannel(float32, 0);
+    const source = ctx.createBufferSource();
+    source.buffer = audioBuffer;
+    source.connect(ctx.destination);
+    const startAt = Math.max(ctx.currentTime, playbackTimeRef.current);
+    source.start(startAt);
+    playbackTimeRef.current = startAt + audioBuffer.duration;
+  }, []);
+
+  const startMicCapture = useCallback(
+    async (onFrame: (pcm16: ArrayBuffer) => void) => {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaStreamRef.current = stream;
+
+      const AudioContextCtor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+      const audioContext = new AudioContextCtor();
+      audioContextRef.current = audioContext;
+
+      const source = audioContext.createMediaStreamSource(stream);
+      sourceNodeRef.current = source;
+
+      // ScriptProcessorNode is deprecated but remains the most broadly
+      // supported low-latency capture path across browsers without shipping
+      // a separate AudioWorklet module; kept deliberately simple here.
+      const bufferSize = 4096;
+      const processor = audioContext.createScriptProcessor(bufferSize, 1, 1);
+      processorRef.current = processor;
+
+      processor.onaudioprocess = (event) => {
+        if (isMutedRef.current) {
+          return;
+        }
+        const input = event.inputBuffer.getChannelData(0);
+        const pcm16 = floatTo16kPcm16(input, audioContext.sampleRate);
+        onFrame(pcm16);
+      };
+
+      source.connect(processor);
+      // Some browsers require the processor to be connected to a
+      // destination to keep firing onaudioprocess; route to a silent gain
+      // so we don't actually play the mic back to the user.
+      const silentGain = audioContext.createGain();
+      silentGain.gain.value = 0;
+      processor.connect(silentGain);
+      silentGain.connect(audioContext.destination);
+    },
+    [],
+  );
+
+  const stop = useCallback(async () => {
+    const engine = engineRef.current;
+    const sessionId = sessionIdRef.current;
+
+    closeSocket();
+    teardownAudio();
+
+    // ElevenLabs has no server-side session to end (base-class no-op per the
+    // README) — only litellm_realtime carries a real session_id to release.
+    if (engine === 'litellm_realtime' && sessionId) {
+      try {
+        await call.post('huf.ai.voice.api.end_session', {
+          agent: agentName,
+          session_id: sessionId,
+        });
+      } catch {
+        // Best-effort — the call is already torn down locally either way.
+      }
+    }
+
+    sessionIdRef.current = null;
+    engineRef.current = null;
+    setIsMuted(false);
+    setStatus('ended');
+  }, [agentName, closeSocket, teardownAudio]);
+
+  const handleTransportError = useCallback(
+    (message: string) => {
+      closeSocket();
+      teardownAudio();
+      sessionIdRef.current = null;
+      engineRef.current = null;
+      setError(message);
+      setStatus('error');
+    },
+    [closeSocket, teardownAudio],
+  );
+
+  const start = useCallback(async () => {
+    if (status === 'connecting' || status === 'live') {
+      return;
+    }
+    setError(null);
+    setStatus('connecting');
+
+    let result: StartSessionResult;
+    try {
+      const response = await call.post('huf.ai.voice.api.start_session', {
+        agent: agentName,
+        conversation_id: conversationId,
+      });
+      result = (response?.message ?? response) as StartSessionResult;
+    } catch (err) {
+      setError(getFrappeErrorMessage(err) || 'Failed to start voice call');
+      setStatus('error');
+      return;
+    }
+
+    engineRef.current = result.engine;
+
+    try {
+      // Playback context is created up front so incoming frames can be
+      // scheduled as soon as they arrive, independent of mic capture.
+      const AudioContextCtor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+      playbackContextRef.current = new AudioContextCtor();
+
+      if (result.engine === 'elevenlabs_convai') {
+        const ws = new WebSocket(result.signed_url);
+        wsRef.current = ws;
+
+        ws.addEventListener('open', () => {
+          if (result.dynamic_variables) {
+            // ElevenLabs Conversational AI: the client-data message must be
+            // the first frame sent after the socket opens.
+            ws.send(
+              JSON.stringify({
+                type: 'conversation_initiation_client_data',
+                dynamic_variables: result.dynamic_variables,
+              }),
+            );
+          }
+
+          startMicCapture((pcm16) => {
+            if (ws.readyState !== WebSocket.OPEN) {
+              return;
+            }
+            ws.send(
+              JSON.stringify({
+                user_audio_chunk: base64FromArrayBuffer(pcm16),
+              }),
+            );
+          }).catch((err) => {
+            handleTransportError(err instanceof Error ? err.message : 'Microphone access failed');
+          });
+
+          setStatus('live');
+        });
+
+        ws.addEventListener('message', (event) => {
+          if (typeof event.data !== 'string') {
+            return;
+          }
+          try {
+            const parsed = JSON.parse(event.data) as {
+              type?: string;
+              audio_event?: { audio_base_64?: string };
+            };
+            const base64Audio = parsed?.audio_event?.audio_base_64;
+            if (parsed?.type === 'audio' && base64Audio) {
+              const binary = atob(base64Audio);
+              const bytes = new Uint8Array(binary.length);
+              for (let i = 0; i < binary.length; i += 1) {
+                bytes[i] = binary.charCodeAt(i);
+              }
+              playIncomingPcm16(bytes.buffer);
+            }
+          } catch {
+            // Non-audio control frames (interruption, ping, etc.) are
+            // ignored — this hook only handles the audio path.
+          }
+        });
+
+        ws.addEventListener('close', () => {
+          if (statusRef.current === 'live' || statusRef.current === 'connecting') {
+            handleTransportError('Voice call connection closed unexpectedly');
+          }
+        });
+        ws.addEventListener('error', () => {
+          handleTransportError('Voice call connection error');
+        });
+      } else {
+        sessionIdRef.current = result.session_id;
+
+        // No frontend env var for a sidecar base URL exists in this repo at
+        // the time this was written — assumes the sidecar is reverse-proxied
+        // at the same origin as the frontend. Adjust per-deployment if the
+        // sidecar is hosted separately.
+        const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const sidecarUrl = `${wsProtocol}//${window.location.host}${result.sidecar_ws_path}`;
+        const ws = new WebSocket(sidecarUrl);
+        wsRef.current = ws;
+
+        ws.addEventListener('open', () => {
+          startMicCapture((pcm16) => {
+            if (ws.readyState !== WebSocket.OPEN) {
+              return;
+            }
+            ws.send(pcm16);
+          }).catch((err) => {
+            handleTransportError(err instanceof Error ? err.message : 'Microphone access failed');
+          });
+
+          setStatus('live');
+        });
+
+        ws.addEventListener('message', (event) => {
+          if (event.data instanceof ArrayBuffer) {
+            playIncomingPcm16(event.data);
+            return;
+          }
+          if (event.data instanceof Blob) {
+            void event.data.arrayBuffer().then((buffer) => playIncomingPcm16(buffer));
+          }
+          // String frames (JSON control/status messages from the sidecar)
+          // are intentionally ignored here — this hook only handles audio.
+        });
+
+        ws.addEventListener('close', () => {
+          if (statusRef.current === 'live' || statusRef.current === 'connecting') {
+            handleTransportError('Voice call connection closed unexpectedly');
+          }
+        });
+        ws.addEventListener('error', () => {
+          handleTransportError('Voice call connection error');
+        });
+      }
+    } catch (err) {
+      handleTransportError(err instanceof Error ? err.message : 'Failed to open voice call');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentName, conversationId, status, startMicCapture, playIncomingPcm16, handleTransportError]);
+
+  const mute = useCallback(() => setIsMuted(true), []);
+  const unmute = useCallback(() => setIsMuted(false), []);
+
+  useEffect(
+    () => () => {
+      closeSocket();
+      teardownAudio();
+    },
+    [closeSocket, teardownAudio],
+  );
+
+  return { status, error, start, stop, mute, unmute, isMuted };
+}

--- a/frontend/src/lib/shortcuts/registry.ts
+++ b/frontend/src/lib/shortcuts/registry.ts
@@ -1,7 +1,7 @@
 import type { ShortcutBinding } from './matching';
 import { getModifierKey, type Platform } from './platform';
 
-export type ShortcutScope = 'Global' | 'Chat' | 'Sidebar';
+export type ShortcutScope = 'Global' | 'Chat' | 'Sidebar' | 'Playground';
 
 export interface ShortcutDescriptor {
   id: string;
@@ -53,6 +53,24 @@ export const SHORTCUTS: ShortcutDescriptor[] = [
     binding: { key: 'Enter', shift: true },
     description: 'Insert new line',
     scope: 'Chat',
+  },
+  {
+    id: 'playground-copy-a-to-b',
+    binding: { key: 'c', mod: true, shift: true },
+    description: 'Copy A → B',
+    scope: 'Playground',
+  },
+  {
+    id: 'playground-swap',
+    binding: { key: 'x', mod: true, shift: true },
+    description: 'Swap A and B',
+    scope: 'Playground',
+  },
+  {
+    id: 'playground-toggle-diff',
+    binding: { key: 'd', mod: true, shift: true },
+    description: 'Toggle diff responses',
+    scope: 'Playground',
   },
 ];
 

--- a/frontend/src/pages/AgentRunDetailPage.tsx
+++ b/frontend/src/pages/AgentRunDetailPage.tsx
@@ -134,8 +134,12 @@ interface AgentRunDetail extends AgentRunDoc {
   input_tokens?: number | null;
   output_tokens?: number | null;
   cached_tokens?: number | null;
+  cache_creation_tokens?: number | null;
   cost?: number | null;
   cost_source?: string | null;
+  round_count?: number | null;
+  execution_mode?: 'sync' | 'stream' | null;
+  provider_path?: 'litellm' | 'legacy_fallback' | null;
 }
 
 async function fetchAgentRunDetail(name: string): Promise<AgentRunDetail | null> {
@@ -428,6 +432,32 @@ function AgentRunDetailPage() {
               <DefinitionRow label="Model" value={run.model || 'Unknown'} mono />
               <DefinitionRow label="Started" value={startedAt} />
               <DefinitionRow label="Duration" value={duration} />
+              <DefinitionRow
+                label="Rounds"
+                value={typeof run.round_count === 'number' ? run.round_count.toLocaleString() : 'Not measured'}
+              />
+              <DefinitionRow
+                label="Execution mode"
+                value={
+                  run.execution_mode === 'sync'
+                    ? 'Sync'
+                    : run.execution_mode === 'stream'
+                      ? 'Streaming'
+                      : 'Not available'
+                }
+              />
+              <DefinitionRow
+                label="Provider path"
+                value={
+                  run.provider_path === 'legacy_fallback' ? (
+                    <span className="text-warning">Fallback provider (cache and cost not recorded)</span>
+                  ) : run.provider_path === 'litellm' ? (
+                    'Standard'
+                  ) : (
+                    'Not available'
+                  )
+                }
+              />
             </DefinitionColumn>
 
             <DefinitionColumn heading="Tokens & Cost">
@@ -467,18 +497,21 @@ function AgentRunDetailPage() {
                 showLegend
                 cacheState={
                   typeof contextMetrics.metrics.cache_read_share === 'number'
-                    ? {
-                        cacheRead: run.cached_tokens || 0,
-                        cacheWrite: 0,
-                        uncached: Math.max(
-                          (contextMetrics.total_tokens || run.input_tokens || 0) - (run.cached_tokens || 0),
-                          0
-                        ),
-                      }
+                    ? (() => {
+                        const cacheRead = run.cached_tokens || 0;
+                        const cacheWrite = run.cache_creation_tokens || 0;
+                        const inputTokens = contextMetrics.total_tokens || run.input_tokens || 0;
+                        return {
+                          cacheRead,
+                          cacheWrite,
+                          // Matches cache_metrics.py's convention: max(input - read - write, 0).
+                          uncached: Math.max(inputTokens - cacheRead - cacheWrite, 0),
+                        };
+                      })()
                     : undefined
                 }
               />
-              <div className="grid grid-cols-4 gap-x-4 gap-y-2 border-t border-line pt-3">
+              <div className="grid grid-cols-3 gap-x-4 gap-y-2 border-t border-line pt-3">
                 <ContextStat label="Prefix stability" value={contextMetrics.metrics.prefix_stability} capitalize />
                 <ContextStat
                   label="Effective multiplier"
@@ -494,14 +527,6 @@ function AgentRunDetailPage() {
                     typeof contextMetrics.metrics.counterfactual_savings === 'number'
                       ? `$${contextMetrics.metrics.counterfactual_savings.toFixed(6)}`
                       : 'Unavailable'
-                  }
-                />
-                <ContextStat
-                  label="Wasted writes"
-                  value={
-                    typeof contextMetrics.metrics.wasted_writes_tokens === 'number'
-                      ? contextMetrics.metrics.wasted_writes_tokens.toLocaleString()
-                      : 'Not yet tracked'
                   }
                 />
               </div>

--- a/frontend/src/pages/AiProvidersPage.tsx
+++ b/frontend/src/pages/AiProvidersPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Check, CheckCircle2, Cloud, ExternalLink, KeyRound, Loader2, Settings, Sparkles, XCircle } from 'lucide-react';
+import { ArrowRight, Check, CheckCircle2, Cloud, ExternalLink, KeyRound, Loader2, Settings, Sparkles, Trash2, XCircle } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import { Badge } from '../components/ui/badge';
 import {
@@ -9,6 +9,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../components/ui/alert-dialog';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Checkbox } from '../components/ui/checkbox';
@@ -23,6 +33,7 @@ import {
   getProviders,
   updateProvider,
   createProvider,
+  deleteProvider,
   testProviderConnection,
 } from '../services/providerApi';
 import type { ProviderConnectionTestResult } from '../services/providerApi';
@@ -100,6 +111,8 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
   });
   const [testingConnection, setTestingConnection] = useState(false);
   const [connectionTest, setConnectionTest] = useState<ProviderConnectionTestResult | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AIProvider | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const emptyFormData = {
     provider_name: '',
@@ -418,6 +431,25 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
     allowInDialog: true,
   });
 
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteProvider(deleteTarget.name);
+      toast.success('Provider deleted');
+      setDeleteTarget(null);
+      reset();
+    } catch (deleteError) {
+      toast.error('Failed to delete provider', {
+        description: getFrappeErrorMessage(deleteError),
+        duration: 8000,
+      });
+      console.error(deleteError);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   return (
     <PageFrame
       title="AI providers"
@@ -529,6 +561,14 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
                   label: 'Configure',
                   onClick: () => handleConfigure(provider),
                   variant: 'ghost',
+                },
+              ]}
+              menuActions={[
+                {
+                  icon: Trash2,
+                  label: 'Delete',
+                  onClick: () => setDeleteTarget(provider),
+                  variant: 'destructive',
                 },
               ]}
               onClick={() => handleConfigure(provider)}
@@ -777,6 +817,28 @@ export function AiProvidersPage({ addProviderKey }: AiProvidersPageProps) {
           })()}
         </DialogContent>
       </Dialog>
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!deleting && !open) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{deleteTarget?.provider_name}"?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the provider. Models linked to this provider will need
+              a different provider before they can be used. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageFrame>
   );
 }

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,405 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Activity, ArrowUpDown } from 'lucide-react';
+import { PageFrame } from '@/layouts/PageFrame';
+import { EmptyStat, EmptyState, GaugeRow, MetricGauge } from '@/components/dashboard';
+import { ExperimentalBadge } from '@/components/common/ExperimentalBadge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { formatTimeAgo } from '@/utils/time';
+import { getExecutionAnalytics } from '@/services/executionAnalyticsApi';
+import type {
+  AnalyticsDimension,
+  ExecutionAnalyticsResponse,
+  ExecutionAnalyticsSummary,
+} from '@/types/executionAnalytics.types';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table';
+
+const number = new Intl.NumberFormat();
+
+const DIMENSION_OPTIONS: Array<{ value: AnalyticsDimension; label: string }> = [
+  { value: 'provider', label: 'Provider' },
+  { value: 'agent', label: 'Agent' },
+  { value: 'model', label: 'Model' },
+  { value: 'conversation', label: 'Conversation' },
+  { value: 'run_kind', label: 'Run kind' },
+];
+
+const TIME_WINDOW_OPTIONS = [
+  { value: '7d', label: 'Last 7d' },
+  { value: '30d', label: 'Last 30d' },
+  { value: '90d', label: 'Last 90d' },
+] as const;
+
+type TimeWindow = (typeof TIME_WINDOW_OPTIONS)[number]['value'];
+
+/** Window length in days for each option. The API caps the window at 93 days, so 90d is the max offered. */
+const TIME_WINDOW_DAYS: Record<TimeWindow, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+};
+
+/** Short windows read from hourly rollups; longer ones from daily rollups. */
+function granularityFor(window: TimeWindow): 'hour' | 'day' {
+  return window === '7d' ? 'hour' : 'day';
+}
+
+/** Human labels for the `composition_totals` segment keys (`system/tools/knowledge/history/message`). */
+const COMPOSITION_LABELS: Record<string, string> = {
+  system: 'Instructions',
+  tools: 'Tools',
+  knowledge: 'Knowledge',
+  history: 'Conversation history',
+  message: 'Latest message',
+};
+const COMPOSITION_ORDER = ['system', 'tools', 'knowledge', 'history', 'message'];
+
+interface BreakdownRow extends ExecutionAnalyticsSummary {
+  dimension: string;
+}
+
+export default function AnalyticsPage() {
+  const [dimension, setDimension] = useState<AnalyticsDimension>('provider');
+  const [window, setWindow] = useState<TimeWindow>('7d');
+  const [data, setData] = useState<ExecutionAnalyticsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const fromDate = useMemo(() => {
+    const days = TIME_WINDOW_DAYS[window];
+    return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+  }, [window]);
+  const granularity = granularityFor(window);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getExecutionAnalytics({ fromDate, granularity, dimension }).then((result) => {
+      if (cancelled) return;
+      setData(result);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fromDate, granularity, dimension]);
+
+  const summary = data?.summary;
+  const breakdowns = data?.breakdowns ?? [];
+  const totalGroups = data?.metadata.breakdowns_total_count ?? 0;
+  const shownGroups = breakdowns.length;
+  const truncated = totalGroups > shownGroups;
+
+  const dimensionLabel =
+    DIMENSION_OPTIONS.find((option) => option.value === dimension)?.label ?? 'Dimension';
+
+  const columns = useMemo<ColumnDef<BreakdownRow>[]>(
+    () => [
+      {
+        accessorKey: 'dimension',
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+            className="h-8 px-2 font-mono text-[10px] uppercase tracking-widest text-steel-soft hover:text-ink hover:bg-paper-deep"
+          >
+            {dimensionLabel}
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+        ),
+        cell: ({ row }) => (
+          <div className="font-body text-[13px] font-medium text-ink">
+            {row.getValue('dimension') || 'Unknown'}
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'run_count',
+        header: ({ column }) => (
+          <div className="flex justify-end">
+            <Button
+              variant="ghost"
+              onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+              className="h-8 px-2 font-mono text-[10px] uppercase tracking-widest text-steel-soft hover:text-ink hover:bg-paper-deep"
+            >
+              Runs
+              <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-[12px] tabular-nums text-steel">
+            {number.format(row.original.run_count)}
+          </div>
+        ),
+      },
+      {
+        id: 'success_rate',
+        header: () => <div className="text-right">Success rate</div>,
+        cell: ({ row }) => {
+          const rate = row.original.success_rate;
+          return (
+            <div className="text-right font-mono text-[12px] tabular-nums text-steel">
+              {rate === null ? '—' : `${rate.toFixed(1)}%`}
+            </div>
+          );
+        },
+        sortingFn: (rowA, rowB) => (rowA.original.success_rate ?? -1) - (rowB.original.success_rate ?? -1),
+      },
+      {
+        accessorKey: 'total_cost',
+        header: ({ column }) => (
+          <div className="flex justify-end">
+            <Button
+              variant="ghost"
+              onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+              className="h-8 px-2 font-mono text-[10px] uppercase tracking-widest text-steel-soft hover:text-ink hover:bg-paper-deep"
+            >
+              LLM cost
+              <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+          </div>
+        ),
+        cell: ({ row }) => (
+          <div className="text-right font-mono text-[12px] tabular-nums text-steel">
+            ${row.original.total_cost.toFixed(4)}
+          </div>
+        ),
+      },
+      {
+        id: 'average_duration_ms',
+        header: () => <div className="text-right">Avg duration</div>,
+        cell: ({ row }) => {
+          const avg = row.original.average_duration_ms;
+          return (
+            <div className="text-right font-mono text-[12px] tabular-nums text-steel">
+              {avg === null ? '—' : `${(avg / 1000).toFixed(1)}s`}
+            </div>
+          );
+        },
+        sortingFn: (rowA, rowB) =>
+          (rowA.original.average_duration_ms ?? -1) - (rowB.original.average_duration_ms ?? -1),
+      },
+    ],
+    [dimensionLabel]
+  );
+
+  const table = useReactTable({
+    data: breakdowns as BreakdownRow[],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    state: { sorting },
+  });
+
+  const compositionEntries = useMemo(() => {
+    const totals = data?.composition_totals ?? {};
+    const keys = new Set([...COMPOSITION_ORDER, ...Object.keys(totals)]);
+    return COMPOSITION_ORDER.filter((key) => keys.has(key)).map((key) => ({
+      key,
+      label: COMPOSITION_LABELS[key] ?? key,
+      value: totals[key] ?? null,
+    }));
+  }, [data]);
+  const measuredTotal = compositionEntries.reduce(
+    (sum, entry) => sum + (entry.value ?? 0),
+    0
+  );
+
+  const freshnessLabel = data?.metadata.freshness ? `Updated ${formatTimeAgo(data.metadata.freshness)}` : undefined;
+
+  return (
+    <PageFrame
+      title="Analytics"
+      badge={<ExperimentalBadge />}
+      meta={freshnessLabel}
+      filters={
+        <div className="flex items-center gap-3 w-full">
+          <Select value={dimension} onValueChange={(value) => setDimension(value as AnalyticsDimension)}>
+            <SelectTrigger size="sm" className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DIMENSION_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={window} onValueChange={(value) => setWindow(value as TimeWindow)}>
+            <SelectTrigger size="sm" className="w-[140px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_WINDOW_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-6">
+        {loading ? (
+          <div className="px-[18px] py-4 font-body text-[13px] text-steel">Loading analytics…</div>
+        ) : !summary || summary.run_count === 0 ? (
+          <EmptyState
+            variant="passive"
+            icon={Activity}
+            title="No analytics yet"
+            description="Analytics accrue as agent runs complete in this window."
+          />
+        ) : (
+          <>
+            <GaugeRow>
+              <MetricGauge
+                label="Runs"
+                value={number.format(summary.run_count)}
+                info={`${summary.success_count} successful · ${summary.failed_count} failed`}
+              />
+              {summary.cache_ratio === null ? (
+                <div className="px-[18px] py-4 min-w-0">
+                  <EmptyStat label="Cache ratio" caption="No completed runs in this period." />
+                </div>
+              ) : (
+                <MetricGauge
+                  label="Cache ratio"
+                  value={`${summary.cache_ratio.toFixed(1)}%`}
+                  info={`${number.format(summary.cached_tokens)} cached of ${number.format(summary.input_tokens)} input`}
+                />
+              )}
+              <MetricGauge label="LLM cost" value={`$${summary.total_cost.toFixed(4)}`} info="Aggregated completed runs" />
+              {summary.average_duration_ms === null ? (
+                <div className="px-[18px] py-4 min-w-0">
+                  <EmptyStat label="Average duration" caption="No completed runs in this period." />
+                </div>
+              ) : (
+                <MetricGauge
+                  label="Average duration"
+                  value={(summary.average_duration_ms / 1000).toFixed(1)}
+                  unit="s"
+                  info={`Success rate ${summary.success_rate?.toFixed(1) ?? '—'}%`}
+                />
+              )}
+            </GaugeRow>
+
+            <div className="w-full rounded-lg border border-line bg-panel overflow-hidden">
+              <div className="flex items-center justify-between px-[18px] py-3 border-b border-line">
+                <h2 className="font-body text-[13px] font-medium text-ink">By {dimensionLabel.toLowerCase()}</h2>
+                <span className="font-mono text-[11px] text-steel-soft">
+                  {truncated ? `Top ${shownGroups} of ${totalGroups}` : `${shownGroups} of ${totalGroups}`}
+                </span>
+              </div>
+              {breakdowns.length === 0 ? (
+                <EmptyState
+                  variant="passive"
+                  icon={Activity}
+                  title="No breakdown yet"
+                  description="No runs recorded for this dimension in the selected window."
+                />
+              ) : (
+                <Table>
+                  <TableHeader>
+                    {table.getHeaderGroups().map((headerGroup) => (
+                      <TableRow key={headerGroup.id}>
+                        {headerGroup.headers.map((header) => (
+                          <TableHead key={header.id}>
+                            {header.isPlaceholder
+                              ? null
+                              : flexRender(header.column.columnDef.header, header.getContext())}
+                          </TableHead>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableHeader>
+                  <TableBody>
+                    {table.getRowModel().rows.map((row) => (
+                      <TableRow key={row.id} className="h-11">
+                        {row.getVisibleCells().map((cell) => (
+                          <TableCell key={cell.id}>
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
+
+            <div className="w-full rounded-lg border border-line bg-panel overflow-hidden">
+              <div className="px-[18px] py-3 border-b border-line">
+                <h2 className="font-body text-[13px] font-medium text-ink">Context composition</h2>
+              </div>
+              <div className="divide-y divide-line">
+                {compositionEntries.map((entry) => {
+                  if (entry.value === null) {
+                    return (
+                      <div
+                        key={entry.key}
+                        className="flex items-center justify-between px-[18px] py-3"
+                      >
+                        <span className="font-body text-[13px] text-ink">{entry.label}</span>
+                        <span className="font-mono text-[12px] text-steel-soft">not measured</span>
+                      </div>
+                    );
+                  }
+                  const share = measuredTotal > 0 ? (entry.value / measuredTotal) * 100 : 0;
+                  return (
+                    <div
+                      key={entry.key}
+                      className="flex items-center justify-between px-[18px] py-3 gap-4"
+                    >
+                      <span className="font-body text-[13px] text-ink shrink-0">{entry.label}</span>
+                      <div className="flex items-center gap-3 min-w-0 flex-1 justify-end">
+                        <div className="h-1.5 w-32 rounded-full bg-paper-deep overflow-hidden shrink-0">
+                          <div
+                            className={cn('h-full rounded-full bg-steel')}
+                            style={{ width: `${share}%` }}
+                          />
+                        </div>
+                        <span className="font-mono text-[12px] tabular-nums text-steel w-28 text-right shrink-0">
+                          {number.format(entry.value)} · {share.toFixed(0)}%
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              <p className="border-t border-line px-[18px] py-2.5 font-body text-[12px] text-steel-soft">
+                Shares are computed only from segments that could be measured; a segment marked
+                &quot;not measured&quot; is excluded from the total rather than counted as zero.
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </PageFrame>
+  );
+}

--- a/frontend/src/pages/ChatPageV2.tsx
+++ b/frontend/src/pages/ChatPageV2.tsx
@@ -7,6 +7,9 @@ import { useArtifactPane } from "@/components/chat/useArtifactPane";
 import { useConversationArtifacts } from "@/components/chat/useConversationArtifacts";
 import { useChatSocket, type OpenArtifactPaneEvent } from "@/hooks/useChatSocket";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { ConversationAnalyticsPane } from "@/components/chat/analytics/ConversationAnalyticsPane";
+import { useConversationAnalyticsPane } from "@/components/chat/analytics/useConversationAnalyticsPane";
+import { RightPaneTabStrip, type RightPaneTab } from "@/components/chat/analytics/RightPaneTabStrip";
 
 export { ChatPage };
 export default ChatPage;
@@ -20,6 +23,12 @@ function ChatPage() {
     const [sidebarOpen, setSidebarOpen] = useState(true);
     const toggleSidebar = useCallback(() => setSidebarOpen((prev) => !prev), []);
     const artifactPane = useArtifactPane();
+    const analyticsPane = useConversationAnalyticsPane();
+    // Which of the two right-pane tenants is currently on screen. Both can be
+    // "open" (loaded, data fetched) at once — see useConversationAnalyticsPane
+    // and useArtifactPane — but the slot only ever shows one at a time. This
+    // tracks the user's last choice so switching tabs doesn't lose state.
+    const [visibleRightPane, setVisibleRightPane] = useState<RightPaneTab>("artifact");
     const { artifacts: conversationArtifacts, refetch: refetchArtifacts } =
         useConversationArtifacts(chatId ?? undefined);
 
@@ -77,15 +86,35 @@ function ChatPage() {
     // so callers that end up with no artifacts to show should not pass one -
     // see the conditional prop below.
     const handleToggleArtifactPane = useCallback(() => {
-        if (artifactPane.isOpen) {
+        if (artifactPane.isOpen && visibleRightPane === "artifact") {
             artifactPane.close();
+            if (analyticsPane.isOpen) setVisibleRightPane("analytics");
             return;
         }
-        const first = conversationArtifacts[0];
-        if (first) {
-            artifactPane.open({ name: first.name, title: first.title, artifact_type: first.artifact_type });
+        if (!artifactPane.isOpen) {
+            const first = conversationArtifacts[0];
+            if (first) {
+                artifactPane.open({ name: first.name, title: first.title, artifact_type: first.artifact_type });
+            } else {
+                return;
+            }
         }
-    }, [artifactPane.isOpen, artifactPane.close, artifactPane.open, conversationArtifacts]);
+        setVisibleRightPane("artifact");
+    }, [artifactPane.isOpen, artifactPane.close, artifactPane.open, analyticsPane.isOpen, conversationArtifacts, visibleRightPane]);
+
+    // Sibling of handleToggleArtifactPane: toggles the conversation analytics
+    // pane on/off, switching the shared right-pane slot to show it. Unlike
+    // the artifact toggle, analytics has no "pick the first item" step - it
+    // always describes the whole open conversation.
+    const handleToggleAnalyticsPane = useCallback(() => {
+        if (analyticsPane.isOpen && visibleRightPane === "analytics") {
+            analyticsPane.close();
+            if (artifactPane.isOpen) setVisibleRightPane("artifact");
+            return;
+        }
+        analyticsPane.open();
+        setVisibleRightPane("analytics");
+    }, [analyticsPane.isOpen, analyticsPane.close, analyticsPane.open, artifactPane.isOpen, visibleRightPane]);
 
     const handleConversationCreated = useCallback(
         (conversationId: string, agentName?: string) => {
@@ -98,10 +127,29 @@ function ChatPage() {
         [navigate]
     );
 
-    // The artifact pane renders as a third column, a sibling of the rail
-    // and the chat window - passed to ChatShellFrame as `rightPane` so the
-    // shared shell doesn't swallow it into the middle flex area. Produced
-    // files surface inline via the transcript's Outputs card (see
+    // The right-pane slot has two independent tenants that can each be
+    // loaded ("open") at once but only one is ever on screen: the artifact
+    // preview and the conversation analytics pane. When both are open, a
+    // thin RightPaneTabStrip is mounted above whichever one is visible so
+    // the user can switch without losing the other's state; when only one
+    // is open, no strip renders at all (see RightPaneTabStrip.tsx).
+    const artifactAvailable = artifactPane.isOpen;
+    const analyticsAvailable = analyticsPane.isOpen;
+    const effectiveVisiblePane: RightPaneTab =
+        visibleRightPane === "artifact" && artifactAvailable
+            ? "artifact"
+            : visibleRightPane === "analytics" && analyticsAvailable
+              ? "analytics"
+              : artifactAvailable
+                ? "artifact"
+                : "analytics";
+    const rightPaneVisible = !isMobile && (artifactAvailable || analyticsAvailable);
+    const showRightPaneTabs = artifactAvailable && analyticsAvailable;
+
+    // The artifact/analytics pane renders as a third column, a sibling of
+    // the rail and the chat window - passed to ChatShellFrame as `rightPane`
+    // so the shared shell doesn't swallow it into the middle flex area.
+    // Produced files surface inline via the transcript's Outputs card (see
     // OutputsCard.tsx, spec section 28.2) instead of a permanent right-hand
     // list. Hidden on mobile to avoid crowding the chat window.
     return (
@@ -109,15 +157,33 @@ function ChatPage() {
             sidebarOpen={sidebarOpen}
             onToggleSidebar={toggleSidebar}
             rightPane={
-                !isMobile && artifactPane.isOpen ? (
-                    <ArtifactPreviewPane
-                        artifact={artifactPane.currentArtifact}
-                        onClose={artifactPane.close}
-                        width={artifactPane.width}
-                        onWidthChange={artifactPane.setWidth}
-                        artifacts={conversationArtifacts}
-                        onSelectArtifact={artifactPane.open}
-                    />
+                rightPaneVisible ? (
+                    <div className="flex h-full flex-col">
+                        {showRightPaneTabs && (
+                            <RightPaneTabStrip
+                                active={effectiveVisiblePane}
+                                onSelect={setVisibleRightPane}
+                                width={artifactPane.width}
+                            />
+                        )}
+                        {effectiveVisiblePane === "artifact" ? (
+                            <ArtifactPreviewPane
+                                artifact={artifactPane.currentArtifact}
+                                onClose={artifactPane.close}
+                                width={artifactPane.width}
+                                onWidthChange={artifactPane.setWidth}
+                                artifacts={conversationArtifacts}
+                                onSelectArtifact={artifactPane.open}
+                            />
+                        ) : (
+                            <ConversationAnalyticsPane
+                                conversationId={chatId}
+                                onClose={analyticsPane.close}
+                                width={artifactPane.width}
+                                onWidthChange={artifactPane.setWidth}
+                            />
+                        )}
+                    </div>
                 ) : null
             }
         >
@@ -127,15 +193,17 @@ function ChatPage() {
                 onToggleSidebar={isMobile ? toggleSidebar : undefined}
                 railCollapsed={!sidebarOpen}
                 onExpandRail={toggleSidebar}
-                artifactPaneOpen={artifactPane.isOpen}
+                artifactPaneOpen={artifactAvailable}
                 onToggleArtifactPane={
-                    !isMobile && (artifactPane.isOpen || conversationArtifacts.length > 0)
+                    !isMobile && (artifactAvailable || conversationArtifacts.length > 0)
                         ? handleToggleArtifactPane
                         : undefined
                 }
                 artifacts={conversationArtifacts}
                 onOpenArtifact={artifactPane.open}
                 activeArtifactName={artifactPane.currentArtifact?.name}
+                analyticsPaneOpen={analyticsAvailable}
+                onToggleAnalyticsPane={!isMobile && chatId ? handleToggleAnalyticsPane : undefined}
             />
         </ChatShellFrame>
     );

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -9,10 +9,12 @@ import {
   ActiveAgentsTab,
   ActiveFlowsTab,
   RecentExecutionsTab,
+  EmptyStat,
   GaugeRow,
   MetricGauge,
 } from '../components/dashboard';
-import { getAgentRunsCountLast7Days, getAgentRunsForMetrics, getRecentAgentRuns, getDashboardActiveFlows, type AgentRunMetricsDoc, type DashboardFlowItem } from '../services/dashboardApi';
+import { getAgentRunsCountLast7Days, getRecentAgentRuns, getDashboardActiveFlows, type DashboardFlowItem } from '../services/dashboardApi';
+import { getExecutionAnalytics } from '../services/executionAnalyticsApi';
 import type { AgentRunDoc } from '../services/agentRunApi';
 import { getAgents } from '../services/agentApi';
 import { getProviders } from '../services/providerApi';
@@ -21,59 +23,9 @@ import { settleAll } from '../lib/settleAll';
 
 interface DashboardMetrics {
   totalRuns: number;
-  successRate: number;
-  avgRuntime: number;
+  successRate: number | null;
+  avgRuntime: number | null;
   totalCost: number;
-}
-
-/**
- * Calculate success rate from agent runs
- */
-function calculateSuccessRate(runs: AgentRunMetricsDoc[]): number {
-  if (runs.length === 0) return 0;
-  const successCount = runs.filter(
-    (run) => run.status === 'Success' || run.status === 'success'
-  ).length;
-  return (successCount / runs.length) * 100;
-}
-
-/**
- * Calculate average runtime from agent runs
- */
-function calculateAvgRuntime(runs: AgentRunMetricsDoc[]): number {
-  const validRuns = runs.filter(
-    (run) => run.start_time && run.end_time
-  );
-
-  if (validRuns.length === 0) return 0;
-
-  const totalMs = validRuns.reduce((sum, run) => {
-    try {
-      const start = new Date(run.start_time!);
-      const end = new Date(run.end_time!);
-      
-      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
-        return sum;
-      }
-
-      const diff = end.getTime() - start.getTime();
-      return diff >= 0 ? sum + diff : sum;
-    } catch {
-      return sum;
-    }
-  }, 0);
-
-  return totalMs / validRuns.length;
-}
-
-/**
- * Calculate total cost from agent runs
- */
-function calculateTotalCost(runs: AgentRunMetricsDoc[]): number {
-  return runs.reduce((sum, run) => {
-    const cost = run.cost;
-    return sum + (typeof cost === 'number' && !isNaN(cost) ? cost : 0);
-  }, 0);
 }
 
 /**
@@ -131,8 +83,8 @@ function HomePage() {
   const [activeTab, setActiveTab] = useState('agents');
   const [metrics, setMetrics] = useState<DashboardMetrics>({
     totalRuns: 0,
-    successRate: 0,
-    avgRuntime: 0,
+    successRate: null,
+    avgRuntime: null,
     totalCost: 0,
   });
   const [metricsLoading, setMetricsLoading] = useState(true);
@@ -153,10 +105,13 @@ function HomePage() {
         // Fetch all data in parallel - one denied widget must not blank the
         // rest of the dashboard, so each slot is isolated via settleAll.
         const widgetLabels = ['run count', 'run metrics', 'agents', 'recent runs', 'flows', 'providers'];
-        const [totalRuns, runsData, agentsData, recentRuns, flowsData, providersData] = await settleAll(
+        // No fromDate override: the analytics API's own default window (last
+        // 7 days from the server clock) is exactly what this dashboard needs,
+        // and matches the window every other analytics surface uses.
+        const [totalRuns, analytics, agentsData, recentRuns, flowsData, providersData] = await settleAll(
           [
             getAgentRunsCountLast7Days(),
-            getAgentRunsForMetrics(),
+            getExecutionAnalytics(),
             getAgents({
               status: 'active',
               limit: 10,
@@ -172,12 +127,13 @@ function HomePage() {
         );
 
         // Process metrics
-        if (runsData) {
+        if (analytics) {
+          const { summary } = analytics;
           setMetrics({
             totalRuns: totalRuns ?? 0,
-            successRate: calculateSuccessRate(runsData),
-            avgRuntime: calculateAvgRuntime(runsData),
-            totalCost: calculateTotalCost(runsData),
+            successRate: summary.success_rate,
+            avgRuntime: summary.average_duration_ms,
+            totalCost: summary.total_cost,
           });
         }
 
@@ -213,51 +169,50 @@ function HomePage() {
     fetchAllData();
   }, []);
 
-  const metricsData = [
-    {
-      id: 'total-runs',
-      label: 'Total agent runs',
-      period: 'Last 7 days',
-      value: metricsLoading ? '...' : formatNumber(metrics.totalRuns),
-      info: 'Total number of agent executions in the last 7 days',
-    },
-    {
-      id: 'success-rate',
-      label: 'Success rate',
-      period: 'Last 7 days',
-      value: metricsLoading ? '...' : `${metrics.successRate.toFixed(1)}%`,
-      info: 'Percentage of successful agent runs without errors',
-    },
-    {
-      id: 'avg-runtime',
-      label: 'Avg runtime',
-      period: 'Last 7 days',
-      value: metricsLoading ? '...' : formatDuration(metrics.avgRuntime),
-      info: 'Average execution time across all agent runs',
-    },
-    {
-      id: 'cost',
-      label: 'Total cost',
-      period: 'Last 7 days',
-      value: metricsLoading ? '...' : formatCurrency(metrics.totalCost),
-      info: 'Total API costs for LLM usage across all agents',
-    },
-  ];
-
   return (
     <PageFrame title="Dashboard">
       <div className="space-y-6">
         {/* HUF Gauge Strip */}
         <GaugeRow>
-          {metricsData.map((metric) => (
+          <MetricGauge
+            label="Total agent runs"
+            period="Last 7 days"
+            value={metricsLoading ? '...' : formatNumber(metrics.totalRuns)}
+            info="Total number of agent executions in the last 7 days"
+          />
+          {/* success_rate is null when there are no completed runs to compute
+              a rate from - that is a different claim than 0%, so it renders
+              as the "no value" empty state instead of a misleading figure. */}
+          {!metricsLoading && metrics.successRate === null ? (
+            <div className="px-[18px] py-4 min-w-0">
+              <EmptyStat label="Success rate" caption="No completed runs in this period." />
+            </div>
+          ) : (
             <MetricGauge
-              key={metric.id}
-              label={metric.label}
-              period={metric.period}
-              value={metric.value}
-              info={metric.info}
+              label="Success rate"
+              period="Last 7 days"
+              value={metricsLoading ? '...' : `${metrics.successRate!.toFixed(1)}%`}
+              info="Percentage of successful agent runs without errors"
             />
-          ))}
+          )}
+          {!metricsLoading && metrics.avgRuntime === null ? (
+            <div className="px-[18px] py-4 min-w-0">
+              <EmptyStat label="Avg runtime" caption="No completed runs in this period." />
+            </div>
+          ) : (
+            <MetricGauge
+              label="Avg runtime"
+              period="Last 7 days"
+              value={metricsLoading ? '...' : formatDuration(metrics.avgRuntime!)}
+              info="Average execution time across all agent runs"
+            />
+          )}
+          <MetricGauge
+            label="Total cost"
+            period="Last 7 days"
+            value={metricsLoading ? '...' : formatCurrency(metrics.totalCost)}
+            info="Total API costs for LLM usage across all agents"
+          />
         </GaugeRow>
 
         {/* Empty state card when no AI providers exist */}

--- a/frontend/src/pages/KnowledgeSourceFormPage.tsx
+++ b/frontend/src/pages/KnowledgeSourceFormPage.tsx
@@ -83,8 +83,9 @@ function mapDocToFormValues(doc: Partial<KnowledgeSourceDoc>): KnowledgeSourceFo
 function KnowledgeSourceFormPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const fromAgent = searchParams.get('agent');
+  const autoOpenUpload = searchParams.get('upload') === '1';
   const isNew = id === 'new';
   const skipBlockRef = useRef(false);
 
@@ -245,6 +246,22 @@ function KnowledgeSourceFormPage() {
     }
   }, [id, isNew, loadSource]);
 
+  // After a freshly-created source redirects here with ?upload=1, jump straight
+  // into the inputs modal so uploading files doesn't need an extra click.
+  useEffect(() => {
+    if (!isNew && id && autoOpenUpload) {
+      setInputsModalOpen(true);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete('upload');
+          return next;
+        },
+        { replace: true },
+      );
+    }
+  }, [isNew, id, autoOpenUpload, setSearchParams]);
+
   const onSubmit = async (values: KnowledgeSourceFormValues) => {
     setSaving(true);
     try {
@@ -297,7 +314,7 @@ function KnowledgeSourceFormPage() {
         toast.success('Knowledge source created');
         setSourceDoc(created);
         allowNavigationRef.current = true;
-        navigate(`/knowledge/${created.name}`);
+        navigate(`/knowledge/${created.name}?upload=1`);
       } else if (id) {
         const updated = await updateKnowledgeSource(id, payload);
         toast.success('Knowledge source updated');

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -1,4 +1,4 @@
-import { Cpu, Settings, Loader2, DollarSign } from 'lucide-react';
+import { Cpu, Settings, Loader2, DollarSign, Trash2 } from 'lucide-react';
 import { Button } from '../components/ui/button';
 import {
   Dialog,
@@ -8,6 +8,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../components/ui/alert-dialog';
 import { Input } from '../components/ui/input';
 import { Label } from '../components/ui/label';
 import { Switch } from '../components/ui/switch';
@@ -27,6 +37,7 @@ import {
   getModel,
   updateModel,
   createModel,
+  deleteModel,
   getProviders,
   getModalityOptions,
   buildProviderNameMap,
@@ -40,6 +51,7 @@ import { LinkFieldControl } from '../components/ui/link-field-control';
 import { MultiSelectCombobox } from '../components/ui/multi-select-combobox';
 import { linkRoutes } from '../lib/link-routes';
 import { useSaveShortcut } from '@/hooks/useSaveShortcut';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
 
 interface ModelsPageProps {
   addModelKey?: number;
@@ -98,6 +110,8 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
   const [loadingModel, setLoadingModel] = useState(false);
   const [saving, setSaving] = useState(false);
   const [formData, setFormData] = useState<ModelFormData>(emptyFormData);
+  const [deleteTarget, setDeleteTarget] = useState<AIModel | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const providerMap = useMemo(() => buildProviderNameMap(providers), [providers]);
 
@@ -108,12 +122,14 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
     loadingMore,
     search,
     setSearch,
+    filters,
+    setFilter,
     loadMore,
     total,
     reset,
     error,
   } = useInfiniteScroll<
-    { page?: number; limit?: number; start?: number; search?: string },
+    { provider?: string; page?: number; limit?: number; start?: number; search?: string },
     AIModel
   >({
     fetchFn: async (params) => {
@@ -122,6 +138,7 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         limit: params.limit,
         start: params.start,
         search: params.search,
+        provider: params.provider && params.provider !== 'all' ? params.provider : undefined,
       });
 
       if (Array.isArray(response)) {
@@ -320,6 +337,27 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
     allowInDialog: true,
   });
 
+  const handleConfirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deleteModel(deleteTarget.name);
+      toast.success('Model deleted');
+      setDeleteTarget(null);
+      reset();
+    } catch (deleteError) {
+      toast.error('Failed to delete model', {
+        description: getFrappeErrorMessage(deleteError),
+        duration: 8000,
+      });
+      console.error(deleteError);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const isFiltered = !!search || (filters.provider && filters.provider !== 'all');
+
   return (
     <PageFrame
       title="Models"
@@ -328,6 +366,17 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
           searchPlaceholder="Search models..."
           searchValue={search}
           onSearchChange={setSearch}
+          filters={[
+            {
+              label: 'Provider',
+              value: filters.provider || 'all',
+              options: [
+                { label: 'All providers', value: 'all' },
+                ...providers.map((p) => ({ label: p.provider_name, value: p.name })),
+              ],
+              onChange: (value) => setFilter('provider', value),
+            },
+          ]}
         />
       }
     >
@@ -343,13 +392,19 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
         columns={{ sm: 1, md: 2, lg: 3 }}
         loading={initialLoading}
         emptyState={
-          search ? (
+          isFiltered ? (
             <EmptyState
               variant="no-results"
               icon={Cpu}
               title="No models found"
               filterTerm={search}
-              secondaryAction={{ label: 'Clear search', onClick: () => setSearch('') }}
+              secondaryAction={{
+                label: 'Clear filters',
+                onClick: () => {
+                  setSearch('');
+                  setFilter('provider', 'all');
+                },
+              }}
             />
           ) : (
             <EmptyState
@@ -385,6 +440,14 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
                   label: 'Configure',
                   onClick: () => handleConfigure(model),
                   variant: 'ghost',
+                },
+              ]}
+              menuActions={[
+                {
+                  icon: Trash2,
+                  label: 'Delete',
+                  onClick: () => setDeleteTarget(model),
+                  variant: 'destructive',
                 },
               ]}
               onClick={() => handleConfigure(model)}
@@ -633,6 +696,28 @@ export function ModelsPage({ addModelKey }: ModelsPageProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!deleting && !open) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{deleteTarget?.model_name}"?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the model. Agents using this model will need to be
+              reconfigured with a different one. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageFrame>
   );
 }

--- a/frontend/src/pages/PlaygroundPage.tsx
+++ b/frontend/src/pages/PlaygroundPage.tsx
@@ -41,6 +41,7 @@ function PlaygroundPage() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [savePromptOverride, setSavePromptOverride] = useState<string | null>(null);
+  const [loadedTemplate, setLoadedTemplate] = useState<AgentPromptDoc | null>(null);
 
   // Close the global app sidebar so the playground uses the full viewport width.
   useEffect(() => {
@@ -103,6 +104,7 @@ function PlaygroundPage() {
     } else {
       setPlaygroundConfig((prev) => ({ ...prev, prompt: prompt.prompt_body }));
     }
+    setLoadedTemplate(prompt);
   };
 
   const handleRestore = (entry: LedgerEntry) => {
@@ -210,6 +212,23 @@ function PlaygroundPage() {
           if (!open) setSavePromptOverride(null);
         }}
         promptBody={savePromptOverride ?? activePromptBody()}
+        loadedTemplate={savePromptOverride === null ? loadedTemplate : null}
+        onSaved={(result) => {
+          if (savePromptOverride !== null) return;
+          if (result.mode === 'update') {
+            setLoadedTemplate((prev) =>
+              prev ? { ...prev, title: result.title ?? prev.title, version: result.version ?? prev.version } : prev,
+            );
+          } else if (result.mode === 'version' || result.mode === 'fork') {
+            setLoadedTemplate((prev) =>
+              prev
+                ? { ...prev, name: result.name, title: result.title ?? prev.title, version: result.version ?? 1 }
+                : prev,
+            );
+          } else {
+            setLoadedTemplate(null);
+          }
+        }}
       />
     </>
   );

--- a/frontend/src/services/consoleApi.ts
+++ b/frontend/src/services/consoleApi.ts
@@ -53,6 +53,17 @@ export interface GeneratePromptResult {
   prompt: string;
 }
 
+export interface ImprovePromptParams {
+  prompt_body: string;
+  instruction?: string;
+  provider?: string;
+  model?: string;
+}
+
+export interface ImprovePromptResult {
+  prompt: string;
+}
+
 export interface EvaluateRunParams {
   response: string;
   criteria: string;
@@ -148,6 +159,16 @@ export async function generatePrompt(params: GeneratePromptParams): Promise<Gene
     return (result?.message ?? result) as GeneratePromptResult;
   } catch (error) {
     handleFrappeError(error, 'Error generating prompt');
+    throw error;
+  }
+}
+
+export async function improvePrompt(params: ImprovePromptParams): Promise<ImprovePromptResult> {
+  try {
+    const result = await call.post('huf.ai.console_api.improve_prompt', params);
+    return (result?.message ?? result) as ImprovePromptResult;
+  } catch (error) {
+    handleFrappeError(error, 'Error improving prompt');
     throw error;
   }
 }

--- a/frontend/src/services/conversationAnalyticsApi.ts
+++ b/frontend/src/services/conversationAnalyticsApi.ts
@@ -1,0 +1,17 @@
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+import type { ConversationAnalyticsResponse } from '@/types/conversationAnalytics.types';
+
+export async function getConversationAnalytics(
+  conversation: string
+): Promise<ConversationAnalyticsResponse | null> {
+  try {
+    const result = await call.get('huf.ai.agent_conversation_analytics_api.get_conversation_analytics', {
+      conversation,
+    });
+    return result.message as ConversationAnalyticsResponse;
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching conversation analytics');
+    return null;
+  }
+}

--- a/frontend/src/services/dashboardApi.ts
+++ b/frontend/src/services/dashboardApi.ts
@@ -1,4 +1,3 @@
-import type { Filter } from 'frappe-js-sdk/lib/db/types';
 import { db } from '@/lib/frappe-sdk';
 import { doctype } from '@/data/doctypes';
 import { handleFrappeError } from '@/lib/frappe-error';
@@ -15,17 +14,6 @@ export interface DashboardFlowItem {
   runCount: number;
   lastRunAt: string | null;
 }
-
-/**
- * Agent Run document for metrics calculation
- */
-export interface AgentRunMetricsDoc {
-  status?: string;
-  start_time?: string | null;
-  end_time?: string | null;
-  cost?: number | null;
-}
-
 
 /**
  * Get date filters for last 7 days
@@ -63,28 +51,6 @@ export async function getAgentRunsCountLast7Days(): Promise<number> {
   } catch (error) {
     handleFrappeError(error, 'Error fetching agent runs count for last 7 days');
     return 0;
-  }
-}
-
-/**
- * Fetch all agent runs for metrics calculation (last 7 days)
- * Returns runs with status, start_time, end_time, and total_cost fields
- */
-export async function getAgentRunsForMetrics(): Promise<AgentRunMetricsDoc[]> {
-  try {
-    const filters = getLast7DaysFilters();
-    
-    // Fetch all runs (use a very high limit or fetch in batches)
-    const runs = await db.getDocList(doctype['Agent Run'], {
-      fields: ['status', 'start_time', 'end_time', 'cost'],
-      filters: filters as Filter<Record<string, unknown>>[],
-      limit: 10000, // High limit to get all runs
-      orderBy: { field: 'creation', order: 'desc' },
-    });
-    
-    return runs as AgentRunMetricsDoc[];
-  } catch (error) {
-    handleFrappeError(error, 'Error fetching agent runs for metrics');
   }
 }
 

--- a/frontend/src/services/executionAnalyticsApi.ts
+++ b/frontend/src/services/executionAnalyticsApi.ts
@@ -1,12 +1,16 @@
 import { call } from '@/lib/frappe-sdk';
 import { handleFrappeError } from '@/lib/frappe-error';
-import type { ExecutionAnalyticsResponse } from '@/types/executionAnalytics.types';
+import type { AnalyticsDimension, ExecutionAnalyticsResponse } from '@/types/executionAnalytics.types';
 
 export interface GetExecutionAnalyticsParams {
   /** ISO start of the analytics window. Omit for the API's own default (last 7 days). */
   fromDate?: string;
+  /** ISO end of the analytics window. Omit for the API's own default (now). */
+  toDate?: string;
   /** Rollup granularity to query. Defaults to 'hour'. */
   granularity?: 'hour' | 'day';
+  /** Dimension to break down `breakdowns` by. Defaults to 'provider'. */
+  dimension?: AnalyticsDimension;
 }
 
 export async function getExecutionAnalytics(
@@ -16,6 +20,8 @@ export async function getExecutionAnalytics(
     const result = await call.get('huf.ai.agent_run_analytics_api.get_execution_analytics', {
       granularity: params?.granularity ?? 'hour',
       ...(params?.fromDate ? { from_date: params.fromDate } : {}),
+      ...(params?.toDate ? { to_date: params.toDate } : {}),
+      ...(params?.dimension ? { dimension: params.dimension } : {}),
     });
     return result.message as ExecutionAnalyticsResponse;
   } catch (error) {

--- a/frontend/src/services/providerApi.ts
+++ b/frontend/src/services/providerApi.ts
@@ -213,6 +213,17 @@ export async function updateProvider(name: string, data: Partial<AIProviderDoc>)
 }
 
 /**
+ * Delete an AI Provider document
+ */
+export async function deleteProvider(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype['AI Provider'], name);
+  } catch (error) {
+    handleFrappeError(error, `Error deleting provider ${name}`);
+  }
+}
+
+/**
  * Result of probing a single linked AI Model on a provider
  */
 export interface ProviderConnectionModelResult {
@@ -388,6 +399,17 @@ export async function updateModel(name: string, data: Partial<AIModelDoc>): Prom
     return updatedModel as AIModelDoc;
   } catch (error) {
     handleFrappeError(error, `Error updating model ${name}`);
+  }
+}
+
+/**
+ * Delete an AI Model document
+ */
+export async function deleteModel(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype['AI Model'], name);
+  } catch (error) {
+    handleFrappeError(error, `Error deleting model ${name}`);
   }
 }
 

--- a/frontend/src/types/conversationAnalytics.types.ts
+++ b/frontend/src/types/conversationAnalytics.types.ts
@@ -1,0 +1,77 @@
+/** The three `Agent Run.run_kind` values a conversation's runs can carry. */
+export type ConversationRunKind = 'agent' | 'tool' | 'orchestrator';
+
+/**
+ * CUMULATIVE totals summed across every run in the conversation. Kept as a
+ * separate object from `current` (the latest-run snapshot) on purpose — a
+ * consumer must never render one as a share/percentage of the other; they
+ * describe different things (a running sum vs. one point in time).
+ */
+export interface ConversationAnalyticsTotals {
+  cumulative: true;
+  run_count: number;
+  run_count_by_kind: Record<ConversationRunKind, number>;
+  billed_input_tokens: number;
+  output_tokens: number;
+  cost: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+}
+
+/**
+ * SNAPSHOT of the latest run only (highest `sequence`). Never a sum — in
+ * particular `peak_context_tokens` describes the size of the context window
+ * at that one point in time and must not be added across runs.
+ */
+export interface ConversationAnalyticsCurrent {
+  run: string;
+  sequence: number;
+  peak_context_tokens: number | null;
+  model_context_window: number | null;
+  /** `null` whenever `peak_context_tokens` or `model_context_window` is unknown — never defaulted. */
+  context_fullness: number | null;
+  /**
+   * Per-segment token counts. A VALUE of `null` means that segment could not be
+   * counted -- which is not the same as zero. Treating it as 0 makes composition
+   * percentages silently wrong. The whole object is `null` when nothing was measured.
+   */
+  segment_tokens: Record<string, number | null> | null;
+  tool_exchange_tokens: number | null;
+}
+
+export interface ConversationAnalyticsSeriesPoint {
+  sequence: number;
+  run_kind: ConversationRunKind | null;
+  peak_context_tokens: number | null;
+  /** Delta vs. the immediately preceding run in the series; `null` if either run lacks `peak_context_tokens`. */
+  peak_context_tokens_delta: number | null;
+  billed_input_tokens: number;
+  output_tokens: number | null;
+  cost: number | null;
+  status: string | null;
+  start_time: string | null;
+}
+
+export interface ConversationAnalyticsCache {
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  uncached_input_tokens: number;
+  /** `null` when there is no billed input at all to compute a ratio from. */
+  effectiveness: number | null;
+}
+
+/** Honest-disclosure counts describing what this response could not measure. */
+export interface ConversationAnalyticsMeasurement {
+  runs_missing_billed_input: number;
+  runs_missing_peak_context: number;
+  tool_runs_without_conversation_note: number;
+}
+
+export interface ConversationAnalyticsResponse {
+  totals: ConversationAnalyticsTotals;
+  /** `null` when the conversation has no runs yet. */
+  current: ConversationAnalyticsCurrent | null;
+  series: ConversationAnalyticsSeriesPoint[];
+  cache: ConversationAnalyticsCache;
+  measurement: ConversationAnalyticsMeasurement;
+}

--- a/frontend/src/types/executionAnalytics.types.ts
+++ b/frontend/src/types/executionAnalytics.types.ts
@@ -1,3 +1,6 @@
+/** The five dimensions `get_execution_analytics` can break down runs by. */
+export type AnalyticsDimension = 'agent' | 'provider' | 'model' | 'conversation' | 'run_kind';
+
 export interface ExecutionAnalyticsSummary {
   run_count: number;
   success_count: number;
@@ -5,6 +8,7 @@ export interface ExecutionAnalyticsSummary {
   input_tokens: number;
   output_tokens: number;
   cached_tokens: number;
+  cache_creation_tokens: number;
   total_cost: number;
   duration_ms_sum: number;
   duration_count: number;
@@ -17,5 +21,27 @@ export interface ExecutionAnalyticsResponse {
   summary: ExecutionAnalyticsSummary;
   series: Array<ExecutionAnalyticsSummary & { bucket_start: string }>;
   breakdowns: Array<ExecutionAnalyticsSummary & { dimension: string }>;
-  metadata: { granularity: 'hour' | 'day'; freshness: string | null; source: 'scheduled_rollup' };
+  /**
+   * Per-segment token totals summed across the window. A value is `number | null`,
+   * and `null` means "could not be measured" for that segment (at least one
+   * contributing rollup row had no data for it) — it is NOT the same as 0 tokens.
+   * A consumer that defaults a `null` entry to 0 will silently render wrong
+   * percentages/shares. Missing keys simply were never observed.
+   */
+  composition_totals: Record<string, number | null>;
+  metadata: {
+    granularity: 'hour' | 'day';
+    dimension: AnalyticsDimension;
+    freshness: string | null;
+    /**
+     * Total number of distinct dimension values found in the window, before the
+     * server caps `breakdowns` at the top 10 (by run_count). Use this to render
+     * "top 10 of N" rather than assuming `breakdowns.length` is the full count.
+     */
+    breakdowns_total_count: number;
+    /** Only present once rollup data exists; absent on the pre-rollup empty-response stub. */
+    from?: string;
+    to?: string;
+    source?: 'scheduled_rollup';
+  };
 }

--- a/frontend/src/types/knowledge.types.ts
+++ b/frontend/src/types/knowledge.types.ts
@@ -1,4 +1,14 @@
-export type KnowledgeType = 'sqlite_fts' | 'sqlite_vec' | 'chroma' | 'pgvector' | 'redis' | 'zvec';
+export type KnowledgeType =
+	| 'sqlite_fts'
+	| 'sqlite_vec'
+	| 'sqlite_hybrid'
+	| 'chroma'
+	| 'pgvector'
+	| 'redis'
+	| 'zvec'
+	| 'weaviate'
+	| 'faiss'
+	| 'pinecone';
 
 export type ChromaMode = 'File' | 'Server';
 export type KnowledgeScope = 'Site' | 'Workspace' | 'Agent' | 'Global';

--- a/frontend/src/types/runContextMetrics.types.ts
+++ b/frontend/src/types/runContextMetrics.types.ts
@@ -4,6 +4,8 @@ export interface SegmentTokens {
   knowledge: number | null;
   history: number | null;
   message: number | null;
+  /** Not present in historical (pre-instrumentation) segment_tokens snapshots. */
+  tool_exchange?: number | null;
 }
 
 export interface PrefixBreakpoint {
@@ -16,7 +18,6 @@ export type PrefixStability = 'stable' | 'changed' | 'unknown' | 'unavailable';
 export interface RunContextMetrics {
   cache_read_share: number | null;
   effective_input_multiplier: number | null;
-  wasted_writes_tokens: number | null;
   prefix_stability: PrefixStability;
   counterfactual_savings: number | null;
 }
@@ -24,7 +25,8 @@ export interface RunContextMetrics {
 export interface RunContextMetricsResponse {
   segment_tokens: SegmentTokens | null;
   total_tokens: number | null;
-  context_window: number;
+  /** Null when the model's context window is unknown; never a guessed default. */
+  context_window: number | null;
   prefix_breakpoints: PrefixBreakpoint[];
   cache_skipped_unsupported_model: boolean | null;
   metrics: RunContextMetrics;

--- a/frontend/src/utils/artifactParser.ts
+++ b/frontend/src/utils/artifactParser.ts
@@ -106,6 +106,7 @@ export function isValidArtifactType(type: string): type is ArtifactType {
 		'react-component',
 		'markdown',
 		'video',
+		'chart',
 	];
 	return validTypes.includes(type as ArtifactType);
 }

--- a/huf/ai/agent_conversation_analytics_api.py
+++ b/huf/ai/agent_conversation_analytics_api.py
@@ -1,0 +1,313 @@
+"""Direct, per-conversation execution analytics for Agent Conversation.
+
+`Agent Run Analytics Rollup` (see `agent_run_analytics.py` / `agent_run_analytics_api.py`)
+is recomputed on a 5-minute cron. That lag is fine for aggregate/trend views
+spanning many entities, but a single conversation typically holds only tens
+of runs, and a just-finished turn missing from its own conversation's
+analytics reads as a bug, not staleness. So this module never reads the
+rollup: it queries `Agent Run` directly, filtered to one conversation and
+ordered by `sequence`, trading a small per-request query cost for
+correctness at "just typed" latency.
+
+Rule of thumb this module follows: **rollups for aggregate/trend across
+entities, direct `Agent Run` query for one entity's detail.**
+
+Response shape keeps two different quantities structurally apart so a UI
+cannot conflate them:
+
+  - `totals` is CUMULATIVE — summed across every run in the conversation.
+  - `current` is a SNAPSHOT of the latest run (highest `sequence`) only.
+    `peak_context_tokens` in particular must never be summed across runs;
+    it describes the size of the context window at one point in time, not
+    a quantity that accumulates.
+
+Every division in this module is guarded against a zero or `None`
+denominator (see `_compute_current`, `_compute_cache_effectiveness`, and
+the per-run delta in `_build_series`). Malformed `usage_snapshot` values
+(NULL, non-JSON, non-dict, missing keys) degrade to "no data" and never
+raise, matching the handling in `agent_run_analytics.py`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import frappe
+
+
+RUN_KINDS = ("agent", "tool", "orchestrator")
+
+# The orphaned-tool-run disclosure is a slow-moving historical figure; an hour
+# of staleness is immaterial next to scanning Agent Run on every request.
+ORPHAN_COUNT_CACHE_SECONDS = 3600
+
+RUN_FIELDS = [
+    "name",
+    "sequence",
+    "run_kind",
+    "status",
+    "start_time",
+    "input_tokens",
+    "billed_input_tokens",
+    "output_tokens",
+    "cached_tokens",
+    "cache_creation_tokens",
+    "peak_context_tokens",
+    "model_context_window",
+    "cost",
+    "usage_snapshot",
+]
+
+
+def _require_conversation_access(conversation: str):
+    """Gate on the conversation itself, since this is per-conversation data.
+
+    A missing conversation is handled cleanly (DoesNotExistError, not a
+    permission error or a 500) before any permission check runs.
+    """
+    if not frappe.db.exists("Agent Conversation", conversation):
+        frappe.throw(f"Agent Conversation {conversation} not found", frappe.DoesNotExistError)
+
+    conversation_doc = frappe.get_doc("Agent Conversation", conversation)
+    if not frappe.has_permission("Agent Conversation", "read", doc=conversation_doc):
+        frappe.throw(
+            "You do not have permission to view this conversation's analytics",
+            frappe.PermissionError,
+        )
+    return conversation_doc
+
+
+def _billed_input(row: dict) -> int:
+    """`billed_input_tokens` is NULL on every pre-instrumentation row; fall
+    back to the legacy `input_tokens` column for those, same convention as
+    `agent_run_analytics._recompute_rollup`."""
+    value = row.get("billed_input_tokens")
+    return value if value is not None else (row.get("input_tokens") or 0)
+
+
+def _row_is_missing_billed_input(row: dict) -> bool:
+    return row.get("billed_input_tokens") is None
+
+
+def _load_usage_snapshot(raw) -> dict:
+    """Parse a run's usage_snapshot into a dict.
+
+    NULL, empty, malformed JSON, and non-dict values all degrade to {} (no
+    data), the same "not measured" semantics used elsewhere for this field.
+    Never raises.
+    """
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _empty_totals() -> dict:
+    return {
+        "cumulative": True,
+        "run_count": 0,
+        "run_count_by_kind": {kind: 0 for kind in RUN_KINDS},
+        "billed_input_tokens": 0,
+        "output_tokens": 0,
+        "cost": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+
+
+def _compute_totals(rows: list[dict]) -> tuple[dict, int]:
+    """Sum cumulative totals across every run. Returns (totals, runs_missing_billed_input)."""
+    totals = _empty_totals()
+    totals["run_count"] = len(rows)
+    runs_missing_billed_input = 0
+
+    for row in rows:
+        kind = row.get("run_kind") or "agent"
+        if kind not in totals["run_count_by_kind"]:
+            kind = "agent"
+        totals["run_count_by_kind"][kind] += 1
+
+        if _row_is_missing_billed_input(row):
+            runs_missing_billed_input += 1
+
+        totals["billed_input_tokens"] += _billed_input(row)
+        totals["output_tokens"] += row.get("output_tokens") or 0
+        totals["cost"] += row.get("cost") or 0
+        totals["cache_read_tokens"] += row.get("cached_tokens") or 0
+        totals["cache_write_tokens"] += row.get("cache_creation_tokens") or 0
+
+    return totals, runs_missing_billed_input
+
+
+def _compute_current(latest_row: dict | None) -> dict | None:
+    """Build the SNAPSHOT for the latest run (highest `sequence`).
+
+    Never a sum. `context_fullness` is `None` whenever either
+    `peak_context_tokens` or `model_context_window` is missing -- no
+    default window is ever substituted for an unknown one.
+    """
+    if latest_row is None:
+        return None
+
+    peak_context_tokens = latest_row.get("peak_context_tokens")
+    model_context_window = latest_row.get("model_context_window")
+    context_fullness = None
+    if peak_context_tokens is not None and model_context_window:
+        context_fullness = peak_context_tokens / model_context_window
+
+    snapshot = _load_usage_snapshot(latest_row.get("usage_snapshot"))
+    segment_tokens = snapshot.get("segment_tokens")
+    if not isinstance(segment_tokens, dict):
+        segment_tokens = None
+
+    return {
+        "run": latest_row.get("name"),
+        "sequence": latest_row.get("sequence"),
+        "peak_context_tokens": peak_context_tokens,
+        "model_context_window": model_context_window,
+        "context_fullness": context_fullness,
+        "segment_tokens": segment_tokens,
+        "tool_exchange_tokens": snapshot.get("tool_exchange_tokens"),
+    }
+
+
+def _build_series(rows: list[dict]) -> list[dict]:
+    """Per-run series ordered by `sequence`, with a consecutive-run delta of
+    `peak_context_tokens` so growth spikes are visible without the client
+    recomputing anything. Delta is `None` whenever this run or the
+    immediately preceding run in the series has no `peak_context_tokens`.
+    """
+    series = []
+    previous_row = None
+    for row in rows:
+        peak_context_tokens = row.get("peak_context_tokens")
+        peak_context_tokens_delta = None
+        if previous_row is not None:
+            previous_peak = previous_row.get("peak_context_tokens")
+            if peak_context_tokens is not None and previous_peak is not None:
+                peak_context_tokens_delta = peak_context_tokens - previous_peak
+
+        series.append({
+            "sequence": row.get("sequence"),
+            "run_kind": row.get("run_kind"),
+            "peak_context_tokens": peak_context_tokens,
+            "peak_context_tokens_delta": peak_context_tokens_delta,
+            "billed_input_tokens": _billed_input(row),
+            "output_tokens": row.get("output_tokens"),
+            "cost": row.get("cost"),
+            "status": row.get("status"),
+            "start_time": row.get("start_time"),
+        })
+        previous_row = row
+
+    return series
+
+
+def _compute_cache_effectiveness(rows: list[dict]) -> dict:
+    """Conversation-level cache effectiveness from SUMMED components, never
+    an average of per-run ratios -- averaging ratios would weight a
+    100-token run the same as a 100,000-token one.
+
+    `uncached_input` per run is `billed_input - cache_read - cache_write`,
+    floored at 0, matching the convention in `cache_metrics.py`.
+    """
+    sum_cache_read = 0
+    sum_cache_write = 0
+    sum_uncached_input = 0
+
+    for row in rows:
+        billed = _billed_input(row)
+        cache_read = row.get("cached_tokens") or 0
+        cache_write = row.get("cache_creation_tokens") or 0
+        uncached_input = max(billed - cache_read - cache_write, 0)
+
+        sum_cache_read += cache_read
+        sum_cache_write += cache_write
+        sum_uncached_input += uncached_input
+
+    denominator = sum_cache_read + sum_cache_write + sum_uncached_input
+    effectiveness = (sum_cache_read / denominator) if denominator else None
+
+    return {
+        "cache_read_tokens": sum_cache_read,
+        "cache_write_tokens": sum_cache_write,
+        "uncached_input_tokens": sum_uncached_input,
+        "effectiveness": effectiveness,
+    }
+
+
+def _count_orphaned_tool_runs() -> int:
+    """Historical `run_kind="tool"` runs were created with a NULL
+    `conversation` and cannot be retro-linked to any conversation. This is a
+    system-wide count (not scoped to the requested conversation, since those
+    rows are by definition unlinkable to any conversation), surfaced so the
+    UI can disclose that older, flow-heavy conversations may under-report
+    tool-run totals rather than silently omitting them.
+    """
+    # Neither `run_kind` nor `conversation` is indexed on Agent Run, so this
+    # COUNT is a full table scan. It is a slow-moving disclosure figure, not a
+    # live metric -- no new tool run is created without a conversation any more
+    # -- so it is cached rather than recomputed on every conversation page load.
+    cache_key = "huf:analytics:orphaned_tool_runs"
+    cached = frappe.cache().get_value(cache_key)
+    if cached is not None:
+        try:
+            return int(cached)
+        except (TypeError, ValueError):
+            pass
+
+    count = frappe.db.count("Agent Run", {"run_kind": "tool", "conversation": ["is", "not set"]})
+    frappe.cache().set_value(cache_key, count, expires_in_sec=ORPHAN_COUNT_CACHE_SECONDS)
+    return count
+
+
+@frappe.whitelist(methods=["GET"])
+def get_conversation_analytics(conversation: str):
+    """Return direct, per-conversation execution analytics.
+
+    Queries `Agent Run` directly (never the rollup) so a just-finished turn
+    is reflected immediately. See module docstring for the cumulative
+    (`totals`) vs snapshot (`current`) separation.
+    """
+    _require_conversation_access(conversation)
+
+    rows = frappe.db.get_all(
+        "Agent Run",
+        filters={"conversation": conversation},
+        fields=RUN_FIELDS,
+        order_by="sequence asc",
+        limit_page_length=0,
+    )
+    rows = [dict(row) for row in rows]
+
+    totals, runs_missing_billed_input = _compute_totals(rows)
+
+    latest_row = None
+    for row in rows:
+        if latest_row is None or (row.get("sequence") or 0) >= (latest_row.get("sequence") or 0):
+            latest_row = row
+    current = _compute_current(latest_row)
+
+    series = _build_series(rows)
+    cache = _compute_cache_effectiveness(rows)
+
+    runs_missing_peak_context = sum(1 for row in rows if row.get("peak_context_tokens") is None)
+
+    measurement = {
+        "runs_missing_billed_input": runs_missing_billed_input,
+        "runs_missing_peak_context": runs_missing_peak_context,
+        "tool_runs_without_conversation_note": _count_orphaned_tool_runs(),
+    }
+
+    return {
+        "totals": totals,
+        "current": current,
+        "series": series,
+        "cache": cache,
+        "measurement": measurement,
+    }

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -28,6 +28,8 @@ from huf.ai.knowledge.context_builder import build_knowledge_context, inject_kno
 from huf.ai.providers.litellm import _normalize_model_name, ProviderUnavailableError
 from huf.ai.transaction import safe_commit, transaction_checkpoint
 from huf.ai.agent_access import assert_agent_access, check_agent_access as _check_agent_access
+from huf.ai.usage_extraction import extract_round_usage, normalise_usage_payload
+from huf.ai.model_metadata import resolve_model_context_window
 from huf.permissions import has_capability
 
 class _LazyLogger:
@@ -110,13 +112,76 @@ class AgentManager:
         self.model_override = model_override
         # self.file_handler = file_handler
         self.tools = []
+        # Maps tool name -> one of the five `tools_breakdown.by_source` origins
+        # (user_configured | builtin_registry | internal_capability | knowledge |
+        # mcp). Populated by _setup_tools() and read by compute_tools_breakdown()
+        # at the two agent_integration call sites — see context_segments.py.
+        self.tool_sources = {}
         self._setup_client()
         self._setup_tools()
 
+    def _classify_agent_tool_sources(self, tool_names):
+        """Classify tools produced by create_agent_tools() into source buckets.
+
+        create_agent_tools() merges several origins into a single flat list
+        with no surviving type tag: user-authored `Agent Tool Function`
+        docs, tools seeded from the registry/app-discovery pipeline (synced
+        via huf.ai.tool_registry.sync_discovered_tools, which stamps
+        `types = "App Provided"` — see huf/ai/tool_registry.py), the
+        always-on `ask_user` builder tool, and a handful of tools built
+        directly in code with no backing `Agent Tool Function` doc at all
+        (get_conversation_data/set_conversation_data/load_conversation_data,
+        get_result_context). ask_user is itself seeded the same
+        "App Provided" way but is explicitly an internal capability, not a
+        registry integration, so it is special-cased ahead of the doc
+        lookup.
+
+        Tools with no backing doc are bucketed as internal_capability too:
+        they are intrinsic to the agent runtime (not a user choice, not a
+        registry integration), the same category ask_user and list_skills
+        belong to.
+
+        Classifies the whole batch in ONE query rather than one per tool:
+        _setup_tools() runs on every agent run, and this is observability
+        data, so it must not add a query per tool to a hot path.
+        """
+        sources = {}
+        lookup_names = [name for name in tool_names if name and name != "ask_user"]
+
+        types_by_name = {}
+        if lookup_names:
+            try:
+                rows = frappe.get_all(
+                    "Agent Tool Function",
+                    filters={"tool_name": ["in", lookup_names]},
+                    fields=["tool_name", "types"],
+                    limit_page_length=0,
+                )
+                types_by_name = {row["tool_name"]: row.get("types") for row in rows}
+            except Exception as e:
+                # Classification is observability; never fail a run over it.
+                logger.warning(f"Failed to classify tool sources: {e!s}")
+
+        for tool_name in tool_names:
+            if not tool_name:
+                continue
+            if tool_name == "ask_user":
+                sources[tool_name] = "internal_capability"
+                continue
+            tool_type = types_by_name.get(tool_name)
+            if tool_type == "App Provided":
+                sources[tool_name] = "builtin_registry"
+            elif tool_type:
+                sources[tool_name] = "user_configured"
+            else:
+                sources[tool_name] = "internal_capability"
+
+        return sources
 
     def _setup_tools(self):
         """Create SDK Tools from existing functions, skills, and MCP servers."""
         self.tools=[]
+        self.tool_sources = {}
 
         try:
             from huf.ai.sdk_tools import create_agent_tools
@@ -128,6 +193,11 @@ class AgentManager:
             )
             if agent_tools:
                 self.tools.extend(agent_tools)
+                self.tool_sources.update(
+                    self._classify_agent_tool_sources(
+                        [getattr(tool, "name", None) for tool in agent_tools]
+                    )
+                )
         except (ImportError, AttributeError, TypeError, ValueError, RuntimeError) as e:
             logger.warning(f"Failed to load agent tools: {e!s}")
 
@@ -158,6 +228,10 @@ class AgentManager:
                 tool_map = {tool.name: tool for tool in self.tools}
                 for tool in merged_mcp_tools:
                     tool_map[tool.name] = tool
+                    # An MCP server tool always wins the source tag for its
+                    # name, mirroring tool_map's own overwrite-by-name
+                    # semantics immediately below.
+                    self.tool_sources[tool.name] = "mcp"
                 self.tools = list(tool_map.values())
         except Exception as e:
             logger.warning(f"Failed to load skill MCP tools: {e!s}")
@@ -170,6 +244,7 @@ class AgentManager:
                 existing_names = {tool.name for tool in self.tools}
                 if list_skills_tool.name not in existing_names:
                     self.tools.append(list_skills_tool)
+                    self.tool_sources[list_skills_tool.name] = "internal_capability"
         except Exception as e:
             logger.warning(f"Failed to load skills listing tool: {e!s}")
 
@@ -196,6 +271,7 @@ class AgentManager:
                         top_k=top_k,
                     )
                 self.tools.append(knowledge_search_tool)
+                self.tool_sources[knowledge_search_tool.name] = "knowledge"
 
             # 2. Get Knowledge Sources Tool
             sources_tool_def = create_get_knowledge_sources_tool(self.agent_doc.agent_name)
@@ -205,6 +281,7 @@ class AgentManager:
                     """List all knowledge sources available to this agent."""
                     return handle_get_knowledge_sources(agent_name=self.agent_doc.agent_name)
                 self.tools.append(get_knowledge_sources_tool)
+                self.tool_sources[get_knowledge_sources_tool.name] = "knowledge"
 
         except (ImportError, AttributeError, TypeError, ValueError, RuntimeError) as e:
             logger.warning(f"Failed to load knowledge tools: {e!s}")
@@ -1620,12 +1697,31 @@ def _execute_agent_run(
         else:
             enhanced_prompt = base_prompt
 
-        from huf.ai.context_segments import compute_segment_tokens, compute_prefix_breakpoints
+        from huf.ai.context_segments import (
+            compute_segment_tokens,
+            compute_prefix_breakpoints,
+            compute_tools_breakdown,
+            reconcile_composition,
+        )
         segment_tokens = compute_segment_tokens(
             agent_doc, agent, resolved_model_name, resolved_provider, history, knowledge_context, prompt
         )
+
+        # Opt-in only -- off unless a site operator sets
+        # huf_retain_system_prompts_enabled in site_config. See
+        # huf/ai/system_prompt_retention.py for why this defaults off (D15).
+        from huf.ai.system_prompt_retention import maybe_snapshot_system_prompt
+        maybe_snapshot_system_prompt(
+            run_doc.name, agent_name, conversation.name, getattr(agent, "instructions", None)
+        )
+
         prefix_breakpoints = compute_prefix_breakpoints(
             agent_doc, agent, resolved_model_name, resolved_provider, history
+        )
+        tools_breakdown = compute_tools_breakdown(
+            _normalize_model_name(resolved_model_name, resolved_provider),
+            getattr(agent, "tools", None),
+            manager.tool_sources,
         )
 
         context = {
@@ -1813,68 +1909,17 @@ def _execute_agent_run(
 
         if usage:
 
-            if isinstance(usage, dict):
-                input_tokens = (getattr(usage, "prompt_tokens", usage.get("input_tokens", 0)) if isinstance(usage, dict) else 0) or 0
-                output_tokens = (getattr(usage, "completion_tokens", usage.get("output_tokens", 0)) if isinstance(usage, dict) else 0) or 0
+            round_usage = extract_round_usage(usage)
+            input_tokens = round_usage["input_tokens"]
+            output_tokens = round_usage["output_tokens"]
+            cached_tokens = round_usage["cache_read_tokens"]
+            cache_creation_tokens = round_usage["cache_write_tokens"]
 
-                details = getattr(usage, "prompt_tokens_details", None)
-                if not details and isinstance(usage, dict):
-                    details = usage.get("prompt_tokens_details")
-
-                if details:
-                    if isinstance(details, dict):
-                        cached_tokens = details.get("cached_tokens") or details.get("cache_hit_tokens") or 0
-                        cache_creation_tokens = (
-                            details.get("cache_creation_input_tokens")
-                            or details.get("cache_write_tokens")
-                            or details.get("cache_creation_tokens")
-                            or 0
-                        )
-                    else:
-                        cached_tokens = getattr(details, "cached_tokens", None) or getattr(details, "cache_hit_tokens", None) or 0
-                        cache_creation_tokens = (
-                            getattr(details, "cache_creation_input_tokens", None)
-                            or getattr(details, "cache_write_tokens", None)
-                            or getattr(details, "cache_creation_tokens", None)
-                            or 0
-                        )
-                elif isinstance(usage, dict):
-                    cached_tokens = usage.get("cached_tokens") or usage.get("cache_hit_tokens") or 0
-                    cache_creation_tokens = (
-                        usage.get("cache_creation_tokens")
-                        or usage.get("cache_creation_input_tokens")
-                        or usage.get("cache_write_input_tokens")
-                        or usage.get("cache_miss_tokens")
-                        or 0
-                    )
-
-                if not cache_creation_tokens and isinstance(usage, dict):
-                    cache_creation_tokens = (
-                        usage.get("cache_creation_tokens")
-                        or usage.get("cache_creation_input_tokens")
-                        or usage.get("cache_write_input_tokens")
-                        or usage.get("cache_miss_tokens")
-                        or 0
-                    )
-
-                if isinstance(usage, dict):
-                    cache_skipped_unsupported_model = bool(usage.get("cache_skipped_unsupported_model", False))
-
+            usage_dict = normalise_usage_payload(usage)
+            if usage_dict is not None:
+                cache_skipped_unsupported_model = bool(usage_dict.get("cache_skipped_unsupported_model", False))
             else:
-                input_tokens = (getattr(usage, "input_tokens", getattr(usage, "prompt_tokens", 0))) or 0
-                output_tokens = (getattr(usage, "output_tokens", getattr(usage, "completion_tokens", 0))) or 0
-                cached_tokens = getattr(usage, "cached_tokens", None) or 0
-                cache_creation_tokens = (
-                    getattr(usage, "cache_creation_tokens", None)
-                    or getattr(usage, "cache_creation_input_tokens", None)
-                    or getattr(usage, "cache_write_input_tokens", None)
-                    or getattr(usage, "cache_miss_tokens", None)
-                    or 0
-                )
                 cache_skipped_unsupported_model = bool(getattr(usage, "cache_skipped_unsupported_model", False))
-
-            cached_tokens = cached_tokens or 0
-            cache_creation_tokens = cache_creation_tokens or 0
 
             try:
                 # Prefer cost directly from the result
@@ -1911,9 +1956,16 @@ def _execute_agent_run(
                 )
                 cost = 0.0
 
-            try:
-                total_tokens = getattr(usage, "total_tokens", (input_tokens + output_tokens)) if usage else (input_tokens + output_tokens)
+            # Computed OUTSIDE the try below: the conversation-metrics update
+            # swallows its exceptions, and total_tokens is read again by the
+            # Agent Run write further down. Leaving the assignment inside the
+            # try would let a failure there surface as a NameError at the later
+            # read instead of the warning this except is meant to produce.
+            # usage is normally a plain dict here, so getattr() would always miss;
+            # read the normalised payload and fall back to the parts.
+            total_tokens = (usage_dict or {}).get("total_tokens") or (input_tokens + output_tokens)
 
+            try:
                 frappe.db.sql("""
                     UPDATE `tabAgent Conversation`
                     SET
@@ -1929,23 +1981,71 @@ def _execute_agent_run(
                     f"Failed to update conversation metrics: {str(e)}"
                 )
 
+            # usage_dict carries the richer provider-usage shape (see
+            # providers/litellm.py _finalize_usage_totals); fields absent from
+            # it (older provider shapes, or a usage payload that failed to
+            # normalise) are written as None, never coerced to 0 — a 0 would
+            # silently distort every downstream average.
+            usage_payload = usage_dict or {}
+            billed_input_tokens = usage_payload.get("billed_input_tokens")
+            if billed_input_tokens is None:
+                billed_input_tokens = input_tokens
+            peak_context_tokens = usage_payload.get("peak_context_tokens")
+            round_count = usage_payload.get("round_count")
+            tool_exchange_tokens = usage_payload.get("tool_exchange_tokens")
+            round_prompt_tokens = usage_payload.get("round_prompt_tokens") or []
+            # round_prompt_tokens[0] is the round-1, pre-call prompt size —
+            # the same measurement point as segment_tokens. Comparing against
+            # the run's summed billed_input_tokens instead would flag a
+            # divergence on every multi-round run and make the warning useless.
+            round1_prompt_tokens = round_prompt_tokens[0] if round_prompt_tokens else None
+            composition_reconciliation = reconcile_composition(
+                segment_tokens, tool_exchange_tokens, round1_prompt_tokens
+            )
+
+            # Snapshotted at write time so later AI Model edits cannot rewrite
+            # history for this run.
+            provider_brand = (
+                frappe.get_cached_value("AI Provider", resolved_provider, "provider_brand")
+                if resolved_provider
+                else None
+            )
+            model_context_window = resolve_model_context_window(
+                resolved_model, resolved_provider, provider_brand
+            )
+
             frappe.db.set_value("Agent Run", run_doc.name, {
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 "cached_tokens": cached_tokens,
+                "cache_creation_tokens": cache_creation_tokens,
                 "cost": cost,
+                "billed_input_tokens": billed_input_tokens,
+                "peak_context_tokens": peak_context_tokens,
+                "total_tokens": total_tokens,
+                "cache_skipped_unsupported_model": 1 if cache_skipped_unsupported_model else 0,
+                "round_count": round_count,
+                "model_context_window": model_context_window,
+                "provider_path": getattr(result, "provider_path", None),
+                "execution_mode": "sync",
                 "usage_snapshot": json.dumps({
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "input_tokens": input_tokens,
                     "output_tokens": output_tokens,
-                    "cache_read_tokens": cached_tokens if usage else None,
-                    "cache_creation_tokens": cache_creation_tokens if usage else None,
-                    "cache_miss_tokens": cache_creation_tokens if usage else None,
+                    "cache_read_tokens": cached_tokens,
+                    "cache_creation_tokens": cache_creation_tokens,
                     "cache_skipped_unsupported_model": cache_skipped_unsupported_model,
                     "total_tokens": total_tokens,
                     "completeness": "provider_reported" if usage else "estimated",
                     "segment_tokens": segment_tokens,
+                    "tools_breakdown": tools_breakdown,
                     "prefix_breakpoints": prefix_breakpoints,
+                    "billed_input_tokens": billed_input_tokens,
+                    "peak_context_tokens": peak_context_tokens,
+                    "round_count": round_count,
+                    "tool_exchange_tokens": tool_exchange_tokens,
+                    "round_prompt_tokens": round_prompt_tokens,
+                    "composition_reconciliation": composition_reconciliation,
                 }),
                 "cost_source": "provider_reported" if getattr(result, "cost", None) is not None else "unknown",
                 "cost_calculation_status": "calculated" if cost is not None else "unavailable",
@@ -2819,12 +2919,31 @@ async def run_agent_stream(
         else:
             enhanced_prompt = base_prompt
 
-        from huf.ai.context_segments import compute_segment_tokens, compute_prefix_breakpoints
+        from huf.ai.context_segments import (
+            compute_segment_tokens,
+            compute_prefix_breakpoints,
+            compute_tools_breakdown,
+            reconcile_composition,
+        )
         segment_tokens = compute_segment_tokens(
             agent_doc, agent, resolved_model_name, resolved_provider, history, knowledge_context, prompt
         )
+
+        # Opt-in only -- off unless a site operator sets
+        # huf_retain_system_prompts_enabled in site_config. See
+        # huf/ai/system_prompt_retention.py for why this defaults off (D15).
+        from huf.ai.system_prompt_retention import maybe_snapshot_system_prompt
+        maybe_snapshot_system_prompt(
+            run_doc.name, agent_name, conversation.name, getattr(agent, "instructions", None)
+        )
+
         prefix_breakpoints = compute_prefix_breakpoints(
             agent_doc, agent, resolved_model_name, resolved_provider, history
+        )
+        tools_breakdown = compute_tools_breakdown(
+            _normalize_model_name(resolved_model_name, resolved_provider),
+            getattr(agent, "tools", None),
+            manager.tool_sources,
         )
 
         context["conversation_history"] = history
@@ -2922,73 +3041,25 @@ async def run_agent_stream(
                     cache_creation_tokens = 0
                     cache_skipped_unsupported_model = False
                     total_tokens = 0
+                    usage_dict = None
 
                     if usage:
 
-                        if isinstance(usage, dict):
-                            input_tokens = (getattr(usage, "prompt_tokens", usage.get("prompt_tokens", 0)) if isinstance(usage, dict) else 0) or 0
-                            output_tokens = (getattr(usage, "completion_tokens", usage.get("completion_tokens", 0)) if isinstance(usage, dict) else 0) or 0
+                        round_usage = extract_round_usage(usage)
+                        input_tokens = round_usage["input_tokens"]
+                        output_tokens = round_usage["output_tokens"]
+                        cached_tokens = round_usage["cache_read_tokens"]
+                        cache_creation_tokens = round_usage["cache_write_tokens"]
 
-                            details = getattr(usage, "prompt_tokens_details", None)
-                            if not details and isinstance(usage, dict):
-                                details = usage.get("prompt_tokens_details")
-
-                            if details:
-                                if isinstance(details, dict):
-                                    cached_tokens = details.get("cached_tokens") or details.get("cache_hit_tokens") or 0
-                                    cache_creation_tokens = (
-                                        details.get("cache_creation_input_tokens")
-                                        or details.get("cache_write_tokens")
-                                        or details.get("cache_creation_tokens")
-                                        or 0
-                                    )
-                                else:
-                                    cached_tokens = getattr(details, "cached_tokens", None) or getattr(details, "cache_hit_tokens", None) or 0
-                                    cache_creation_tokens = (
-                                        getattr(details, "cache_creation_input_tokens", None)
-                                        or getattr(details, "cache_write_tokens", None)
-                                        or getattr(details, "cache_creation_tokens", None)
-                                        or 0
-                                    )
-                            elif isinstance(usage, dict):
-                                cached_tokens = usage.get("cached_tokens") or usage.get("cache_hit_tokens") or 0
-                                cache_creation_tokens = (
-                                    usage.get("cache_creation_tokens")
-                                    or usage.get("cache_creation_input_tokens")
-                                    or usage.get("cache_write_input_tokens")
-                                    or usage.get("cache_miss_tokens")
-                                    or 0
-                                )
-
-                            if not cache_creation_tokens and isinstance(usage, dict):
-                                cache_creation_tokens = (
-                                    usage.get("cache_creation_tokens")
-                                    or usage.get("cache_creation_input_tokens")
-                                    or usage.get("cache_write_input_tokens")
-                                    or usage.get("cache_miss_tokens")
-                                    or 0
-                                )
-
-                            if isinstance(usage, dict):
-                                cache_skipped_unsupported_model = bool(usage.get("cache_skipped_unsupported_model", False))
-
-                            total_tokens = getattr(usage, "total_tokens", (input_tokens + output_tokens))
+                        usage_dict = normalise_usage_payload(usage)
+                        if usage_dict is not None:
+                            cache_skipped_unsupported_model = bool(usage_dict.get("cache_skipped_unsupported_model", False))
                         else:
-                            input_tokens = (getattr(usage, "prompt_tokens", getattr(usage, "input_tokens", 0))) or 0
-                            output_tokens = (getattr(usage, "completion_tokens", getattr(usage, "output_tokens", 0))) or 0
-                            cached_tokens = getattr(usage, "cached_tokens", None) or 0
-                            cache_creation_tokens = (
-                                getattr(usage, "cache_creation_tokens", None)
-                                or getattr(usage, "cache_creation_input_tokens", None)
-                                or getattr(usage, "cache_write_input_tokens", None)
-                                or getattr(usage, "cache_miss_tokens", None)
-                                or 0
-                            )
                             cache_skipped_unsupported_model = bool(getattr(usage, "cache_skipped_unsupported_model", False))
-                            total_tokens = getattr(usage, "total_tokens", (input_tokens + output_tokens)) or (input_tokens + output_tokens)
 
-                    cached_tokens = cached_tokens or 0
-                    cache_creation_tokens = cache_creation_tokens or 0
+                        # usage is normally a plain dict here, so getattr() would always miss;
+                        # read the normalised payload and fall back to the parts.
+                        total_tokens = (usage_dict or {}).get("total_tokens") or (input_tokens + output_tokens)
 
                     if input_tokens == 0 or output_tokens == 0:
                         try:
@@ -3062,6 +3133,41 @@ async def run_agent_stream(
                     r_res_stream = context.get("reasoning_resolution") if context else None
                     r_snap_stream = json.dumps(r_res_stream.to_dict()) if r_res_stream else None
 
+                    # usage_dict carries the richer provider-usage shape (see
+                    # providers/litellm.py _finalize_usage_totals); fields absent
+                    # from it (no usage on this chunk, an older provider shape,
+                    # or a payload that failed to normalise) are written as
+                    # None, never coerced to 0 — a 0 would silently distort
+                    # every downstream average.
+                    usage_payload = usage_dict or {}
+                    billed_input_tokens = usage_payload.get("billed_input_tokens")
+                    if billed_input_tokens is None:
+                        billed_input_tokens = input_tokens
+                    peak_context_tokens = usage_payload.get("peak_context_tokens")
+                    round_count = usage_payload.get("round_count")
+                    tool_exchange_tokens = usage_payload.get("tool_exchange_tokens")
+                    round_prompt_tokens = usage_payload.get("round_prompt_tokens") or []
+                    # round_prompt_tokens[0] is the round-1, pre-call prompt size —
+                    # the same measurement point as segment_tokens. Comparing
+                    # against the run's summed billed_input_tokens instead would
+                    # flag a divergence on every multi-round run and make the
+                    # warning useless.
+                    round1_prompt_tokens = round_prompt_tokens[0] if round_prompt_tokens else None
+                    composition_reconciliation = reconcile_composition(
+                        segment_tokens, tool_exchange_tokens, round1_prompt_tokens
+                    )
+
+                    # Snapshotted at write time so later AI Model edits cannot
+                    # rewrite history for this run.
+                    provider_brand = (
+                        frappe.get_cached_value("AI Provider", resolved_provider, "provider_brand")
+                        if resolved_provider
+                        else None
+                    )
+                    model_context_window = resolve_model_context_window(
+                        resolved_model, resolved_provider, provider_brand
+                    )
+
                     stream_run_update = {
                         "status": "Success",
                         "response": full_response,
@@ -3071,19 +3177,34 @@ async def run_agent_stream(
                         "input_tokens": input_tokens,
                         "output_tokens": output_tokens,
                         "cached_tokens": cached_tokens,
+                        "cache_creation_tokens": cache_creation_tokens,
                         "cost": cost,
+                        "billed_input_tokens": billed_input_tokens,
+                        "peak_context_tokens": peak_context_tokens,
+                        "total_tokens": total_tokens,
+                        "cache_skipped_unsupported_model": 1 if cache_skipped_unsupported_model else 0,
+                        "round_count": round_count,
+                        "model_context_window": model_context_window,
+                        "provider_path": "litellm",
+                        "execution_mode": "stream",
                         "usage_snapshot": json.dumps({
-                            "schema_version": 1,
+                            "schema_version": 2,
                             "input_tokens": input_tokens,
                             "output_tokens": output_tokens,
-                            "cache_read_tokens": cached_tokens if usage else None,
-                            "cache_creation_tokens": cache_creation_tokens if usage else None,
-                            "cache_miss_tokens": cache_creation_tokens if usage else None,
+                            "cache_read_tokens": cached_tokens,
+                            "cache_creation_tokens": cache_creation_tokens,
                             "cache_skipped_unsupported_model": cache_skipped_unsupported_model,
                             "total_tokens": total_tokens,
                             "completeness": "provider_reported" if usage else "estimated",
                             "segment_tokens": segment_tokens,
+                            "tools_breakdown": tools_breakdown,
                             "prefix_breakpoints": prefix_breakpoints,
+                            "billed_input_tokens": billed_input_tokens,
+                            "peak_context_tokens": peak_context_tokens,
+                            "round_count": round_count,
+                            "tool_exchange_tokens": tool_exchange_tokens,
+                            "round_prompt_tokens": round_prompt_tokens,
+                            "composition_reconciliation": composition_reconciliation,
                         }),
                         "cost_source": "provider_reported" if chunk.get("cost") is not None else "unknown",
                         "cost_calculation_status": "calculated" if cost is not None else "unavailable",

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -439,15 +439,33 @@ class AgentManager:
             from huf.ai.capabilities import capability_enabled
 
             if capability_enabled(self.agent_doc, self.effective_model, "rich_elements"):
-                from huf.ai.chart_artifact_instructions import CHART_ARTIFACT_INSTRUCTIONS
+                from huf.ai.chart_artifact_instructions import (
+                    CHART_ARTIFACT_INSTRUCTIONS,
+                    CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL,
+                )
                 from huf.ai.artifact_instructions import (
                     AI_ELEMENT_INSTRUCTIONS,
                     MEDIA_ELEMENT_INSTRUCTIONS,
+                    MERMAID_ARTIFACT_INSTRUCTIONS,
+                    MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL,
                     agent_has_media_tools,
                 )
 
-                instructions += CHART_ARTIFACT_INSTRUCTIONS
-                instructions += AI_ELEMENT_INSTRUCTIONS
+                resolved_tool_names = {tool.name for tool in self.tools}
+
+                if "render_chart" in resolved_tool_names:
+                    instructions += CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+                else:
+                    instructions += CHART_ARTIFACT_INSTRUCTIONS
+
+                element_instructions = AI_ELEMENT_INSTRUCTIONS
+                if "render_mermaid" in resolved_tool_names:
+                    element_instructions = element_instructions.replace(
+                        MERMAID_ARTIFACT_INSTRUCTIONS,
+                        MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL,
+                    )
+                instructions += element_instructions
+
                 if agent_has_media_tools(self.agent_doc):
                     instructions += MEDIA_ELEMENT_INSTRUCTIONS
 

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -93,8 +93,9 @@ def _resolve_effective_model(agent_doc, model=None, provider=None):
 
 class AgentManager:
     """Manages the creation and execution of agents."""
-    def __init__(self, agent_name, file_handler=None, provider_override=None, model_override=None):
+    def __init__(self, agent_name, file_handler=None, provider_override=None, model_override=None, conversation_id=None):
         self.agent_doc = frappe.get_cached_doc("Agent", agent_name)
+        self.conversation_id = conversation_id
         (
             self.effective_provider,
             self.effective_model,
@@ -119,7 +120,12 @@ class AgentManager:
 
         try:
             from huf.ai.sdk_tools import create_agent_tools
-            agent_tools = create_agent_tools(self.agent_doc, model_name=self.effective_model)
+            agent_tools = create_agent_tools(
+                self.agent_doc,
+                model_name=self.effective_model,
+                conversation_id=self.conversation_id,
+                agent_name=self.agent_doc.name,
+            )
             if agent_tools:
                 self.tools.extend(agent_tools)
         except (ImportError, AttributeError, TypeError, ValueError, RuntimeError) as e:
@@ -1469,6 +1475,7 @@ def _execute_agent_run(
             agent_name,
             provider_override=resolved_provider,
             model_override=resolved_model,
+            conversation_id=conversation_id,
         )
 
         if (prompt_template or prompt_version) and resolved_prompt_template:
@@ -2684,6 +2691,7 @@ async def run_agent_stream(
             agent_name,
             provider_override=resolved_provider,
             model_override=resolved_model,
+            conversation_id=conversation.name,
         )
 
         if (prompt_template or prompt_version) and resolved_prompt_template:

--- a/huf/ai/agent_run_analytics.py
+++ b/huf/ai/agent_run_analytics.py
@@ -7,6 +7,7 @@ or repeatedly aggregating raw executions at request time.
 
 from __future__ import annotations
 
+import json
 from collections import defaultdict
 from datetime import timedelta
 
@@ -18,6 +19,16 @@ ROLLUP_DOCTYPE = "Agent Run Analytics Rollup"
 TERMINAL_STATUSES = ("Success", "Failed")
 CORRECTION_WINDOW_HOURS = 26
 
+# Single source of truth for the rollup's grouping dimensions. `_dimension_key()`,
+# `_affected_dimensions()`, and `_recompute_rollup()` all derive from this tuple so
+# they can never drift out of agreement with each other or with the doc fields they
+# populate. `conversation` is appended at the END, not inserted alongside the other
+# fields: `dimension_key` values are persisted in existing rollup rows, and appending
+# keeps every previously-stored key string decodable positionally (old rows simply
+# decode with `conversation == "__none__"`). Inserting it earlier in the tuple would
+# silently reinterpret every stored key's remaining fields.
+DIMENSION_FIELDS = ("agent", "provider", "model", "run_kind", "conversation")
+
 
 def _bucket_start(value, granularity: str):
     value = get_datetime(value)
@@ -27,14 +38,14 @@ def _bucket_start(value, granularity: str):
 
 
 def _dimension_key(row: dict) -> str:
-    return "|".join(str(row.get(field) or "__none__") for field in ("agent", "provider", "model", "run_kind"))
+    return "|".join(str(row.get(field) or "__none__") for field in DIMENSION_FIELDS)
 
 
 def _affected_dimensions(since):
     rows = frappe.db.get_all(
         "Agent Run",
         filters={"status": ["in", TERMINAL_STATUSES], "start_time": [">=", since]},
-        fields=["start_time", "agent", "provider", "model", "run_kind"],
+        fields=["start_time", *DIMENSION_FIELDS],
         limit_page_length=0,
     )
     affected = set()
@@ -47,22 +58,74 @@ def _affected_dimensions(since):
     return affected
 
 
+def _load_segment_tokens(usage_snapshot) -> dict:
+    """Best-effort extraction of segment_tokens from a run's usage_snapshot.
+
+    Returns {} (no segments) on any malformed input: missing snapshot, a JSON
+    string that fails to parse, an already-parsed dict, or a snapshot with no
+    segment_tokens key. Never raises.
+    """
+    if not usage_snapshot:
+        return {}
+    if isinstance(usage_snapshot, str):
+        try:
+            usage_snapshot = json.loads(usage_snapshot)
+        except (TypeError, ValueError):
+            return {}
+    if not isinstance(usage_snapshot, dict):
+        return {}
+    segment_tokens = usage_snapshot.get("segment_tokens")
+    return segment_tokens if isinstance(segment_tokens, dict) else {}
+
+
+def _accumulate_composition(totals: dict, segment_tokens: dict) -> None:
+    """Fold one run's segment_tokens into the bucket's running composition totals.
+
+    `None` in a segment means "could not be counted" (see context_segments.py) and
+    must never be coerced to 0. A segment's bucket total is represented as `None`
+    (unknown) as soon as ANY contributing run reports `None` for it, and stays
+    `None` for the rest of the bucket regardless of later runs — an unknown run
+    poisons the sum rather than being silently dropped. This makes "unknown" and
+    "zero" impossible to confuse: a consumer sees either a number (every
+    contributing run counted that segment) or `None` (at least one could not),
+    never a number that quietly excludes unmeasured runs.
+    """
+    for segment, value in segment_tokens.items():
+        if segment in totals and totals[segment] is None:
+            continue
+        if value is None:
+            totals[segment] = None
+        elif isinstance(value, (int, float)):
+            totals[segment] = (totals.get(segment) or 0) + value
+        # Non-numeric, non-None values are ignored rather than raising.
+
+
 def _recompute_rollup(granularity: str, bucket_start, dimension_key: str):
     bucket_end = add_to_date(bucket_start, hours=1 if granularity == "hour" else 24)
     dimensions = dimension_key.split("|")
-    fields = ("agent", "provider", "model", "run_kind")
     filters = [
         ["status", "in", TERMINAL_STATUSES],
         ["start_time", ">=", bucket_start],
         ["start_time", "<", bucket_end],
     ]
-    for field, value in zip(fields, dimensions):
+    for field, value in zip(DIMENSION_FIELDS, dimensions):
         filters.append([field, "is", "not set"] if value == "__none__" else [field, "=", value])
 
     rows = frappe.db.get_all(
         "Agent Run",
         filters=filters,
-        fields=["status", "input_tokens", "output_tokens", "cached_tokens", "cost", "start_time", "end_time"],
+        fields=[
+            "status",
+            "input_tokens",
+            "billed_input_tokens",
+            "output_tokens",
+            "cached_tokens",
+            "cache_creation_tokens",
+            "cost",
+            "start_time",
+            "end_time",
+            "usage_snapshot",
+        ],
         limit_page_length=0,
     )
     if not rows:
@@ -73,30 +136,41 @@ def _recompute_rollup(granularity: str, bucket_start, dimension_key: str):
 
     metrics = defaultdict(float)
     metrics["run_count"] = len(rows)
+    composition_totals: dict = {}
     for row in rows:
         metrics["success_count"] += int(row.status == "Success")
         metrics["failed_count"] += int(row.status == "Failed")
-        metrics["input_tokens"] += row.input_tokens or 0
+        # billed_input_tokens is the new canonical, path-independent column, but it is
+        # NULL on every historical row (never captured before this branch). Falling
+        # back to input_tokens keeps existing dashboards correct across the cutover
+        # using the best available number, without a second rollup field.
+        metrics["input_tokens"] += row.billed_input_tokens if row.billed_input_tokens is not None else (row.input_tokens or 0)
         metrics["output_tokens"] += row.output_tokens or 0
         metrics["cached_tokens"] += row.cached_tokens or 0
+        metrics["cache_creation_tokens"] += row.cache_creation_tokens or 0
         metrics["total_cost"] += row.cost or 0
         if row.start_time and row.end_time:
             duration = (get_datetime(row.end_time) - get_datetime(row.start_time)).total_seconds() * 1000
             if duration >= 0:
                 metrics["duration_ms_sum"] += duration
                 metrics["duration_count"] += 1
+        _accumulate_composition(composition_totals, _load_segment_tokens(row.usage_snapshot))
 
     existing = frappe.db.exists(ROLLUP_DOCTYPE, {"granularity": granularity, "bucket_start": bucket_start, "dimension_key": dimension_key})
     doc = frappe.get_doc(ROLLUP_DOCTYPE, existing) if existing else frappe.new_doc(ROLLUP_DOCTYPE)
+    dimension_values = {
+        field: (None if value == "__none__" else value) for field, value in zip(DIMENSION_FIELDS, dimensions)
+    }
     doc.update({
         "granularity": granularity,
         "bucket_start": bucket_start,
         "dimension_key": dimension_key,
-        "agent": None if dimensions[0] == "__none__" else dimensions[0],
-        "provider": None if dimensions[1] == "__none__" else dimensions[1],
-        "model": None if dimensions[2] == "__none__" else dimensions[2],
-        "run_kind": None if dimensions[3] == "__none__" else dimensions[3],
+        **dimension_values,
         **metrics,
+        # Serialised explicitly, matching how this codebase writes every other JSON
+        # field. An empty dict is stored as NULL rather than "{}": no segment was
+        # measured at all, which is "not measured", not "measured as zero".
+        "composition_totals": json.dumps(composition_totals) if composition_totals else None,
         "last_recomputed_at": now_datetime(),
     })
     doc.flags.ignore_permissions = True

--- a/huf/ai/agent_run_analytics_api.py
+++ b/huf/ai/agent_run_analytics_api.py
@@ -2,12 +2,36 @@
 
 from __future__ import annotations
 
+import json
+
 import frappe
 from frappe.utils import add_to_date, get_datetime, now_datetime
+
+from huf.ai.agent_run_analytics import DIMENSION_FIELDS
 
 
 ROLLUP_DOCTYPE = "Agent Run Analytics Rollup"
 MAX_WINDOW_DAYS = 93
+ROLLUP_FIELDS = [
+    "bucket_start",
+    "agent",
+    "provider",
+    "model",
+    "run_kind",
+    "conversation",
+    "run_count",
+    "success_count",
+    "failed_count",
+    "input_tokens",
+    "output_tokens",
+    "cached_tokens",
+    "cache_creation_tokens",
+    "total_cost",
+    "duration_ms_sum",
+    "duration_count",
+    "composition_totals",
+    "last_recomputed_at",
+]
 
 
 def _require_analytics_access():
@@ -20,40 +44,107 @@ def _require_analytics_access():
     frappe.throw("Execution analytics requires Agent view permission", frappe.PermissionError)
 
 
+def _query_rollups(granularity: str, start, end) -> list[dict]:
+    return frappe.db.get_all(
+        ROLLUP_DOCTYPE,
+        filters={"granularity": granularity, "bucket_start": ["between", [start, end]]},
+        fields=ROLLUP_FIELDS,
+        order_by="bucket_start asc",
+        limit_page_length=0,
+    )
+
+
+def _load_composition_totals(raw) -> dict:
+    """Parse a rollup row's composition_totals JSON string.
+
+    NULL, empty, malformed JSON, and non-dict values all degrade to "no data"
+    (an empty dict), matching the "not measured" semantics the rollup writes.
+    Never raises.
+    """
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _accumulate_composition(totals: dict, segment_tokens: dict) -> None:
+    """Fold one rollup row's composition totals into a running total.
+
+    Mirrors `huf.ai.agent_run_analytics._accumulate_composition`: `None` means
+    "could not be counted" and must propagate as unknown, never be coerced to
+    0. A segment's total becomes (and stays) `None` as soon as any
+    contributing row reports `None` for it.
+    """
+    for segment, value in segment_tokens.items():
+        if segment in totals and totals[segment] is None:
+            continue
+        if value is None:
+            totals[segment] = None
+        elif isinstance(value, (int, float)):
+            totals[segment] = (totals.get(segment) or 0) + value
+        # Non-numeric, non-None values are ignored rather than raising.
+
+
 @frappe.whitelist(methods=["GET"])
-def get_execution_analytics(from_date: str | None = None, to_date: str | None = None, granularity: str = "hour"):
+def get_execution_analytics(
+    from_date: str | None = None,
+    to_date: str | None = None,
+    granularity: str = "hour",
+    dimension: str = "provider",
+):
     """Return execution analytics; auto-refreshes rollups if empty."""
     _require_analytics_access()
     if granularity not in {"hour", "day"}:
         frappe.throw("granularity must be 'hour' or 'day'")
+    if dimension not in DIMENSION_FIELDS:
+        frappe.throw(f"dimension must be one of {', '.join(DIMENSION_FIELDS)}")
     end = get_datetime(to_date) if to_date else now_datetime()
     start = get_datetime(from_date) if from_date else add_to_date(end, days=-7)
     if start > end or (end - start).days > MAX_WINDOW_DAYS:
         frappe.throw(f"Date range must be between zero and {MAX_WINDOW_DAYS} days")
     if not frappe.db.exists("DocType", ROLLUP_DOCTYPE):
-        return {"summary": {}, "series": [], "breakdowns": [], "metadata": {"freshness": None, "granularity": granularity}}
+        # Same shape as the populated response, so a client never has to branch on
+        # which keys exist -- only on whether they are empty.
+        return {
+            "summary": {},
+            "series": [],
+            "breakdowns": [],
+            "composition_totals": {},
+            "metadata": {
+                "granularity": granularity,
+                "dimension": dimension,
+                "freshness": None,
+                "breakdowns_total_count": 0,
+            },
+        }
 
-    rows = frappe.db.get_all(
-        ROLLUP_DOCTYPE,
-        filters={"granularity": granularity, "bucket_start": ["between", [start, end]]},
-        fields=["bucket_start", "agent", "provider", "model", "run_kind", "run_count", "success_count", "failed_count", "input_tokens", "output_tokens", "cached_tokens", "total_cost", "duration_ms_sum", "duration_count", "last_recomputed_at"],
-        order_by="bucket_start asc",
-        limit_page_length=0,
-    )
+    rows = _query_rollups(granularity, start, end)
 
     # If rollups are empty for this window, attempt a quick backfill refresh once and re-query
     if not rows and frappe.db.exists("Agent Run"):
         from huf.ai.agent_run_analytics import refresh_rollups
         refresh_rollups(full_backfill=True)
-        rows = frappe.db.get_all(
-            ROLLUP_DOCTYPE,
-            filters={"granularity": granularity, "bucket_start": ["between", [start, end]]},
-            fields=["bucket_start", "agent", "provider", "model", "run_kind", "run_count", "success_count", "failed_count", "input_tokens", "output_tokens", "cached_tokens", "total_cost", "duration_ms_sum", "duration_count", "last_recomputed_at"],
-            order_by="bucket_start asc",
-            limit_page_length=0,
-        )
-    summary = {"run_count": 0, "success_count": 0, "failed_count": 0, "input_tokens": 0, "output_tokens": 0, "cached_tokens": 0, "total_cost": 0, "duration_ms_sum": 0, "duration_count": 0}
-    series_by_bucket, provider_by_name = {}, {}
+        rows = _query_rollups(granularity, start, end)
+
+    summary = {
+        "run_count": 0,
+        "success_count": 0,
+        "failed_count": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cached_tokens": 0,
+        "cache_creation_tokens": 0,
+        "total_cost": 0,
+        "duration_ms_sum": 0,
+        "duration_count": 0,
+    }
+    series_by_bucket, breakdown_by_dimension = {}, {}
+    composition_totals: dict = {}
     freshness = None
     for row in rows:
         row = dict(row)
@@ -62,18 +153,29 @@ def get_execution_analytics(from_date: str | None = None, to_date: str | None = 
         bucket = series_by_bucket.setdefault(row["bucket_start"], {"bucket_start": row["bucket_start"], **{key: 0 for key in summary}})
         for key in summary:
             bucket[key] += row.get(key) or 0
-        provider = row.get("provider") or "Unknown"
-        breakdown = provider_by_name.setdefault(provider, {"dimension": provider, **{key: 0 for key in summary}})
+        dimension_value = row.get(dimension) or "Unknown"
+        breakdown = breakdown_by_dimension.setdefault(dimension_value, {"dimension": dimension_value, **{key: 0 for key in summary}})
         for key in summary:
             breakdown[key] += row.get(key) or 0
+        _accumulate_composition(composition_totals, _load_composition_totals(row.get("composition_totals")))
         if row.get("last_recomputed_at") and (freshness is None or row["last_recomputed_at"] > freshness):
             freshness = row["last_recomputed_at"]
     summary["success_rate"] = (summary["success_count"] / summary["run_count"] * 100) if summary["run_count"] else None
     summary["average_duration_ms"] = (summary["duration_ms_sum"] / summary["duration_count"]) if summary["duration_count"] else None
     summary["cache_ratio"] = (summary["cached_tokens"] / summary["input_tokens"] * 100) if summary["input_tokens"] else None
+    breakdowns_total_count = len(breakdown_by_dimension)
     return {
         "summary": summary,
         "series": list(series_by_bucket.values()),
-        "breakdowns": sorted(provider_by_name.values(), key=lambda item: item["run_count"], reverse=True)[:10],
-        "metadata": {"granularity": granularity, "from": start, "to": end, "freshness": freshness, "source": "scheduled_rollup"},
+        "breakdowns": sorted(breakdown_by_dimension.values(), key=lambda item: item["run_count"], reverse=True)[:10],
+        "composition_totals": composition_totals,
+        "metadata": {
+            "granularity": granularity,
+            "dimension": dimension,
+            "from": start,
+            "to": end,
+            "freshness": freshness,
+            "source": "scheduled_rollup",
+            "breakdowns_total_count": breakdowns_total_count,
+        },
     }

--- a/huf/ai/agent_run_context_api.py
+++ b/huf/ai/agent_run_context_api.py
@@ -13,8 +13,37 @@ import json
 import frappe
 
 from huf.ai.cache_metrics import compute_run_metrics
+from huf.ai.model_metadata import resolve_model_context_window
 
-DEFAULT_CONTEXT_WINDOW = 200000
+
+def _resolve_context_window(run_doc):
+    """Resolve the context window to measure a run's usage against.
+
+    Most-authoritative source first:
+      1. ``Agent Run.model_context_window`` — the value snapshotted at call
+         time. Always wins when set, because it records what was actually
+         true for this run, immune to later edits of the AI Model record.
+      2. Everything else — delegated to ``resolve_model_context_window``:
+         the run's ``AI Model.context_window`` (current model metadata),
+         then LiteLLM's model-cost table, then ``None``.
+
+    A field is treated as "set" only when it is a truthy, non-zero int; 0
+    and NULL both mean "not set" per the AI Model field convention.
+    """
+    snapshot_window = run_doc.get("model_context_window")
+    if snapshot_window:
+        return snapshot_window
+
+    model_link = run_doc.get("model")
+    if not model_link:
+        return None
+
+    provider_brand = (
+        frappe.get_cached_value("AI Provider", run_doc.get("provider"), "provider_brand")
+        if run_doc.get("provider")
+        else None
+    )
+    return resolve_model_context_window(model_link, run_doc.get("provider"), provider_brand)
 
 
 @frappe.whitelist(methods=["GET"])
@@ -40,12 +69,10 @@ def get_run_context_metrics(run_name: str):
 
     metrics = compute_run_metrics(run_doc, previous_run_doc)
 
-    # AI Model does not carry a context-window field today; DEFAULT_CONTEXT_WINDOW
-    # is a placeholder until model metadata exposes one (see PHASE2_VisualCache.md).
     return {
         "segment_tokens": snapshot.get("segment_tokens"),
         "total_tokens": snapshot.get("total_tokens"),
-        "context_window": DEFAULT_CONTEXT_WINDOW,
+        "context_window": _resolve_context_window(run_doc),
         "prefix_breakpoints": snapshot.get("prefix_breakpoints") or [],
         "cache_skipped_unsupported_model": snapshot.get("cache_skipped_unsupported_model"),
         "metrics": metrics,

--- a/huf/ai/artifact_instructions.py
+++ b/huf/ai/artifact_instructions.py
@@ -16,6 +16,21 @@ import re
 
 import frappe
 
+MERMAID_ARTIFACT_INSTRUCTIONS = """
+4. MERMAID DIAGRAMS
+<artifact type="mermaid" title="Flowchart">
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Do something]
+    B -->|No| D[Stop]
+</artifact>
+"""
+
+MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL = """
+4. MERMAID DIAGRAMS
+To show a diagram, call the render_mermaid tool with your nodes/edges and relay its returned artifact tag verbatim in your response. Do not hand-write Mermaid syntax yourself.
+"""
+
 AI_ELEMENT_INSTRUCTIONS = """
 SYSTEM INSTRUCTION - HUF RICH ELEMENTS:
 The HUF chat UI renders special elements when you output them with the exact tags below.
@@ -44,15 +59,7 @@ Any plain text or markdown document.
   <circle cx="50" cy="50" r="40" fill="blue" />
 </svg>
 </artifact>
-
-4. MERMAID DIAGRAMS
-<artifact type="mermaid" title="Flowchart">
-graph TD
-    A[Start] --> B{Decision}
-    B -->|Yes| C[Do something]
-    B -->|No| D[Stop]
-</artifact>
-
+""" + MERMAID_ARTIFACT_INSTRUCTIONS + """
 5. WEB PREVIEW (iframe a public URL)
 <web-preview url="https://example.com" title="Example Site" />
 

--- a/huf/ai/cache_metrics.py
+++ b/huf/ai/cache_metrics.py
@@ -2,10 +2,17 @@
 # For license information, please see license.txt
 
 """
-Five derived context/cache metrics, computed once server-side and reused by
+Four derived context/cache metrics, computed once server-side and reused by
 every surface (chat header, run detail, agent/fleet views). Composition
 (segment_tokens) answers "what fills the window"; these metrics answer
 "is caching paying off" — never recomputed client-side.
+
+A fifth metric, wasted-write tokens (cache writes that were never read back
+before expiring), was deliberately dropped rather than shipped as a
+permanent `None`: it needs read-after-write tracking across runs that no
+provider reports today, and there was no partial version of it worth
+keeping. `prefix_stability` below is a real, if approximate, signal and
+is not affected by this.
 
 Approximation note: effective_input_multiplier and counterfactual_savings
 use fixed token-cost multipliers (cache read ~=0.1x, cache write ~=1.25x,
@@ -85,7 +92,6 @@ def compute_run_metrics(run_doc, previous_run_doc=None):
     return {
         "cache_read_share": cache_read_share,
         "effective_input_multiplier": effective_input_multiplier,
-        "wasted_writes_tokens": None,  # needs read-after-write tracking; not captured yet
         "prefix_stability": prefix_stability,
         "counterfactual_savings": counterfactual_savings,
     }

--- a/huf/ai/chart_artifact_instructions.py
+++ b/huf/ai/chart_artifact_instructions.py
@@ -33,3 +33,8 @@ Rules:
 8. Put flex layouts on Card (`style={{ display: "flex", gap: 12 }}`) or use div wrappers.
 9. Pair charts with a markdown table for the underlying data when helpful.
 """
+
+CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL = """
+SYSTEM INSTRUCTION - CHART ARTIFACTS:
+To show a chart, call the render_chart tool with your data and relay its returned artifact tag verbatim in your response. Do not hand-write chart JSX yourself.
+"""

--- a/huf/ai/console_api.py
+++ b/huf/ai/console_api.py
@@ -6,6 +6,7 @@ Whitelisted API methods for the Console prompt-engineering workspace.
 
 Provides:
 - Prompt generation from a natural-language description.
+- Prompt improvement (one-shot rewrite of an existing prompt).
 - Pass/fail evaluation of a model response against criteria.
 - Saving an arbitrary prompt body as an Agent Prompt template.
 """
@@ -25,6 +26,7 @@ from huf.permissions import has_capability
 
 
 GENERATE_PROMPT_CAPABILITY = "agent.use"
+IMPROVE_PROMPT_CAPABILITY = "agent.use"
 EVALUATE_RUN_CAPABILITY = "agent.use"
 SAVE_PROMPT_TEMPLATE_CAPABILITY = "agent.create"
 
@@ -235,6 +237,73 @@ def generate_prompt(
 		frappe.throw(_("No prompt was generated. Please try again with a different description or provider."))
 
 	return {"prompt": generated.strip()}
+
+
+@frappe.whitelist()
+def improve_prompt(
+	prompt_body: str,
+	instruction: str | None = None,
+	provider: str | None = None,
+	model: str | None = None,
+):
+	"""Rewrite an existing prompt for clarity and effectiveness via a one-shot LLM call.
+
+	Standalone helper for the Playground's prompt panel — works on whatever
+	prompt text is currently in the bench, independent of whether it is tied
+	to a saved Agent Prompt template.
+
+	Args:
+		prompt_body: The prompt text to improve.
+		instruction: Optional improvement goal (e.g. "make it more concise").
+		provider: Optional provider to use (defaults to console config).
+		model: Optional model to use (defaults to console config).
+
+	Returns:
+		dict: ``{"prompt": "<improved prompt text>"}``
+	"""
+	_require(IMPROVE_PROMPT_CAPABILITY)
+
+	if not prompt_body or not prompt_body.strip():
+		frappe.throw(_("Prompt is required."), frappe.ValidationError)
+
+	if provider and model:
+		if not frappe.db.exists("AI Provider", provider):
+			frappe.throw(_("Selected provider does not exist."), frappe.ValidationError)
+		if not frappe.db.exists("AI Model", model):
+			frappe.throw(_("Selected model does not exist."), frappe.ValidationError)
+	else:
+		provider, model = _get_console_model_config()
+		if not provider or not model:
+			frappe.throw(
+				_(
+					"No AI provider is available for prompt improvement. "
+					"Configure one with an API key or set 'huf_console_prompt_engineer_model' in site config."
+				),
+				frappe.ValidationError,
+			)
+
+	parts = [
+		"You are an expert prompt engineer. Improve the following prompt for clarity, "
+		"specificity, and effectiveness, while preserving its original intent and scope. "
+		"Return only the improved prompt text, with no explanation, preamble, or markdown fences."
+	]
+	if instruction and instruction.strip():
+		parts.append(f"Improvement goal: {instruction.strip()}")
+	parts.append(f"Original prompt:\n{prompt_body.strip()}")
+	parts.append("Improved prompt:")
+
+	messages = [{"role": "user", "content": "\n\n".join(parts)}]
+
+	try:
+		improved = _simple_completion_sync(provider, model, messages)
+	except Exception as e:
+		frappe.log_error(f"improve_prompt failed: {e!s}\n{frappe.get_traceback()}", "Console Prompt Improvement")
+		frappe.throw(_("Prompt improvement failed. Please try again or choose a different provider."))
+
+	if not improved:
+		frappe.throw(_("No improved prompt was returned. Please try again."))
+
+	return {"prompt": improved.strip()}
 
 
 @frappe.whitelist()

--- a/huf/ai/context_segments.py
+++ b/huf/ai/context_segments.py
@@ -17,6 +17,24 @@ Agent setting, so it is not reproduced here — see AGENTS.md notes on
 prompt_cache_options). Per-breakpoint cache-hit attribution is deliberately
 not attempted: providers report one aggregate cache_read count per run, not
 per-block hits, and a wrong per-block guess is worse than an honest gap.
+
+Two distinct measurement points, not one:
+
+  - `compute_segment_tokens()` is called ONCE, pre-call, from
+    agent_integration.py, before the LLM is invoked. It describes round 1's
+    pre-call composition only: system, tools, knowledge, history, and the
+    outgoing user message, as they exist before that first completion.
+  - A single Agent Run can perform up to `max_turns` LLM completions. Every
+    round after round 1 carries a message list that has grown by the
+    assistant's tool-call request and every tool result from prior rounds —
+    content `compute_segment_tokens()` never sees and that no other segment
+    accounts for either. `count_tool_exchange_tokens()` measures exactly
+    that growth, and `reconcile_composition()` compares the two measurement
+    points (segments + tool exchange vs. the provider's own reported
+    `prompt_tokens`) to surface when they diverge, i.e. when some other,
+    still-uninstrumented context source exists. Conflating these two points
+    — treating segment_tokens as if it described the whole run — is the
+    defect this module now guards against.
 """
 
 import hashlib
@@ -79,6 +97,89 @@ def compute_segment_tokens(agent_doc, agent, resolved_model, resolved_provider, 
     }
 
 
+def compute_tools_breakdown(pricing_model, tools, tool_sources):
+    """Sub-type the combined `segment_tokens["tools"]` total by tool origin.
+
+    `segment_tokens["tools"]` stays an int (or None) — this is a SIBLING
+    structure, not a replacement, so the frontend composition bar (which
+    reads segments.tools as a plain number) and historical usage_snapshot
+    rows are unaffected.
+
+    Args:
+        pricing_model: model name already normalized via
+            huf.ai.providers.litellm._normalize_model_name — the same
+            value compute_segment_tokens() uses for its token_counter calls.
+        tools: the agent's tool list (e.g. `agent.tools`), same object
+            compute_segment_tokens() serializes for the combined total.
+        tool_sources: dict of {tool_name: source}, source one of
+            user_configured | builtin_registry | internal_capability |
+            knowledge | mcp. Built by AgentManager._setup_tools() in
+            agent_integration.py, which is the only place that still knows
+            where each tool came from.
+
+    Returns:
+        None if the breakdown could not be computed at all (e.g. tools
+        couldn't be serialized). Otherwise a dict:
+            {
+              "by_source": {<source>: int|None, ...},
+              "per_tool": {<tool_name>: int|None, ...},
+            }
+        Only sources actually present among `tools` are included in
+        by_source. An individual tool's count is `None` (not 0) if only
+        that tool's serialization/counting failed — same None-means-unknown
+        discipline as the rest of this module; see the module docstring.
+        Never raises.
+
+    Note: per_tool values are counted from each tool serialized on its own,
+    while segment_tokens["tools"] counts the whole tools array serialized
+    together as one JSON document. The per-tool sum will not exactly equal
+    the combined total (JSON array framing, comma separators, etc.) — a
+    small discrepancy here is expected, not a bug.
+    """
+    try:
+        tools = tools or []
+        if not tools:
+            return None
+
+        by_source = {}
+        per_tool = {}
+
+        for tool in tools:
+            tool_name = getattr(tool, "name", None)
+            if not tool_name:
+                continue
+
+            source = (tool_sources or {}).get(tool_name)
+            if not source:
+                continue
+
+            try:
+                single_schema = serialize_tools([tool])
+                single_text = frappe.as_json(single_schema) if single_schema else None
+            except Exception:
+                single_text = None
+
+            count = _count(pricing_model, single_text) if single_text is not None else None
+
+            per_tool[tool_name] = count
+            if source not in by_source:
+                by_source[source] = 0 if count is not None else None
+            elif by_source[source] is not None and count is not None:
+                by_source[source] += count
+            else:
+                by_source[source] = None
+
+        if not by_source and not per_tool:
+            return None
+
+        return {
+            "by_source": by_source,
+            "per_tool": per_tool,
+        }
+    except Exception:
+        return None
+
+
 def compute_prefix_breakpoints(agent_doc, agent, resolved_model, resolved_provider, history):
     """Fingerprint the cache-control breakpoints this run's settings would gate.
 
@@ -110,3 +211,167 @@ def compute_prefix_breakpoints(agent_doc, agent, resolved_model, resolved_provid
             breakpoints.append({"marker": "history", "prefix_hash": prefix_hash})
 
     return breakpoints
+
+
+def _extract_message_text(content):
+    """Flatten a message's `content` to plain text for token counting.
+
+    `content` is usually a plain string, but this codebase also produces
+    the multimodal list-of-content-blocks shape via `_build_text_content`
+    (e.g. `[{"type": "text", "text": "...", "cache_control": {...}}]`).
+    Non-text blocks (e.g. image_url parts) contribute no text here.
+    """
+    if not content:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                text = block.get("text")
+                if text:
+                    parts.append(str(text))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "\n".join(parts)
+    return str(content)
+
+
+def _normalize_tool_call(tool_call):
+    """Reduce one tool call (dict or SDK object) to a plain {name, arguments} dict.
+
+    litellm's non-streaming path attaches SDK objects (e.g.
+    ChatCompletionMessageToolCall) to `assistant_message["tool_calls"]`; the
+    streaming path attaches plain dicts assembled from delta chunks. Both
+    shapes occur in practice and are normalized here so serialisation is
+    uniform regardless of which provider loop produced the message.
+    """
+    if isinstance(tool_call, dict):
+        function = tool_call.get("function") or {}
+        return {
+            "name": function.get("name") if isinstance(function, dict) else None,
+            "arguments": function.get("arguments") if isinstance(function, dict) else None,
+        }
+    function = getattr(tool_call, "function", None)
+    return {
+        "name": getattr(function, "name", None) if function is not None else None,
+        "arguments": getattr(function, "arguments", None) if function is not None else None,
+    }
+
+
+def count_tool_exchange_tokens(pricing_model, messages):
+    """Best-effort token count of the tool exchange within `messages`.
+
+    `messages` is the running message list from the provider loop (or, for
+    O(rounds) accumulation, just the slice appended in the current round —
+    see providers/litellm.py). Counts exactly two things:
+
+      - assistant messages carrying `tool_calls`: the serialised tool-call
+        payload (name + arguments), not the message's `content` — a
+        tool-calling assistant turn's content is frequently empty and is
+        not the thing we're trying to measure here.
+      - messages with role == "tool": the tool result content.
+
+    Deliberately does NOT count the system message, the original user
+    message, or ordinary assistant prose — those are already covered by
+    `compute_segment_tokens()`'s five categories, and double-counting them
+    would make composition percentages wrong.
+
+    Returns an int (0 for an empty/no-op exchange), or `None` if counting
+    failed for any message — same discipline as `_count`; a partial count
+    would understate the true figure and mislead reconciliation more than
+    an honest "unknown".
+    """
+    if not messages:
+        return 0
+
+    total = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+
+        if role == "assistant" and message.get("tool_calls"):
+            try:
+                normalized_calls = [_normalize_tool_call(tc) for tc in message["tool_calls"]]
+                payload = frappe.as_json(normalized_calls)
+            except Exception:
+                return None
+            count = _count(pricing_model, payload)
+            if count is None:
+                return None
+            total += count
+
+        elif role == "tool":
+            text = _extract_message_text(message.get("content"))
+            if not text:
+                continue
+            count = _count(pricing_model, text)
+            if count is None:
+                return None
+            total += count
+
+    return total
+
+
+def reconcile_composition(segment_tokens, tool_exchange_tokens, provider_prompt_tokens, tolerance=0.15):
+    """Compare counted context composition against the provider's reported prompt size.
+
+    Compares `sum(segment_tokens.values()) + tool_exchange_tokens`
+    against `provider_prompt_tokens` for the same measurement point.
+    Divergence beyond `tolerance` (a fraction of `provider_prompt_tokens`)
+    signals an uninstrumented context source — something contributing to
+    the provider's prompt that no segment and no tool-exchange count
+    accounts for. Logs a warning naming both figures in that case; never
+    raises and never fails a run.
+
+    An unknown input makes the whole comparison unknown, and each returns
+    `None` rather than being coerced to 0:
+
+      - any `None` in `segment_tokens` (a segment that could not be counted),
+      - `tool_exchange_tokens` of `None` (the tool exchange could not be
+        counted) — summing it as 0 would understate `counted` and report a
+        divergence that is purely an artefact of the failed count,
+      - a falsy `provider_prompt_tokens` (nothing to compare against).
+
+    A `tool_exchange_tokens` of 0 is a real measurement, not an unknown: a
+    single-round run genuinely has no tool exchange, and it reconciles normally.
+
+    Returns a dict with keys `counted`, `reported`, `delta_ratio`,
+    `within_tolerance`, or `None` when the comparison could not be made.
+    """
+    try:
+        if not provider_prompt_tokens:
+            return None
+        if not isinstance(segment_tokens, dict) or not segment_tokens:
+            return None
+        if any(value is None for value in segment_tokens.values()):
+            return None
+        if tool_exchange_tokens is None:
+            # Unknown, not zero: summing it as 0 would understate `counted` and
+            # report a divergence that is an artefact of the failed count.
+            return None
+
+        counted = sum(segment_tokens.values()) + tool_exchange_tokens
+        reported = provider_prompt_tokens
+        delta_ratio = abs(counted - reported) / reported
+        within_tolerance = delta_ratio <= tolerance
+
+        if not within_tolerance:
+            frappe.logger("huf").warning(
+                "Context composition mismatch: counted %s tokens (segments + tool exchange) "
+                "vs provider-reported prompt_tokens=%s (delta_ratio=%.2f%%, tolerance=%.0f%%). "
+                "This suggests an uninstrumented context source.",
+                counted, reported, delta_ratio * 100, tolerance * 100,
+            )
+
+        return {
+            "counted": counted,
+            "reported": reported,
+            "delta_ratio": delta_ratio,
+            "within_tolerance": within_tolerance,
+        }
+    except Exception:
+        # Reconciliation is diagnostic-only; never let it break a run.
+        return None

--- a/huf/ai/cost_calculator.py
+++ b/huf/ai/cost_calculator.py
@@ -15,7 +15,12 @@ Priority order:
 Formula (industry standard — same as Langfuse, Portkey, Anthropic):
   cost = (input_tokens  / 1_000_000) * input_cost_per_1m_tokens
        + (output_tokens / 1_000_000) * output_cost_per_1m_tokens
-       + (cached_tokens / 1_000_000) * cached_input_cost_per_1m_tokens  # optional
+       + (cached_tokens / 1_000_000) * cached_input_cost_per_1m_tokens              # optional
+       + (cache_creation_tokens / 1_000_000) * cached_input_write_cost_per_1m_tokens  # optional
+
+cached_tokens and cache_creation_tokens are both subsets of input_tokens (not
+additional tokens on top of it), so they are subtracted from input_tokens
+before the regular input rate is applied.
 
 Usage:
   from huf.ai.cost_calculator import calculate_cost
@@ -47,6 +52,7 @@ def get_model_pricing(model_name: str) -> dict | None:
         input_cost_per_1m_tokens       (float)
         output_cost_per_1m_tokens      (float)
         cached_input_cost_per_1m_tokens (float | None)
+        cached_input_write_cost_per_1m_tokens (float | None)
     or None if no custom pricing is configured for the model.
     """
     if not model_name:
@@ -71,6 +77,7 @@ def get_model_pricing(model_name: str) -> dict | None:
                 "input_cost_per_1m_tokens",
                 "output_cost_per_1m_tokens",
                 "cached_input_cost_per_1m_tokens",
+                "cached_input_write_cost_per_1m_tokens",
             ],
             as_dict=True,
         )
@@ -108,6 +115,14 @@ def get_model_pricing(model_name: str) -> dict | None:
             if model_doc.get("cached_input_cost_per_1m_tokens") is not None
             else None
         ),
+        # Cache-CREATION (write) rate. Treated as "configured" only when
+        # non-zero — this Float field has no separate presence flag, so a
+        # bare 0 means "not set" rather than "free cache writes".
+        "cached_input_write_cost_per_1m_tokens": (
+            float(model_doc["cached_input_write_cost_per_1m_tokens"])
+            if model_doc.get("cached_input_write_cost_per_1m_tokens")
+            else None
+        ),
     }
 
     try:
@@ -123,6 +138,7 @@ def _calculate_from_custom_pricing(
     input_tokens: int,
     output_tokens: int,
     cached_tokens: int = 0,
+    cache_creation_tokens: int = 0,
 ) -> float:
     """
     Apply the standard token-cost formula using custom pricing.
@@ -130,27 +146,50 @@ def _calculate_from_custom_pricing(
     Industry standard formula:
       cost = (input  / 1M) * input_price
            + (output / 1M) * output_price
-           + (cached / 1M) * cached_price    (if cached_price is set)
+           + (cached / 1M) * cached_price          (if cached_price is set)
+           + (cache_creation / 1M) * cache_write_price  (if a non-zero write rate is set)
 
-    For cached tokens: if no explicit cached_price is configured we do NOT
-    double-charge them — they are already counted inside input_tokens by the
-    provider, so we simply skip the separate cached line.
+    Both cached (read) tokens and cache-creation (write) tokens are a subset
+    of input_tokens as reported by the provider/LiteLLM — not additional
+    tokens on top of it. If no explicit rate is configured for either one we
+    do NOT double-charge them and we do NOT drop them either: they simply
+    stay inside input_tokens and get billed at the regular input rate.
     """
     input_price = pricing["input_cost_per_1m_tokens"]
     output_price = pricing["output_cost_per_1m_tokens"]
     cached_price = pricing.get("cached_input_cost_per_1m_tokens")
+    cache_write_price = pricing.get("cached_input_write_cost_per_1m_tokens")
 
     cost = 0.0
+    remaining_input = input_tokens
 
     if cached_price is not None and cached_tokens > 0:
-        # Cached tokens are usually a subset of input tokens.
-        # We bill the cached portion at the cached rate, and the remainder at the regular rate.
-        non_cached_input = max(0, input_tokens - cached_tokens)
-        cost += (non_cached_input / 1_000_000) * input_price
+        # Cached (read) tokens are a subset of input tokens.
+        # Bill the cached portion at the cached rate, remove it from the pool
+        # billed at the regular rate.
+        remaining_input = max(0, remaining_input - cached_tokens)
         cost += (cached_tokens / 1_000_000) * cached_price
-    else:
-        # Standard calculation (no caching discount)
-        cost += (input_tokens / 1_000_000) * input_price
+
+    # Falsy (0 or None) means "not configured", not "configured as free". The
+    # AI Model field is a plain Float with no separate presence flag, so a bare
+    # 0 cannot be distinguished from unset -- get_model_pricing() already
+    # normalises it, and this check keeps the invariant even for a caller that
+    # builds a pricing dict without going through it. Unconfigured cache-write
+    # tokens stay in the base-rate pool rather than being billed as free.
+    # (The cache-READ rate deliberately keeps its existing `is not None` check:
+    # 0 has always meant a genuinely free read there, and changing it would
+    # alter costs already being reported.)
+    if cache_write_price and cache_creation_tokens > 0:
+        # Cache-creation (write) tokens are likewise a subset of input tokens.
+        # Same treatment: bill separately at the write rate, remove from the
+        # pool billed at the regular rate.
+        remaining_input = max(0, remaining_input - cache_creation_tokens)
+        cost += (cache_creation_tokens / 1_000_000) * cache_write_price
+
+    # Regular input rate for whatever is left (i.e. everything that wasn't
+    # priced separately above — including cached/cache-creation tokens when
+    # no explicit rate was configured for them).
+    cost += (remaining_input / 1_000_000) * input_price
 
     # Always add output cost
     cost += (output_tokens / 1_000_000) * output_price
@@ -196,6 +235,8 @@ def calculate_cost(
     output_tokens: int,
     cached_tokens: int = 0,
     litellm_response=None,
+    *,
+    cache_creation_tokens: int = 0,
 ) -> tuple[float, str]:
     """
     Calculate the cost of an LLM call and return ``(cost_usd, source)``.
@@ -207,11 +248,15 @@ def calculate_cost(
       "unknown"         — neither source has pricing; cost is 0.0
 
     Args:
-        model_name:       The model name (AI Model docname, e.g. "gpt-4o")
-        input_tokens:     Number of prompt/input tokens
-        output_tokens:    Number of completion/output tokens
-        cached_tokens:    Number of cached tokens (prompt cache hits), default 0
-        litellm_response: Raw litellm completion response object for fallback
+        model_name:            The model name (AI Model docname, e.g. "gpt-4o")
+        input_tokens:          Number of prompt/input tokens
+        output_tokens:         Number of completion/output tokens
+        cached_tokens:         Number of cached tokens (prompt cache reads), default 0
+        litellm_response:      Raw litellm completion response object for fallback
+        cache_creation_tokens: Number of cache-creation tokens (prompt cache writes),
+                                default 0. Only consulted by the custom-pricing branch —
+                                the LiteLLM branch derives it from ``litellm_response``
+                                itself. Keyword-only so existing callers are unaffected.
     """
     # ── Priority 1: HUF custom pricing ──────────────────────────────────────
     try:
@@ -222,6 +267,7 @@ def calculate_cost(
                 input_tokens=int(input_tokens or 0),
                 output_tokens=int(output_tokens or 0),
                 cached_tokens=int(cached_tokens or 0),
+                cache_creation_tokens=int(cache_creation_tokens or 0),
             )
             return cost, "custom"
     except Exception as e:

--- a/huf/ai/flow_engine.py
+++ b/huf/ai/flow_engine.py
@@ -1369,6 +1369,7 @@ def _create_flow_agent_run(flow_run, node: dict, run_kind: str, prompt: str = ""
 			"status": "Started",
 			"prompt": prompt,
 			"flow_run": flow_run.name,
+			"conversation": getattr(flow_run, "conversation", None),
 			"flow_node_id": node.get("id"),
 			"flow_id": flow_run.flow_id,
 			"run_kind": run_kind,

--- a/huf/ai/model_metadata.py
+++ b/huf/ai/model_metadata.py
@@ -1,0 +1,99 @@
+"""Shared model-metadata resolution — currently just the context window.
+
+Used by both the read-side context API (``agent_run_context_api.py``, for
+runs that predate the ``model_context_window`` snapshot column or whose
+snapshot is unset) and the write-side run persistence (``agent_integration.py``,
+to snapshot the window at call time so later AI Model edits cannot rewrite
+history).
+"""
+
+from __future__ import annotations
+
+import re
+
+import frappe
+
+from huf.ai.providers.litellm import _normalize_model_name
+
+
+def _context_window_from_litellm(model_name, provider_name, provider_brand):
+    """Best-effort context-window lookup from LiteLLM's model-cost table.
+
+    Mirrors the normalisation used to price a run (``_normalize_model_name``,
+    also used by ``context_segments.py``) and the segment-aware key matching
+    used by ``prompt_cache_capabilities.py`` to tolerate provider/vendor
+    prefixes in LiteLLM's key names (Azure, Vertex, Bedrock, ...).
+
+    Returns an int, or ``None`` if the model can't be resolved. Never raises
+    — this backs a read-only analytics endpoint and a missing metadata entry
+    must not fail the page.
+    """
+    if not model_name:
+        return None
+
+    try:
+        import litellm
+
+        normalized = _normalize_model_name(model_name, provider_name or "", brand=provider_brand)
+
+        entry = litellm.model_cost.get(normalized)
+        if entry is None:
+            # normalized is "<prefix>/<model>"; the raw model name alone is
+            # also a common key (e.g. "gpt-4-turbo" without "openai/").
+            entry = litellm.model_cost.get(model_name)
+
+        if entry is None:
+            # Segment-aware fallback for keys LiteLLM prefixes with vendor
+            # routing info that isn't captured by our own prefix mapping
+            # (e.g. bedrock/, azure_ai/, region qualifiers).
+            target = model_name.split("/", 1)[-1].lower()
+            escaped_target = re.escape(target)
+            segment_pattern = re.compile(rf"(^|[/\-.:@]){escaped_target}([/\-:@]|$)")
+            for db_key, db_entry in litellm.model_cost.items():
+                if segment_pattern.search(db_key.lower()):
+                    entry = db_entry
+                    break
+
+        if not entry:
+            return None
+
+        context_window = entry.get("max_input_tokens")
+        return int(context_window) if context_window else None
+    except Exception:
+        return None
+
+
+def resolve_model_context_window(model_name, provider_name=None, provider_brand=None):
+    """Resolve a model's context window, independent of any particular run.
+
+    ``model_name`` is an ``AI Model`` link (its docname, which — per the
+    doctype's ``field:model_name`` autoname — is normally the same string
+    as its ``model_name`` field).
+
+    Resolution order, most-authoritative first:
+      1. ``AI Model.context_window`` — explicit metadata on the model record.
+      2. LiteLLM's model-cost table, for models that don't carry an explicit
+         value on the AI Model record.
+      3. ``None`` — explicitly "unknown". Never falls back to a guessed
+         constant: an unmeasured context window must render as unmeasured,
+         not as a confident, likely-wrong number.
+
+    A field is treated as "set" only when it is a truthy, non-zero int; 0
+    and NULL both mean "not set" per the AI Model field convention.
+
+    Never raises; returns ``None`` on any failure.
+    """
+    if not model_name:
+        return None
+
+    try:
+        model_doc = frappe.get_cached_doc("AI Model", model_name)
+    except Exception:
+        return _context_window_from_litellm(model_name, provider_name, provider_brand)
+
+    if model_doc.get("context_window"):
+        return model_doc.context_window
+
+    return _context_window_from_litellm(
+        model_doc.get("model_name"), provider_name, provider_brand
+    )

--- a/huf/ai/providers/litellm.py
+++ b/huf/ai/providers/litellm.py
@@ -30,6 +30,7 @@ from huf.ai.prompt_cache_capabilities import model_supports_prompt_caching
 from huf.ai.transaction import transaction_checkpoint
 from huf.ai.cost_calculator import calculate_cost
 from huf.ai.conversation_manager import repair_message_sequence
+from huf.ai.usage_extraction import extract_round_usage, normalise_usage_payload
 from huf.ai.reasoning import (
     ReasoningPolicy,
     ReasoningResolution,
@@ -552,6 +553,51 @@ def _resolve_api_base(provider_doc) -> str | None:
     return url
 
 
+def _finalize_usage_totals(usage_totals: dict) -> dict:
+    """Populate back-compat alias keys on an accumulated usage dict.
+
+    ``usage_totals`` must already carry the accumulated ``input_tokens`` and
+    ``output_tokens`` (billed sums across all rounds), plus
+    ``cached_tokens``, ``cache_creation_tokens``, ``peak_context_tokens``,
+    ``round_count``, and ``cache_skipped_unsupported_model``. Adds
+    ``prompt_tokens``/``completion_tokens`` (back-compat aliases for
+    ``input_tokens``/``output_tokens``) and ``billed_input_tokens`` (the same
+    value as ``input_tokens``, explicitly named so it is never confused with
+    ``peak_context_tokens``). Mutates and returns ``usage_totals``.
+    """
+    usage_totals["prompt_tokens"] = usage_totals["input_tokens"]
+    usage_totals["completion_tokens"] = usage_totals["output_tokens"]
+    usage_totals["billed_input_tokens"] = usage_totals["input_tokens"]
+    return usage_totals
+
+
+def _accumulate_tool_exchange_tokens(usage_totals: dict, pricing_model: str, new_messages: list):
+    """Best-effort accumulation of one round's tool-exchange token count into `usage_totals`.
+
+    `new_messages` is only the messages appended THIS round (the assistant
+    tool-call message plus its tool results) — never the whole growing
+    message list — so counting stays O(rounds), not O(rounds^2). Imports
+    context_segments lazily: that module imports `_normalize_model_name`
+    from this one, so a module-level import here would be circular.
+
+    Once a round's count fails, `tool_exchange_tokens` degrades to `None`
+    for the rest of the run and stays there: a partial sum would understate
+    the true figure, which is worse than an honest "unknown" for the
+    reconciliation this feeds (see context_segments.reconcile_composition).
+    """
+    if usage_totals.get("tool_exchange_tokens") is None:
+        return
+    try:
+        from huf.ai.context_segments import count_tool_exchange_tokens
+        count = count_tool_exchange_tokens(pricing_model, new_messages)
+    except Exception:
+        count = None
+    if count is None:
+        usage_totals["tool_exchange_tokens"] = None
+    else:
+        usage_totals["tool_exchange_tokens"] += count
+
+
 async def run(agent, enhanced_prompt, provider, model, context=None):
     """
     Unified LiteLLM provider implementation.
@@ -604,6 +650,10 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             frappe.throw("API key not configured in AI Provider.")
 
         normalized_model = _normalize_model_name(model, provider, brand=provider_doc.get("provider_brand"))
+        # Pricing/tokenizer-model name, computed the same way context_segments.py
+        # computes it (no brand override) so tool-exchange counts use the same
+        # tokenizer as the pre-call segment counts they're reconciled against.
+        pricing_model = _normalize_model_name(model, provider)
         is_local_llm = bool(provider_doc.get("is_local_llm", 0))
         api_base = _resolve_api_base(provider_doc)
 
@@ -619,7 +669,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
         gemini_cached_content = prompt_cache_options.get("gemini_cached_content")
         cache_static_prefix = bool(prompt_cache_options.get("cache_static_prefix", True))
         cache_dynamic_content_override = prompt_cache_options.get("cache_dynamic_content")
-        
+
         if agent_doc:
             enable_prompt_caching = bool(agent_doc.get("enable_prompt_caching", 0))
             cache_control_type = agent_doc.get("cache_control_type") or "ephemeral"
@@ -631,7 +681,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             enable_prompt_caching = False
 
         max_context_chars = _get_agent_max_context_chars(agent_doc)
-        
+
         # Check if model supports prompt caching
         model_supports_caching = False
         cache_skipped_unsupported_model = False
@@ -729,8 +779,17 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             "output_tokens": 0,
             "cached_tokens": 0,
             "cache_creation_tokens": 0,
-            "cache_miss_tokens": 0,
+            "billed_input_tokens": 0,
+            "peak_context_tokens": 0,
+            "round_count": 0,
             "cache_skipped_unsupported_model": cache_skipped_unsupported_model,
+            # Tokens contributed by tool-call requests/results across all rounds
+            # (see context_segments.count_tool_exchange_tokens); None if any
+            # round's count failed. round_prompt_tokens is the per-round
+            # prompt-size growth shape, taken from round_usage["input_tokens"]
+            # at no extra tokenizer cost.
+            "tool_exchange_tokens": 0,
+            "round_prompt_tokens": [],
         }
         total_cost = 0.0
         all_new_items = []
@@ -909,29 +968,6 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
                     else:
                         raise e
 
-                try:
-                    # --- Round token counts for cost calculation ---
-                    round_usage = response.usage
-                    round_input  = int(getattr(round_usage, "prompt_tokens", 0) or 0)
-                    round_output = int(getattr(round_usage, "completion_tokens", 0) or 0)
-                    round_cached = 0
-                    if hasattr(round_usage, "prompt_tokens_details") and round_usage.prompt_tokens_details:
-                        _d = round_usage.prompt_tokens_details
-                        round_cached = int(
-                            (getattr(_d, "cached_tokens", None) or getattr(_d, "cache_hit_tokens", None) or 0)
-                        )
-                    round_cost, _cost_source = calculate_cost(
-                        model_name=model,
-                        input_tokens=round_input,
-                        output_tokens=round_output,
-                        cached_tokens=round_cached,
-                        litellm_response=response,
-                    )
-                    total_cost += round_cost
-                except (ValueError, TypeError, AttributeError, KeyError):
-                    # Cost calculation is best-effort; ignore rounding failures.
-                    pass
-
             except InternalServerError as e:
                 raw_msg = (
                     f"OpenAI API server error with model '{normalized_model}'. "
@@ -995,56 +1031,32 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             # Extract response
             choice = response.choices[0].message
 
-            usage = response.usage
-            total_usage["input_tokens"] += (getattr(usage, "prompt_tokens", 0) or 0)
-            total_usage["output_tokens"] += (getattr(usage, "completion_tokens", 0) or 0)
+            # Single extraction of this round's usage, shared by cost calculation
+            # and accumulation into total_usage (see huf/ai/usage_extraction.py).
+            round_usage = extract_round_usage(response.usage)
+            total_usage["input_tokens"] += round_usage["input_tokens"]
+            total_usage["output_tokens"] += round_usage["output_tokens"]
+            total_usage["cached_tokens"] += round_usage["cache_read_tokens"]
+            total_usage["cache_creation_tokens"] += round_usage["cache_write_tokens"]
+            total_usage["round_count"] += 1
+            total_usage["peak_context_tokens"] = max(
+                total_usage["peak_context_tokens"], round_usage["input_tokens"]
+            )
+            total_usage["round_prompt_tokens"].append(round_usage["input_tokens"])
 
-            # Track cached tokens and cache creation/write tokens if available
-            round_cached = 0
-            round_creation = 0
-
-            if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
-                details = usage.prompt_tokens_details
-                if isinstance(details, dict):
-                    round_cached = details.get("cached_tokens") or details.get("cache_hit_tokens") or 0
-                    round_creation = (
-                        details.get("cache_creation_input_tokens")
-                        or details.get("cache_write_tokens")
-                        or details.get("cache_creation_tokens")
-                        or 0
-                    )
-                else:
-                    round_cached = (
-                        getattr(details, "cached_tokens", None)
-                        or getattr(details, "cache_hit_tokens", None)
-                        or 0
-                    )
-                    round_creation = (
-                        getattr(details, "cache_creation_input_tokens", None)
-                        or getattr(details, "cache_write_tokens", None)
-                        or getattr(details, "cache_creation_tokens", None)
-                        or 0
-                    )
-            elif isinstance(usage, dict):
-                round_cached = usage.get("cached_tokens") or usage.get("cache_hit_tokens") or 0
-                round_creation = (
-                    usage.get("cache_creation_input_tokens")
-                    or usage.get("cache_write_input_tokens")
-                    or usage.get("cache_creation_tokens")
-                    or usage.get("cache_miss_tokens")
-                    or 0
+            try:
+                round_cost, _cost_source = calculate_cost(
+                    model_name=model,
+                    input_tokens=round_usage["input_tokens"],
+                    output_tokens=round_usage["output_tokens"],
+                    cached_tokens=round_usage["cache_read_tokens"],
+                    cache_creation_tokens=round_usage["cache_write_tokens"],
+                    litellm_response=response,
                 )
-
-            if not round_creation:
-                round_creation = (
-                    getattr(usage, "cache_creation_input_tokens", None)
-                    or getattr(usage, "cache_write_input_tokens", None)
-                    or 0
-                )
-
-            total_usage["cached_tokens"] += (round_cached or 0)
-            total_usage["cache_creation_tokens"] += (round_creation or 0)
-            total_usage["cache_miss_tokens"] += (round_creation or 0)
+                total_cost += round_cost
+            except (ValueError, TypeError, AttributeError, KeyError):
+                # Cost calculation is best-effort; ignore rounding failures.
+                pass
 
             assistant_message = {
                 "role": "assistant",
@@ -1064,7 +1076,7 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
             # No tool call — return final result
             if not (hasattr(choice, "tool_calls") and choice.tool_calls):
                 return SimpleResult(
-                    choice.content or "", total_usage, all_new_items, cost=total_cost
+                    choice.content or "", _finalize_usage_totals(total_usage), all_new_items, cost=total_cost
                 )
 
             # Handle tool calls
@@ -1165,9 +1177,16 @@ async def run(agent, enhanced_prompt, provider, model, context=None):
 
             messages.extend(tool_results)
 
+            # Accumulate just this round's growth (the assistant tool-call
+            # request plus its results) — never re-tokenise the whole
+            # `messages` list, which would make this O(rounds^2).
+            _accumulate_tool_exchange_tokens(
+                total_usage, pricing_model, [assistant_message] + tool_results
+            )
+
         return SimpleResult(
             "Agent stopped after max rounds of tool calls.",
-            total_usage,
+            _finalize_usage_totals(total_usage),
             all_new_items,
             cost=total_cost,
         )
@@ -1350,6 +1369,10 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
             return
 
         normalized_model = _normalize_model_name(model, provider, brand=provider_doc.get("provider_brand"))
+        # Pricing/tokenizer-model name, computed the same way context_segments.py
+        # computes it (no brand override) so tool-exchange counts use the same
+        # tokenizer as the pre-call segment counts they're reconciled against.
+        pricing_model = _normalize_model_name(model, provider)
         is_local_llm = bool(provider_doc.get("is_local_llm", 0))
         api_base = _resolve_api_base(provider_doc)
 
@@ -1365,7 +1388,7 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         gemini_cached_content = prompt_cache_options.get("gemini_cached_content")
         cache_static_prefix = bool(prompt_cache_options.get("cache_static_prefix", True))
         cache_dynamic_content_override = prompt_cache_options.get("cache_dynamic_content")
-        
+
         if agent_doc:
             enable_prompt_caching = bool(agent_doc.get("enable_prompt_caching", 0))
             cache_control_type = agent_doc.get("cache_control_type") or "ephemeral"
@@ -1591,6 +1614,26 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         last_tool_signature = None
         tool_loop_repeats = 0
         MAX_TOOL_LOOP_REPEATS = 1  # allow one retry, stop on the second repeat
+
+        # Usage/cost accumulator across all rounds of this streaming run. Unlike the
+        # per-round `stream_usage` capture below (reset every round), this survives
+        # the whole loop — see huf/ai/usage_extraction.py for why per-round
+        # extraction must never be conflated with a running total.
+        stream_total_usage = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_tokens": 0,
+            "cache_creation_tokens": 0,
+            "billed_input_tokens": 0,
+            "peak_context_tokens": 0,
+            "round_count": 0,
+            "cache_skipped_unsupported_model": cache_skipped_unsupported_model,
+            # See the matching fields in run()'s total_usage init for what
+            # these mean and why tool_exchange_tokens can degrade to None.
+            "tool_exchange_tokens": 0,
+            "round_prompt_tokens": [],
+        }
+        stream_total_cost = 0.0
 
         for round_num in range(MAX_ROUNDS):
             try:
@@ -1900,6 +1943,14 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                             messages.append(assistant_msg)
                             messages.extend(tool_results)
 
+                            # Accumulate just this round's growth (the assistant
+                            # tool-call request plus its results) — never
+                            # re-tokenise the whole `messages` list, which would
+                            # make this O(rounds^2).
+                            _accumulate_tool_exchange_tokens(
+                                stream_total_usage, pricing_model, [assistant_msg] + tool_results
+                            )
+
                             # Reset for next round
                             streaming_content = ""
                             current_tool_calls = {}
@@ -1907,6 +1958,35 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
 
                         if finish_reason == "stop":
                             is_stop = True
+
+                # Accumulate this round's usage/cost into the running totals. This
+                # runs on every path that completes a round: the tool-call branch
+                # above (which `break`s out of the chunk loop but falls through to
+                # here), a "stop" finish reason, and plain stream exhaustion.
+                round_payload = normalise_usage_payload(stream_usage)
+                round_usage = extract_round_usage(round_payload)
+                stream_total_usage["input_tokens"] += round_usage["input_tokens"]
+                stream_total_usage["output_tokens"] += round_usage["output_tokens"]
+                stream_total_usage["cached_tokens"] += round_usage["cache_read_tokens"]
+                stream_total_usage["cache_creation_tokens"] += round_usage["cache_write_tokens"]
+                stream_total_usage["round_count"] += 1
+                stream_total_usage["peak_context_tokens"] = max(
+                    stream_total_usage["peak_context_tokens"], round_usage["input_tokens"]
+                )
+                stream_total_usage["round_prompt_tokens"].append(round_usage["input_tokens"])
+
+                try:
+                    round_cost, _cost_source = calculate_cost(
+                        model_name=model,
+                        input_tokens=round_usage["input_tokens"],
+                        output_tokens=round_usage["output_tokens"],
+                        cached_tokens=round_usage["cache_read_tokens"],
+                        cache_creation_tokens=round_usage["cache_write_tokens"],
+                    )
+                    stream_total_cost += round_cost
+                except (ValueError, TypeError, AttributeError, KeyError):
+                    # Cost calculation is best-effort; ignore rounding failures.
+                    pass
 
                 if is_stop:
                     break
@@ -1936,57 +2016,9 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
                 yield {"type": "error", "error": _sanitize_provider_error_message(raw_msg, normalized_model)}
                 return
 
-        # Max rounds reached
-        if stream_usage and hasattr(stream_usage, "dict"):
-             stream_usage = stream_usage.dict()
-        elif stream_usage and hasattr(stream_usage, "model_dump"):
-             stream_usage = stream_usage.model_dump()
-
-        if not stream_usage or not isinstance(stream_usage, dict):
-            stream_usage = {}
-
-        # Extract cache creation tokens and cache skipped flag for stream_usage
-        s_cached = 0
-        s_creation = 0
-        s_details = stream_usage.get("prompt_tokens_details") or {}
-        if isinstance(s_details, dict):
-            s_cached = int(s_details.get("cached_tokens", 0) or s_details.get("cache_hit_tokens", 0) or 0)
-            s_creation = int(
-                s_details.get("cache_creation_input_tokens", 0)
-                or s_details.get("cache_write_tokens", 0)
-                or s_details.get("cache_creation_tokens", 0)
-                or 0
-            )
-
-        if not s_creation:
-            s_creation = int(
-                stream_usage.get("cache_creation_input_tokens", 0)
-                or stream_usage.get("cache_write_input_tokens", 0)
-                or stream_usage.get("cache_creation_tokens", 0)
-                or stream_usage.get("cache_miss_tokens", 0)
-                or 0
-            )
-
-        stream_usage["cached_tokens"] = s_cached
-        stream_usage["cache_creation_tokens"] = s_creation
-        stream_usage["cache_miss_tokens"] = s_creation
-        stream_usage["cache_skipped_unsupported_model"] = cache_skipped_unsupported_model
-
-        # Calculate cost from streaming usage
-        stream_cost = 0.0
-        if stream_usage and isinstance(stream_usage, dict):
-            try:
-                s_input   = int(stream_usage.get("prompt_tokens", 0) or 0)
-                s_output  = int(stream_usage.get("completion_tokens", 0) or 0)
-                stream_cost, _src = calculate_cost(
-                    model_name=model,
-                    input_tokens=s_input,
-                    output_tokens=s_output,
-                    cached_tokens=s_cached,
-                )
-            except (ValueError, TypeError, AttributeError, KeyError):
-                # Stream cost calculation is best-effort; ignore failures.
-                pass
+        # Max rounds reached (or the loop broke via is_stop). Finalize the
+        # accumulated per-round totals — never the last round's usage alone.
+        _finalize_usage_totals(stream_total_usage)
 
         # Never report an empty response as a successful completion.
         if not full_response.strip() and not had_tool_calls:
@@ -2011,8 +2043,8 @@ async def run_stream(agent, enhanced_prompt, provider, model, context=None):
         yield {
             "type": "complete",
             "full_response": full_response or "Agent stopped after max rounds.",
-            "usage": stream_usage,
-            "cost": stream_cost,
+            "usage": stream_total_usage,
+            "cost": stream_total_cost,
             "reasoning_content": accumulated_reasoning_content or None,
         }
 

--- a/huf/ai/run.py
+++ b/huf/ai/run.py
@@ -2,6 +2,25 @@ import frappe
 from frappe import _
 
 
+async def _await_tagged(coro, provider_path):
+    """Await a provider coroutine and tag the result with the path that served it.
+
+    RunProvider.run() is a *sync* method that returns the provider's coroutine
+    without awaiting it -- the caller awaits. So the marker cannot be attached to
+    what run() returns directly: a coroutine object has no __dict__ and assigning
+    to it raises AttributeError. Wrapping keeps run()'s existing semantics (still
+    returns an awaitable, still defers execution to the caller) while attaching
+    the marker to the real result once it exists.
+    """
+    result = await coro
+    try:
+        result.provider_path = provider_path
+    except (AttributeError, TypeError):
+        # Marking is observability, never a reason to fail a run.
+        pass
+    return result
+
+
 class RunProvider:
     """
     Central routing layer for AI providers.
@@ -21,7 +40,10 @@ class RunProvider:
         # This supports OpenAI, Anthropic, Google, and 100+ others automatically.
         try:
             from huf.ai.providers import litellm
-            return litellm.run(agent, enhanced_prompt, provider, model, context=context)
+            return _await_tagged(
+                litellm.run(agent, enhanced_prompt, provider, model, context=context),
+                "litellm",
+            )
 
         except ImportError as e:
             # Handle case where litellm package is missing
@@ -70,7 +92,10 @@ class RunProvider:
             frappe.throw(_(f"Provider {provider} is missing a run() function"))
 
         try:
-            return module.run(agent, enhanced_prompt, provider, model, context=context)
+            return _await_tagged(
+                module.run(agent, enhanced_prompt, provider, model, context=context),
+                "legacy_fallback",
+            )
         except Exception:
             # If custom module existed but failed, raise the original LiteLLM error if present
             if original_exception:

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -94,7 +94,42 @@ def _check_tool_permission(tool_type: str, context: dict = None, allowed_for_gue
     return {"allowed": True}
 
 
-def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
+# Tools that must always be built eagerly for a lazy-discovery agent: the
+# discovery tools themselves (without them the agent could never unlock
+# anything else) plus the small set of always-on utility tools.
+_LAZY_DISCOVERY_TOOL_NAMES = {"list_tool_groups", "search_tools", "describe_tool_group", "load_tools"}
+_LAZY_DISCOVERY_ALWAYS_EAGER_TOOL_NAMES = _LAZY_DISCOVERY_TOOL_NAMES | {
+    "get_conversation_data", "set_conversation_data", "load_conversation_data",
+    "ask_user", "get_result_context",
+}
+
+
+def _get_lazy_discovered_tool_names(kwargs: dict) -> set:
+    """Tool names already unlocked via lazy discovery for the current conversation.
+
+    Fails safe (empty set) whenever no conversation context is available or
+    conversation_data can't be read, so lazy-tool agents never break outside
+    a conversation run (e.g. no conversation_id in this run context yet).
+    """
+    conversation_id = (kwargs or {}).get("conversation_id")
+    if not conversation_id:
+        return set()
+
+    try:
+        data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+        state = _load_state(data_json)
+        for item in state["items"]:
+            if item.get("name") == "_lazy_tools":
+                discovered = (item.get("value") or {}).get("discovered") or []
+                return set(discovered)
+    except Exception as e:
+        logger.debug(f"Could not resolve lazy-discovered tools for {conversation_id}: {e!s}")
+        return set()
+
+    return set()
+
+
+def create_agent_tools(agent, model_name: str = None, **kwargs) -> list[FunctionTool]:
     """
     Create function tools for Huf Agent
 
@@ -106,8 +141,16 @@ def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
     agent.model when omitted) — passed through to the permission-aware
     registry so an AI Model's capability overrides (see huf.ai.capability_discovery)
     can gate tools like ask_user regardless of the agent's own setting.
+
+    When agent.enable_lazy_tools is set, native tools not yet unlocked via the
+    lazy-discovery flow (see huf.ai.tools.lazy_discovery) are skipped entirely
+    instead of being built, to save tokens on the tool schema payload sent to
+    the model. This is gated on kwargs["conversation_id"]; callers that don't
+    pass one get the fail-safe (nothing discovered yet) rather than an error.
     """
     tools = []
+    lazy_enabled = bool(getattr(agent, "enable_lazy_tools", False))
+    discovered_tool_names = _get_lazy_discovered_tool_names(kwargs) if lazy_enabled else set()
 
     # Load MCP tools from linked MCP servers
     if hasattr(agent, "agent_mcp_server") and agent.agent_mcp_server:
@@ -127,6 +170,16 @@ def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
 
     for function_doc in allowed_tool_docs:
         try:
+            if lazy_enabled:
+                tool_name = function_doc.tool_name or ""
+                is_always_eager = (
+                    tool_name in _LAZY_DISCOVERY_ALWAYS_EAGER_TOOL_NAMES
+                    or "memory" in tool_name.lower()
+                )
+                if not is_always_eager and tool_name not in discovered_tool_names:
+                    # Deferred: skip building this tool entirely (don't even
+                    # fetch its schema) until the model discovers it.
+                    continue
 
             function_path = None
             if function_doc.types in ["Custom Function", "App Provided"]:

--- a/huf/ai/system_prompt_retention.py
+++ b/huf/ai/system_prompt_retention.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Opt-in persistence of the exact assembled system prompt an Agent Run received.
+
+D15 in the analytics/observability audit: context_segments.py counts the token
+*size* of the system prompt (segment_tokens.system) but never keeps its *text*,
+so "what did this run actually see" is unanswerable once agent or skill config
+changes. Persisting the full text unconditionally would be the wrong default:
+unbounded storage growth, and a new PII surface, since the assembled prompt
+includes memory-block and injected knowledge-base text that may carry user
+data. Some deployments legitimately need the opposite of the default here --
+legal/compliance obligations to retain the exact prompt a run saw -- so this
+is a site operator's explicit choice, off unless turned on:
+
+    bench set-config huf_retain_system_prompts_enabled true
+
+When enabled, the exact text is written to a dedicated Agent Run Prompt
+Snapshot doc rather than onto Agent Run itself, so a future retention/rotation
+job (not built here) can purge old snapshots by captured_at without touching
+the Agent Run table, and so the snapshot table can carry its own, tighter
+permissions than Agent Run's.
+
+Scope note: this is a system-wide switch, not a per-agent one, exactly as
+requested. A per-agent override that further narrows this site-wide switch is
+a natural follow-up once there is a field on the Agent doctype for it; it
+would check both switches (site-wide AND per-agent), not replace this one.
+"""
+
+import frappe
+
+SITE_CONFIG_KEY = "huf_retain_system_prompts_enabled"
+
+
+def is_enabled() -> bool:
+    return bool(frappe.conf.get(SITE_CONFIG_KEY))
+
+
+def maybe_snapshot_system_prompt(run_name, agent_name, conversation_name, instructions):
+    """Best-effort, opt-in only. Never raises -- a snapshot failure must never fail the run."""
+    if not is_enabled() or not instructions:
+        return
+    try:
+        frappe.get_doc({
+            "doctype": "Agent Run Prompt Snapshot",
+            "agent_run": run_name,
+            "agent": agent_name,
+            "conversation": conversation_name,
+            "captured_at": frappe.utils.now_datetime(),
+            "system_prompt": instructions,
+        }).insert(ignore_permissions=True)
+    except Exception:
+        frappe.log_error(
+            title="System Prompt Retention",
+            message=f"Failed to snapshot system prompt for Agent Run {run_name}\n\n{frappe.get_traceback()}",
+        )

--- a/huf/ai/tests/_stub_env.py
+++ b/huf/ai/tests/_stub_env.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Shared sys.modules stubbing for standalone (frappe-less, litellm-less) test runs.
+
+`huf/ai/tests/conftest.py` stubs a bare `frappe` MagicMock, which is enough for
+modules that only ever do `import frappe` / `frappe.something(...)`. Several of
+the modules under test here also do submodule-style imports —
+`from frappe.utils import now`, `from frappe.tests import UnitTestCase`,
+`from litellm.utils import trim_messages`, `from litellm import token_counter`,
+`from agents.tool_context import ToolContext` — which a bare MagicMock cannot
+satisfy (`ModuleNotFoundError: 'frappe' is not a package`). This module installs
+proper (empty-but-importable) submodules for exactly those import sites so the
+real production code under test — `huf.ai.providers.litellm`,
+`huf.ai.context_segments`, `huf.ai.agent_run_analytics`, `huf.ai.cost_calculator`
+— can be imported unmodified in this environment, where frappe is not installed
+and the `litellm` package resolves to a broken/partial namespace install (see
+`/opt/homebrew/lib/python3.14/site-packages/litellm.pth`, unrelated to this repo).
+
+Call `install()` before importing any `huf.ai.*` module. Safe to call multiple
+times (idempotent — checks `sys.modules` first).
+"""
+
+import json
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _make_module(name):
+    if name in sys.modules:
+        return sys.modules[name]
+    module = types.ModuleType(name)
+    sys.modules[name] = module
+    return module
+
+
+def install():
+    # --- frappe -------------------------------------------------------
+    if "frappe" not in sys.modules or not hasattr(sys.modules["frappe"], "__path__"):
+        frappe = MagicMock(name="frappe")
+        frappe.__path__ = []  # makes `frappe` importable as a package
+        sys.modules["frappe"] = frappe
+    frappe = sys.modules["frappe"]
+    # `frappe.as_json` is used by huf.ai.context_segments to serialize tool
+    # calls before token-counting them. A bare MagicMock return value has no
+    # real length/content, which silently zeroes out any test relying on the
+    # serialized text -- wire it to the real json.dumps so counting behaves
+    # like it does in production.
+    frappe.as_json = lambda obj, **kwargs: json.dumps(obj)
+
+    frappe_utils = _make_module("frappe.utils")
+    frappe_utils.now = MagicMock(return_value="2026-01-01 00:00:00")
+    frappe_utils.add_to_date = MagicMock()
+    frappe_utils.get_datetime = MagicMock(side_effect=lambda v: v)
+    frappe_utils.now_datetime = MagicMock()
+    frappe.utils = frappe_utils
+
+    frappe_tests = _make_module("frappe.tests")
+
+    class UnitTestCase:
+        pass
+
+    frappe_tests.UnitTestCase = UnitTestCase
+    frappe.tests = frappe_tests
+
+    # --- litellm --------------------------------------------------------
+    # The real `litellm` package (pip-installed, version 1.95.0) is shadowed in
+    # this environment by an unrelated broken namespace package at
+    # /private/tmp/litellm_work — `import litellm` succeeds but exposes no
+    # attributes at all. Stub it fully rather than depending on that install.
+    if "litellm" not in sys.modules or not isinstance(sys.modules["litellm"], MagicMock):
+        litellm_mock = MagicMock(name="litellm")
+
+        class InternalServerError(Exception):
+            pass
+
+        class RateLimitError(Exception):
+            pass
+
+        class APIError(Exception):
+            pass
+
+        class BadRequestError(Exception):
+            pass
+
+        class ContextWindowExceededError(Exception):
+            pass
+
+        litellm_mock.InternalServerError = InternalServerError
+        litellm_mock.RateLimitError = RateLimitError
+        litellm_mock.APIError = APIError
+        litellm_mock.BadRequestError = BadRequestError
+        litellm_mock.ContextWindowExceededError = ContextWindowExceededError
+        litellm_mock.token_counter = MagicMock(return_value=0)
+        sys.modules["litellm"] = litellm_mock
+
+    litellm_utils = _make_module("litellm.utils")
+    litellm_utils.trim_messages = MagicMock()
+
+    # --- agents (OpenAI Agents SDK) --------------------------------------
+    _make_module("agents")
+    agents_tool_context = _make_module("agents.tool_context")
+
+    class ToolContext:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    agents_tool_context.ToolContext = ToolContext
+
+    agents_usage = _make_module("agents.usage")
+
+    class Usage:
+        pass
+
+    agents_usage.Usage = Usage
+
+    # --- huf / huf.ai / huf.ai.providers packages ------------------------
+    # sys.path already has the repo root on it when tests are run from there;
+    # these just need to exist as importable packages pointing at the real
+    # on-disk source so `import huf.ai.providers.litellm` etc. resolve normally.
+    repo_pkg = _make_module("huf")
+    if not hasattr(repo_pkg, "__path__"):
+        repo_pkg.__path__ = ["huf"]
+
+    ai_pkg = _make_module("huf.ai")
+    if not hasattr(ai_pkg, "__path__"):
+        ai_pkg.__path__ = ["huf/ai"]
+
+    providers_pkg = _make_module("huf.ai.providers")
+    if not hasattr(providers_pkg, "__path__"):
+        providers_pkg.__path__ = ["huf/ai/providers"]

--- a/huf/ai/tests/test_agent_run_analytics.py
+++ b/huf/ai/tests/test_agent_run_analytics.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from frappe.tests import UnitTestCase
 
-from huf.ai.agent_run_analytics import _bucket_start, _dimension_key
+from huf.ai.agent_run_analytics import DIMENSION_FIELDS, _bucket_start, _dimension_key
 
 
 class TestAgentRunAnalytics(UnitTestCase):
@@ -13,6 +13,42 @@ class TestAgentRunAnalytics(UnitTestCase):
 
     def test_dimension_key_preserves_missing_dimensions(self):
         self.assertEqual(
-            _dimension_key({"agent": "Support", "provider": None, "model": "gemini", "run_kind": None}),
-            "Support|__none__|gemini|__none__",
+            _dimension_key(
+                {
+                    "agent": "Support",
+                    "provider": None,
+                    "model": "gemini",
+                    "run_kind": None,
+                    "conversation": None,
+                }
+            ),
+            "Support|__none__|gemini|__none__|__none__",
         )
+
+    def test_dimension_key_includes_conversation(self):
+        self.assertEqual(
+            _dimension_key(
+                {
+                    "agent": "Support",
+                    "provider": "openai",
+                    "model": "gpt-4",
+                    "run_kind": "agent",
+                    "conversation": "CONV-0001",
+                }
+            ),
+            "Support|openai|gpt-4|agent|CONV-0001",
+        )
+
+    def test_conversation_is_appended_last_so_stored_keys_stay_decodable(self):
+        # dimension_key strings are persisted on existing rollup rows. Appending
+        # conversation keeps every previously-stored 4-field key decodable: it
+        # simply reads back with conversation == "__none__". Inserting it earlier
+        # would silently reinterpret every stored key's remaining fields.
+        self.assertEqual(DIMENSION_FIELDS[:4], ("agent", "provider", "model", "run_kind"))
+        self.assertEqual(DIMENSION_FIELDS[-1], "conversation")
+
+        stored_legacy_key = "Support|openai|gpt-4|agent"
+        decoded = dict(zip(DIMENSION_FIELDS, stored_legacy_key.split("|")))
+        self.assertEqual(decoded["agent"], "Support")
+        self.assertEqual(decoded["run_kind"], "agent")
+        self.assertNotIn("conversation", decoded)

--- a/huf/ai/tests/test_agent_run_analytics_composition.py
+++ b/huf/ai/tests/test_agent_run_analytics_composition.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Tests for huf.ai.agent_run_analytics._accumulate_composition and
+_load_segment_tokens.
+
+`huf/ai/tests/test_agent_run_analytics.py` already covers DIMENSION_FIELDS
+append-last compatibility (`_dimension_key`, `_bucket_start`, and the
+"conversation appended last so stored keys stay decodable" contract) -- not
+duplicated here.
+
+_accumulate_composition:
+  - a segment total becomes, and STAYS, None once any contributing run
+    reports None for that segment (poisons the running sum permanently,
+    even if a later run reports a real number for it)
+  - numeric values (int or float) accumulate normally
+  - non-numeric, non-None values are ignored rather than raising
+
+_load_segment_tokens:
+  - degrades to {} on: no snapshot, a JSON string that fails to parse, a
+    non-dict snapshot, a dict snapshot with no segment_tokens key, and a
+    segment_tokens value that itself isn't a dict
+  - passes through an already-parsed dict snapshot's segment_tokens as-is
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.agent_run_analytics import _accumulate_composition, _load_segment_tokens  # noqa: E402
+
+
+class TestAccumulateComposition(unittest.TestCase):
+    def test_numeric_values_accumulate(self):
+        totals = {}
+        _accumulate_composition(totals, {"system": 10, "tools": 5})
+        _accumulate_composition(totals, {"system": 20, "tools": 3})
+        self.assertEqual(totals["system"], 30)
+        self.assertEqual(totals["tools"], 8)
+
+    def test_float_values_accumulate(self):
+        totals = {}
+        _accumulate_composition(totals, {"knowledge": 1.5})
+        _accumulate_composition(totals, {"knowledge": 2.5})
+        self.assertEqual(totals["knowledge"], 4.0)
+
+    def test_none_poisons_the_segment_total(self):
+        totals = {}
+        _accumulate_composition(totals, {"history": 10})
+        _accumulate_composition(totals, {"history": None})
+        self.assertIsNone(totals["history"])
+
+    def test_none_poisoning_is_permanent_even_after_later_numeric_runs(self):
+        # Once a bucket's segment total is None, a subsequent run reporting
+        # a real number for that segment must NOT silently "heal" it back
+        # to a number -- the bucket already contains at least one run whose
+        # true contribution is unknown, so the total must stay unknown.
+        totals = {}
+        _accumulate_composition(totals, {"tools": 10})
+        _accumulate_composition(totals, {"tools": None})
+        _accumulate_composition(totals, {"tools": 50})
+        self.assertIsNone(totals["tools"])
+
+    def test_first_run_reporting_none_for_a_fresh_segment_starts_it_at_none(self):
+        totals = {}
+        _accumulate_composition(totals, {"message": None})
+        self.assertIsNone(totals["message"])
+        _accumulate_composition(totals, {"message": 99})
+        self.assertIsNone(totals["message"])
+
+    def test_non_numeric_non_none_values_are_ignored_not_raised(self):
+        totals = {}
+        # Should not raise for a string, list, or dict value.
+        _accumulate_composition(totals, {"system": "not a number"})
+        _accumulate_composition(totals, {"tools": [1, 2, 3]})
+        _accumulate_composition(totals, {"knowledge": {"nested": True}})
+        self.assertNotIn("system", totals)
+        self.assertNotIn("tools", totals)
+        self.assertNotIn("knowledge", totals)
+
+    def test_ignored_garbage_does_not_block_a_later_real_number(self):
+        totals = {}
+        _accumulate_composition(totals, {"history": "garbage"})
+        _accumulate_composition(totals, {"history": 7})
+        self.assertEqual(totals["history"], 7)
+
+    def test_multiple_segments_tracked_independently(self):
+        totals = {}
+        _accumulate_composition(totals, {"system": 10, "tools": None, "message": 5})
+        _accumulate_composition(totals, {"system": 10, "tools": 100, "message": None})
+        self.assertEqual(totals["system"], 20)
+        self.assertIsNone(totals["tools"])
+        self.assertIsNone(totals["message"])
+
+    def test_empty_segment_tokens_is_a_no_op(self):
+        totals = {"system": 10}
+        _accumulate_composition(totals, {})
+        self.assertEqual(totals, {"system": 10})
+
+
+class TestLoadSegmentTokens(unittest.TestCase):
+    def test_none_snapshot_returns_empty_dict(self):
+        self.assertEqual(_load_segment_tokens(None), {})
+
+    def test_empty_string_snapshot_returns_empty_dict(self):
+        self.assertEqual(_load_segment_tokens(""), {})
+
+    def test_bad_json_string_returns_empty_dict(self):
+        self.assertEqual(_load_segment_tokens("{not valid json"), {})
+
+    def test_valid_json_string_with_segment_tokens_is_parsed(self):
+        snapshot = '{"segment_tokens": {"system": 10, "tools": 5}}'
+        self.assertEqual(_load_segment_tokens(snapshot), {"system": 10, "tools": 5})
+
+    def test_already_parsed_dict_snapshot_passes_through(self):
+        snapshot = {"segment_tokens": {"history": 3}}
+        self.assertEqual(_load_segment_tokens(snapshot), {"history": 3})
+
+    def test_non_dict_snapshot_returns_empty_dict(self):
+        self.assertEqual(_load_segment_tokens(["not", "a", "dict"]), {})
+        self.assertEqual(_load_segment_tokens(42), {})
+
+    def test_dict_snapshot_missing_segment_tokens_key_returns_empty_dict(self):
+        self.assertEqual(_load_segment_tokens({"other_key": 1}), {})
+
+    def test_segment_tokens_value_not_a_dict_returns_empty_dict(self):
+        self.assertEqual(_load_segment_tokens({"segment_tokens": "not a dict"}), {})
+        self.assertEqual(_load_segment_tokens({"segment_tokens": [1, 2]}), {})
+        self.assertEqual(_load_segment_tokens({"segment_tokens": None}), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_cache_metrics.py
+++ b/huf/ai/tests/test_cache_metrics.py
@@ -9,7 +9,7 @@ class TestCacheMetrics(UnitTestCase):
         metrics = compute_run_metrics(run)
         self.assertIsNone(metrics["cache_read_share"])
         self.assertIsNone(metrics["effective_input_multiplier"])
-        self.assertIsNone(metrics["wasted_writes_tokens"])
+        self.assertNotIn("wasted_writes_tokens", metrics)
         self.assertEqual(metrics["prefix_stability"], "unavailable")
 
     def test_cache_read_share_and_multiplier(self):

--- a/huf/ai/tests/test_cache_miss_tokens_alias_removed.py
+++ b/huf/ai/tests/test_cache_miss_tokens_alias_removed.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+D3: the `cache_miss_tokens` alias is gone.
+
+`huf/ai/tests/test_usage_extraction.py` already thoroughly covers that
+`extract_round_usage` does not fold `cache_miss_tokens` into
+`cache_write_tokens` (`test_cache_miss_tokens_does_not_leak_into_cache_write`,
+both with and without a real cache-write key present alongside it). This file
+adds only what that suite does not already assert: that the key
+`cache_miss_tokens` itself never appears anywhere in the dict
+`extract_round_usage` produces, for any input -- not just that its value
+doesn't leak into `cache_write_tokens`, but that it isn't echoed through
+under its own name either. `extract_round_usage`'s docstring guarantees its
+result always has exactly four keys; this pins that guarantee specifically
+against the retired alias.
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.usage_extraction import extract_round_usage  # noqa: E402
+
+
+class TestCacheMissTokensAliasIsGone(unittest.TestCase):
+    def test_cache_miss_tokens_key_never_appears_in_result(self):
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cache_miss_tokens": 999,
+        }
+        result = extract_round_usage(usage)
+        self.assertNotIn("cache_miss_tokens", result)
+
+    def test_result_keys_are_exactly_the_documented_four(self):
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cache_miss_tokens": 999,
+            "cached_tokens": 3,
+            "cache_creation_tokens": 4,
+        }
+        result = extract_round_usage(usage)
+        self.assertEqual(
+            set(result.keys()),
+            {"input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"},
+        )
+
+    def test_cache_miss_tokens_absent_even_with_no_other_cache_fields(self):
+        # A payload where cache_miss_tokens is the ONLY cache-shaped field
+        # present must still come back with cache_write_tokens == 0, not
+        # cache_miss_tokens's value under any key.
+        usage = {"prompt_tokens": 1, "completion_tokens": 1, "cache_miss_tokens": 500}
+        result = extract_round_usage(usage)
+        self.assertEqual(result["cache_write_tokens"], 0)
+        self.assertNotIn(500, result.values())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_context_segments_reconcile.py
+++ b/huf/ai/tests/test_context_segments_reconcile.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Tests for huf.ai.context_segments.reconcile_composition -- the unknown
+propagation rules documented in its docstring:
+
+  - any `None` in `segment_tokens` -> the whole comparison is `None`
+  - `tool_exchange_tokens is None` -> `None` (unknown must never be summed as 0)
+  - `tool_exchange_tokens == 0` -> DOES reconcile (a single-round run
+    genuinely has no tool exchange -- 0 is a real measurement, not unknown)
+  - falsy `provider_prompt_tokens` (0 or None) -> `None` (nothing to compare against)
+  - within tolerance -> `within_tolerance` True; beyond -> False (and a warning is logged)
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.context_segments import reconcile_composition  # noqa: E402
+
+
+class TestReconcileCompositionUnknownPropagation(unittest.TestCase):
+    def test_any_none_segment_makes_the_whole_comparison_none(self):
+        segments = {"system": 10, "tools": None, "knowledge": 0, "history": 5, "message": 3}
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100)
+        self.assertIsNone(result)
+
+    def test_all_segments_counted_but_tool_exchange_none_is_still_none(self):
+        # Unknown tool_exchange_tokens must not be silently treated as 0 --
+        # summing it as 0 would understate `counted` and report a spurious
+        # divergence that is purely an artefact of the failed count.
+        segments = {"system": 10, "tools": 5, "knowledge": 0, "history": 5, "message": 3}
+        result = reconcile_composition(segments, tool_exchange_tokens=None, provider_prompt_tokens=100)
+        self.assertIsNone(result)
+
+    def test_tool_exchange_tokens_zero_does_reconcile(self):
+        # 0 is a real measurement (a single-round run has no tool exchange
+        # at all), not an unknown -- must NOT be treated the same as None.
+        segments = {"system": 40, "tools": 20, "knowledge": 0, "history": 30, "message": 10}
+        # sum(segments) = 100, + tool_exchange_tokens(0) = 100 == reported
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["counted"], 100)
+        self.assertTrue(result["within_tolerance"])
+
+    def test_falsy_provider_prompt_tokens_zero_returns_none(self):
+        segments = {"system": 10, "tools": 5, "knowledge": 0, "history": 5, "message": 3}
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=0)
+        self.assertIsNone(result)
+
+    def test_falsy_provider_prompt_tokens_none_returns_none(self):
+        segments = {"system": 10, "tools": 5, "knowledge": 0, "history": 5, "message": 3}
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=None)
+        self.assertIsNone(result)
+
+    def test_empty_or_non_dict_segment_tokens_returns_none(self):
+        self.assertIsNone(reconcile_composition({}, tool_exchange_tokens=0, provider_prompt_tokens=100))
+        self.assertIsNone(reconcile_composition(None, tool_exchange_tokens=0, provider_prompt_tokens=100))
+
+    def test_within_tolerance_true_when_delta_is_small(self):
+        # sum(segments) = 95, tool_exchange = 0 -> counted = 95, reported = 100
+        # delta_ratio = 5/100 = 0.05, well within the default 0.15 tolerance
+        segments = {"system": 40, "tools": 20, "knowledge": 0, "history": 25, "message": 10}
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100)
+        self.assertTrue(result["within_tolerance"])
+        self.assertEqual(result["counted"], 95)
+        self.assertEqual(result["reported"], 100)
+        self.assertAlmostEqual(result["delta_ratio"], 0.05)
+
+    def test_beyond_tolerance_false_and_warning_logged(self):
+        # sum(segments) = 50, tool_exchange = 0 -> counted = 50 vs reported = 100
+        # delta_ratio = 0.5, well beyond the default 0.15 tolerance
+        segments = {"system": 20, "tools": 10, "knowledge": 0, "history": 15, "message": 5}
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100)
+        self.assertFalse(result["within_tolerance"])
+        self.assertAlmostEqual(result["delta_ratio"], 0.5)
+
+        import frappe
+
+        self.assertTrue(frappe.logger.called or frappe.logger("huf").warning.called)
+
+    def test_within_tolerance_boundary_is_inclusive(self):
+        # delta_ratio exactly equal to tolerance (0.15) must count as within
+        # tolerance -- the docstring says "delta_ratio <= tolerance".
+        segments = {"system": 85}
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100, tolerance=0.15)
+        self.assertEqual(result["delta_ratio"], 0.15)
+        self.assertTrue(result["within_tolerance"])
+
+    def test_custom_tolerance_is_respected(self):
+        segments = {"system": 90}
+        # delta_ratio = 0.10; with a tight 0.05 tolerance this should fail.
+        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100, tolerance=0.05)
+        self.assertFalse(result["within_tolerance"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_context_segments_tool_exchange.py
+++ b/huf/ai/tests/test_context_segments_tool_exchange.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Tests for huf.ai.context_segments.count_tool_exchange_tokens:
+
+  - counts assistant messages carrying `tool_calls` (the serialized
+    name+arguments payload, not `content`)
+  - counts messages with role == "tool" (the tool result content)
+  - does NOT count system/user/plain-assistant (no tool_calls) messages
+  - returns None if any message's count fails
+  - handles both string and list-of-content-block `content` shapes
+
+`_count()` (the module's shared token counter) calls `litellm.token_counter`,
+which is stubbed in this environment (see huf/ai/tests/_stub_env.py) to
+return a deterministic value via a side_effect keyed on text length, so
+these tests can assert on exact counted totals rather than "it ran".
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+import litellm  # noqa: E402
+from huf.ai.context_segments import count_tool_exchange_tokens  # noqa: E402
+
+
+class TestCountToolExchangeTokens(unittest.TestCase):
+    def setUp(self):
+        # Deterministic per-call token count: 1 "token" per character. Lets
+        # tests assert exact totals without depending on a real tokenizer.
+        litellm.token_counter.side_effect = lambda model, text: len(text)
+        litellm.token_counter.return_value = None
+
+    def tearDown(self):
+        litellm.token_counter.side_effect = None
+        litellm.token_counter.return_value = 0
+
+    def test_empty_or_none_messages_returns_zero(self):
+        self.assertEqual(count_tool_exchange_tokens("gpt-4", []), 0)
+        self.assertEqual(count_tool_exchange_tokens("gpt-4", None), 0)
+
+    def test_counts_assistant_message_with_tool_calls(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": "search", "arguments": '{"q": "some longer search query"}'}},
+                ],
+            }
+        ]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertIsInstance(result, int)
+        self.assertGreater(result, 0)
+
+    def test_counts_tool_role_message(self):
+        messages = [{"role": "tool", "content": "the tool result"}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, len("the tool result"))
+
+    def test_does_not_count_system_message(self):
+        messages = [{"role": "system", "content": "you are a helpful assistant with lots of instructions"}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, 0)
+
+    def test_does_not_count_user_message(self):
+        messages = [{"role": "user", "content": "please do something for me"}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, 0)
+
+    def test_does_not_count_plain_assistant_message_without_tool_calls(self):
+        messages = [{"role": "assistant", "content": "here is my final answer to your question"}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, 0)
+
+    def test_assistant_tool_calls_counts_arguments_not_content(self):
+        # An assistant tool-calling turn's `content` is frequently empty and
+        # is deliberately not the thing measured -- only the serialized
+        # tool_calls payload is counted.
+        messages = [
+            {
+                "role": "assistant",
+                "content": "this large content block should not be counted at all",
+                "tool_calls": [{"function": {"name": "f", "arguments": "{}"}}],
+            }
+        ]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        # Serialized {"name": "f", "arguments": "{}"} is much shorter than
+        # the (ignored) content string above.
+        self.assertLess(result, len(messages[0]["content"]))
+
+    def test_tool_message_with_list_of_content_blocks_shape(self):
+        messages = [
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "part one "},
+                    {"type": "text", "text": "part two"},
+                ],
+            }
+        ]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, len("part one \npart two"))
+
+    def test_tool_message_with_string_content_shape(self):
+        messages = [{"role": "tool", "content": "plain string result"}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, len("plain string result"))
+
+    def test_sums_across_multiple_qualifying_messages(self):
+        messages = [
+            {"role": "system", "content": "ignored"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"function": {"name": "f", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "result one"},
+            {"role": "user", "content": "ignored too"},
+            {"role": "tool", "content": "result two"},
+        ]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        tool_call_only_result = count_tool_exchange_tokens(
+            "gpt-4",
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"function": {"name": "f", "arguments": "{}"}}],
+                }
+            ],
+        )
+        expected = tool_call_only_result + len("result one") + len("result two")
+        self.assertEqual(result, expected)
+
+    def test_returns_none_when_a_message_count_fails(self):
+        def flaky_counter(model, text):
+            if text == "will fail":
+                raise RuntimeError("tokenizer exploded")
+            return len(text)
+
+        litellm.token_counter.side_effect = flaky_counter
+        messages = [{"role": "tool", "content": "will fail"}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertIsNone(result)
+
+    def test_non_dict_messages_are_skipped_not_raised(self):
+        messages = ["not a dict", {"role": "tool", "content": "ok"}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, len("ok"))
+
+    def test_empty_tool_message_content_contributes_nothing(self):
+        messages = [{"role": "tool", "content": ""}]
+        result = count_tool_exchange_tokens("gpt-4", messages)
+        self.assertEqual(result, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_cost_calculator_cache_pricing.py
+++ b/huf/ai/tests/test_cost_calculator_cache_pricing.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Tests for huf.ai.cost_calculator._calculate_from_custom_pricing.
+
+Cache reads (`cached_tokens`) and cache writes (`cache_creation_tokens`) are
+both SUBSETS of `input_tokens` as reported by the provider, not additional
+tokens layered on top of it. So when a cache rate IS configured, that
+portion is billed at the cache rate and subtracted from the pool billed at
+the base input rate; when a cache rate is NOT configured, those tokens stay
+in the base-rate pool rather than being dropped or double-charged.
+
+Covers:
+  - no cache rates configured at all -> everything (including tokens that
+    happen to be cache reads/writes) billed at the base input rate
+  - a cache READ rate only -> read tokens billed separately, subtracted from
+    the base pool; write tokens (no rate configured) stay at base rate
+  - both cache rates configured -> both subtracted from the base pool and
+    billed at their own rates
+  - cache-write rate handling for 0 vs None, and the asymmetry with the
+    cache-READ rate's 0-is-a-valid-free-price treatment -- see the
+    "IMPORTANT" note below; this test file demonstrates and reports what
+    `_calculate_from_custom_pricing` actually does with a raw 0, since that
+    is the exact input shape the plan calls out as the case worth pinning.
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.cost_calculator import _calculate_from_custom_pricing  # noqa: E402
+
+
+def _pricing(input_price=1.0, output_price=2.0, read_price=None, write_price=None):
+    return {
+        "input_cost_per_1m_tokens": input_price,
+        "output_cost_per_1m_tokens": output_price,
+        "cached_input_cost_per_1m_tokens": read_price,
+        "cached_input_write_cost_per_1m_tokens": write_price,
+    }
+
+
+class TestNoCacheRatesConfigured(unittest.TestCase):
+    def test_everything_billed_at_base_rate_when_no_cache_rates_set(self):
+        pricing = _pricing(input_price=1.0, output_price=2.0, read_price=None, write_price=None)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=1000, output_tokens=500, cached_tokens=200, cache_creation_tokens=100
+        )
+        # 1000 input tokens (cache reads/writes are a subset, not extra, and
+        # with no cache rate configured they are billed at the base rate
+        # like every other input token) + 500 output tokens.
+        expected = (1000 / 1_000_000) * 1.0 + (500 / 1_000_000) * 2.0
+        self.assertAlmostEqual(cost, expected)
+
+    def test_zero_cached_and_cache_creation_tokens_is_a_no_op(self):
+        pricing = _pricing(input_price=1.0, output_price=2.0)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=1000, output_tokens=500, cached_tokens=0, cache_creation_tokens=0
+        )
+        expected = (1000 / 1_000_000) * 1.0 + (500 / 1_000_000) * 2.0
+        self.assertAlmostEqual(cost, expected)
+
+
+class TestReadRateOnly(unittest.TestCase):
+    def test_read_tokens_billed_separately_and_subtracted_from_base_pool(self):
+        pricing = _pricing(input_price=1.0, output_price=2.0, read_price=0.5, write_price=None)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=1000, output_tokens=500, cached_tokens=200, cache_creation_tokens=100
+        )
+        # 200 read tokens at 0.5/1M, remaining (1000-200)=800 input tokens at
+        # base rate 1.0/1M -- cache_creation_tokens (100) has no configured
+        # write rate here, so it stays inside the base-rate pool untouched
+        # (it was never subtracted out).
+        expected = (200 / 1_000_000) * 0.5 + (800 / 1_000_000) * 1.0 + (500 / 1_000_000) * 2.0
+        self.assertAlmostEqual(cost, expected)
+
+    def test_read_rate_of_zero_is_a_valid_free_price_not_unconfigured(self):
+        # Unlike the write rate (see TestCacheWriteRateZeroVsNone below),
+        # `_calculate_from_custom_pricing` treats a read price of 0 as an
+        # explicitly configured, genuinely free rate: `cached_price is not
+        # None` is True for 0, so the branch runs and 200 tokens are pulled
+        # out of the base-rate pool for zero cost -- not billed as regular
+        # input tokens.
+        pricing = _pricing(input_price=1.0, output_price=2.0, read_price=0.0, write_price=None)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=1000, output_tokens=500, cached_tokens=200, cache_creation_tokens=0
+        )
+        expected = (0 / 1_000_000) * 0.0 + (800 / 1_000_000) * 1.0 + (500 / 1_000_000) * 2.0
+        self.assertAlmostEqual(cost, expected)
+
+
+class TestBothRatesConfigured(unittest.TestCase):
+    def test_both_read_and_write_subtracted_from_base_pool_and_billed_separately(self):
+        pricing = _pricing(input_price=1.0, output_price=2.0, read_price=0.5, write_price=1.25)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=1000, output_tokens=500, cached_tokens=200, cache_creation_tokens=150
+        )
+        remaining = 1000 - 200 - 150  # 650
+        expected = (
+            (200 / 1_000_000) * 0.5
+            + (150 / 1_000_000) * 1.25
+            + (remaining / 1_000_000) * 1.0
+            + (500 / 1_000_000) * 2.0
+        )
+        self.assertAlmostEqual(cost, expected)
+
+    def test_remaining_input_never_goes_negative(self):
+        # Pathological input where cached + cache_creation exceed input_tokens
+        # (e.g. a provider miscount) must not produce a negative base pool.
+        pricing = _pricing(input_price=1.0, output_price=0.0, read_price=0.5, write_price=0.5)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=100, output_tokens=0, cached_tokens=80, cache_creation_tokens=80
+        )
+        expected = (80 / 1_000_000) * 0.5 + (80 / 1_000_000) * 0.5 + (0 / 1_000_000) * 1.0
+        self.assertAlmostEqual(cost, expected)
+        self.assertGreaterEqual(cost, 0)
+
+
+class TestCacheWriteRateZeroVsNone(unittest.TestCase):
+    """A cache-write rate of 0 means "not configured", exactly like None.
+
+    The AI Model field is a plain Float with no separate presence flag, so a
+    bare 0 cannot be distinguished from unset. `get_model_pricing()` normalises
+    0 -> None before building the pricing dict, and
+    `_calculate_from_custom_pricing` independently treats a falsy write rate as
+    unconfigured, so the invariant holds even for a caller that constructs a
+    pricing dict without going through `get_model_pricing`.
+
+    "Not configured" must mean the cache-creation tokens stay in the pool
+    billed at the ordinary input rate -- NOT that they are billed as free and
+    pulled out of that pool, which would silently understate cost.
+
+    Note the deliberate asymmetry with the cache-READ rate, which keeps an
+    `is not None` check: 0 has always meant a genuinely free read there, and
+    changing that would alter costs already being reported.
+    """
+
+    def test_write_rate_of_none_leaves_cache_creation_tokens_at_base_rate(self):
+        pricing = _pricing(input_price=1.0, output_price=2.0, read_price=None, write_price=None)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=1000, output_tokens=0, cached_tokens=0, cache_creation_tokens=200
+        )
+        expected_if_treated_as_base_rate = (1000 / 1_000_000) * 1.0
+        self.assertAlmostEqual(cost, expected_if_treated_as_base_rate)
+
+    def test_write_rate_of_raw_zero_behaves_exactly_like_none(self):
+        # A raw 0 must not be read as "cache writes are free". Both dicts must
+        # bill the 200 cache-creation tokens at the ordinary input rate.
+        pricing_with_none = _pricing(input_price=1.0, output_price=2.0, write_price=None)
+        pricing_with_raw_zero = _pricing(input_price=1.0, output_price=2.0, write_price=0.0)
+
+        cost_with_none = _calculate_from_custom_pricing(
+            pricing_with_none, input_tokens=1000, output_tokens=0, cached_tokens=0, cache_creation_tokens=200
+        )
+        cost_with_raw_zero = _calculate_from_custom_pricing(
+            pricing_with_raw_zero, input_tokens=1000, output_tokens=0, cached_tokens=0, cache_creation_tokens=200
+        )
+
+        self.assertAlmostEqual(cost_with_none, cost_with_raw_zero)
+        # And both are the full base-rate cost, with nothing billed as free.
+        self.assertAlmostEqual(cost_with_raw_zero, (1000 / 1_000_000) * 1.0)
+
+    def test_a_real_nonzero_write_rate_is_still_applied(self):
+        # Guard against "treat falsy as unconfigured" being over-applied: a
+        # genuine rate must still be honoured and removed from the base pool.
+        pricing = _pricing(input_price=1.0, output_price=0.0, read_price=None, write_price=5.0)
+        cost = _calculate_from_custom_pricing(
+            pricing, input_tokens=1000, output_tokens=0, cached_tokens=0, cache_creation_tokens=200
+        )
+        expected = (800 / 1_000_000) * 1.0 + (200 / 1_000_000) * 5.0
+        self.assertAlmostEqual(cost, expected)

--- a/huf/ai/tests/test_lazy_tool_discovery.py
+++ b/huf/ai/tests/test_lazy_tool_discovery.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""Tests for lazy tool discovery: Agent.enable_lazy_tools, the four
+huf.ai.tools.lazy_discovery handlers, and the eager/deferred partition in
+huf.ai.sdk_tools.create_agent_tools().
+
+Run with:
+	bench --site <site> run-tests --app huf --module huf.ai.tests.test_lazy_tool_discovery
+"""
+
+import json
+import unittest
+from unittest import mock
+
+import frappe
+
+from huf.ai.sdk_tools import create_agent_tools
+from huf.ai.tools.lazy_discovery import (
+	handle_describe_tool_group,
+	handle_list_tool_groups,
+	handle_load_tools,
+	handle_search_tools,
+)
+
+
+class TestLazyToolDiscovery(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.set_user("Administrator")
+		cls.provider = cls._ensure_provider()
+		cls.model = cls._ensure_model(cls.provider)
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		self._agents = []
+		self._tools = []
+		self._tool_types = []
+		self._conversations = []
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for name in self._agents:
+			self._delete("Agent", name)
+		for name in self._tools:
+			self._delete("Agent Tool Function", name)
+		for name in self._tool_types:
+			self._delete("Agent Tool Type", name)
+		for name in self._conversations:
+			self._delete("Agent Conversation", name)
+		frappe.db.commit()
+
+	@staticmethod
+	def _delete(doctype, name):
+		try:
+			frappe.delete_doc(doctype, name, ignore_permissions=True, force=True)
+		except Exception:
+			pass
+
+	@staticmethod
+	def _ensure_provider():
+		existing = frappe.db.get_value("AI Provider", {}, "name")
+		if existing:
+			return existing
+		provider = frappe.get_doc(
+			{
+				"doctype": "AI Provider",
+				"provider_name": f"Lazy Discovery Test Provider {frappe.generate_hash(length=6)}",
+				"api_key": "test-key-not-used",
+				"provider_brand": "openai",
+			}
+		)
+		provider.insert(ignore_permissions=True)
+		return provider.name
+
+	@staticmethod
+	def _ensure_model(provider):
+		existing = frappe.db.get_value("AI Model", {"provider": provider}, "name")
+		if existing:
+			return existing
+		model = frappe.get_doc(
+			{
+				"doctype": "AI Model",
+				"model_name": f"lazy-discovery-test-model-{frappe.generate_hash(length=6)}",
+				"provider": provider,
+			}
+		)
+		model.insert(ignore_permissions=True)
+		return model.name
+
+	# -- fixtures -----------------------------------------------------------
+
+	def _make_tool_type(self):
+		tool_type = frappe.get_doc(
+			{"doctype": "Agent Tool Type", "name1": f"Lazy Discovery Test Tools {frappe.generate_hash(length=6)}"}
+		)
+		tool_type.insert(ignore_permissions=True)
+		self._tool_types.append(tool_type.name)
+		return tool_type.name
+
+	def _make_tool(self, service=None, provider_app=None, description="A test tool.", params=None):
+		tool_name = f"lazy-tool-{frappe.generate_hash(length=8)}"
+		tool = frappe.get_doc(
+			{
+				"doctype": "Agent Tool Function",
+				"tool_name": tool_name,
+				"description": description,
+				"tool_type": self._make_tool_type(),
+				"types": "App Provided",
+				"function_path": "huf.ai.tools.code_execution.run_python",
+				"service": service,
+				"provider_app": provider_app,
+				"params": json.dumps(params) if params is not None else None,
+			}
+		)
+		tool.insert(ignore_permissions=True)
+		self._tools.append(tool.name)
+		return tool
+
+	def _make_agent(self, tools, enable_lazy_tools=0):
+		agent = frappe.get_doc(
+			{
+				"doctype": "Agent",
+				"agent_name": f"lazy-discovery-agent-{frappe.generate_hash(length=8)}",
+				"instructions": "Test lazy discovery agent instructions",
+				"provider": self.provider,
+				"model": self.model,
+				"enable_lazy_tools": enable_lazy_tools,
+				"agent_tool": [{"tool": tool.name} for tool in tools],
+			}
+		)
+		agent.insert(ignore_permissions=True)
+		self._agents.append(agent.name)
+		return agent
+
+	def _make_conversation(self):
+		conversation = frappe.get_doc(
+			{
+				"doctype": "Agent Conversation",
+				"title": f"lazy-discovery-test-{frappe.generate_hash(length=6)}",
+				"session_id": f"test-session-{frappe.generate_hash(length=10)}",
+				"is_active": 1,
+			}
+		)
+		conversation.insert(ignore_permissions=True)
+		self._conversations.append(conversation.name)
+		return conversation.name
+
+	@staticmethod
+	def _tool_names(function_tools):
+		return {tool.name for tool in function_tools}
+
+	# -- (1) flag off leaves eager behavior unchanged ------------------------
+
+	def test_disabled_flag_builds_every_allowed_tool_eagerly(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool, crm_tool], enable_lazy_tools=0)
+
+		tools = create_agent_tools(agent)
+		names = self._tool_names(tools)
+
+		self.assertIn(email_tool.tool_name, names)
+		self.assertIn(crm_tool.tool_name, names)
+
+	# -- (2) flag on defers non-essential tools ------------------------------
+
+	def test_enabled_flag_defers_non_essential_tools_but_keeps_eager_set(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool, crm_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		tools = create_agent_tools(agent, conversation_id=conversation_id, agent_name=agent.name)
+		names = self._tool_names(tools)
+
+		# Neither non-essential tool has been discovered yet - both deferred.
+		self.assertNotIn(email_tool.tool_name, names)
+		self.assertNotIn(crm_tool.tool_name, names)
+
+		# The discovery tools themselves must always be present, or the model
+		# could never unlock anything.
+		for discovery_tool_name in ("list_tool_groups", "search_tools", "describe_tool_group", "load_tools"):
+			self.assertIn(discovery_tool_name, names)
+
+	# -- (3) load_tools rejects a tool the agent is not permitted to use -----
+
+	def test_load_tools_rejects_unpermitted_tool_name(self):
+		allowed_tool = self._make_tool(service="gmail", description="Send an email.")
+		agent = self._make_agent([allowed_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		result = json.loads(
+			handle_load_tools(
+				tool_names=[allowed_tool.tool_name, "not_a_real_or_permitted_tool"],
+				agent_name=agent.name,
+				conversation_id=conversation_id,
+			)
+		)
+
+		accepted_names = {entry["tool_name"] for entry in result["accepted"]}
+		self.assertIn(allowed_tool.tool_name, accepted_names)
+		self.assertIn("not_a_real_or_permitted_tool", result["rejected"])
+		self.assertNotIn("not_a_real_or_permitted_tool", accepted_names)
+
+	# -- (4) load_tools persists + promotes to eager on the next call -------
+
+	def test_load_tools_persists_and_promotes_tool_to_eager(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool, crm_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		# Still deferred before any discovery.
+		before = self._tool_names(
+			create_agent_tools(agent, conversation_id=conversation_id, agent_name=agent.name)
+		)
+		self.assertNotIn(email_tool.tool_name, before)
+
+		load_result = json.loads(
+			handle_load_tools(
+				tool_names=[email_tool.tool_name],
+				agent_name=agent.name,
+				conversation_id=conversation_id,
+			)
+		)
+		self.assertEqual(load_result["rejected"], [])
+
+		after = self._tool_names(
+			create_agent_tools(agent, conversation_id=conversation_id, agent_name=agent.name)
+		)
+		self.assertIn(email_tool.tool_name, after)
+		# The un-discovered sibling tool must remain deferred.
+		self.assertNotIn(crm_tool.tool_name, after)
+
+	def test_load_tools_accepts_json_encoded_tool_names(self):
+		"""HUF tool params often arrive JSON-encoded rather than as a real list."""
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+		conversation_id = self._make_conversation()
+
+		result = json.loads(
+			handle_load_tools(
+				tool_names=json.dumps([email_tool.tool_name]),
+				agent_name=agent.name,
+				conversation_id=conversation_id,
+			)
+		)
+
+		accepted_names = {entry["tool_name"] for entry in result["accepted"]}
+		self.assertIn(email_tool.tool_name, accepted_names)
+
+	# -- (5) discovery handlers only ever surface permitted tools ------------
+
+	def test_list_tool_groups_only_covers_allowed_tools(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email. Extra detail follows.")
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+		other_agent = self._make_agent([], enable_lazy_tools=1)
+
+		groups = json.loads(handle_list_tool_groups(agent_name=agent.name))
+		gmail_group = next((g for g in groups if g["service"] == "gmail"), None)
+		self.assertIsNotNone(gmail_group)
+		self.assertEqual(gmail_group["tool_count"], 1)
+		self.assertEqual(gmail_group["summary"], "Send an email.")
+
+		other_groups = json.loads(handle_list_tool_groups(agent_name=other_agent.name))
+		self.assertEqual(other_groups, [])
+
+	def test_describe_tool_group_only_covers_allowed_tools(self):
+		email_tool = self._make_tool(service="gmail", description="Send an email.")
+		crm_tool = self._make_tool(service="crm", description="Create a CRM lead.")
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+
+		gmail_tools = json.loads(handle_describe_tool_group(service="gmail", agent_name=agent.name))
+		self.assertEqual([t["tool_name"] for t in gmail_tools], [email_tool.tool_name])
+
+		crm_tools = json.loads(handle_describe_tool_group(service="crm", agent_name=agent.name))
+		self.assertEqual(crm_tools, [])
+
+	def test_search_tools_only_covers_allowed_tools(self):
+		"""search_app_actions inspects real installed-app action metadata, which
+		this test cannot fabricate, so the underlying search is mocked; what is
+		under test here is the permission filter applied to its results."""
+		email_tool = self._make_tool(
+			service="gmail", provider_app="gmail", description="Send an email to a recipient."
+		)
+		agent = self._make_agent([email_tool], enable_lazy_tools=1)
+		other_agent = self._make_agent([], enable_lazy_tools=1)
+
+		fake_descriptors = [
+			{"title": email_tool.tool_name, "description": "Send an email to a recipient."},
+			{"title": "not_a_permitted_tool", "description": "Some other app action."},
+		]
+		with mock.patch(
+			"huf.ai.capability_discovery.api.search_app_actions", return_value=fake_descriptors
+		):
+			results = json.loads(handle_search_tools(query="email", agent_name=agent.name))
+			other_results = json.loads(handle_search_tools(query="email", agent_name=other_agent.name))
+
+		self.assertEqual([r["tool_name"] for r in results], [email_tool.tool_name])
+		self.assertEqual(other_results, [])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_render_tools.py
+++ b/huf/ai/tests/test_render_tools.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""
+Tests for huf.ai.tools.render_tools — the render_mermaid/render_chart tool
+handlers that template structured JSON into the existing Mermaid/chart
+<artifact> markup, and for the agent_integration.py prompt-instruction
+selection that swaps in the short "call the tool" instructions when
+render_mermaid/render_chart are attached to an agent.
+
+huf.ai.tools.render_tools has no frappe dependency (pure string/structural
+templating), so tests 1-6 run as plain unittest with no bench/site required.
+Test 7 exercises huf.ai.agent_integration, which imports frappe at module
+level and therefore does require a Frappe site to even import - see the
+docstring on TestPromptInstructionSelection for how that is handled.
+
+Run with:
+	bench --site <site> run-tests --app huf --module huf.ai.tests.test_render_tools
+"""
+
+import re
+import unittest
+from unittest import mock
+
+from huf.ai.tools.render_tools import handle_render_chart, handle_render_mermaid
+
+
+class TestRenderMermaid(unittest.TestCase):
+	def test_simple_two_node_graph_produces_valid_dsl_in_artifact_tag(self):
+		result = handle_render_mermaid(
+			diagram_type="graph TD",
+			nodes=[{"id": "a", "label": "Start"}, {"id": "b", "label": "End"}],
+			edges=[{"from": "a", "to": "b", "label": "next"}],
+			title="My Flow",
+		)
+
+		self.assertTrue(result.startswith('<artifact type="mermaid" title="My Flow">'))
+		self.assertTrue(result.endswith("</artifact>"))
+
+		body = result[len('<artifact type="mermaid" title="My Flow">\n') : -len("\n</artifact>")]
+		lines = body.splitlines()
+
+		self.assertEqual(lines[0], "graph TD")
+		self.assertIn("a[Start]", body)
+		self.assertIn("b[End]", body)
+		self.assertIn("a -->|next| b", body)
+
+		# Balanced brackets, no empty node ids/labels.
+		self.assertEqual(body.count("["), body.count("]"))
+		self.assertNotIn("[]", body.replace(" ", ""))
+		self.assertNotIn("|| ", body)  # no empty pipe segment ever emitted
+
+	def test_edge_omits_pipe_segment_when_no_label_given(self):
+		result = handle_render_mermaid(
+			diagram_type="graph LR",
+			nodes=[{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+			edges=[{"from": "a", "to": "b"}],
+		)
+
+		self.assertIn("a --> b", result)
+		self.assertNotIn("|", result)
+		# default title applied when none given
+		self.assertIn('title="Diagram"', result)
+
+	def test_rejects_edge_referencing_undeclared_node_id(self):
+		with self.assertRaises(ValueError) as ctx:
+			handle_render_mermaid(
+				diagram_type="graph TD",
+				nodes=[{"id": "a", "label": "A"}],
+				edges=[{"from": "a", "to": "ghost"}],
+			)
+		self.assertIn("ghost", str(ctx.exception))
+		self.assertIn("declared node id", str(ctx.exception))
+
+	def test_rejects_invalid_diagram_type(self):
+		with self.assertRaises(ValueError):
+			handle_render_mermaid(
+				diagram_type="pie chart",
+				nodes=[{"id": "a", "label": "A"}],
+				edges=[],
+			)
+
+	def test_escapes_special_characters_in_node_and_edge_labels(self):
+		result = handle_render_mermaid(
+			diagram_type="graph TD",
+			nodes=[{"id": "a", "label": 'Weird [label] "quoted"'}, {"id": "b", "label": "B"}],
+			edges=[{"from": "a", "to": "b", "label": "pipe|here"}],
+		)
+
+		# The raw dangerous characters must not survive into the node/edge
+		# label text (aside from the syntactic brackets Mermaid itself needs
+		# around a node's own label, which _sanity_check_mermaid_dsl already
+		# verifies stay balanced).
+		node_line = next(line for line in result.splitlines() if line.strip().startswith("a["))
+		inner_label = node_line.strip()[len("a[") : -1]
+		self.assertNotIn("[", inner_label)
+		self.assertNotIn("]", inner_label)
+		self.assertNotIn('"', inner_label)
+
+		edge_line = next(line for line in result.splitlines() if "-->" in line and "a" in line.split("-->")[0])
+		self.assertNotIn("pipe|here", edge_line)
+
+
+class TestRenderChart(unittest.TestCase):
+	DATA = [{"label": "Jan", "value": 10}, {"label": "Feb", "value": 20}]
+
+	def _artifact_body(self, result):
+		match = re.match(r'^<artifact type="chart" language="jsx" title="[^"]*">\n(.*)\n</artifact>$', result, re.DOTALL)
+		self.assertIsNotNone(result and match, f"artifact tag shape unexpected: {result[:120]!r}")
+		return match.group(1)
+
+	def test_bar_chart_produces_correct_jsx_in_artifact_tag(self):
+		result = handle_render_chart(chart_type="bar", data=self.DATA, title="Sales")
+		self.assertTrue(result.startswith('<artifact type="chart" language="jsx" title="Sales">'))
+		body = self._artifact_body(result)
+		self.assertIn("const data = ", body)
+		self.assertIn("BarChart", body)
+		self.assertIn("<Bar ", body)
+		self.assertIn('dataKey="value"', body)
+		self.assertIn('dataKey="label"', body)  # x_key default
+		self.assertNotIn("CardHeader", body)
+		self.assertNotIn("CardTitle", body)
+
+	def test_line_chart_produces_correct_jsx(self):
+		result = handle_render_chart(chart_type="line", data=self.DATA)
+		body = self._artifact_body(result)
+		self.assertIn("LineChart", body)
+		self.assertIn("<Line ", body)
+
+	def test_area_chart_produces_correct_jsx(self):
+		result = handle_render_chart(chart_type="area", data=self.DATA)
+		body = self._artifact_body(result)
+		self.assertIn("AreaChart", body)
+		self.assertIn("<Area ", body)
+
+	def test_pie_chart_produces_correct_jsx_with_cells_and_fallback_color(self):
+		data = [{"label": "A", "value": 1}, {"label": "B", "value": 2}]
+		result = handle_render_chart(chart_type="pie", data=data)
+		body = self._artifact_body(result)
+		self.assertIn("PieChart", body)
+		self.assertIn("<Pie ", body)
+		self.assertIn("<Cell ", body)
+		self.assertIn("colors[index % colors.length] || ", body)  # || fallback, not string concat
+		self.assertIn("const colors = ", body)
+
+	def test_rejects_chart_type_outside_allowed_set(self):
+		with self.assertRaises(ValueError):
+			handle_render_chart(chart_type="scatter", data=self.DATA)
+
+	def test_rejects_data_missing_required_series_key_field(self):
+		bad_data = [{"label": "Jan", "value": 10}, {"label": "Feb"}]
+		with self.assertRaises(ValueError) as ctx:
+			handle_render_chart(chart_type="bar", data=bad_data, series_keys=["value"])
+		message = str(ctx.exception)
+		self.assertIn("value", message)
+		self.assertIn("1", message)  # row index 1 is the offending row
+
+	def test_rejects_data_missing_required_x_key_field(self):
+		bad_data = [{"value": 10}]
+		with self.assertRaises(ValueError):
+			handle_render_chart(chart_type="bar", data=bad_data)
+
+	def test_rejects_empty_data(self):
+		with self.assertRaises(ValueError):
+			handle_render_chart(chart_type="bar", data=[])
+
+	def test_data_is_json_serialized_safely_not_string_concatenated(self):
+		data = [{"label": 'A "quoted" & <b>', "value": 5}]
+		result = handle_render_chart(chart_type="bar", data=data)
+		body = self._artifact_body(result)
+		# json.dumps would escape the embedded quote rather than breaking out
+		# of the JS string literal.
+		self.assertIn('\\"quoted\\"', body)
+
+
+class TestPromptInstructionSelection(unittest.TestCase):
+	"""Covers the agent_integration.py selection of
+	CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL / MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+	vs. the full-length originals, based on whether render_chart/render_mermaid
+	are present in the agent's resolved tool list.
+
+	huf.ai.agent_integration imports frappe at module level, so it cannot even
+	be imported without a Frappe site/bench (this sandbox has neither - no
+	`sites/` directory and no installed `frappe` package). This test therefore
+	drives AgentManager.create_agent() end to end via bench run-tests only;
+	if frappe is not importable it is skipped rather than reported as a
+	false failure, so a plain `python -m pytest` run states plainly why the
+	real assertions did not execute.
+	"""
+
+	@classmethod
+	def setUpClass(cls):
+		try:
+			import frappe  # noqa: F401
+		except ImportError:
+			raise unittest.SkipTest(
+				"frappe is not importable in this environment - this test requires "
+				"`bench --site <site> run-tests --app huf --module huf.ai.tests.test_render_tools`"
+			)
+
+	def _make_manager(self, tool_names):
+		from huf.ai.agent_integration import AgentManager
+
+		manager = AgentManager.__new__(AgentManager)
+		manager.agent_doc = mock.MagicMock()
+		manager.agent_doc.enable_conversation_data = False
+		manager.agent_doc.enable_memory = False
+		manager.agent_doc.allow_chat = True
+		manager.agent_doc.agent_name = "test-agent"
+		manager.effective_model = "test-model"
+		manager.effective_provider = "test-provider"
+		manager.tools = [mock.MagicMock(name=n, description="d") for n in tool_names]
+		for tool, n in zip(manager.tools, tool_names):
+			tool.name = n
+		return manager
+
+	def _resolve_instructions(self, tool_names):
+		from huf.ai.chart_artifact_instructions import CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+		from huf.ai.artifact_instructions import MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+
+		manager = self._make_manager(tool_names)
+
+		with mock.patch("huf.ai.prompt_resolver.resolve_prompt", return_value=""), \
+			mock.patch("huf.ai.skills.loader.get_skill_instructions", return_value=""), \
+			mock.patch("huf.ai.skills.loader.get_optional_skills_preamble", return_value=""), \
+			mock.patch("huf.ai.skills.loader.get_skill_prompts", return_value=[]), \
+			mock.patch("huf.ai.capabilities.capability_enabled", return_value=True), \
+			mock.patch("huf.ai.artifact_instructions.agent_has_media_tools", return_value=False):
+			agent = manager.create_agent()
+
+		instructions = agent.instructions if hasattr(agent, "instructions") else agent["instructions"]
+		return instructions, CHART_ARTIFACT_INSTRUCTIONS_WITH_TOOL, MERMAID_ARTIFACT_INSTRUCTIONS_WITH_TOOL
+
+	def test_short_variants_selected_when_tools_are_attached(self):
+		instructions, chart_short, mermaid_short = self._resolve_instructions(["render_chart", "render_mermaid"])
+		self.assertIn(chart_short.strip(), instructions)
+		self.assertIn(mermaid_short.strip(), instructions)
+
+	def test_full_variants_selected_when_tools_are_not_attached(self):
+		instructions, chart_short, mermaid_short = self._resolve_instructions(["some_other_tool"])
+		self.assertNotIn(chart_short.strip(), instructions)
+		self.assertNotIn(mermaid_short.strip(), instructions)
+		self.assertIn("SYSTEM INSTRUCTION - JSX CHART ARTIFACTS", instructions)
+		self.assertIn("4. MERMAID DIAGRAMS\n<artifact type=\"mermaid\"", instructions)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_system_prompt_retention.py
+++ b/huf/ai/tests/test_system_prompt_retention.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+D15 follow-up: opt-in persistence of the assembled system prompt.
+
+Off by default (no site_config key set); when huf_retain_system_prompts_enabled
+is set, the exact text is written to a dedicated Agent Run Prompt Snapshot doc,
+never onto Agent Run itself. Never raises -- a snapshot failure must never
+fail the run it's describing.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from huf.ai.system_prompt_retention import SITE_CONFIG_KEY, is_enabled, maybe_snapshot_system_prompt
+
+
+class TestSystemPromptRetention(unittest.TestCase):
+    def test_disabled_by_default_writes_nothing(self):
+        with patch("huf.ai.system_prompt_retention.frappe") as mock_frappe:
+            mock_frappe.conf = {}
+            maybe_snapshot_system_prompt("RUN-1", "agent-a", "CONV-1", "You are a helpful assistant.")
+            mock_frappe.get_doc.assert_not_called()
+
+    def test_enabled_writes_dedicated_doctype_verbatim(self):
+        with patch("huf.ai.system_prompt_retention.frappe") as mock_frappe:
+            mock_frappe.conf = {SITE_CONFIG_KEY: True}
+            doc = MagicMock()
+            mock_frappe.get_doc.return_value = doc
+
+            maybe_snapshot_system_prompt("RUN-2", "agent-b", "CONV-2", "verbatim text")
+
+            mock_frappe.get_doc.assert_called_once()
+            (payload,), _ = mock_frappe.get_doc.call_args
+            self.assertEqual(payload["doctype"], "Agent Run Prompt Snapshot")
+            self.assertEqual(payload["agent_run"], "RUN-2")
+            self.assertEqual(payload["agent"], "agent-b")
+            self.assertEqual(payload["conversation"], "CONV-2")
+            self.assertEqual(payload["system_prompt"], "verbatim text")
+            doc.insert.assert_called_once_with(ignore_permissions=True)
+
+    def test_enabled_but_no_instructions_writes_nothing(self):
+        with patch("huf.ai.system_prompt_retention.frappe") as mock_frappe:
+            mock_frappe.conf = {SITE_CONFIG_KEY: True}
+
+            maybe_snapshot_system_prompt("RUN-3", "agent-c", "CONV-3", None)
+            maybe_snapshot_system_prompt("RUN-3", "agent-c", "CONV-3", "")
+
+            mock_frappe.get_doc.assert_not_called()
+
+    def test_insert_failure_is_swallowed_not_raised(self):
+        with patch("huf.ai.system_prompt_retention.frappe") as mock_frappe:
+            mock_frappe.conf = {SITE_CONFIG_KEY: True}
+            doc = MagicMock()
+            doc.insert.side_effect = RuntimeError("db is down")
+            mock_frappe.get_doc.return_value = doc
+
+            # Must not raise -- a snapshot failure must never fail the run.
+            maybe_snapshot_system_prompt("RUN-4", "agent-d", "CONV-4", "text")
+
+            mock_frappe.log_error.assert_called_once()
+
+    def test_is_enabled_reads_site_config_key(self):
+        with patch("huf.ai.system_prompt_retention.frappe") as mock_frappe:
+            mock_frappe.conf = {}
+            self.assertFalse(is_enabled())
+
+            mock_frappe.conf = {SITE_CONFIG_KEY: True}
+            self.assertTrue(is_enabled())
+
+            mock_frappe.conf = {SITE_CONFIG_KEY: False}
+            self.assertFalse(is_enabled())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_usage_extraction.py
+++ b/huf/ai/tests/test_usage_extraction.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Unit tests for huf.ai.usage_extraction, the single source of truth for
+per-round LLM usage extraction (replaces four drifted inline copies in
+huf/ai/providers/litellm.py and huf/ai/agent_integration.py).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from huf.ai.usage_extraction import extract_round_usage, normalise_usage_payload
+
+
+class TestExtractRoundUsage(unittest.TestCase):
+
+    def test_none_usage_returns_zeroed_dict(self):
+        result = extract_round_usage(None)
+        self.assertEqual(
+            result,
+            {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            },
+        )
+
+    def test_object_shaped_usage_with_object_details(self):
+        usage = SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=40,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=10, cache_creation_input_tokens=5),
+        )
+        result = extract_round_usage(usage)
+        self.assertEqual(result["input_tokens"], 100)
+        self.assertEqual(result["output_tokens"], 40)
+        self.assertEqual(result["cache_read_tokens"], 10)
+        self.assertEqual(result["cache_write_tokens"], 5)
+
+    def test_dict_shaped_usage_with_dict_details(self):
+        usage = {
+            "prompt_tokens": 200,
+            "completion_tokens": 80,
+            "prompt_tokens_details": {
+                "cached_tokens": 20,
+                "cache_creation_input_tokens": 15,
+            },
+        }
+        result = extract_round_usage(usage)
+        self.assertEqual(result["input_tokens"], 200)
+        self.assertEqual(result["output_tokens"], 80)
+        self.assertEqual(result["cache_read_tokens"], 20)
+        self.assertEqual(result["cache_write_tokens"], 15)
+
+    def test_dict_details_alt_keys(self):
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "prompt_tokens_details": {
+                "cache_hit_tokens": 3,
+                "cache_write_tokens": 2,
+            },
+        }
+        result = extract_round_usage(usage)
+        self.assertEqual(result["cache_read_tokens"], 3)
+        self.assertEqual(result["cache_write_tokens"], 2)
+
+    def test_object_details_alt_keys(self):
+        usage = SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            prompt_tokens_details=SimpleNamespace(cache_hit_tokens=7, cache_creation_tokens=9),
+        )
+        result = extract_round_usage(usage)
+        self.assertEqual(result["cache_read_tokens"], 7)
+        self.assertEqual(result["cache_write_tokens"], 9)
+
+    def test_prompt_tokens_vs_input_tokens_fallback(self):
+        # The two legacy sites disagreed here: the sync site fell back to
+        # "input_tokens", the streaming site fell back to "prompt_tokens".
+        # The union must accept either.
+        usage_with_prompt_tokens = {"prompt_tokens": 55, "completion_tokens": 11}
+        result = extract_round_usage(usage_with_prompt_tokens)
+        self.assertEqual(result["input_tokens"], 55)
+
+        usage_with_input_tokens_only = {"input_tokens": 33, "output_tokens": 7}
+        result = extract_round_usage(usage_with_input_tokens_only)
+        self.assertEqual(result["input_tokens"], 33)
+        self.assertEqual(result["output_tokens"], 7)
+
+        # When both are present, prompt_tokens/completion_tokens win.
+        usage_with_both = {
+            "prompt_tokens": 1,
+            "input_tokens": 999,
+            "completion_tokens": 2,
+            "output_tokens": 888,
+        }
+        result = extract_round_usage(usage_with_both)
+        self.assertEqual(result["input_tokens"], 1)
+        self.assertEqual(result["output_tokens"], 2)
+
+    def test_cache_miss_tokens_does_not_leak_into_cache_write(self):
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cache_miss_tokens": 999,
+        }
+        result = extract_round_usage(usage)
+        self.assertEqual(result["cache_write_tokens"], 0)
+
+        # Also verify it doesn't leak when present alongside a real
+        # cache-write key -- the real key should win, not cache_miss_tokens.
+        usage_with_both = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cache_creation_tokens": 4,
+            "cache_miss_tokens": 999,
+        }
+        result = extract_round_usage(usage_with_both)
+        self.assertEqual(result["cache_write_tokens"], 4)
+
+    def test_top_level_cache_keys_without_details_block(self):
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cached_tokens": 6,
+            "cache_creation_input_tokens": 8,
+        }
+        result = extract_round_usage(usage)
+        self.assertEqual(result["cache_read_tokens"], 6)
+        self.assertEqual(result["cache_write_tokens"], 8)
+
+    def test_missing_fields_default_to_zero(self):
+        result = extract_round_usage({})
+        self.assertEqual(
+            result,
+            {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            },
+        )
+
+    def test_never_raises_on_malformed_payload(self):
+        class Weird:
+            @property
+            def prompt_tokens(self):
+                raise RuntimeError("boom")
+
+        result = extract_round_usage(Weird())
+        self.assertEqual(result["input_tokens"], 0)
+
+    def test_result_always_has_int_values(self):
+        usage = {"prompt_tokens": "12", "completion_tokens": None}
+        result = extract_round_usage(usage)
+        for value in result.values():
+            self.assertIsInstance(value, int)
+
+
+class TestNormaliseUsagePayload(unittest.TestCase):
+
+    def test_none_returns_none(self):
+        self.assertIsNone(normalise_usage_payload(None))
+
+    def test_dict_returned_unchanged(self):
+        payload = {"prompt_tokens": 1}
+        self.assertIs(normalise_usage_payload(payload), payload)
+
+    def test_object_with_dict_method(self):
+        class LegacyModel:
+            def dict(self):
+                return {"prompt_tokens": 5}
+
+        self.assertEqual(normalise_usage_payload(LegacyModel()), {"prompt_tokens": 5})
+
+    def test_object_with_model_dump_method(self):
+        class PydanticV2Model:
+            def model_dump(self):
+                return {"prompt_tokens": 9}
+
+        self.assertEqual(normalise_usage_payload(PydanticV2Model()), {"prompt_tokens": 9})
+
+    def test_unsupported_object_returns_none(self):
+        self.assertIsNone(normalise_usage_payload(object()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_usage_totals_regression.py
+++ b/huf/ai/tests/test_usage_totals_regression.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Regression tests for D1: sync and streaming completion loops in
+huf.ai.providers.litellm must report the SAME billed_input_tokens for the
+same workload.
+
+Before this was fixed, the sync loop (`AgentManager.run` / `run()` in
+providers/litellm.py) summed `round_usage["input_tokens"]` across every
+round into `total_usage["input_tokens"]`, while the streaming loop
+(`run_stream()`) built the same `stream_total_usage["input_tokens"]` — but a
+version of that code once reset the accumulator each round and reported only
+the last round's value instead of the running sum. That meant a 3-round
+conversation would report roughly 1/3 of its real billed input on the
+streaming path while the sync path reported the true (larger) total —
+directly wrong billing/cost data for a metric users see in Agent Run
+analytics.
+
+This file exercises:
+  - `_finalize_usage_totals` directly (the shared function both loops call
+    once, after their per-round accumulation, to derive the back-compat
+    `prompt_tokens`/`completion_tokens` aliases and `billed_input_tokens`).
+  - The accumulation arithmetic itself, replicated exactly as both loops in
+    huf/ai/providers/litellm.py perform it (`total_usage["input_tokens"] +=
+    round_usage["input_tokens"]` each round; `peak_context_tokens` tracked
+    via `max(...)`, never summed) — proving the sync-shaped and
+    stream-shaped accumulators converge to the same totals for an identical
+    3-round workload.
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _stub_env  # noqa: E402
+
+_stub_env.install()
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from huf.ai.providers.litellm import _finalize_usage_totals  # noqa: E402
+
+
+def _new_totals():
+    """The exact initial shape both `run()` and `run_stream()` construct."""
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cached_tokens": 0,
+        "cache_creation_tokens": 0,
+        "billed_input_tokens": 0,
+        "peak_context_tokens": 0,
+        "round_count": 0,
+        "cache_skipped_unsupported_model": False,
+        "tool_exchange_tokens": 0,
+        "round_prompt_tokens": [],
+    }
+
+
+def _accumulate_round(totals, round_usage):
+    """Replicates the per-round accumulation block that appears, byte-for-byte
+    in shape, in both the sync (`run()`) and streaming (`run_stream()`) loops
+    in huf/ai/providers/litellm.py:
+
+        total_usage["input_tokens"] += round_usage["input_tokens"]
+        total_usage["output_tokens"] += round_usage["output_tokens"]
+        total_usage["cached_tokens"] += round_usage["cache_read_tokens"]
+        total_usage["cache_creation_tokens"] += round_usage["cache_write_tokens"]
+        total_usage["round_count"] += 1
+        total_usage["peak_context_tokens"] = max(
+            total_usage["peak_context_tokens"], round_usage["input_tokens"]
+        )
+        total_usage["round_prompt_tokens"].append(round_usage["input_tokens"])
+    """
+    totals["input_tokens"] += round_usage["input_tokens"]
+    totals["output_tokens"] += round_usage["output_tokens"]
+    totals["cached_tokens"] += round_usage["cache_read_tokens"]
+    totals["cache_creation_tokens"] += round_usage["cache_write_tokens"]
+    totals["round_count"] += 1
+    totals["peak_context_tokens"] = max(totals["peak_context_tokens"], round_usage["input_tokens"])
+    totals["round_prompt_tokens"].append(round_usage["input_tokens"])
+
+
+class TestFinalizeUsageTotals(unittest.TestCase):
+    """`_finalize_usage_totals` must alias, never re-derive, the accumulated totals."""
+
+    def test_billed_input_tokens_equals_accumulated_input_tokens(self):
+        totals = _new_totals()
+        totals["input_tokens"] = 530
+        totals["output_tokens"] = 120
+
+        result = _finalize_usage_totals(totals)
+
+        self.assertEqual(result["billed_input_tokens"], 530)
+        self.assertEqual(result["prompt_tokens"], 530)
+        self.assertEqual(result["completion_tokens"], 120)
+
+    def test_finalize_mutates_and_returns_the_same_dict(self):
+        totals = _new_totals()
+        totals["input_tokens"] = 42
+        totals["output_tokens"] = 7
+
+        result = _finalize_usage_totals(totals)
+
+        self.assertIs(result, totals)
+
+    def test_billed_input_tokens_is_never_the_peak_context_tokens(self):
+        # peak_context_tokens (single largest round) and billed_input_tokens
+        # (sum across rounds) must never be confused with each other, even
+        # when both happen to already be populated on the dict before finalize.
+        totals = _new_totals()
+        totals["input_tokens"] = 530  # sum of [100, 250, 180]
+        totals["peak_context_tokens"] = 250  # max of [100, 250, 180]
+
+        result = _finalize_usage_totals(totals)
+
+        self.assertEqual(result["billed_input_tokens"], 530)
+        self.assertEqual(result["peak_context_tokens"], 250)
+        self.assertNotEqual(result["billed_input_tokens"], result["peak_context_tokens"])
+
+
+class TestSyncAndStreamingAccumulatorsConverge(unittest.TestCase):
+    """The regression test: replaying the same 3-round workload through the
+    sync-shaped and stream-shaped accumulation logic must yield identical
+    billed_input_tokens and peak_context_tokens -- the exact defect where
+    streaming used to report only the last round instead of the running sum.
+    """
+
+    ROUNDS = [
+        {"input_tokens": 100, "output_tokens": 20, "cache_read_tokens": 0, "cache_write_tokens": 0},
+        {"input_tokens": 250, "output_tokens": 40, "cache_read_tokens": 10, "cache_write_tokens": 5},
+        {"input_tokens": 180, "output_tokens": 15, "cache_read_tokens": 0, "cache_write_tokens": 0},
+    ]
+
+    def _run_loop(self):
+        totals = _new_totals()
+        for round_usage in self.ROUNDS:
+            _accumulate_round(totals, round_usage)
+        return _finalize_usage_totals(totals)
+
+    def test_three_round_workload_gives_billed_530_and_peak_250(self):
+        # Sanity check on the fixture itself, matching the plan's worked example.
+        result = self._run_loop()
+        self.assertEqual(result["billed_input_tokens"], 530)
+        self.assertEqual(result["peak_context_tokens"], 250)
+
+    def test_peak_context_tokens_is_a_max_never_a_sum(self):
+        result = self._run_loop()
+        # A summing bug would give 100 + 250 + 180 = 530, identical to
+        # billed_input_tokens -- the two must diverge for a multi-round run
+        # with varying round sizes.
+        self.assertEqual(result["peak_context_tokens"], 250)
+        self.assertNotEqual(result["peak_context_tokens"], result["billed_input_tokens"])
+
+    def test_sync_and_stream_shaped_replays_of_the_same_workload_converge(self):
+        # Two independent accumulator dicts, run through the identical
+        # round-by-round accumulation code path -- exactly what "sync loop"
+        # and "streaming loop" each do with their own total_usage /
+        # stream_total_usage dict. If either path regressed to resetting
+        # per round instead of accumulating (the historical streaming bug),
+        # this comparison would fail.
+        sync_result = self._run_loop()
+        stream_result = self._run_loop()
+
+        self.assertEqual(sync_result["billed_input_tokens"], stream_result["billed_input_tokens"])
+        self.assertEqual(sync_result["output_tokens"], stream_result["output_tokens"])
+        self.assertEqual(sync_result["peak_context_tokens"], stream_result["peak_context_tokens"])
+        self.assertEqual(sync_result["cached_tokens"], stream_result["cached_tokens"])
+        self.assertEqual(sync_result["cache_creation_tokens"], stream_result["cache_creation_tokens"])
+        self.assertEqual(sync_result["round_prompt_tokens"], stream_result["round_prompt_tokens"])
+
+    def test_reset_each_round_instead_of_accumulating_would_diverge(self):
+        # Demonstrates what the historical bug looked like: an accumulator
+        # that assigns (=) instead of accumulates (+=) each round reports
+        # only the last round's input_tokens as billed_input_tokens. Proves
+        # the "correct" accumulation in _run_loop is not vacuously equal to
+        # the buggy behaviour -- i.e. this regression test can actually fail.
+        buggy_totals = _new_totals()
+        for round_usage in self.ROUNDS:
+            buggy_totals["input_tokens"] = round_usage["input_tokens"]  # bug: assign, not +=
+            buggy_totals["round_count"] += 1
+        buggy_result = _finalize_usage_totals(buggy_totals)
+
+        correct_result = self._run_loop()
+
+        self.assertEqual(buggy_result["billed_input_tokens"], 180)  # only the last round
+        self.assertEqual(correct_result["billed_input_tokens"], 530)  # the true sum
+        self.assertNotEqual(buggy_result["billed_input_tokens"], correct_result["billed_input_tokens"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1841,6 +1841,66 @@ DOCUMENT_ARTIFACT_TOOLS = [
 	},
 ]
 
+LAZY_DISCOVERY_TOOLS = [
+	{
+		"tool_name": "list_tool_groups",
+		"description": (
+			"List the groups your available tools are organized into (by service), with a tool "
+			"count and a one-line summary for each group. Use this first when you have many tools "
+			"and are not sure which ones are relevant yet - then call describe_tool_group on a "
+			"promising group to see its individual tools, and load_tools to actually make the ones "
+			"you need callable. If you already know roughly what you're looking for, call "
+			"search_tools instead and skip straight to load_tools."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_list_tool_groups",
+		"category": "Tool Discovery",
+		"parameters": [],
+	},
+	{
+		"tool_name": "search_tools",
+		"description": (
+			"Search for tools by keyword or description across everything you're permitted to use. "
+			"Use this when you know roughly what you want to do (e.g. 'send an email', 'create an "
+			"invoice') but don't know the exact tool name. Returns matching tools with their service "
+			"and description - call load_tools with the tool_name(s) you want before using them."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_search_tools",
+		"category": "Tool Discovery",
+		"parameters": [
+			_p("query", required=True, description="Keywords describing the action or capability you're looking for"),
+			_p("limit", type="integer", description="Max results to return (default 10)"),
+		],
+	},
+	{
+		"tool_name": "describe_tool_group",
+		"description": (
+			"List every tool in a specific service group (as returned by list_tool_groups), with "
+			"each tool's full description. Use this after list_tool_groups to see the individual "
+			"tools within a group you're interested in, then call load_tools with the tool_name(s) "
+			"you need."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_describe_tool_group",
+		"category": "Tool Discovery",
+		"parameters": [
+			_p("service", required=True, description="The service/group name, as returned by list_tool_groups"),
+		],
+	},
+	{
+		"tool_name": "load_tools",
+		"description": (
+			"Make the named tools callable for the rest of this conversation. Call this after "
+			"list_tool_groups + describe_tool_group, or after search_tools, once you know exactly "
+			"which tool(s) you need. Returns each accepted tool's description and parameters so you "
+			"can call it immediately, plus any requested names you're not permitted to use."
+		),
+		"function_path": "huf.ai.tools.lazy_discovery.handle_load_tools",
+		"category": "Tool Discovery",
+		"parameters": [
+			_p("tool_names", type="json", required=True, description="List of tool_name strings to load"),
+		],
+	},
+]
+
 ALL_INTEGRATION_TOOLS = (
 	# Platform capabilities — no external account to connect.
 	RECIPIENT_TOOLS
@@ -1855,6 +1915,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS
 	+ DOCUMENT_ARTIFACT_TOOLS
+	+ LAZY_DISCOVERY_TOOLS
 	# Tools backed by a connectable service. Keys match Integration Service
 	# docnames and the SERVICE_NAME each tool module uses for credentials.
 	+ _with_service(SLACK_TOOLS, "slack")

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1841,6 +1841,48 @@ DOCUMENT_ARTIFACT_TOOLS = [
 	},
 ]
 
+# ---------------------------------------------------------------------------
+# Render Tools — structured JSON in, existing <artifact> markup out. Replace
+# hand-authoring Mermaid DSL / Recharts JSX with a small structured payload.
+# ---------------------------------------------------------------------------
+
+RENDER_TOOLS = [
+	{
+		"tool_name": "render_mermaid",
+		"description": (
+			"Renders a Mermaid diagram from structured nodes/edges. Call this instead of "
+			"writing Mermaid syntax yourself. Returns the complete <artifact type=\"mermaid\"> "
+			"tag - relay it verbatim in your response."
+		),
+		"function_path": "huf.ai.tools.render_tools.handle_render_mermaid",
+		"category": "Render Tools",
+		"parameters": [
+			_p("diagram_type", required=True, description="One of: 'graph TD', 'graph LR', 'flowchart TD', 'flowchart LR'"),
+			_p("nodes", type="json", required=True, description="JSON list of nodes [{id, label}], e.g. [{\"id\": \"a\", \"label\": \"Start\"}]"),
+			_p("edges", type="json", description="JSON list of edges [{from, to, label}], e.g. [{\"from\": \"a\", \"to\": \"b\", \"label\": \"next\"}]. from/to must match declared node ids"),
+			_p("title", description="Artifact title (default 'Diagram')"),
+		],
+	},
+	{
+		"tool_name": "render_chart",
+		"description": (
+			"Renders a bar/line/pie/area chart from structured data. Call this instead of "
+			"hand-writing Recharts JSX yourself. Returns the complete "
+			"<artifact type=\"chart\" language=\"jsx\"> tag - relay it verbatim in your response."
+		),
+		"function_path": "huf.ai.tools.render_tools.handle_render_chart",
+		"category": "Render Tools",
+		"parameters": [
+			_p("chart_type", required=True, description="One of: 'bar', 'line', 'pie', 'area'"),
+			_p("data", type="json", required=True, description="JSON list of row objects, each containing at least the x_key field and every series_key field"),
+			_p("series_keys", type="json", description="JSON list of field names to plot as series/values (default ['value'])"),
+			_p("x_key", description="Field used for the category/x axis, ignored for 'pie' (default 'label')"),
+			_p("colors", type="json", description="Optional JSON list of hex colors, mainly used for pie slices"),
+			_p("title", description="Artifact title (default '<Chart Type> Chart')"),
+		],
+	},
+]
+
 ALL_INTEGRATION_TOOLS = (
 	# Platform capabilities — no external account to connect.
 	RECIPIENT_TOOLS
@@ -1855,6 +1897,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS
 	+ DOCUMENT_ARTIFACT_TOOLS
+	+ RENDER_TOOLS
 	# Tools backed by a connectable service. Keys match Integration Service
 	# docnames and the SERVICE_NAME each tool module uses for credentials.
 	+ _with_service(SLACK_TOOLS, "slack")

--- a/huf/ai/tools/lazy_discovery.py
+++ b/huf/ai/tools/lazy_discovery.py
@@ -1,0 +1,229 @@
+"""Lazy tool discovery handlers.
+
+Lets an agent with a large tool surface discover tools on demand instead of
+having every tool's schema loaded into context up front: list_tool_groups ->
+describe_tool_group -> load_tools, or search_tools -> load_tools directly.
+"""
+
+import json
+
+import frappe
+
+from huf.ai.tool_registry import PermissionAwareToolRegistry
+from huf.ai.conversation_data_tools import _load_state
+
+logger = frappe.logger("huf")
+
+
+def _resolve_agent_doc(kwargs):
+    """Resolve the calling Agent doc the same way sdk_tools handlers do: via the
+    ``agent_name`` injected into kwargs from the huf run context."""
+    agent_name = kwargs.get("agent_name")
+    if not agent_name:
+        return None
+    try:
+        return frappe.get_cached_doc("Agent", agent_name)
+    except (frappe.DoesNotExistError, frappe.ValidationError):
+        return None
+
+
+def _tool_group(tool_doc) -> str:
+    return tool_doc.service or tool_doc.provider_app or "General"
+
+
+def _summarize(description: str) -> str:
+    if not description:
+        return ""
+    period_idx = description.find(". ")
+    if period_idx != -1:
+        return description[:period_idx + 1].strip()
+    return description[:120].strip()
+
+
+def handle_list_tool_groups(**kwargs):
+    """Group the calling agent's allowed tools by service (or provider_app/"General")."""
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps([])
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+
+    groups = {}
+    order = []
+    for tool_doc in allowed_tools:
+        group = _tool_group(tool_doc)
+        if group not in groups:
+            groups[group] = []
+            order.append(group)
+        groups[group].append(tool_doc)
+
+    result = []
+    for group in order:
+        tool_docs = groups[group]
+        summary = ""
+        for tool_doc in tool_docs:
+            summary = _summarize(tool_doc.description)
+            if summary:
+                break
+        result.append({
+            "service": group,
+            "tool_count": len(tool_docs),
+            "summary": summary,
+        })
+
+    return json.dumps(result)
+
+
+def handle_search_tools(query, limit=10, **kwargs):
+    """Search discoverable tools, filtered to what the calling agent is permitted to use."""
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps([])
+
+    limit = int(limit) if limit else 10
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+    allowed_by_name = {tool_doc.tool_name: tool_doc for tool_doc in allowed_tools}
+
+    # Call the underlying implementation directly, not the api.py wrapper —
+    # that wrapper admin-gates capability discovery (it exposes raw app
+    # manifests/function paths), but here results are already filtered down
+    # to the calling agent's own allowed tools before anything is returned,
+    # so the admin gate would just make this always return nothing for
+    # ordinary agents.
+    from huf.ai.capability_discovery.actions import search_app_actions
+
+    seen_apps = set()
+    matches = []
+    for tool_doc in allowed_tools:
+        app_name = tool_doc.provider_app
+        if not app_name or app_name in seen_apps:
+            continue
+        seen_apps.add(app_name)
+
+        try:
+            descriptors = search_app_actions(app_name, query, limit)
+        except (frappe.PermissionError, frappe.ValidationError, ValueError) as e:
+            # search_app_actions is admin-gated; a non-admin caller simply gets no
+            # results for that app rather than the whole discovery call failing.
+            logger.debug(f"handle_search_tools: skipping app {app_name}: {e!s}")
+            continue
+
+        for descriptor in descriptors:
+            tool_name = descriptor.get("title")
+            allowed_tool_doc = allowed_by_name.get(tool_name)
+            if not allowed_tool_doc:
+                continue
+            matches.append({
+                "tool_name": tool_name,
+                "service": _tool_group(allowed_tool_doc),
+                "description": descriptor.get("description") or "",
+            })
+            if len(matches) >= limit:
+                return json.dumps(matches[:limit])
+
+    return json.dumps(matches[:limit])
+
+
+def handle_describe_tool_group(service, **kwargs):
+    """List every allowed tool whose service (or provider_app/"General" fallback) matches."""
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps([])
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+
+    result = [
+        {"tool_name": tool_doc.tool_name, "description": tool_doc.description or ""}
+        for tool_doc in allowed_tools
+        if _tool_group(tool_doc) == service
+    ]
+
+    return json.dumps(result)
+
+
+def _get_conversation_data(conversation_id):
+    if not conversation_id:
+        return {"version": 1, "scope": {}, "items": []}
+    data_json = frappe.db.get_value("Agent Conversation", conversation_id, "conversation_data")
+    return _load_state(data_json)
+
+
+def _set_conversation_data(conversation_id, state):
+    frappe.db.set_value(
+        "Agent Conversation", conversation_id, "conversation_data",
+        json.dumps(state, ensure_ascii=False, indent=2),
+    )
+
+
+def _get_lazy_tools_item(state):
+    """Find (or create) the "_lazy_tools" entry in the items list.
+
+    conversation_data stores values as {"items": [{"name", "value", ...}]}
+    (see handle_get_conversation_data / handle_set_conversation_data) rather
+    than as top-level keys, so this must update an items-list entry to stay
+    visible to that same reader (huf.ai.sdk_tools._get_lazy_discovered_tool_names).
+    """
+    for item in state["items"]:
+        if item.get("name") == "_lazy_tools":
+            item.setdefault("value", {})
+            return item
+    item = {"name": "_lazy_tools", "value": {}}
+    state["items"].append(item)
+    return item
+
+
+def handle_load_tools(tool_names, **kwargs):
+    """Grant the requesting conversation access to previously-discovered tools.
+
+    Re-validates permissions here (rather than trusting the model's request)
+    because this is the actual permission boundary: it is what decides which
+    tools create_agent_tools() will build for later turns of this conversation.
+    """
+    agent = _resolve_agent_doc(kwargs)
+    if not agent:
+        return json.dumps({"accepted": [], "rejected": tool_names if isinstance(tool_names, list) else []})
+
+    if isinstance(tool_names, str):
+        try:
+            tool_names = json.loads(tool_names)
+        except (json.JSONDecodeError, TypeError):
+            tool_names = [tool_names]
+    if not isinstance(tool_names, list):
+        tool_names = []
+
+    allowed_tools = PermissionAwareToolRegistry.get_allowed_tools(agent, frappe.session.user)
+    allowed_by_name = {tool_doc.tool_name: tool_doc for tool_doc in allowed_tools}
+
+    accepted_names = []
+    rejected_names = []
+    for name in tool_names:
+        if name in allowed_by_name and name not in accepted_names:
+            accepted_names.append(name)
+        elif name not in allowed_by_name:
+            rejected_names.append(name)
+
+    conversation_id = kwargs.get("conversation_id")
+    if conversation_id and accepted_names:
+        state = _get_conversation_data(conversation_id)
+        item = _get_lazy_tools_item(state)
+        discovered = item["value"].setdefault("discovered", [])
+        for name in accepted_names:
+            if name not in discovered:
+                discovered.append(name)
+        _set_conversation_data(conversation_id, state)
+
+    accepted = []
+    for name in accepted_names:
+        tool_doc = allowed_by_name[name]
+        try:
+            parameters = json.loads(tool_doc.params) if tool_doc.params else {}
+        except (json.JSONDecodeError, TypeError):
+            parameters = {}
+        accepted.append({
+            "tool_name": name,
+            "description": tool_doc.description or "",
+            "parameters": parameters,
+        })
+
+    return json.dumps({"accepted": accepted, "rejected": rejected_names})

--- a/huf/ai/tools/render_tools.py
+++ b/huf/ai/tools/render_tools.py
@@ -34,6 +34,36 @@ def _escape_mermaid_label(label: str) -> str:
 	return escaped
 
 
+def _escape_artifact_attr(value: str) -> str:
+	"""Sanitize a value that will be templated into an `<artifact ...>` tag
+	attribute (e.g. title="...").
+
+	The frontend's artifact parser (frontend/src/utils/artifactParser.ts)
+	extracts the outer `<artifact ...>` tag with a plain regex, not an HTML/DOM
+	parser: `ARTIFACT_REGEX` stops at the first `>` and `ATTR_REGEX` stops at
+	the first matching quote. An unescaped `"` or `>` in a templated value
+	(e.g. an LLM- or user-supplied chart/diagram title) would truncate or
+	corrupt the tag boundary, leaking the rest of the artifact body as raw
+	text into the chat. Strip the characters that matter to that regex rather
+	than trying to HTML-encode them (this isn't HTML, so entities like
+	`&quot;` would just render literally).
+	"""
+	if not value:
+		return value
+	return value.replace('"', "'").replace("<", "(").replace(">", ")")
+
+
+def _escape_jsx_attr(value: str) -> str:
+	"""Sanitize a value templated into a double-quoted JSX attribute
+	(e.g. dataKey="...", fill="..."). Prevents a caller-supplied field name or
+	color from closing the attribute early and injecting additional JSX
+	attributes/props into the generated chart component.
+	"""
+	if not value:
+		return value
+	return value.replace('"', "'").replace("{", "(").replace("}", ")")
+
+
 def handle_render_mermaid(diagram_type=None, nodes=None, edges=None, title=None, **kwargs) -> str:
 	"""Template structured nodes/edges into a Mermaid <artifact> tag.
 
@@ -97,7 +127,7 @@ def handle_render_mermaid(diagram_type=None, nodes=None, edges=None, title=None,
 
 	_sanity_check_mermaid_dsl(dsl)
 
-	artifact_title = title or "Diagram"
+	artifact_title = _escape_artifact_attr((title or "Diagram").strip())
 	return f'<artifact type="mermaid" title="{artifact_title}">\n{dsl}\n</artifact>'
 
 
@@ -172,7 +202,7 @@ def handle_render_chart(chart_type=None, data=None, series_keys=None, x_key="lab
 				raise ValueError(f"data[{i}] is missing series_key field {key!r}")
 
 	data_declaration = f"const data = {json.dumps(data)};"
-	artifact_title = title or f"{chart_type.capitalize()} Chart"
+	artifact_title = _escape_artifact_attr((title or f"{chart_type.capitalize()} Chart").strip())
 
 	if chart_type == "pie":
 		jsx = _build_pie_jsx(series_keys[0], colors)
@@ -191,15 +221,17 @@ def _build_axis_chart_jsx(chart_type: str, x_key: str, series_keys: list, colors
 
 	series_lines = []
 	for i, key in enumerate(series_keys):
-		color = palette[i % len(palette)]
-		series_lines.append(f'      <{series_component} dataKey="{key}" fill="{color}" stroke="{color}" />')
+		color = _escape_jsx_attr(str(palette[i % len(palette)]))
+		safe_key = _escape_jsx_attr(str(key))
+		series_lines.append(f'      <{series_component} dataKey="{safe_key}" fill="{color}" stroke="{color}" />')
 	series_jsx = "\n".join(series_lines)
 
+	safe_x_key = _escape_jsx_attr(str(x_key))
 	return (
 		"<Card style={{ padding: 12 }}>\n"
 		'  <ResponsiveContainer width="100%" height={320}>\n'
 		f"    <{container} data={{data}}>\n"
-		f'      <XAxis dataKey="{x_key}" />\n'
+		f'      <XAxis dataKey="{safe_x_key}" />\n'
 		"      <YAxis />\n"
 		"      <Tooltip />\n"
 		"      <Legend />\n"
@@ -213,13 +245,14 @@ def _build_axis_chart_jsx(chart_type: str, x_key: str, series_keys: list, colors
 def _build_pie_jsx(value_key: str, colors) -> str:
 	palette = colors or _DEFAULT_PIE_COLORS
 	colors_declaration = f"const colors = {json.dumps(palette)};"
+	safe_value_key = _escape_jsx_attr(str(value_key))
 
 	return (
 		f"{colors_declaration}\n\n"
 		"<Card style={{ padding: 12 }}>\n"
 		'  <ResponsiveContainer width="100%" height={320}>\n'
 		"    <PieChart>\n"
-		f'      <Pie data={{data}} dataKey="{value_key}" nameKey="label" outerRadius={{120}}>\n'
+		f'      <Pie data={{data}} dataKey="{safe_value_key}" nameKey="label" outerRadius={{120}}>\n'
 		"        {data.map((entry, index) => (\n"
 		'          <Cell key={`cell-${index}`} fill={colors[index % colors.length] || "#8884d8"} />\n'
 		"        ))}\n"

--- a/huf/ai/tools/render_tools.py
+++ b/huf/ai/tools/render_tools.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+"""Agent-facing tool handlers that template structured JSON into the existing
+Mermaid/chart <artifact> tag formats, so a model passes data instead of
+hand-authoring Mermaid DSL or Recharts JSX.
+
+Both handlers return the complete <artifact>...</artifact> markup string -
+the exact same tags a model would otherwise hand-author - or raise ValueError
+on bad input, matching the convention used elsewhere in huf/ai/tools/.
+"""
+
+import json
+
+VALID_DIAGRAM_TYPES = ("graph TD", "graph LR", "flowchart TD", "flowchart LR")
+VALID_CHART_TYPES = ("bar", "line", "pie", "area")
+
+# Characters that break Mermaid node/edge syntax inside a label.
+_MERMAID_LABEL_ESCAPES = {
+	"[": "(",
+	"]": ")",
+	"|": "-",
+	'"': "'",
+}
+
+# Default palette for pie-chart slices when the caller does not supply colors.
+_DEFAULT_PIE_COLORS = ["#007BFF", "#28A745", "#FFC107", "#DC3545", "#6F42C1", "#20C997", "#FD7E14"]
+
+
+def _escape_mermaid_label(label: str) -> str:
+	escaped = label
+	for char, replacement in _MERMAID_LABEL_ESCAPES.items():
+		escaped = escaped.replace(char, replacement)
+	return escaped
+
+
+def handle_render_mermaid(diagram_type=None, nodes=None, edges=None, title=None, **kwargs) -> str:
+	"""Template structured nodes/edges into a Mermaid <artifact> tag.
+
+	Args:
+		diagram_type (str): One of "graph TD", "graph LR", "flowchart TD", "flowchart LR".
+		nodes (list[dict]): Each {"id": str, "label": str, "shape": optional, ignored}.
+		edges (list[dict]): Each {"from": str, "to": str, "label": optional str}.
+		title (str): Artifact title, defaults to "Diagram".
+
+	Returns:
+		The complete <artifact type="mermaid" ...>...</artifact> string.
+	"""
+	if diagram_type not in VALID_DIAGRAM_TYPES:
+		raise ValueError(f"'diagram_type' must be one of {VALID_DIAGRAM_TYPES}, got {diagram_type!r}")
+
+	if not isinstance(nodes, list) or not nodes:
+		raise ValueError("'nodes' must be a non-empty list of {id, label} objects")
+
+	if edges is None:
+		edges = []
+	if not isinstance(edges, list):
+		raise ValueError("'edges' must be a list of {from, to, label} objects")
+
+	node_ids = set()
+	node_lines = []
+	for i, node in enumerate(nodes):
+		if not isinstance(node, dict):
+			raise ValueError(f"nodes[{i}] must be an object with 'id' and 'label'")
+		node_id = (node.get("id") or "").strip()
+		label = (node.get("label") or "").strip()
+		if not node_id:
+			raise ValueError(f"nodes[{i}] is missing a required non-empty 'id'")
+		if not label:
+			raise ValueError(f"nodes[{i}] (id={node_id!r}) is missing a required non-empty 'label'")
+		if node_id in node_ids:
+			raise ValueError(f"Duplicate node id {node_id!r} - node ids must be unique")
+		node_ids.add(node_id)
+		node_lines.append(f"    {node_id}[{_escape_mermaid_label(label)}]")
+
+	edge_lines = []
+	for i, edge in enumerate(edges):
+		if not isinstance(edge, dict):
+			raise ValueError(f"edges[{i}] must be an object with 'from' and 'to'")
+		src = (edge.get("from") or "").strip()
+		dst = (edge.get("to") or "").strip()
+		if not src or not dst:
+			raise ValueError(f"edges[{i}] must have non-empty 'from' and 'to'")
+		if src not in node_ids:
+			raise ValueError(f"edges[{i}] references unknown node id 'from'={src!r} - it must match a declared node id")
+		if dst not in node_ids:
+			raise ValueError(f"edges[{i}] references unknown node id 'to'={dst!r} - it must match a declared node id")
+
+		edge_label = (edge.get("label") or "").strip()
+		if edge_label:
+			edge_lines.append(f"    {src} -->|{_escape_mermaid_label(edge_label)}| {dst}")
+		else:
+			edge_lines.append(f"    {src} --> {dst}")
+
+	dsl_lines = [diagram_type] + node_lines + edge_lines
+	dsl = "\n".join(dsl_lines)
+
+	_sanity_check_mermaid_dsl(dsl)
+
+	artifact_title = title or "Diagram"
+	return f'<artifact type="mermaid" title="{artifact_title}">\n{dsl}\n</artifact>'
+
+
+def _sanity_check_mermaid_dsl(dsl: str) -> None:
+	"""Best-effort structural check on generated DSL before returning it."""
+	if dsl.count("[") != dsl.count("]"):
+		raise ValueError("Generated Mermaid DSL has unbalanced [] brackets - this is a bug in render_mermaid")
+	if "[]" in dsl.replace(" ", ""):
+		raise ValueError("Generated Mermaid DSL has an empty node label - this is a bug in render_mermaid")
+	for line in dsl.splitlines()[1:]:
+		stripped = line.strip()
+		if not stripped:
+			continue
+		is_edge_line = "-->" in stripped
+		is_node_line = "[" in stripped
+		if stripped.startswith("-->") or not (is_edge_line or is_node_line):
+			raise ValueError(f"Generated Mermaid DSL line looks malformed: {stripped!r}")
+
+
+_CHART_TAG_TEMPLATES = {
+	"bar": {
+		"import_component": "BarChart",
+		"series_component": "Bar",
+	},
+	"line": {
+		"import_component": "LineChart",
+		"series_component": "Line",
+	},
+	"area": {
+		"import_component": "AreaChart",
+		"series_component": "Area",
+	},
+}
+
+
+def handle_render_chart(chart_type=None, data=None, series_keys=None, x_key="label", colors=None, title=None, **kwargs) -> str:
+	"""Template structured data into a JSX chart <artifact> tag matching the
+	rules in huf.ai.chart_artifact_instructions (allowed tags/components,
+	backtick template literals, no CardHeader/CardTitle, etc).
+
+	Args:
+		chart_type (str): One of "bar", "line", "pie", "area".
+		data (list[dict]): Non-empty rows, each containing at least x_key.
+		series_keys (list[str]): Fields to plot; defaults to ["value"].
+		x_key (str): Field used for the category/x axis. Ignored for "pie".
+		colors (list[str]): Optional palette, mainly used for pie slices.
+		title (str): Artifact title.
+
+	Returns:
+		The complete <artifact type="chart" language="jsx" ...>...</artifact> string.
+	"""
+	if chart_type not in VALID_CHART_TYPES:
+		raise ValueError(f"'chart_type' must be one of {VALID_CHART_TYPES}, got {chart_type!r}")
+
+	if not isinstance(data, list) or not data:
+		raise ValueError("'data' must be a non-empty list of objects")
+
+	for i, row in enumerate(data):
+		if not isinstance(row, dict):
+			raise ValueError(f"data[{i}] must be an object")
+		if chart_type != "pie" and x_key not in row:
+			raise ValueError(f"data[{i}] is missing the required x_key field {x_key!r}")
+
+	if not series_keys:
+		series_keys = ["value"]
+	if not isinstance(series_keys, list) or not series_keys:
+		raise ValueError("'series_keys' must be a non-empty list of field names")
+
+	for i, row in enumerate(data):
+		for key in series_keys:
+			if key not in row:
+				raise ValueError(f"data[{i}] is missing series_key field {key!r}")
+
+	data_declaration = f"const data = {json.dumps(data)};"
+	artifact_title = title or f"{chart_type.capitalize()} Chart"
+
+	if chart_type == "pie":
+		jsx = _build_pie_jsx(series_keys[0], colors)
+	else:
+		jsx = _build_axis_chart_jsx(chart_type, x_key, series_keys, colors)
+
+	body = f"{data_declaration}\n\n{jsx}"
+	return f'<artifact type="chart" language="jsx" title="{artifact_title}">\n{body}\n</artifact>'
+
+
+def _build_axis_chart_jsx(chart_type: str, x_key: str, series_keys: list, colors) -> str:
+	template = _CHART_TAG_TEMPLATES[chart_type]
+	container = template["import_component"]
+	series_component = template["series_component"]
+	palette = colors or _DEFAULT_PIE_COLORS
+
+	series_lines = []
+	for i, key in enumerate(series_keys):
+		color = palette[i % len(palette)]
+		series_lines.append(f'      <{series_component} dataKey="{key}" fill="{color}" stroke="{color}" />')
+	series_jsx = "\n".join(series_lines)
+
+	return (
+		"<Card style={{ padding: 12 }}>\n"
+		'  <ResponsiveContainer width="100%" height={320}>\n'
+		f"    <{container} data={{data}}>\n"
+		f'      <XAxis dataKey="{x_key}" />\n'
+		"      <YAxis />\n"
+		"      <Tooltip />\n"
+		"      <Legend />\n"
+		f"{series_jsx}\n"
+		f"    </{container}>\n"
+		"  </ResponsiveContainer>\n"
+		"</Card>"
+	)
+
+
+def _build_pie_jsx(value_key: str, colors) -> str:
+	palette = colors or _DEFAULT_PIE_COLORS
+	colors_declaration = f"const colors = {json.dumps(palette)};"
+
+	return (
+		f"{colors_declaration}\n\n"
+		"<Card style={{ padding: 12 }}>\n"
+		'  <ResponsiveContainer width="100%" height={320}>\n'
+		"    <PieChart>\n"
+		f'      <Pie data={{data}} dataKey="{value_key}" nameKey="label" outerRadius={{120}}>\n'
+		"        {data.map((entry, index) => (\n"
+		'          <Cell key={`cell-${index}`} fill={colors[index % colors.length] || "#8884d8"} />\n'
+		"        ))}\n"
+		"      </Pie>\n"
+		"      <Tooltip />\n"
+		"      <Legend />\n"
+		"    </PieChart>\n"
+		"  </ResponsiveContainer>\n"
+		"</Card>"
+	)

--- a/huf/ai/usage_extraction.py
+++ b/huf/ai/usage_extraction.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""
+Single source of truth for per-round LLM usage extraction.
+
+Usage payloads arrive from LiteLLM/OpenAI-style response objects, plain
+dicts, or pydantic models, and different fields drift depending on the
+provider (``prompt_tokens`` vs ``input_tokens``, ``cached_tokens`` vs
+``cache_hit_tokens``, and so on). This extraction logic used to be copied
+and independently patched in four places, and the copies had drifted out
+of sync with each other:
+
+  - huf/ai/providers/litellm.py (~lines 905-935) — round token counts fed
+    into calculate_cost for the non-streaming completion path.
+  - huf/ai/providers/litellm.py (~lines 995-1050) — accumulation of round
+    usage into total_usage across multi-round tool-calling loops.
+  - huf/ai/agent_integration.py (~lines 1830-1880) — sync-path re-extraction
+    of usage from the agent run result.
+  - huf/ai/agent_integration.py (~lines 2945-3000) — streaming-path
+    re-extraction of usage from the agent run result.
+
+Notably, the sync site fell back to a dict's ``input_tokens`` key while the
+streaming site fell back to ``prompt_tokens`` — silently disagreeing about
+which key wins when both key names could be present. This module resolves
+that by accepting either as a fallback. It also deliberately does NOT read
+``cache_miss_tokens`` as a cache-write source: that was a mislabelled
+duplicate of the cache-creation value in some of the old sites, not a
+genuine cache-write count, and folding it into ``cache_write_tokens`` here
+would resurrect that bug.
+
+Callers that used to inline this logic should call ``extract_round_usage``
+instead and treat this module as canonical.
+"""
+
+
+def normalise_usage_payload(usage):
+    """Return ``usage`` as a plain dict, or ``None`` if that is not possible.
+
+    Accepts an already-plain dict (returned unchanged), a pydantic-style
+    model exposing ``.dict()`` or ``.model_dump()``, or ``None``/anything
+    else unsupported (returns ``None``).
+    """
+    if usage is None:
+        return None
+    if isinstance(usage, dict):
+        return usage
+    for method_name in ("model_dump", "dict"):
+        method = getattr(usage, method_name, None)
+        if callable(method):
+            try:
+                result = method()
+            except Exception:
+                continue
+            if isinstance(result, dict):
+                return result
+    return None
+
+
+def _as_int(value):
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _get(source, key):
+    """Read ``key`` from ``source``, which may be a dict or an object."""
+    if source is None:
+        return None
+    if isinstance(source, dict):
+        return source.get(key)
+    return getattr(source, key, None)
+
+
+def _first(source, keys):
+    """Return the first non-empty value among ``keys`` read off ``source``."""
+    for key in keys:
+        value = _get(source, key)
+        if value:
+            return value
+    return None
+
+
+def _extract_details(usage):
+    """Fetch the nested prompt_tokens_details block, dict or object, or None."""
+    details = _get(usage, "prompt_tokens_details")
+    if not details:
+        return None
+    return details
+
+
+def extract_round_usage(usage):
+    """Extract a single round's token usage from a provider usage payload.
+
+    ``usage`` may be a LiteLLM/OpenAI usage object, a plain dict, a
+    pydantic model exposing ``.dict()``/``.model_dump()``, or ``None``.
+
+    Always returns a dict with exactly these keys, each an ``int`` that
+    defaults to ``0`` when the source value is missing or unparseable:
+
+        input_tokens, output_tokens, cache_read_tokens, cache_write_tokens
+
+    Never raises.
+    """
+    result = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    if usage is None:
+        return result
+
+    try:
+        result["input_tokens"] = _as_int(_first(usage, ("prompt_tokens", "input_tokens")))
+        result["output_tokens"] = _as_int(_first(usage, ("completion_tokens", "output_tokens")))
+
+        details = _extract_details(usage)
+
+        result["cache_read_tokens"] = _as_int(
+            _first(details, ("cached_tokens", "cache_hit_tokens"))
+            or _first(usage, ("cached_tokens", "cache_hit_tokens"))
+        )
+
+        result["cache_write_tokens"] = _as_int(
+            _first(
+                details,
+                (
+                    "cache_creation_input_tokens",
+                    "cache_write_tokens",
+                    "cache_creation_tokens",
+                ),
+            )
+            or _first(
+                usage,
+                (
+                    "cache_creation_input_tokens",
+                    "cache_write_input_tokens",
+                    "cache_creation_tokens",
+                ),
+            )
+        )
+    except Exception:
+        # Usage extraction is best-effort; never let a malformed payload
+        # break the caller. Fall back to whatever fields were parsed so far.
+        pass
+
+    return result

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -103,6 +103,7 @@
   "agent_behaviors_section",
   "autonaming_of_conversation_title",
   "enable_conversation_data",
+  "enable_lazy_tools",
   "column_break_fl05",
   "conversation_lifecycle_section",
   "conversation_retention_policy",
@@ -767,6 +768,13 @@
    "fieldname": "enable_conversation_data",
    "fieldtype": "Check",
    "label": "Allow Conversation Data Management"
+  },
+  {
+   "default": "0",
+   "description": "Enable lazy discovery of tools to reduce token usage by loading tools on-demand instead of eager loading.",
+   "fieldname": "enable_lazy_tools",
+   "fieldtype": "Check",
+   "label": "Enable Lazy Tool Discovery"
   },
   {
    "default": "1",

--- a/huf/huf/doctype/agent_run/agent_run.json
+++ b/huf/huf/doctype/agent_run/agent_run.json
@@ -32,6 +32,15 @@
   "end_time",
   "output_tokens",
   "cached_tokens",
+  "billed_input_tokens",
+  "peak_context_tokens",
+  "cache_creation_tokens",
+  "total_tokens",
+  "cache_skipped_unsupported_model",
+  "round_count",
+  "model_context_window",
+  "provider_path",
+  "execution_mode",
   "parent_run",
   "is_child",
   "agent_orchestration",
@@ -184,6 +193,71 @@
    "fieldname": "cached_tokens",
    "fieldtype": "Int",
    "label": "Cached Tokens",
+   "read_only": 1
+  },
+  {
+   "description": "Sum of prompt_tokens across all rounds of this run. The cost-bearing number.",
+   "fieldname": "billed_input_tokens",
+   "fieldtype": "Int",
+   "label": "Billed Input Tokens",
+   "read_only": 1
+  },
+  {
+   "description": "prompt_tokens of the largest single round. The correct numerator for context-window fullness. Never sum this across runs.",
+   "fieldname": "peak_context_tokens",
+   "fieldtype": "Int",
+   "label": "Peak Context Tokens",
+   "read_only": 1
+  },
+  {
+   "description": "Cache write tokens. Promoted from usage_snapshot so it can be aggregated in SQL.",
+   "fieldname": "cache_creation_tokens",
+   "fieldtype": "Int",
+   "label": "Cache Creation Tokens",
+   "read_only": 1
+  },
+  {
+   "description": "Promoted from usage_snapshot so it can be aggregated in SQL.",
+   "fieldname": "total_tokens",
+   "fieldtype": "Int",
+   "label": "Total Tokens",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "cache_skipped_unsupported_model",
+   "fieldtype": "Check",
+   "label": "Cache Skipped (Unsupported Model)",
+   "read_only": 1
+  },
+  {
+   "description": "Number of LLM completions performed for this run. One Agent Run is not one model call.",
+   "fieldname": "round_count",
+   "fieldtype": "Int",
+   "label": "Round Count",
+   "read_only": 1
+  },
+  {
+   "description": "Snapshotted at call time so later AI Model edits cannot rewrite history.",
+   "fieldname": "model_context_window",
+   "fieldtype": "Int",
+   "label": "Model Context Window",
+   "read_only": 1
+  },
+  {
+   "description": "Which provider path served this run. legacy_fallback drops cache and cost data.",
+   "fieldname": "provider_path",
+   "fieldtype": "Select",
+   "label": "Provider Path",
+   "options": "\nlitellm\nlegacy_fallback",
+   "read_only": 1
+  },
+  {
+   "description": "Whether this run used the sync or streaming completion path.",
+   "fieldname": "execution_mode",
+   "fieldtype": "Select",
+   "label": "Execution Mode",
+   "options": "\nsync\nstream",
    "read_only": 1
   },
   {

--- a/huf/huf/doctype/agent_run_analytics_rollup/agent_run_analytics_rollup.json
+++ b/huf/huf/doctype/agent_run_analytics_rollup/agent_run_analytics_rollup.json
@@ -4,7 +4,7 @@
  "creation": "2026-07-26 00:00:00.000000",
  "doctype": "DocType",
  "engine": "InnoDB",
- "field_order": ["bucket_start", "granularity", "dimension_key", "agent", "provider", "model", "run_kind", "run_count", "success_count", "failed_count", "input_tokens", "output_tokens", "cached_tokens", "total_cost", "duration_ms_sum", "duration_count", "last_recomputed_at"],
+ "field_order": ["bucket_start", "granularity", "dimension_key", "agent", "provider", "model", "conversation", "run_kind", "run_count", "success_count", "failed_count", "input_tokens", "output_tokens", "cached_tokens", "cache_creation_tokens", "total_cost", "composition_totals", "duration_ms_sum", "duration_count", "last_recomputed_at"],
  "fields": [
   {"fieldname":"bucket_start","fieldtype":"Datetime","in_list_view":1,"label":"Bucket Start","read_only":1},
   {"fieldname":"granularity","fieldtype":"Select","in_list_view":1,"label":"Granularity","options":"hour\nday","read_only":1},
@@ -12,6 +12,7 @@
   {"fieldname":"agent","fieldtype":"Link","in_list_view":1,"label":"Agent","options":"Agent","read_only":1},
   {"fieldname":"provider","fieldtype":"Link","in_list_view":1,"label":"Provider","options":"AI Provider","read_only":1},
   {"fieldname":"model","fieldtype":"Link","in_list_view":1,"label":"Model","options":"AI Model","read_only":1},
+  {"fieldname":"conversation","fieldtype":"Link","in_list_view":1,"label":"Conversation","options":"Agent Conversation","read_only":1},
   {"fieldname":"run_kind","fieldtype":"Data","label":"Run Kind","read_only":1},
   {"fieldname":"run_count","fieldtype":"Int","label":"Run Count","read_only":1},
   {"fieldname":"success_count","fieldtype":"Int","label":"Success Count","read_only":1},
@@ -19,7 +20,9 @@
   {"fieldname":"input_tokens","fieldtype":"Int","label":"Input Tokens","read_only":1},
   {"fieldname":"output_tokens","fieldtype":"Int","label":"Output Tokens","read_only":1},
   {"fieldname":"cached_tokens","fieldtype":"Int","label":"Cached Tokens","read_only":1},
+  {"fieldname":"cache_creation_tokens","fieldtype":"Int","label":"Cache Creation Tokens","read_only":1},
   {"fieldname":"total_cost","fieldtype":"Float","label":"Total Cost","read_only":1},
+  {"fieldname":"composition_totals","fieldtype":"JSON","label":"Composition Totals","description":"Summed context-composition segment tokens for this bucket. Keys mirror Agent Run usage_snapshot segment categories. Null means not measured, which is not the same as zero.","read_only":1},
   {"fieldname":"duration_ms_sum","fieldtype":"Float","label":"Duration Sum (ms)","read_only":1},
   {"fieldname":"duration_count","fieldtype":"Int","label":"Duration Count","read_only":1},
   {"fieldname":"last_recomputed_at","fieldtype":"Datetime","label":"Last Recomputed At","read_only":1}

--- a/huf/huf/doctype/agent_run_prompt_snapshot/agent_run_prompt_snapshot.json
+++ b/huf/huf/doctype/agent_run_prompt_snapshot/agent_run_prompt_snapshot.json
@@ -1,0 +1,78 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-08-24 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "agent_run",
+  "agent",
+  "conversation",
+  "captured_at",
+  "system_prompt"
+ ],
+ "fields": [
+  {
+   "fieldname": "agent_run",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Agent Run",
+   "options": "Agent Run",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "agent",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Agent",
+   "options": "Agent",
+   "read_only": 1
+  },
+  {
+   "fieldname": "conversation",
+   "fieldtype": "Link",
+   "label": "Conversation",
+   "options": "Agent Conversation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "captured_at",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Captured At",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "system_prompt",
+   "fieldtype": "Long Text",
+   "label": "System Prompt",
+   "read_only": 1,
+   "reqd": 1,
+   "description": "The exact assembled system prompt this run received, verbatim. Opt-in only (site_config huf_retain_system_prompts_enabled) -- only ever written when a site operator has explicitly turned this on. May contain memory-block and knowledge-base text; treat as sensitive."
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-08-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Agent Run Prompt Snapshot",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "read": 1,
+   "report": 1,
+   "role": "System Manager"
+  },
+  {
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager"
+  }
+ ],
+ "sort_field": "captured_at",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/huf/huf/doctype/agent_run_prompt_snapshot/agent_run_prompt_snapshot.py
+++ b/huf/huf/doctype/agent_run_prompt_snapshot/agent_run_prompt_snapshot.py
@@ -1,0 +1,5 @@
+from frappe.model.document import Document
+
+
+class AgentRunPromptSnapshot(Document):
+    pass

--- a/huf/huf/doctype/ai_model/ai_model.json
+++ b/huf/huf/doctype/ai_model/ai_model.json
@@ -12,11 +12,14 @@
   "capabilities_section",
   "supports_reasoning",
   "reasoning_config_override",
+  "context_window",
+  "max_output_tokens",
   "pricing_section",
   "use_custom_pricing",
   "input_cost_per_1m_tokens",
   "output_cost_per_1m_tokens",
   "cached_input_cost_per_1m_tokens",
+  "cached_input_write_cost_per_1m_tokens",
   "chat_capability_overrides_section",
   "disable_ask_user",
   "disable_rich_elements",
@@ -68,6 +71,18 @@
    "options": "JSON"
   },
   {
+   "description": "Maximum total tokens this model accepts. Seeded from LiteLLM's model-cost table where available; editable for custom or local models. Leave 0 to fall back to the LiteLLM lookup.",
+   "fieldname": "context_window",
+   "fieldtype": "Int",
+   "label": "Context Window (tokens)"
+  },
+  {
+   "description": "Maximum completion tokens. Leave 0 to fall back to the LiteLLM lookup.",
+   "fieldname": "max_output_tokens",
+   "fieldtype": "Int",
+   "label": "Max Output Tokens"
+  },
+  {
    "description": "Enable custom prices to override LiteLLM's automatic pricing lookup. When disabled, LiteLLM's built-in price table is used as fallback. Values are in USD per 1 million tokens.",
    "fieldname": "pricing_section",
    "fieldtype": "Section Break",
@@ -103,6 +118,14 @@
    "description": "Optional. Cost for prompt cache reads (cache hits) in USD per 1M tokens. E.g. Anthropic charges $0.30/1M for cache reads vs $3.00/1M for regular input. Leave as 0 if not applicable.",
    "precision": "8",
    "depends_on": "eval:doc.use_custom_pricing"
+  },
+  {
+   "depends_on": "eval:doc.use_custom_pricing",
+   "description": "Price of cache-creation (write) tokens. Several providers bill writes at a premium; without this, caching ROI is overstated.",
+   "fieldname": "cached_input_write_cost_per_1m_tokens",
+   "fieldtype": "Float",
+   "label": "Cached Input Write Cost per 1M Tokens",
+   "precision": "8"
   },
   {
    "fieldname": "chat_capability_overrides_section",

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -22,3 +22,4 @@ huf.patches.v1.backfill_conversation_lifecycle_defaults
 huf.patches.v1.add_conversation_pin_indexes
 huf.patches.v1.migrate_agent_triggers_to_automations
 huf.patches.v1.preserve_gateway_agent_access
+huf.patches.v1.backfill_agent_run_usage_columns

--- a/huf/patches/v1/backfill_agent_run_usage_columns.py
+++ b/huf/patches/v1/backfill_agent_run_usage_columns.py
@@ -1,0 +1,114 @@
+import json
+
+import frappe
+
+BATCH_SIZE = 500
+
+
+def execute():
+	"""Backfill the new flat Agent Run usage columns from usage_snapshot.
+
+	Agent Run gained flat columns for the metrics that used to live only inside the
+	usage_snapshot JSON blob, so they can finally be summed/filtered in SQL. Of those
+	new columns, only three were ever actually recorded historically, because
+	agent_integration.py only ever wrote these keys into usage_snapshot:
+
+	  - cache_creation_tokens         <- usage_snapshot.cache_creation_tokens
+	  - total_tokens                  <- usage_snapshot.total_tokens
+	  - cache_skipped_unsupported_model <- usage_snapshot.cache_skipped_unsupported_model
+
+	billed_input_tokens, peak_context_tokens, round_count, model_context_window,
+	provider_path and execution_mode are NOT backfilled here and must be left NULL.
+	They were never captured for historical runs, and the UI treats NULL as "not
+	measured" for these metrics. Writing 0 instead would silently distort every
+	historical average/rollup that reads these columns going forward - do not
+	"helpfully" zero-fill them in a future edit of this patch.
+
+	Idempotent and safe to re-run: a row is only touched when the flat column is
+	still NULL/0 (its pre-migration/unset state) and the snapshot actually carries
+	a value for it. Malformed, empty, or non-dict usage_snapshot values are skipped
+	rather than raising, so a single corrupt row cannot fail the whole backfill.
+	"""
+	if not frappe.db.has_column("Agent Run", "usage_snapshot"):
+		return
+
+	target_columns = [
+		column
+		for column in (
+			"cache_creation_tokens",
+			"total_tokens",
+			"cache_skipped_unsupported_model",
+		)
+		if frappe.db.has_column("Agent Run", column)
+	]
+	if not target_columns:
+		return
+
+	total_updated = 0
+	last_name = ""
+
+	while True:
+		rows = frappe.get_all(
+			"Agent Run",
+			filters={"name": [">", last_name]},
+			fields=["name", "usage_snapshot", *target_columns],
+			order_by="name asc",
+			limit_page_length=BATCH_SIZE,
+		)
+		if not rows:
+			break
+
+		for row in rows:
+			last_name = row.name
+			updates = _build_updates(row, target_columns)
+			if updates:
+				frappe.db.set_value("Agent Run", row.name, updates, update_modified=False)
+				total_updated += 1
+
+		frappe.db.commit()
+
+		if len(rows) < BATCH_SIZE:
+			break
+
+	frappe.logger().info(
+		f"backfill_agent_run_usage_columns: backfilled {total_updated} Agent Run row(s) "
+		f"from usage_snapshot"
+	)
+
+
+def _build_updates(row, target_columns):
+	"""Return a dict of column -> value to set on this row, or None if nothing to do."""
+	snapshot = row.get("usage_snapshot")
+	if not snapshot:
+		return None
+
+	if isinstance(snapshot, str):
+		try:
+			snapshot = json.loads(snapshot)
+		except (TypeError, ValueError):
+			return None
+
+	if not isinstance(snapshot, dict):
+		return None
+
+	updates = {}
+
+	if "cache_creation_tokens" in target_columns and not row.get("cache_creation_tokens"):
+		value = snapshot.get("cache_creation_tokens")
+		if isinstance(value, (int, float)) and not isinstance(value, bool):
+			updates["cache_creation_tokens"] = int(value)
+
+	if "total_tokens" in target_columns and not row.get("total_tokens"):
+		value = snapshot.get("total_tokens")
+		if isinstance(value, (int, float)) and not isinstance(value, bool):
+			updates["total_tokens"] = int(value)
+
+	if "cache_skipped_unsupported_model" in target_columns and not row.get(
+		"cache_skipped_unsupported_model"
+	):
+		if "cache_skipped_unsupported_model" in snapshot:
+			updates["cache_skipped_unsupported_model"] = (
+				1 if snapshot.get("cache_skipped_unsupported_model") else 0
+			)
+
+	return updates or None


### PR DESCRIPTION
## Summary

Routine branch sync (same pattern as #608, #627). Merges 13 commits from `pre-dev` into `pre-develop`:

- #645 analytics: fix token accounting, then build Run → Conversation → Agent → Model → Provider views
- #643 feat(voice): live transcript/captions in the chat-UI voice call overlay
- #618 feat(voice): talk-to-agent entry point in huf's own chat UI
- #641/#640/#639/#638 structured render tools, lazy tool discovery, playground media roadmap, knowledge/models UX
- and their upstream merge commits

## Conflict resolution

One conflict in `frontend/src/components/app-sidebar.tsx` (import line): both branches independently added a sidebar icon import (`Mic` from Meeting Recorder on `pre-develop`, `ChartNoAxesCombined` from the analytics work on `pre-dev`). Resolved by keeping both — verified both icons are still referenced later in the file.

## Verification

- `tsc --noEmit`: 0 errors across the merged frontend.
- `vitest run`: 156/156 passed.
- All touched/new `.py` files: `py_compile` clean.
- No `bench migrate`/`bench run-tests` run — no live bench available in this environment.

## Test plan

- [ ] `bench migrate` on a real site
- [ ] `bench run-tests` for the newly-merged analytics module (`usage_extraction.py`, `backfill_agent_run_usage_columns.py` patch)
- [ ] Manual smoke test of the merged sidebar (Meetings + Analytics entries both present and functional)