### PR TITLE
fix: pre-develop's real frontend build is currently broken (unused import)

### DIFF
--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ArrowLeft, Home, ChartColumnIncreasing, ChartNoAxesCombined, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
+import { ArrowLeft, Home, ChartColumnIncreasing, SquareAsterisk, FileText, Workflow, Database, Layers, MessageSquare, Zap, Server, Users, BookOpen, Link2, Terminal, Settings, LayoutGrid, Brain, Sparkles, SquareChevronRight, ChevronsLeftRightEllipsis, GlobeLock, Keyboard, SlidersHorizontal, type LucideIcon } from "lucide-react"
 import { useLocation } from "react-router-dom"
 
 import { NavMain } from "@/components/nav-main"


### PR DESCRIPTION
## Summary

\`pre-develop\` HEAD (currently \`247e787b\`, from my own #652 merge) fails a real production frontend build right now: \`ChartNoAxesCombined\` is imported in \`app-sidebar.tsx\` but never used.

## Root cause

My fault, introduced while rebasing #652 onto \`pre-develop\` (merge commit \`5f4a25b3\`). #648 and #653 had already correctly removed the unused "Analytics" sidebar nav item and its \`ChartNoAxesCombined\` import. When I resolved that merge's conflict in \`app-sidebar.tsx\`, I took my branch's version wholesale instead of reconciling against \`pre-develop\`'s already-clean one — which resurrected the dead import without the usage that used to justify it.

I verified #652 with \`tsc --noEmit\`, which does **not** enforce \`noUnusedLocals\` the way this repo's actual build does (\`tsc -b\` in project-reference/incremental mode, invoked by \`bench build\` → \`yarn build\`). Confirmed by running the real \`yarn build\` on a live bench: it fails on current \`pre-develop\` HEAD right now, unrelated to any other PR.

## Fix

One-line removal of the dead import.

## Verification

Ran the actual build commands this time, not just \`tsc --noEmit\`:
- \`tsc -b --force\` (the real incremental/project-reference build): clean, 0 errors.
- \`vite build --base=/assets/huf/frontend/\`: succeeds.

## Test plan

- [ ] \`bench build --app huf\` on a real bench — confirm it no longer fails.