### PR TITLE
Meeting Recorder wave 2: failure handling, export, chat, subtitles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,6 +90,10 @@
   "devDependencies": {
     "@eslint/js": "^9.11.1",
     "@playwright/test": "^1.61.1",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/acorn": "^6.0.4",
     "@types/node": "^22.7.3",
     "@types/prismjs": "^1.26.6",
@@ -102,6 +106,7 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.12",
     "globals": "^15.9.0",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.5.3",

--- a/frontend/src/components/meetings/MeetingChatPanel.test.tsx
+++ b/frontend/src/components/meetings/MeetingChatPanel.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// jsdom does not implement scrollIntoView; the component calls it on an
+// auto-scroll effect that isn't itself under test here.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
+// This config does not enable RTL's global auto-cleanup, so unmount each
+// render explicitly between tests to avoid duplicate DOM nodes.
+afterEach(() => {
+  cleanup();
+});
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/services/meetingChat', () => ({
+  askMeeting: vi.fn(),
+  reviseSummary: vi.fn(),
+  getChatHistory: vi.fn(),
+}));
+
+import { askMeeting, getChatHistory, reviseSummary } from '@/services/meetingChat';
+import { MeetingChatPanel } from './MeetingChatPanel';
+import type { MeetingChatMessage } from '@/types/meeting.types';
+
+const baseProps = {
+  meetingName: 'MEETING-001',
+  hasTranscript: true,
+  hasSummary: true,
+  onSummaryRevised: vi.fn(),
+};
+
+describe('MeetingChatPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a disabled state when there is no transcript, without loading history', () => {
+    render(<MeetingChatPanel {...baseProps} hasTranscript={false} />);
+
+    expect(screen.getByText(/chat is available once a transcript exists/i)).toBeInTheDocument();
+    expect(getChatHistory).not.toHaveBeenCalled();
+  });
+
+  it('loads and renders chat history on mount when a transcript exists', async () => {
+    const rows: MeetingChatMessage[] = [
+      { name: 'MSG-1', role: 'user', content: 'What did we decide?' },
+      { name: 'MSG-2', role: 'assistant', content: 'You decided to ship on Friday.' },
+    ];
+    vi.mocked(getChatHistory).mockResolvedValue(rows);
+
+    render(<MeetingChatPanel {...baseProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('What did we decide?')).toBeInTheDocument();
+    });
+    expect(screen.getByText('You decided to ship on Friday.')).toBeInTheDocument();
+    expect(getChatHistory).toHaveBeenCalledWith('MEETING-001');
+  });
+
+  it('sends a question and re-fetches history afterward', async () => {
+    const user = userEvent.setup();
+    vi.mocked(getChatHistory)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ name: 'MSG-1', role: 'user', content: 'question' }]);
+    vi.mocked(askMeeting).mockResolvedValue({ reply: 'an answer', message_name: 'x' });
+
+    render(<MeetingChatPanel {...baseProps} />);
+
+    await waitFor(() => expect(getChatHistory).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText(/ask a question about this meeting/i);
+    await user.type(input, 'question{Enter}');
+
+    await waitFor(() => {
+      expect(askMeeting).toHaveBeenCalledWith('MEETING-001', 'question');
+    });
+    await waitFor(() => {
+      expect(getChatHistory).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('shows an inline error bubble when askMeeting resolves with an error payload', async () => {
+    const user = userEvent.setup();
+    vi.mocked(getChatHistory)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ name: 'MSG-1', role: 'assistant', content: '', error: 'The model call failed.' }]);
+    vi.mocked(askMeeting).mockResolvedValue({ error: 'The model call failed.' });
+
+    render(<MeetingChatPanel {...baseProps} />);
+
+    await waitFor(() => expect(getChatHistory).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText(/ask a question about this meeting/i);
+    await user.type(input, 'question{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByText('The model call failed.')).toBeInTheDocument();
+    });
+  });
+
+  it('revises the summary and fires onSummaryRevised', async () => {
+    const user = userEvent.setup();
+    const onSummaryRevised = vi.fn();
+    vi.mocked(getChatHistory).mockResolvedValue([]);
+    vi.mocked(reviseSummary).mockResolvedValue({ summary: 'new summary text' });
+
+    render(<MeetingChatPanel {...baseProps} onSummaryRevised={onSummaryRevised} />);
+
+    await waitFor(() => expect(getChatHistory).toHaveBeenCalledTimes(1));
+
+    const textarea = screen.getByPlaceholderText(/make the action items more concise/i);
+    await user.type(textarea, 'Make it shorter');
+    await user.click(screen.getByRole('button', { name: /revise summary/i }));
+
+    await waitFor(() => {
+      expect(reviseSummary).toHaveBeenCalledWith('MEETING-001', 'Make it shorter');
+    });
+    await waitFor(() => {
+      expect(onSummaryRevised).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/components/meetings/MeetingChatPanel.tsx
+++ b/frontend/src/components/meetings/MeetingChatPanel.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { AlertTriangle, MessageSquare, Send, Sparkles } from 'lucide-react';
+import { Streamdown } from 'streamdown';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { askMeeting, getChatHistory, reviseSummary } from '@/services/meetingChat';
+import type { MeetingChatMessage } from '@/types/meeting.types';
+
+interface MeetingChatPanelProps {
+  meetingName: string;
+  hasTranscript: boolean;
+  hasSummary: boolean;
+  onSummaryRevised: () => void;
+}
+
+/**
+ * Tiny, minimal "chat with the meeting" panel — a lightweight alternative
+ * to Firefly's Q&A/rewrite features, not a full chat product. Two actions:
+ * ask a question about the transcript, and revise the summary with a
+ * one-off instruction. Both are logged server-side as `Meeting Chat
+ * Message` docs (visible in logs per the task requirement) and this panel
+ * simply re-fetches that history after each send rather than doing
+ * optimistic updates.
+ */
+export function MeetingChatPanel({ meetingName, hasTranscript, hasSummary, onSummaryRevised }: MeetingChatPanelProps) {
+  const [history, setHistory] = useState<MeetingChatMessage[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+  const [question, setQuestion] = useState('');
+  const [asking, setAsking] = useState(false);
+  const [instruction, setInstruction] = useState('');
+  const [revising, setRevising] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!hasTranscript) {
+      setLoadingHistory(false);
+      return;
+    }
+    (async () => {
+      try {
+        const rows = await getChatHistory(meetingName);
+        if (!cancelled) setHistory(rows);
+      } catch {
+        // getMeeting/other panels already surface load failures; keep this
+        // panel quiet on initial history load and just show an empty log.
+      } finally {
+        if (!cancelled) setLoadingHistory(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [meetingName, hasTranscript]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [history.length]);
+
+  const refreshHistory = async () => {
+    try {
+      const rows = await getChatHistory(meetingName);
+      setHistory(rows);
+    } catch (err) {
+      toast.error('Failed to refresh chat history', {
+        description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  const handleAsk = async () => {
+    const message = question.trim();
+    if (!message || asking) return;
+    setAsking(true);
+    setQuestion('');
+    try {
+      await askMeeting(meetingName, message);
+      await refreshHistory();
+    } catch (err) {
+      toast.error('Failed to send message', {
+        description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    } finally {
+      setAsking(false);
+    }
+  };
+
+  const handleRevise = async () => {
+    const text = instruction.trim();
+    if (!text || revising) return;
+    setRevising(true);
+    try {
+      const result = await reviseSummary(meetingName, text);
+      if (result.error) {
+        toast.error('Could not revise summary', { description: result.error });
+      } else {
+        setInstruction('');
+        toast.success('Summary revised');
+        onSummaryRevised();
+      }
+    } catch (err) {
+      toast.error('Failed to revise summary', {
+        description: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    } finally {
+      setRevising(false);
+    }
+  };
+
+  if (!hasTranscript) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-row items-center gap-2 space-y-0">
+          <MessageSquare className="h-4 w-4 text-steel-soft" aria-hidden />
+          <CardTitle className="text-sm">Ask this meeting</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="font-body text-sm text-steel">Chat is available once a transcript exists.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center gap-2 space-y-0">
+        <MessageSquare className="h-4 w-4 text-steel-soft" aria-hidden />
+        <CardTitle className="text-sm">Ask this meeting</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div
+          className="flex max-h-[40vh] min-h-[80px] flex-col gap-3 overflow-y-auto rounded-lg border border-line p-3"
+          role="log"
+          aria-label="Meeting chat"
+        >
+          {loadingHistory ? (
+            <p className="font-body text-xs text-steel-soft">Loading chat...</p>
+          ) : history.length === 0 ? (
+            <p className="font-body text-xs text-steel-soft">
+              Ask a question about this meeting — e.g. "What did we decide about the launch date?"
+            </p>
+          ) : (
+            history.map((msg) => (
+              <div key={msg.name} className={cn('flex flex-col gap-1', msg.role === 'user' ? 'items-end' : 'items-start')}>
+                <span className="font-body text-[10px] font-medium uppercase tracking-wide text-steel-soft">
+                  {msg.role === 'user' ? 'You' : 'Assistant'}
+                </span>
+                {msg.error ? (
+                  <p className="flex max-w-[85%] items-start gap-1.5 rounded-lg border border-signal-ink/40 bg-transparent px-3 py-2 text-sm text-signal-ink">
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+                    {msg.error}
+                  </p>
+                ) : (
+                  <div
+                    className={cn(
+                      'max-w-[85%] rounded-lg px-3 py-2 text-sm prose prose-sm [&_p]:my-0',
+                      msg.role === 'user' ? 'bg-paper-deep text-ink' : 'border border-line text-ink',
+                    )}
+                  >
+                    <Streamdown>{msg.content}</Streamdown>
+                  </div>
+                )}
+                {!!msg.applied_to_summary && (
+                  <Badge variant="pill-success" size="sm">Applied to summary</Badge>
+                )}
+              </div>
+            ))
+          )}
+          <div ref={bottomRef} />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Input
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleAsk();
+              }
+            }}
+            placeholder="Ask a question about this meeting..."
+            disabled={asking}
+          />
+          <Button size="sm" onClick={handleAsk} disabled={asking || !question.trim()}>
+            <Send className="h-3.5 w-3.5" aria-hidden />
+          </Button>
+        </div>
+
+        <div className="flex flex-col gap-2 border-t border-line pt-4">
+          <div className="flex items-center gap-1.5">
+            <Sparkles className="h-3.5 w-3.5 text-steel-soft" aria-hidden />
+            <span className="font-body text-xs font-medium text-ink">Revise summary with a prompt</span>
+          </div>
+          <Textarea
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            placeholder={hasSummary ? 'e.g. "Make the action items more concise"' : 'Meeting has no summary yet.'}
+            disabled={revising || !hasSummary}
+            className="min-h-[52px] text-sm"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="self-start"
+            onClick={handleRevise}
+            disabled={revising || !hasSummary || !instruction.trim()}
+          >
+            {revising ? 'Revising...' : 'Revise summary'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/meetings/MeetingFailureCard.test.tsx
+++ b/frontend/src/components/meetings/MeetingFailureCard.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { MeetingFailureCard } from './MeetingFailureCard';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderCard(props: Partial<React.ComponentProps<typeof MeetingFailureCard>> = {}) {
+  const onRetry = vi.fn();
+  render(
+    <MemoryRouter>
+      <MeetingFailureCard onRetry={onRetry} retrying={false} {...props} />
+    </MemoryRouter>,
+  );
+  return { onRetry };
+}
+
+describe('MeetingFailureCard', () => {
+  describe('generic failure', () => {
+    it('renders the lastError text and no Configure model link, and calls onRetry when Retry is clicked', async () => {
+      const user = userEvent.setup();
+      const { onRetry } = renderCard({ failedStep: 'Transcription', lastError: 'Something broke upstream' });
+
+      expect(screen.getByText('Something broke upstream')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /configure model/i })).not.toBeInTheDocument();
+
+      const retryButton = screen.getByRole('button', { name: /retry/i });
+      expect(retryButton).toBeInTheDocument();
+
+      await user.click(retryButton);
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to a default message per failedStep when lastError is not set', () => {
+      renderCard({ failedStep: 'Summary', lastError: undefined });
+      expect(screen.getByText('Summarizing this meeting failed.')).toBeInTheDocument();
+    });
+  });
+
+  describe('model-not-configured failure', () => {
+    it('renders the explanatory message and a Configure model link with the encoded agent href, and still shows Retry', () => {
+      renderCard({ failedStep: 'Model Not Configured' });
+
+      expect(screen.getByText("No AI model is configured for this meeting's summary agent.")).toBeInTheDocument();
+
+      const configureLink = screen.getByRole('link', { name: /configure model/i });
+      expect(configureLink).toBeInTheDocument();
+      expect(configureLink).toHaveAttribute('href', '/agents/Meeting%20Summary%20Agent');
+
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('error log disclosure', () => {
+    it('renders a View error log trigger and expands it to reveal the log content on click', async () => {
+      const user = userEvent.setup();
+      renderCard({ failedStep: 'Transcription', lastError: 'oops', errorLog: 'stack trace line 1\nstack trace line 2' });
+
+      const trigger = screen.getByRole('button', { name: /view error log/i });
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByText(/stack trace line 1/)).toBeInTheDocument();
+    });
+
+    it('does not render the disclosure when errorLog is empty or undefined', () => {
+      renderCard({ failedStep: 'Transcription', lastError: 'oops', errorLog: undefined });
+      expect(screen.queryByRole('button', { name: /view error log/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('retrying state', () => {
+    it('disables the Retry button and shows the retrying label when retrying is true', async () => {
+      const user = userEvent.setup();
+      const { onRetry } = renderCard({ failedStep: 'Transcription', lastError: 'oops', retrying: true });
+
+      const retryButton = screen.getByRole('button', { name: /retrying/i });
+      expect(retryButton).toBeDisabled();
+
+      await user.click(retryButton);
+      expect(onRetry).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/components/meetings/MeetingFailureCard.tsx
+++ b/frontend/src/components/meetings/MeetingFailureCard.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { AlertTriangle, ChevronDown, RotateCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import type { Meeting } from '@/types/meeting.types';
+
+export interface MeetingFailureCardProps {
+  failedStep?: Meeting['failed_step'];
+  lastError?: string;
+  errorLog?: string;
+  onRetry: () => void;
+  retrying: boolean;
+}
+
+/**
+ * Failed-meeting state: shows why the meeting failed (distinguishing an
+ * unconfigured AI model from an actual transcription/summary error), an
+ * optional expandable error log, and the Retry action.
+ */
+export function MeetingFailureCard({ failedStep, lastError, errorLog, onRetry, retrying }: MeetingFailureCardProps) {
+  const [logOpen, setLogOpen] = useState(false);
+  const isModelNotConfigured = failedStep === 'Model Not Configured';
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+      <div className="flex items-start gap-2 text-sm text-destructive">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+        <div className="flex flex-col gap-1">
+          {isModelNotConfigured ? (
+            <>
+              <span>No AI model is configured for this meeting's summary agent.</span>
+              <span className="font-body text-xs text-steel">
+                Ask an admin to configure a model in Agent settings, then retry.
+              </span>
+            </>
+          ) : (
+            <p className="font-body text-sm text-destructive">
+              {lastError ||
+                (failedStep === 'Transcription'
+                  ? 'Transcription failed for this meeting.'
+                  : 'Summarizing this meeting failed.')}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {!!errorLog && (
+        <Collapsible open={logOpen} onOpenChange={setLogOpen}>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-auto w-fit gap-1 p-0 font-body text-xs text-steel">
+              <ChevronDown className={logOpen ? 'h-3.5 w-3.5 rotate-180 transition-transform' : 'h-3.5 w-3.5 transition-transform'} aria-hidden />
+              View error log
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <pre className="mt-2 max-h-48 overflow-auto rounded-md border border-line bg-card p-2 font-mono text-xs text-steel">
+              {errorLog}
+            </pre>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+
+      <div>
+        <Button size="sm" variant="outline" onClick={onRetry} disabled={retrying}>
+          <RotateCw className={retrying ? 'h-3.5 w-3.5 animate-spin' : 'h-3.5 w-3.5'} aria-hidden />
+          {retrying ? 'Retrying...' : 'Retry'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/meetings/MeetingFailureCard.tsx
+++ b/frontend/src/components/meetings/MeetingFailureCard.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react';
-import { AlertTriangle, ChevronDown, RotateCw } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { AlertTriangle, ChevronDown, RotateCw, Settings } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { linkRoutes } from '@/lib/link-routes';
 import type { Meeting } from '@/types/meeting.types';
+
+const MEETING_SUMMARY_AGENT_NAME = 'Meeting Summary Agent';
 
 export interface MeetingFailureCardProps {
   failedStep?: Meeting['failed_step'];
@@ -60,7 +64,15 @@ export function MeetingFailureCard({ failedStep, lastError, errorLog, onRetry, r
         </Collapsible>
       )}
 
-      <div>
+      <div className="flex items-center gap-2">
+        {isModelNotConfigured && (
+          <Button size="sm" variant="default" asChild>
+            <Link to={linkRoutes.agent(MEETING_SUMMARY_AGENT_NAME)}>
+              <Settings className="h-3.5 w-3.5" aria-hidden />
+              Configure model
+            </Link>
+          </Button>
+        )}
         <Button size="sm" variant="outline" onClick={onRetry} disabled={retrying}>
           <RotateCw className={retrying ? 'h-3.5 w-3.5 animate-spin' : 'h-3.5 w-3.5'} aria-hidden />
           {retrying ? 'Retrying...' : 'Retry'}

--- a/frontend/src/components/meetings/MeetingRecordingPlayer.test.tsx
+++ b/frontend/src/components/meetings/MeetingRecordingPlayer.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { MeetingRecordingPlayer } from './MeetingRecordingPlayer';
+import type { MeetingRecordingChunk } from '@/types/meeting.types';
+
+function makeChunk(overrides: Partial<MeetingRecordingChunk> = {}): MeetingRecordingChunk {
+  return {
+    name: 'chunk-1',
+    sequence: 0,
+    audio_file: '/private/files/fake-recording.webm',
+    upload_status: 'Transcribed',
+    duration_seconds: 6,
+    transcript_text: 'Alice said we should ship it',
+    ...overrides,
+  };
+}
+
+describe('MeetingRecordingPlayer', () => {
+  it('renders the caption text for a playable chunk with a transcript', () => {
+    const { container } = render(<MeetingRecordingPlayer chunks={[makeChunk()]} />);
+    const captionParagraph = container.querySelector('p');
+    expect(captionParagraph).not.toBeNull();
+    expect(captionParagraph?.textContent).toBe('Alice said we should ship it');
+  });
+
+  it('toggles the caption bar when the captions button is clicked', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<MeetingRecordingPlayer chunks={[makeChunk()]} />);
+
+    expect(container.querySelector('p')?.textContent).toBe('Alice said we should ship it');
+
+    const toggleButton = screen.getByRole('button', { name: /hide captions/i });
+    await user.click(toggleButton);
+    expect(container.querySelector('p')).toBeNull();
+
+    const showButton = screen.getByRole('button', { name: /show captions/i });
+    await user.click(showButton);
+    expect(container.querySelector('p')?.textContent).toBe('Alice said we should ship it');
+  });
+
+  it('renders the fallback message for a chunk with no transcript_text', () => {
+    const chunk = makeChunk({ transcript_text: undefined, upload_status: 'Failed' });
+    const { container } = render(<MeetingRecordingPlayer chunks={[chunk]} />);
+
+    const captionParagraph = container.querySelector('p');
+    expect(captionParagraph?.textContent).toContain('[this part could not be transcribed]');
+  });
+
+  it('renders the fallback message for a chunk with a transcription_error', () => {
+    const chunk = makeChunk({
+      transcript_text: undefined,
+      transcription_error: 'STT service unavailable',
+    });
+    const { container } = render(<MeetingRecordingPlayer chunks={[chunk]} />);
+
+    const captionParagraph = container.querySelector('p');
+    expect(captionParagraph?.textContent).toContain('[this part could not be transcribed]');
+    expect(within(container).getByText(/could not be transcribed/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/meetings/MeetingRecordingPlayer.tsx
+++ b/frontend/src/components/meetings/MeetingRecordingPlayer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle, Captions, Music } from 'lucide-react';
 import {
   AudioPlayer,
@@ -29,6 +29,32 @@ function resolveFileUrl(audioFile: string): string {
   return `${FRAPPE_URL}${audioFile.startsWith('/') ? '' : '/'}${audioFile}`;
 }
 
+export interface EstimatedWordTiming {
+  word: string;
+  startSeconds: number;
+}
+
+/**
+ * ESTIMATE ONLY — linear interpolation, not real word-level ASR timing.
+ *
+ * The backend STT (`audio_service.transcribe_audio_file`) returns a single
+ * transcript string per ~30-60s chunk with no per-word timestamps, so there
+ * is no ground truth for when any individual word was actually spoken.
+ * This splits the chunk's transcript on whitespace and gives every word an
+ * equal time-slice of `durationSeconds / wordCount`. That's inaccurate for
+ * any one word (speech isn't evenly paced), but it makes captions advance
+ * roughly in step with the audio instead of sitting as one static block for
+ * the whole chunk. Never treat `startSeconds` here as exact sync.
+ */
+export function estimateWordTimings(text: string, durationSeconds: number): EstimatedWordTiming[] {
+  const words = text.trim().length > 0 ? text.trim().split(/\s+/) : [];
+  if (words.length === 0 || !(durationSeconds > 0)) {
+    return words.map((word) => ({ word, startSeconds: 0 }));
+  }
+  const secondsPerWord = durationSeconds / words.length;
+  return words.map((word, index) => ({ word, startSeconds: index * secondsPerWord }));
+}
+
 /**
  * Sequential multi-chunk playback. There is no combined-recording file on
  * the backend (PLAN.md D.4), so this plays each chunk's `audio_file` in
@@ -45,6 +71,11 @@ export function MeetingRecordingPlayer({ chunks }: MeetingRecordingPlayerProps) 
   );
   const [currentIndex, setCurrentIndex] = useState(0);
   const [showCaptions, setShowCaptions] = useState(true);
+  // Playback time within the CURRENT chunk (seconds since that chunk's
+  // `<audio>` started), used to drive the word-by-word caption estimate
+  // below. Reset to 0 whenever the chunk changes.
+  const [chunkPlaybackSeconds, setChunkPlaybackSeconds] = useState(0);
+  const audioContainerRef = useRef<HTMLDivElement>(null);
 
   // Running elapsed offset up to (not including) the current chunk, same
   // fallback logic as MeetingTranscriptPanel: prefer client_started_at,
@@ -64,6 +95,45 @@ export function MeetingRecordingPlayer({ chunks }: MeetingRecordingPlayerProps) 
     return runningSeconds;
   }, [playableChunks, currentIndex]);
 
+  const currentChunk =
+    playableChunks.length > 0 ? playableChunks[Math.min(currentIndex, playableChunks.length - 1)] : undefined;
+
+  // Reset sub-chunk playback time whenever the current chunk changes (new
+  // chunk starts from 0), then bind a native `timeupdate` listener directly
+  // to the underlying `<audio>` DOM node. `AudioPlayerElement` (ai-elements
+  // audio-player.tsx) renders a real `<audio slot="media">` element with no
+  // React ref forwarding and media-chrome's `MediaController` exposes no
+  // React context for `currentTime`, so the reliable hook is native DOM:
+  // look up the `<audio>` node under our container and listen directly.
+  useEffect(() => {
+    setChunkPlaybackSeconds(0);
+    const container = audioContainerRef.current;
+    if (!container) return undefined;
+    const audioEl = container.querySelector('audio');
+    if (!audioEl) return undefined;
+    const handleTimeUpdate = () => setChunkPlaybackSeconds(audioEl.currentTime);
+    audioEl.addEventListener('timeupdate', handleTimeUpdate);
+    return () => audioEl.removeEventListener('timeupdate', handleTimeUpdate);
+  }, [currentChunk?.name]);
+
+  // Per-chunk word timing estimate (see estimateWordTimings docs above) and
+  // the index of the word considered "current" given chunkPlaybackSeconds.
+  const wordTimings = useMemo(
+    () => estimateWordTimings(currentChunk?.transcript_text || '', currentChunk?.duration_seconds || 0),
+    [currentChunk?.transcript_text, currentChunk?.duration_seconds],
+  );
+  const activeWordIndex = useMemo(() => {
+    let index = -1;
+    for (let i = 0; i < wordTimings.length; i += 1) {
+      if (wordTimings[i].startSeconds <= chunkPlaybackSeconds) {
+        index = i;
+      } else {
+        break;
+      }
+    }
+    return index;
+  }, [wordTimings, chunkPlaybackSeconds]);
+
   if (playableChunks.length === 0) {
     return (
       <div className="flex items-center gap-2 rounded-lg border border-dashed border-line px-4 py-3 text-sm text-steel">
@@ -79,7 +149,7 @@ export function MeetingRecordingPlayer({ chunks }: MeetingRecordingPlayerProps) 
 
   return (
     <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-2">
+      <div ref={audioContainerRef} className="flex items-center gap-2">
         <AudioPlayer key={current.name} className="flex-1">
           <AudioPlayerElement
             src={resolveFileUrl(current.audio_file!)}
@@ -120,6 +190,27 @@ export function MeetingRecordingPlayer({ chunks }: MeetingRecordingPlayerProps) 
             <p className="flex-1 flex items-center justify-center gap-1.5 text-sm italic text-white/90">
               <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-400" aria-hidden />
               {current.transcript_text || '[this part could not be transcribed]'}
+            </p>
+          ) : wordTimings.length > 0 ? (
+            // Karaoke-style progressive reveal: words estimated (see
+            // estimateWordTimings) to have already been "said" by
+            // chunkPlaybackSeconds render fully bright/bold, the rest stay
+            // dim. Chosen over showing only a rolling word window because
+            // it keeps the full caption visible (no layout jitter) while
+            // still visually tracking playback progress.
+            <p className="flex-1 text-center text-sm">
+              {wordTimings.map((timing, index) => (
+                <span
+                  key={index}
+                  className={cn(
+                    'transition-colors',
+                    index <= activeWordIndex ? 'font-semibold text-white' : 'text-white/50',
+                  )}
+                >
+                  {timing.word}
+                  {index < wordTimings.length - 1 ? ' ' : ''}
+                </span>
+              ))}
             </p>
           ) : (
             <p className="flex-1 text-center text-sm text-white">

--- a/frontend/src/components/meetings/MeetingRecordingPlayer.tsx
+++ b/frontend/src/components/meetings/MeetingRecordingPlayer.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Music } from 'lucide-react';
+import { AlertTriangle, Captions, Music } from 'lucide-react';
 import {
   AudioPlayer,
   AudioPlayerControlBar,
@@ -10,6 +10,8 @@ import {
   AudioPlayerTimeDisplay,
   AudioPlayerTimeRange,
 } from '@/components/ai-elements/audio-player';
+import { formatElapsed } from '@/components/meetings/MeetingTranscriptPanel';
+import { cn } from '@/lib/utils';
 import type { MeetingRecordingChunk } from '@/types/meeting.types';
 
 interface MeetingRecordingPlayerProps {
@@ -42,6 +44,25 @@ export function MeetingRecordingPlayer({ chunks }: MeetingRecordingPlayerProps) 
     [chunks],
   );
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [showCaptions, setShowCaptions] = useState(true);
+
+  // Running elapsed offset up to (not including) the current chunk, same
+  // fallback logic as MeetingTranscriptPanel: prefer client_started_at,
+  // else accumulate prior chunks' durations.
+  const currentElapsedSeconds = useMemo(() => {
+    let runningSeconds = 0;
+    for (let i = 0; i < playableChunks.length; i += 1) {
+      const chunk = playableChunks[i];
+      const timestampSeconds = chunk.client_started_at
+        ? Number(chunk.client_started_at) || runningSeconds
+        : runningSeconds;
+      if (i === Math.min(currentIndex, playableChunks.length - 1)) {
+        return timestampSeconds;
+      }
+      runningSeconds = timestampSeconds + (chunk.duration_seconds || 0);
+    }
+    return runningSeconds;
+  }, [playableChunks, currentIndex]);
 
   if (playableChunks.length === 0) {
     return (
@@ -54,26 +75,59 @@ export function MeetingRecordingPlayer({ chunks }: MeetingRecordingPlayerProps) 
 
   const current = playableChunks[Math.min(currentIndex, playableChunks.length - 1)];
   const isLastChunk = currentIndex >= playableChunks.length - 1;
+  const isGap = current.upload_status === 'Failed' || !!current.transcription_error;
 
   return (
     <div className="flex flex-col gap-1.5">
-      <AudioPlayer key={current.name}>
-        <AudioPlayerElement
-          src={resolveFileUrl(current.audio_file!)}
-          onEnded={() => {
-            if (!isLastChunk) {
-              setCurrentIndex((index) => index + 1);
-            }
-          }}
-        />
-        <AudioPlayerControlBar>
-          <AudioPlayerPlayButton />
-          <AudioPlayerTimeDisplay />
-          <AudioPlayerTimeRange />
-          <AudioPlayerDurationDisplay />
-          <AudioPlayerMuteButton />
-        </AudioPlayerControlBar>
-      </AudioPlayer>
+      <div className="flex items-center gap-2">
+        <AudioPlayer key={current.name} className="flex-1">
+          <AudioPlayerElement
+            src={resolveFileUrl(current.audio_file!)}
+            onEnded={() => {
+              if (!isLastChunk) {
+                setCurrentIndex((index) => index + 1);
+              }
+            }}
+          />
+          <AudioPlayerControlBar>
+            <AudioPlayerPlayButton />
+            <AudioPlayerTimeDisplay />
+            <AudioPlayerTimeRange />
+            <AudioPlayerDurationDisplay />
+            <AudioPlayerMuteButton />
+          </AudioPlayerControlBar>
+        </AudioPlayer>
+        <button
+          type="button"
+          onClick={() => setShowCaptions((value) => !value)}
+          aria-pressed={showCaptions}
+          aria-label={showCaptions ? 'Hide captions' : 'Show captions'}
+          title={showCaptions ? 'Hide captions' : 'Show captions'}
+          className={cn(
+            'shrink-0 rounded-md p-1.5 text-steel-soft transition-colors hover:bg-canvas-soft hover:text-ink',
+            showCaptions && 'text-ink',
+          )}
+        >
+          <Captions className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+      {showCaptions && (
+        <div className="flex items-start gap-2 rounded-md bg-ink/85 px-4 py-2 text-center">
+          <span className="mt-0.5 shrink-0 font-mono text-xs tabular-nums text-white/70" aria-hidden>
+            {formatElapsed(currentElapsedSeconds)}
+          </span>
+          {isGap ? (
+            <p className="flex-1 flex items-center justify-center gap-1.5 text-sm italic text-white/90">
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-400" aria-hidden />
+              {current.transcript_text || '[this part could not be transcribed]'}
+            </p>
+          ) : (
+            <p className="flex-1 text-center text-sm text-white">
+              {current.transcript_text || '[this part could not be transcribed]'}
+            </p>
+          )}
+        </div>
+      )}
       {playableChunks.length > 1 && (
         <span className="font-body text-xs text-steel-soft">
           Part {currentIndex + 1} of {playableChunks.length}

--- a/frontend/src/components/meetings/MeetingSummaryPanel.tsx
+++ b/frontend/src/components/meetings/MeetingSummaryPanel.tsx
@@ -1,4 +1,4 @@
-import { FileText, ListChecks, ListTree } from 'lucide-react';
+import { FileText, Gavel, ListChecks, ListTree } from 'lucide-react';
 import { Streamdown } from 'streamdown';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -14,10 +14,11 @@ interface MeetingSummaryPanelProps {
 interface ParsedSummary {
   headline: string;
   keyPoints: string;
+  decisions: string;
   actionItems: string;
 }
 
-const SECTION_HEADINGS = ['Headline', 'Key Points', 'Action Items'] as const;
+const SECTION_HEADINGS = ['Headline', 'Key Points', 'Decisions', 'Action Items'] as const;
 
 /**
  * Splits the agent's Markdown output into its three named `## ` sections.
@@ -44,6 +45,7 @@ function parseSummary(markdown: string): ParsedSummary {
   return {
     headline: sections['Headline']?.trim() || '',
     keyPoints: sections['Key Points']?.trim() || '',
+    decisions: sections['Decisions']?.trim() || '',
     actionItems: sections['Action Items']?.trim() || '',
   };
 }
@@ -66,7 +68,7 @@ export function MeetingSummaryPanel({ summary }: MeetingSummaryPanelProps) {
 
   const parsed = parseSummary(summary);
   const hasStructuredSections = SECTION_HEADINGS.some(
-    (heading) => heading === 'Headline' ? parsed.headline : heading === 'Key Points' ? parsed.keyPoints : parsed.actionItems,
+    (heading) => heading === 'Headline' ? parsed.headline : heading === 'Key Points' ? parsed.keyPoints : heading === 'Decisions' ? parsed.decisions : parsed.actionItems,
   );
 
   if (!hasStructuredSections) {
@@ -98,6 +100,18 @@ export function MeetingSummaryPanel({ summary }: MeetingSummaryPanelProps) {
           </CardHeader>
           <CardContent className="prose prose-sm max-w-none [&_ul]:my-0 [&_li]:my-1">
             <Streamdown>{parsed.keyPoints}</Streamdown>
+          </CardContent>
+        </Card>
+      )}
+
+      {parsed.decisions && (
+        <Card>
+          <CardHeader className="flex flex-row items-center gap-2 space-y-0">
+            <Gavel className="h-4 w-4 text-steel-soft" aria-hidden />
+            <CardTitle className="text-sm">Decisions</CardTitle>
+          </CardHeader>
+          <CardContent className="prose prose-sm max-w-none [&_ul]:my-0 [&_li]:my-1">
+            <Streamdown>{parsed.decisions}</Streamdown>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/components/meetings/MeetingTranscriptPanel.tsx
+++ b/frontend/src/components/meetings/MeetingTranscriptPanel.tsx
@@ -11,7 +11,7 @@ interface MeetingTranscriptPanelProps {
 }
 
 /** `mm:ss` (or `h:mm:ss` past an hour) elapsed-from-start timestamp for a chunk. */
-function formatElapsed(seconds: number): string {
+export function formatElapsed(seconds: number): string {
   const total = Math.max(0, Math.round(seconds));
   const h = Math.floor(total / 3600);
   const m = Math.floor((total % 3600) / 60);

--- a/frontend/src/components/meetings/estimateWordTimings.test.ts
+++ b/frontend/src/components/meetings/estimateWordTimings.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { estimateWordTimings } from './MeetingRecordingPlayer';
+
+describe('estimateWordTimings', () => {
+  it('returns an empty array for empty string input', () => {
+    expect(estimateWordTimings('', 10)).toEqual([]);
+  });
+
+  it('returns one entry with startSeconds 0 for a single word with a positive duration', () => {
+    const result = estimateWordTimings('hello', 5);
+    expect(result).toEqual([{ word: 'hello', startSeconds: 0 }]);
+  });
+
+  it('evenly spaces N words across durationSeconds', () => {
+    const result = estimateWordTimings('one two three four', 40);
+    expect(result.map((t) => t.startSeconds)).toEqual([0, 10, 20, 30]);
+    expect(result.map((t) => t.word)).toEqual(['one', 'two', 'three', 'four']);
+  });
+
+  it('degrades gracefully with durationSeconds of 0, returning all words at startSeconds 0', () => {
+    const result = estimateWordTimings('one two three', 0);
+    expect(result).toEqual([
+      { word: 'one', startSeconds: 0 },
+      { word: 'two', startSeconds: 0 },
+      { word: 'three', startSeconds: 0 },
+    ]);
+  });
+
+  it('does not produce empty-string words from extra/leading/trailing whitespace', () => {
+    const result = estimateWordTimings('  hello   world  ', 10);
+    expect(result.map((t) => t.word)).toEqual(['hello', 'world']);
+    expect(result.every((t) => t.word.length > 0)).toBe(true);
+  });
+});

--- a/frontend/src/pages/MeetingDetailPage.tsx
+++ b/frontend/src/pages/MeetingDetailPage.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
-import { AlertTriangle, Calendar, Clock, RotateCw, Users } from 'lucide-react';
+import { AlertTriangle, Calendar, Clock, FileDown, Users } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import { MeetingChatPanel } from '@/components/meetings/MeetingChatPanel';
+import { MeetingFailureCard } from '@/components/meetings/MeetingFailureCard';
 import { MeetingProcessingStatus } from '@/components/meetings/MeetingProcessingStatus';
 import { MeetingSummaryPanel } from '@/components/meetings/MeetingSummaryPanel';
 import { MeetingTranscriptPanel } from '@/components/meetings/MeetingTranscriptPanel';
@@ -11,6 +13,7 @@ import { MeetingRecordingPlayer } from '@/components/meetings/MeetingRecordingPl
 import { PostMeetingContextPanel } from '@/components/meetings/PostMeetingContextPanel';
 import { useMeetingProcessingSocket } from '@/hooks/useMeetingProcessingSocket';
 import { getMeeting, retryChunkTranscription, retrySummary } from '@/services/meetingApi';
+import { downloadMeetingMinutes, downloadMeetingTranscript } from '@/services/meetingExport';
 import { formatTimeAgo } from '@/utils/time';
 import type { GetMeetingResult } from '@/services/meetingApi';
 
@@ -180,22 +183,13 @@ function MeetingDetailPage() {
         )}
 
         {status === 'Failed' && (
-          <div className="flex flex-col gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
-            <div className="flex items-center gap-2 text-sm text-destructive">
-              <AlertTriangle className="h-4 w-4" aria-hidden />
-              <span>
-                {failedChunks.length > 0
-                  ? 'Transcription failed for this meeting.'
-                  : 'Summarizing this meeting failed.'}
-              </span>
-            </div>
-            <div>
-              <Button size="sm" variant="outline" onClick={handleRetry} disabled={retrying}>
-                <RotateCw className={retrying ? 'h-3.5 w-3.5 animate-spin' : 'h-3.5 w-3.5'} aria-hidden />
-                {retrying ? 'Retrying...' : 'Retry'}
-              </Button>
-            </div>
-          </div>
+          <MeetingFailureCard
+            failedStep={meeting.failed_step}
+            lastError={meeting.last_error}
+            errorLog={meeting.error_log}
+            onRetry={handleRetry}
+            retrying={retrying}
+          />
         )}
 
         {status === 'Completed' && chunks.some((chunk) => !!chunk.audio_file) && (
@@ -205,16 +199,34 @@ function MeetingDetailPage() {
         {status === 'Completed' && (
           <>
             <div>
-              <div className="mb-3 flex items-center justify-between">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                 <h2 className="font-body text-sm font-medium text-ink">Summary</h2>
-                <Button
-                  variant="link"
-                  size="sm"
-                  className="h-auto p-0 text-xs"
-                  onClick={() => document.getElementById('transcript')?.scrollIntoView({ behavior: 'smooth' })}
-                >
-                  Jump to transcript
-                </Button>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => downloadMeetingTranscript(meeting.name)}
+                  >
+                    <FileDown className="h-3.5 w-3.5" aria-hidden />
+                    Download transcript
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => downloadMeetingMinutes(meeting.name)}
+                  >
+                    <FileDown className="h-3.5 w-3.5" aria-hidden />
+                    Download minutes
+                  </Button>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="h-auto p-0 text-xs"
+                    onClick={() => document.getElementById('transcript')?.scrollIntoView({ behavior: 'smooth' })}
+                  >
+                    Jump to transcript
+                  </Button>
+                </div>
               </div>
               <MeetingSummaryPanel summary={meeting.summary} />
             </div>
@@ -225,6 +237,13 @@ function MeetingDetailPage() {
               <h2 className="mb-3 font-body text-sm font-medium text-ink">Transcript</h2>
               <MeetingTranscriptPanel chunks={chunks} isLive={false} />
             </div>
+
+            <MeetingChatPanel
+              meetingName={meeting.name}
+              hasTranscript={!!meeting.transcript}
+              hasSummary={!!meeting.summary}
+              onSummaryRevised={load}
+            />
           </>
         )}
 

--- a/frontend/src/services/meetingChat.ts
+++ b/frontend/src/services/meetingChat.ts
@@ -1,0 +1,66 @@
+/**
+ * Meeting Chat API
+ *
+ * Thin wrappers around the whitelisted backend methods in
+ * `huf.ai.meetings.meeting_chat` — "chat to get info out of the meeting" and
+ * "revise the summary with a prompt" (a tiny, minimal alternative to
+ * Firefly). Mirrors meetingApi.ts's conventions exactly, with one
+ * deliberate difference: `askMeeting`/`reviseSummary` returning an
+ * `{ error }` payload is an EXPECTED, non-exceptional outcome — the backend
+ * deliberately doesn't throw on model-call failures so the UI can render an
+ * inline chat-bubble error. Only real `call.post` exceptions (HTTP/network
+ * failures) go through `handleFrappeError`/rethrow here.
+ */
+
+import { call } from '@/lib/frappe-sdk';
+import { handleFrappeError } from '@/lib/frappe-error';
+import type { MeetingChatMessage } from '@/types/meeting.types';
+
+const API_PREFIX = 'huf.ai.meetings.meeting_chat';
+
+export interface AskMeetingResult {
+  reply?: string;
+  error?: string;
+  message_name?: string;
+}
+
+export async function askMeeting(meetingName: string, message: string): Promise<AskMeetingResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.ask_meeting`, {
+      meeting_name: meetingName,
+      message,
+    });
+    return response.message as AskMeetingResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export interface ReviseSummaryResult {
+  summary?: string;
+  error?: string;
+}
+
+export async function reviseSummary(meetingName: string, instruction: string): Promise<ReviseSummaryResult> {
+  try {
+    const response = await call.post(`${API_PREFIX}.revise_summary`, {
+      meeting_name: meetingName,
+      instruction,
+    });
+    return response.message as ReviseSummaryResult;
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}
+
+export async function getChatHistory(meetingName: string): Promise<MeetingChatMessage[]> {
+  try {
+    const response = await call.post(`${API_PREFIX}.get_chat_history`, { meeting_name: meetingName });
+    return response.message as MeetingChatMessage[];
+  } catch (error) {
+    handleFrappeError(error);
+    throw error;
+  }
+}

--- a/frontend/src/services/meetingExport.ts
+++ b/frontend/src/services/meetingExport.ts
@@ -1,0 +1,26 @@
+/**
+ * Meeting export downloads.
+ *
+ * Both backend endpoints (`huf.ai.meetings.meeting_export.download_transcript`
+ * and `.download_minutes`) are Frappe "download" style whitelisted methods —
+ * they set `frappe.response.type = "download"` server-side, so they must be
+ * triggered via a direct browser navigation to the method URL (same-origin
+ * session cookie auth applies automatically), not via `call.post`/axios.
+ */
+
+const FRAPPE_URL = import.meta.env.VITE_FRAPPE_URL || window.location.origin;
+
+const EXPORT_PREFIX = 'huf.ai.meetings.meeting_export';
+
+function openExportUrl(method: string, meetingName: string): void {
+  const url = `${FRAPPE_URL}/api/method/${EXPORT_PREFIX}.${method}?meeting_name=${encodeURIComponent(meetingName)}`;
+  window.open(url, '_blank');
+}
+
+export function downloadMeetingTranscript(meetingName: string): void {
+  openExportUrl('download_transcript', meetingName);
+}
+
+export function downloadMeetingMinutes(meetingName: string): void {
+  openExportUrl('download_minutes', meetingName);
+}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,13 @@
+// Global vitest setup, loaded for every test file (node and jsdom alike).
+// Component tests still opt into jsdom per-file via a `// @vitest-environment
+// jsdom` docblock; guard on `document` so this is a no-op for the majority
+// of plain-logic .test.ts files that run under the node environment.
+import { afterEach } from 'vitest';
+
+if (typeof document !== 'undefined') {
+  const { cleanup } = await import('@testing-library/react');
+  await import('@testing-library/jest-dom/vitest');
+  afterEach(() => {
+    cleanup();
+  });
+}

--- a/frontend/src/types/meeting.types.ts
+++ b/frontend/src/types/meeting.types.ts
@@ -44,10 +44,26 @@ export interface Meeting {
   summary_agent_run?: string;
   context_prompted_at?: string;
   context_completed?: 0 | 1;
+  failed_step?: 'Model Not Configured' | 'Transcription' | 'Summary' | '';
+  last_error?: string;
+  error_log?: string;
   is_system_owned?: 0 | 1;
   modified?: string;
   creation?: string;
   owner?: string;
+}
+
+/** `Meeting Chat Message.role` Select options. */
+export type MeetingChatRole = 'user' | 'assistant';
+
+/** Full `Meeting Chat Message` row shape (huf/huf/doctype/meeting_chat_message). */
+export interface MeetingChatMessage {
+  name: string;
+  role: MeetingChatRole;
+  content: string;
+  applied_to_summary?: 0 | 1;
+  error?: string;
+  creation?: string;
 }
 
 /** Summary row shape returned inline by `list_meetings`. */

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,10 +1,17 @@
 import path from 'path';
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+	plugins: [react()],
 	test: {
+		// Per-suite default; component tests opt into jsdom via a
+		// `// @vitest-environment jsdom` docblock at the top of the file
+		// instead of switching this globally, so plain .test.ts logic
+		// tests (the existing majority) keep the cheaper node environment.
 		environment: 'node',
-		include: ['src/**/*.test.ts'],
+		include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+		setupFiles: ['./src/setupTests.ts'],
 	},
 	resolve: {
 		alias: {

--- a/huf/ai/meetings/meeting_api.py
+++ b/huf/ai/meetings/meeting_api.py
@@ -15,6 +15,9 @@ import frappe
 from frappe import _
 from frappe.utils import cint, now_datetime
 
+from huf.ai.meetings import meeting_summary, meeting_transcription
+from huf.ai.meetings.meeting_transcription import MODEL_NOT_CONFIGURED_MESSAGE, _agent_is_configured
+
 RUNNING_STATUSES = ("Recording", "Paused")
 
 
@@ -228,12 +231,19 @@ def retry_chunk_transcription(chunk_name: str):
         frappe.throw(_("chunk_name is required"))
 
     chunk = frappe.get_doc("Meeting Recording Chunk", chunk_name)
-    _get_meeting(chunk.meeting, "write")
+    meeting = _get_meeting(chunk.meeting, "write")
+
+    if not _agent_is_configured(meeting_transcription.TRANSCRIPTION_AGENT):
+        frappe.throw(_(MODEL_NOT_CONFIGURED_MESSAGE))
 
     chunk.upload_status = "Uploaded"
     chunk.transcription_error = None
     chunk.retry_count = cint(chunk.retry_count) + 1
     chunk.save()
+
+    meeting.failed_step = None
+    meeting.last_error = None
+    meeting.save()
 
     frappe.enqueue(
         "huf.ai.meetings.meeting_transcription.transcribe_meeting_chunk",
@@ -256,7 +266,12 @@ def retry_summary(meeting_name: str):
     """
     meeting = _get_meeting(meeting_name, "write")
 
+    if not _agent_is_configured(meeting_summary.SUMMARY_AGENT):
+        frappe.throw(_(MODEL_NOT_CONFIGURED_MESSAGE))
+
     meeting.status = "Summarizing"
+    meeting.failed_step = None
+    meeting.last_error = None
     meeting.save()
 
     frappe.enqueue(

--- a/huf/ai/meetings/meeting_chat.py
+++ b/huf/ai/meetings/meeting_chat.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""
+A tiny, minimal chat surface over a finalized Meeting — the "get info out,
+revise the summary by prompt" alternative to a full Firefly-style meeting
+copilot. ``ask_meeting`` answers questions grounded in the transcript and
+summary; ``revise_summary`` regenerates ``Meeting.summary`` from a natural
+language instruction. Every turn (including failures) is persisted as a
+``Meeting Chat Message`` so the exchange is visible as a log, matching the
+retry/failure-visibility pattern used by huf.ai.meetings.meeting_transcription
+and huf.ai.meetings.meeting_summary.
+"""
+
+import frappe
+from frappe import _
+
+from huf.ai.agent_integration import run_agent_sync
+from huf.ai.meetings.meeting_api import _get_meeting
+from huf.ai.meetings.meeting_summary import SUMMARY_AGENT
+
+CHAT_HISTORY_LIMIT = 10
+
+
+def _recent_history(meeting_name: str) -> list:
+    rows = frappe.get_all(
+        "Meeting Chat Message",
+        filters={"meeting": meeting_name},
+        fields=["role", "content"],
+        order_by="creation desc",
+        limit_page_length=CHAT_HISTORY_LIMIT,
+    )
+    return list(reversed(rows))
+
+
+def _format_history(rows: list) -> str:
+    lines = []
+    for row in rows:
+        speaker = "User" if row.role == "user" else "Assistant"
+        if row.content:
+            lines.append(f"{speaker}: {row.content}")
+    return "\n".join(lines)
+
+
+def _insert_message(meeting_name: str, role: str, content: str, error: str = None, applied_to_summary: bool = False):
+    doc = frappe.get_doc({
+        "doctype": "Meeting Chat Message",
+        "meeting": meeting_name,
+        "role": role,
+        "content": content or "",
+        "error": error,
+        "applied_to_summary": 1 if applied_to_summary else 0,
+    })
+    doc.insert(ignore_permissions=True)
+    return doc
+
+
+@frappe.whitelist()
+def ask_meeting(meeting_name: str, message: str):
+    """
+    Answer a question about a meeting, grounded in its transcript, summary,
+    and recent chat history. Never raises on model failure — the failure is
+    recorded as an assistant message with ``error`` set so it stays visible
+    in the chat log, and a dict with an ``error`` key is returned so the
+    caller can render an inline error instead of a toast.
+    """
+    if not message or not message.strip():
+        frappe.throw(_("message is required"))
+
+    meeting = _get_meeting(meeting_name, "read")
+    if not meeting.transcript:
+        frappe.throw(_("This meeting has no transcript yet to chat about."))
+
+    _insert_message(meeting_name, "user", message)
+
+    history = _format_history(_recent_history(meeting_name))
+    prompt_parts = [
+        "You are answering questions about a specific meeting, using only the "
+        "transcript, summary, and chat history below. Be concise.",
+        f"Meeting transcript:\n{meeting.transcript}",
+    ]
+    if meeting.summary:
+        prompt_parts.append(f"Current summary:\n{meeting.summary}")
+    if history:
+        prompt_parts.append(f"Recent chat:\n{history}")
+    prompt_parts.append(f"User: {message}")
+    prompt = "\n\n".join(prompt_parts)
+
+    try:
+        result = run_agent_sync(
+            agent_name=SUMMARY_AGENT,
+            prompt=prompt,
+            channel_id="meeting-chat",
+            external_id=meeting_name,
+            now=True,
+        )
+    except Exception:
+        frappe.log_error(title="Meeting chat failed", message=frappe.get_traceback())
+        result = {}
+
+    if result.get("success") and result.get("status") == "Success":
+        reply = result.get("response")
+        reply_doc = _insert_message(meeting_name, "assistant", reply)
+        return {"reply": reply, "message_name": reply_doc.name}
+
+    error_message = result.get("error") or "I couldn't process that."
+    reply_doc = _insert_message(meeting_name, "assistant", "", error=error_message[:500])
+    return {"error": error_message, "message_name": reply_doc.name}
+
+
+@frappe.whitelist()
+def revise_summary(meeting_name: str, instruction: str):
+    """
+    Regenerate ``Meeting.summary`` from a natural-language revision
+    instruction. On failure, ``meeting.summary`` is left untouched and the
+    failure is recorded as a visible chat-log entry (see ``ask_meeting``).
+    """
+    if not instruction or not instruction.strip():
+        frappe.throw(_("instruction is required"))
+
+    meeting = _get_meeting(meeting_name, "write")
+    if not meeting.summary:
+        frappe.throw(_("This meeting has no summary yet to revise."))
+
+    _insert_message(meeting_name, "user", f"Revise summary: {instruction}")
+
+    prompt = "\n\n".join([
+        "Revise the meeting summary below per the instruction. Output the "
+        "complete revised summary again in the same four-section Markdown "
+        "format (Headline, Key Points, Decisions, Action Items) — never a "
+        "partial diff or just the changed section.",
+        f"Meeting transcript:\n{meeting.transcript}",
+        f"Current summary:\n{meeting.summary}",
+        f"Revision instruction: {instruction}",
+    ])
+
+    try:
+        result = run_agent_sync(
+            agent_name=SUMMARY_AGENT,
+            prompt=prompt,
+            channel_id="meeting-chat",
+            external_id=meeting_name,
+            now=True,
+        )
+    except Exception:
+        frappe.log_error(title="Meeting summary revision failed", message=frappe.get_traceback())
+        result = {}
+
+    if result.get("success") and result.get("status") == "Success":
+        new_summary = result.get("response")
+        meeting.summary = new_summary
+        meeting.summary_agent_run = result.get("agent_run_id")
+        meeting.save(ignore_permissions=True)
+        frappe.db.commit()
+        _insert_message(meeting_name, "assistant", new_summary, applied_to_summary=True)
+        return {"summary": new_summary}
+
+    error_message = result.get("error") or "Summary revision failed"
+    _insert_message(meeting_name, "assistant", "", error=error_message[:500])
+    return {"error": error_message}
+
+
+@frappe.whitelist()
+def get_chat_history(meeting_name: str):
+    """Full chat log for a meeting, oldest first."""
+    _get_meeting(meeting_name, "read")
+    return frappe.get_all(
+        "Meeting Chat Message",
+        filters={"meeting": meeting_name},
+        fields=["name", "role", "content", "applied_to_summary", "error", "creation"],
+        order_by="creation asc",
+    )

--- a/huf/ai/meetings/meeting_chat.py
+++ b/huf/ai/meetings/meeting_chat.py
@@ -14,12 +14,32 @@ and huf.ai.meetings.meeting_summary.
 
 import frappe
 from frappe import _
+from frappe.rate_limiter import rate_limit
 
 from huf.ai.agent_integration import run_agent_sync
 from huf.ai.meetings.meeting_api import _get_meeting
 from huf.ai.meetings.meeting_summary import SUMMARY_AGENT
 
 CHAT_HISTORY_LIMIT = 10
+MAX_TRANSCRIPT_CHARS = 24_000
+
+
+def _truncate_transcript(transcript: str) -> str:
+    """Cap the transcript text sent to the model to protect against a
+    pathologically long, multi-hour meeting blowing the context window (or
+    being needlessly expensive) on every chat turn. Keeps the LAST
+    ``MAX_TRANSCRIPT_CHARS`` characters — the most recent portion of a
+    meeting is usually more relevant for Q&A/revision than the opening — and
+    prepends a marker line so it's clear (in the prompt and when debugging
+    via error_log/chat history) that content was cut, not silently missing.
+    This only affects what's sent to the model; the stored/displayed
+    transcript is untouched."""
+    if len(transcript) <= MAX_TRANSCRIPT_CHARS:
+        return transcript
+    return (
+        "[transcript truncated — showing the most recent portion]\n"
+        + transcript[-MAX_TRANSCRIPT_CHARS:]
+    )
 
 
 def _recent_history(meeting_name: str) -> list:
@@ -56,6 +76,7 @@ def _insert_message(meeting_name: str, role: str, content: str, error: str = Non
 
 
 @frappe.whitelist()
+@rate_limit(limit=20, seconds=60)
 def ask_meeting(meeting_name: str, message: str):
     """
     Answer a question about a meeting, grounded in its transcript, summary,
@@ -77,7 +98,7 @@ def ask_meeting(meeting_name: str, message: str):
     prompt_parts = [
         "You are answering questions about a specific meeting, using only the "
         "transcript, summary, and chat history below. Be concise.",
-        f"Meeting transcript:\n{meeting.transcript}",
+        f"Meeting transcript:\n{_truncate_transcript(meeting.transcript)}",
     ]
     if meeting.summary:
         prompt_parts.append(f"Current summary:\n{meeting.summary}")
@@ -109,6 +130,7 @@ def ask_meeting(meeting_name: str, message: str):
 
 
 @frappe.whitelist()
+@rate_limit(limit=10, seconds=60)
 def revise_summary(meeting_name: str, instruction: str):
     """
     Regenerate ``Meeting.summary`` from a natural-language revision
@@ -129,7 +151,7 @@ def revise_summary(meeting_name: str, instruction: str):
         "complete revised summary again in the same four-section Markdown "
         "format (Headline, Key Points, Decisions, Action Items) — never a "
         "partial diff or just the changed section.",
-        f"Meeting transcript:\n{meeting.transcript}",
+        f"Meeting transcript:\n{_truncate_transcript(meeting.transcript)}",
         f"Current summary:\n{meeting.summary}",
         f"Revision instruction: {instruction}",
     ])

--- a/huf/ai/meetings/meeting_export.py
+++ b/huf/ai/meetings/meeting_export.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+"""
+Download endpoints for a completed Meeting's transcript and Minutes of
+Meeting (MoM) export.
+
+Both methods reuse ``meeting_api._get_meeting`` for permission checks (the
+same ``frappe.get_doc`` + ``has_permission`` pattern used across
+``huf.ai.meetings``) and use the standard Frappe file-download response
+(``frappe.response["filename"]`` / ``["filecontent"]`` / ``["type"]``) to
+trigger a browser download from a whitelisted method, matching
+``huf.ai.skills.exporter.download_skill_huf``.
+"""
+
+import frappe
+from frappe import _
+
+from huf.ai.meetings.meeting_api import _get_meeting
+
+
+def _meeting_metadata_lines(meeting) -> list[str]:
+    lines = [f"Title: {meeting.title or meeting.name}"]
+    if meeting.started_at:
+        lines.append(f"Date: {meeting.started_at}")
+    if meeting.duration_seconds:
+        lines.append(f"Duration (seconds): {meeting.duration_seconds}")
+    if meeting.participants:
+        lines.append(f"Participants: {meeting.participants}")
+    return lines
+
+
+@frappe.whitelist()
+def download_transcript(meeting_name: str):
+    """Download a Meeting's raw transcript as a plain-text file."""
+    meeting = _get_meeting(meeting_name, "read")
+
+    if not meeting.transcript:
+        frappe.throw(_("This Meeting does not have a transcript yet"))
+
+    header = "\n".join(_meeting_metadata_lines(meeting))
+    content = f"{header}\n\n{meeting.transcript}"
+
+    frappe.response["filename"] = f"{meeting.name}-transcript.txt"
+    frappe.response["filecontent"] = content.encode("utf-8")
+    frappe.response["type"] = "download"
+
+
+@frappe.whitelist()
+def download_minutes(meeting_name: str):
+    """Download a Meeting's Minutes of Meeting (MoM) as a Markdown file.
+
+    Includes the summary verbatim (it already carries its own ## sections)
+    and, when available, appends the full transcript so a single file can
+    capture both the MoM and the full transcript.
+    """
+    meeting = _get_meeting(meeting_name, "read")
+
+    if not meeting.summary:
+        frappe.throw(_("This Meeting does not have a summary yet"))
+
+    title = meeting.title or "Meeting"
+    metadata = "\n".join(_meeting_metadata_lines(meeting)[1:])
+
+    parts = [f"# {title} — Minutes of Meeting"]
+    if metadata:
+        parts.append(metadata)
+    parts.append(meeting.summary)
+
+    if meeting.transcript:
+        parts.append("## Full Transcript")
+        parts.append(meeting.transcript)
+
+    content = "\n\n".join(parts)
+
+    frappe.response["filename"] = f"{meeting.name}-minutes.md"
+    frappe.response["filecontent"] = content.encode("utf-8")
+    frappe.response["type"] = "download"

--- a/huf/ai/meetings/meeting_summary.py
+++ b/huf/ai/meetings/meeting_summary.py
@@ -17,7 +17,12 @@ after it resets a failed Meeting back to "Summarizing".
 import frappe
 
 from huf.ai.agent_integration import run_agent_sync
-from huf.ai.meetings.meeting_transcription import _emit_processing_status
+from huf.ai.meetings.meeting_transcription import (
+    MODEL_NOT_CONFIGURED_MESSAGE,
+    _agent_is_configured,
+    _append_error_log,
+    _emit_processing_status,
+)
 
 SUMMARY_AGENT = "Meeting Summary Agent"
 
@@ -37,6 +42,17 @@ def _build_summary_prompt(meeting) -> str:
 
 def run_meeting_summary(meeting_name: str):
     meeting = frappe.get_doc("Meeting", meeting_name)
+
+    if not _agent_is_configured(SUMMARY_AGENT):
+        meeting.status = "Failed"
+        meeting.failed_step = "Model Not Configured"
+        meeting.last_error = MODEL_NOT_CONFIGURED_MESSAGE
+        _append_error_log(meeting, MODEL_NOT_CONFIGURED_MESSAGE)
+        meeting.save(ignore_permissions=True)
+        frappe.db.commit()
+        _emit_processing_status(meeting_name, meeting.status)
+        return
+
     prompt = _build_summary_prompt(meeting)
 
     try:
@@ -55,8 +71,14 @@ def run_meeting_summary(meeting_name: str):
         meeting.summary = result.get("response")
         meeting.summary_agent_run = result.get("agent_run_id")
         meeting.status = "Completed"
+        meeting.failed_step = None
+        meeting.last_error = None
     else:
+        error_message = result.get("error") or "Summary generation failed"
         meeting.status = "Failed"
+        meeting.failed_step = "Summary"
+        meeting.last_error = error_message[:500]
+        _append_error_log(meeting, error_message)
 
     meeting.save(ignore_permissions=True)
     frappe.db.commit()

--- a/huf/ai/meetings/meeting_transcription.py
+++ b/huf/ai/meetings/meeting_transcription.py
@@ -18,7 +18,7 @@ built in Phase 5).
 import time
 
 import frappe
-from frappe.utils import cint, flt, get_datetime, time_diff_in_seconds
+from frappe.utils import cint, flt, get_datetime, now_datetime, time_diff_in_seconds
 
 from huf.ai import audio_service
 
@@ -27,10 +27,47 @@ MAX_RETRY_COUNT = 3
 RETRY_BACKOFF_SECONDS = 5
 FINALIZE_POLL_SECONDS = 5
 TERMINAL_UPLOAD_STATUSES = ("Transcribed", "Failed")
+MODEL_NOT_CONFIGURED_MESSAGE = (
+    "No AI model is configured for the Meeting Summary Agent. Configure a model in"
+    " Agent settings, then retry."
+)
+
+
+def _agent_is_configured(agent_name: str = TRANSCRIPTION_AGENT) -> bool:
+    """Return whether the given Agent is usable (not disabled, has a model set)."""
+    agent = frappe.get_cached_doc("Agent", agent_name)
+    return not agent.disabled and bool(agent.model)
+
+
+def _append_error_log(meeting_doc, message: str):
+    """Append a timestamped line to ``meeting_doc.error_log``, in place."""
+    entry = f"[{now_datetime()}] {message}"
+    meeting_doc.error_log = f"{meeting_doc.error_log}\n{entry}" if meeting_doc.error_log else entry
+
+
+def _fail_meeting_for_unconfigured_model(meeting_name: str):
+    meeting = frappe.get_doc("Meeting", meeting_name)
+    meeting.status = "Failed"
+    meeting.failed_step = "Model Not Configured"
+    meeting.last_error = MODEL_NOT_CONFIGURED_MESSAGE
+    _append_error_log(meeting, MODEL_NOT_CONFIGURED_MESSAGE)
+    meeting.save(ignore_permissions=True)
+    frappe.db.commit()
+    _emit_processing_status(meeting_name, meeting.status)
 
 
 def transcribe_meeting_chunk(chunk_name: str):
     chunk = frappe.get_doc("Meeting Recording Chunk", chunk_name)
+
+    if not _agent_is_configured():
+        chunk.upload_status = "Failed"
+        chunk.transcription_error = MODEL_NOT_CONFIGURED_MESSAGE
+        chunk.save(ignore_permissions=True)
+        frappe.db.commit()
+        _fail_meeting_for_unconfigured_model(chunk.meeting)
+        _maybe_finalize_meeting(chunk.meeting)
+        return
+
     chunk.upload_status = "Transcribing"
     chunk.save(ignore_permissions=True)
     frappe.db.commit()
@@ -74,6 +111,13 @@ def _handle_transcription_failure(chunk, error_message: str):
 
     chunk.upload_status = "Failed"
     chunk.save(ignore_permissions=True)
+    frappe.db.commit()
+
+    meeting = frappe.get_doc("Meeting", chunk.meeting)
+    meeting.failed_step = "Transcription"
+    meeting.last_error = error_message[:500]
+    _append_error_log(meeting, error_message)
+    meeting.save(ignore_permissions=True)
     frappe.db.commit()
     _emit_processing_status(chunk.meeting, "Transcribing")
 
@@ -172,6 +216,8 @@ def finalize_meeting(meeting_name: str):
     meeting.transcript = transcript
     meeting.duration_seconds = duration_seconds
     meeting.status = "Summarizing"
+    meeting.failed_step = None
+    meeting.last_error = None
     meeting.save(ignore_permissions=True)
     frappe.db.commit()
     _emit_processing_status(meeting_name, "Summarizing")

--- a/huf/ai/meetings/test_meeting_api.py
+++ b/huf/ai/meetings/test_meeting_api.py
@@ -121,11 +121,78 @@ class TestMeetingApi(unittest.TestCase):
         meeting_api.start_recording(name)
         meeting_api.stop_recording(name)
 
-        with patch("frappe.enqueue") as mock_enqueue:
+        with (
+            patch("huf.ai.meetings.meeting_api._agent_is_configured", return_value=True),
+            patch("frappe.enqueue") as mock_enqueue,
+        ):
             result = meeting_api.retry_summary(name)
 
         mock_enqueue.assert_called_once()
         self.assertEqual(result["status"], "Summarizing")
+
+    def test_retry_summary_clears_stale_failure_fields(self):
+        name = self._create()
+        doc = frappe.get_doc("Meeting", name)
+        doc.status = "Failed"
+        doc.failed_step = "Summary"
+        doc.last_error = "provider down"
+        doc.error_log = "[2026-08-24 00:00:00] provider down"
+        doc.save(ignore_permissions=True)
+
+        with (
+            patch("huf.ai.meetings.meeting_api._agent_is_configured", return_value=True),
+            patch("frappe.enqueue"),
+        ):
+            meeting_api.retry_summary(name)
+
+        doc.reload()
+        self.assertFalse(doc.failed_step)
+        self.assertFalse(doc.last_error)
+        self.assertIn("provider down", doc.error_log)
+
+    def test_retry_summary_throws_when_model_not_configured(self):
+        name = self._create()
+
+        with patch("huf.ai.meetings.meeting_api._agent_is_configured", return_value=False):
+            with self.assertRaises(frappe.ValidationError):
+                meeting_api.retry_summary(name)
+
+    def test_retry_chunk_transcription_throws_when_model_not_configured(self):
+        name = self._create()
+        chunk = frappe.get_doc({
+            "doctype": "Meeting Recording Chunk",
+            "meeting": name,
+            "sequence": 0,
+            "upload_status": "Failed",
+        }).insert(ignore_permissions=True)
+
+        with patch("huf.ai.meetings.meeting_api._agent_is_configured", return_value=False):
+            with self.assertRaises(frappe.ValidationError):
+                meeting_api.retry_chunk_transcription(chunk.name)
+
+    def test_retry_chunk_transcription_clears_stale_failure_fields(self):
+        name = self._create()
+        doc = frappe.get_doc("Meeting", name)
+        doc.status = "Failed"
+        doc.failed_step = "Transcription"
+        doc.last_error = "provider down"
+        doc.save(ignore_permissions=True)
+        chunk = frappe.get_doc({
+            "doctype": "Meeting Recording Chunk",
+            "meeting": name,
+            "sequence": 0,
+            "upload_status": "Failed",
+        }).insert(ignore_permissions=True)
+
+        with (
+            patch("huf.ai.meetings.meeting_api._agent_is_configured", return_value=True),
+            patch("frappe.enqueue"),
+        ):
+            meeting_api.retry_chunk_transcription(chunk.name)
+
+        doc.reload()
+        self.assertFalse(doc.failed_step)
+        self.assertFalse(doc.last_error)
 
 
 if __name__ == "__main__":

--- a/huf/ai/meetings/test_meeting_chat.py
+++ b/huf/ai/meetings/test_meeting_chat.py
@@ -9,6 +9,24 @@ import frappe
 from huf.ai.meetings import meeting_api, meeting_chat
 
 
+class TestTruncateTranscript(unittest.TestCase):
+    def test_under_limit_returned_unchanged(self):
+        transcript = "Alice: hello.\nBob: hi." * 10
+        self.assertLess(len(transcript), meeting_chat.MAX_TRANSCRIPT_CHARS)
+        self.assertEqual(meeting_chat._truncate_transcript(transcript), transcript)
+
+    def test_over_limit_truncated_to_tail_with_marker(self):
+        transcript = "x" * (meeting_chat.MAX_TRANSCRIPT_CHARS + 500)
+        # Make the tail distinguishable from the truncated-away head.
+        transcript = transcript[:-10] + "END-MARKER"
+
+        result = meeting_chat._truncate_transcript(transcript)
+
+        self.assertTrue(result.startswith("[transcript truncated — showing the most recent portion]\n"))
+        self.assertTrue(result.endswith("END-MARKER"))
+        self.assertEqual(len(result) - len("[transcript truncated — showing the most recent portion]\n"), meeting_chat.MAX_TRANSCRIPT_CHARS)
+
+
 class TestMeetingChat(unittest.TestCase):
     def setUp(self):
         frappe.set_user("Administrator")

--- a/huf/ai/meetings/test_meeting_chat.py
+++ b/huf/ai/meetings/test_meeting_chat.py
@@ -30,6 +30,16 @@ class TestMeetingChat(unittest.TestCase):
                 pass
         frappe.db.commit()
 
+    def _make_agent_run(self):
+        """
+        Meeting.summary_agent_run is a Link to Agent Run, so a fake string
+        id fails Frappe's link validation on save — create a real row so
+        tests exercise the same save() path production code does.
+        """
+        doc = frappe.get_doc({"doctype": "Agent Run"}).insert(ignore_permissions=True)
+        self.addCleanup(lambda: frappe.delete_doc("Agent Run", doc.name, ignore_permissions=True, force=True))
+        return doc.name
+
     def test_ask_meeting_success_inserts_two_messages(self):
         with patch(
             "huf.ai.meetings.meeting_chat.run_agent_sync",
@@ -70,16 +80,17 @@ class TestMeetingChat(unittest.TestCase):
 
     def test_revise_summary_success_updates_meeting(self):
         new_summary = "## Headline\nRevised.\n\n## Key Points\n- Ship it\n\n## Decisions\n- Ship now\n\n## Action Items\n- None identified."
+        agent_run_name = self._make_agent_run()
         with patch(
             "huf.ai.meetings.meeting_chat.run_agent_sync",
-            return_value={"success": True, "status": "Success", "response": new_summary, "agent_run_id": "Agent Run 2"},
+            return_value={"success": True, "status": "Success", "response": new_summary, "agent_run_id": agent_run_name},
         ):
             result = meeting_chat.revise_summary(self.meeting_name, "Make it shorter")
 
         self.assertEqual(result["summary"], new_summary)
         meeting = frappe.get_doc("Meeting", self.meeting_name)
         self.assertEqual(meeting.summary, new_summary)
-        self.assertEqual(meeting.summary_agent_run, "Agent Run 2")
+        self.assertEqual(meeting.summary_agent_run, agent_run_name)
 
         messages = meeting_chat.get_chat_history(self.meeting_name)
         self.assertEqual(messages[-1].role, "assistant")

--- a/huf/ai/meetings/test_meeting_chat.py
+++ b/huf/ai/meetings/test_meeting_chat.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from huf.ai.meetings import meeting_api, meeting_chat
+
+
+class TestMeetingChat(unittest.TestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self._meetings = []
+        self.meeting_name = meeting_api.create_meeting()["meeting_name"]
+        self._meetings.append(self.meeting_name)
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        meeting.transcript = "Alice: Let's ship the feature.\nBob: Agreed."
+        meeting.summary = "## Headline\nShipping the feature.\n\n## Key Points\n- Ship it\n\n## Decisions\n- Ship now\n\n## Action Items\n- None identified."
+        meeting.status = "Completed"
+        meeting.save(ignore_permissions=True)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for name in self._meetings:
+            try:
+                frappe.delete_doc("Meeting", name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.db.commit()
+
+    def test_ask_meeting_success_inserts_two_messages(self):
+        with patch(
+            "huf.ai.meetings.meeting_chat.run_agent_sync",
+            return_value={"success": True, "status": "Success", "response": "They agreed to ship it."},
+        ):
+            result = meeting_chat.ask_meeting(self.meeting_name, "What was decided?")
+
+        self.assertEqual(result["reply"], "They agreed to ship it.")
+        messages = meeting_chat.get_chat_history(self.meeting_name)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].role, "user")
+        self.assertEqual(messages[0].content, "What was decided?")
+        self.assertEqual(messages[1].role, "assistant")
+        self.assertEqual(messages[1].content, "They agreed to ship it.")
+
+    def test_ask_meeting_failure_records_error_and_does_not_raise(self):
+        with (
+            patch(
+                "huf.ai.meetings.meeting_chat.run_agent_sync",
+                return_value={"success": False, "status": "Failed", "error": "provider down"},
+            ),
+        ):
+            result = meeting_chat.ask_meeting(self.meeting_name, "What was decided?")
+
+        self.assertEqual(result["error"], "provider down")
+        messages = meeting_chat.get_chat_history(self.meeting_name)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[1].role, "assistant")
+        self.assertEqual(messages[1].error, "provider down")
+
+    def test_ask_meeting_requires_transcript(self):
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        meeting.transcript = None
+        meeting.save(ignore_permissions=True)
+
+        with self.assertRaises(frappe.ValidationError):
+            meeting_chat.ask_meeting(self.meeting_name, "hi")
+
+    def test_revise_summary_success_updates_meeting(self):
+        new_summary = "## Headline\nRevised.\n\n## Key Points\n- Ship it\n\n## Decisions\n- Ship now\n\n## Action Items\n- None identified."
+        with patch(
+            "huf.ai.meetings.meeting_chat.run_agent_sync",
+            return_value={"success": True, "status": "Success", "response": new_summary, "agent_run_id": "Agent Run 2"},
+        ):
+            result = meeting_chat.revise_summary(self.meeting_name, "Make it shorter")
+
+        self.assertEqual(result["summary"], new_summary)
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        self.assertEqual(meeting.summary, new_summary)
+        self.assertEqual(meeting.summary_agent_run, "Agent Run 2")
+
+        messages = meeting_chat.get_chat_history(self.meeting_name)
+        self.assertEqual(messages[-1].role, "assistant")
+        self.assertTrue(messages[-1].applied_to_summary)
+
+    def test_revise_summary_failure_leaves_summary_untouched(self):
+        original_summary = frappe.get_doc("Meeting", self.meeting_name).summary
+
+        with patch(
+            "huf.ai.meetings.meeting_chat.run_agent_sync",
+            return_value={"success": False, "status": "Failed", "error": "provider down"},
+        ):
+            result = meeting_chat.revise_summary(self.meeting_name, "Make it shorter")
+
+        self.assertEqual(result["error"], "provider down")
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        self.assertEqual(meeting.summary, original_summary)
+
+    def test_revise_summary_requires_existing_summary(self):
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        meeting.summary = None
+        meeting.save(ignore_permissions=True)
+
+        with self.assertRaises(frappe.ValidationError):
+            meeting_chat.revise_summary(self.meeting_name, "Make it shorter")
+
+    def test_get_chat_history_ordered_oldest_first(self):
+        with patch(
+            "huf.ai.meetings.meeting_chat.run_agent_sync",
+            return_value={"success": True, "status": "Success", "response": "First reply."},
+        ):
+            meeting_chat.ask_meeting(self.meeting_name, "First question")
+        with patch(
+            "huf.ai.meetings.meeting_chat.run_agent_sync",
+            return_value={"success": True, "status": "Success", "response": "Second reply."},
+        ):
+            meeting_chat.ask_meeting(self.meeting_name, "Second question")
+
+        messages = meeting_chat.get_chat_history(self.meeting_name)
+        self.assertEqual([m.content for m in messages], [
+            "First question", "First reply.", "Second question", "Second reply.",
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/meetings/test_meeting_export.py
+++ b/huf/ai/meetings/test_meeting_export.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, Huf and Contributors
+# For license information, please see license.txt
+
+import unittest
+
+import frappe
+
+from huf.ai.meetings import meeting_api, meeting_export
+
+
+class TestMeetingExport(unittest.TestCase):
+    def setUp(self):
+        frappe.set_user("Administrator")
+        self._meetings = []
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        for name in self._meetings:
+            try:
+                frappe.delete_doc("Meeting", name, ignore_permissions=True, force=True)
+            except Exception:
+                pass
+        frappe.db.commit()
+
+    def _create(self, **kwargs):
+        result = meeting_api.create_meeting(**kwargs)
+        self._meetings.append(result["meeting_name"])
+        return result["meeting_name"]
+
+    def test_download_transcript_requires_transcript(self):
+        name = self._create(title="Standup")
+        with self.assertRaises(frappe.ValidationError):
+            meeting_export.download_transcript(name)
+
+    def test_download_minutes_requires_summary(self):
+        name = self._create(title="Standup")
+        with self.assertRaises(frappe.ValidationError):
+            meeting_export.download_minutes(name)
+
+    def test_download_transcript_sets_response(self):
+        name = self._create(title="Standup", participants="Alice, Bob")
+        doc = frappe.get_doc("Meeting", name)
+        doc.transcript = "Alice: hello there\nBob: hi"
+        doc.save(ignore_permissions=True)
+
+        frappe.response.clear()
+        meeting_export.download_transcript(name)
+
+        self.assertEqual(frappe.response["filename"], f"{name}-transcript.txt")
+        self.assertEqual(frappe.response["type"], "download")
+        content = frappe.response["filecontent"]
+        self.assertTrue(content)
+        text = content.decode("utf-8")
+        self.assertIn("Standup", text)
+        self.assertIn("Alice, Bob", text)
+        self.assertIn("Alice: hello there", text)
+
+    def test_download_minutes_sets_response_with_transcript(self):
+        name = self._create(title="Planning Sync", participants="Carol")
+        doc = frappe.get_doc("Meeting", name)
+        doc.transcript = "Carol: let's plan the sprint"
+        doc.summary = "## Headline\nSprint planning\n\n## Action Items\n- Carol to file tickets"
+        doc.save(ignore_permissions=True)
+
+        frappe.response.clear()
+        meeting_export.download_minutes(name)
+
+        self.assertEqual(frappe.response["filename"], f"{name}-minutes.md")
+        self.assertEqual(frappe.response["type"], "download")
+        content = frappe.response["filecontent"]
+        self.assertTrue(content)
+        text = content.decode("utf-8")
+        self.assertIn("Planning Sync", text)
+        self.assertIn("Sprint planning", text)
+        self.assertIn("Carol to file tickets", text)
+        self.assertIn("## Full Transcript", text)
+        self.assertIn("Carol: let's plan the sprint", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/meetings/test_meeting_summary.py
+++ b/huf/ai/meetings/test_meeting_summary.py
@@ -54,14 +54,17 @@ class TestMeetingSummary(unittest.TestCase):
         self.assertNotIn("Participants", prompt)
 
     def test_success_sets_summary_and_completes(self):
-        with patch(
-            "huf.ai.meetings.meeting_summary.run_agent_sync",
-            return_value={
-                "success": True,
-                "status": "Success",
-                "response": "## Headline\nShipping the feature.",
-                "agent_run_id": "Agent Run 1",
-            },
+        with (
+            patch("huf.ai.meetings.meeting_summary._agent_is_configured", return_value=True),
+            patch(
+                "huf.ai.meetings.meeting_summary.run_agent_sync",
+                return_value={
+                    "success": True,
+                    "status": "Success",
+                    "response": "## Headline\nShipping the feature.",
+                    "agent_run_id": "Agent Run 1",
+                },
+            ),
         ):
             meeting_summary.run_meeting_summary(self.meeting_name)
 
@@ -69,13 +72,18 @@ class TestMeetingSummary(unittest.TestCase):
         self.assertEqual(meeting.summary, "## Headline\nShipping the feature.")
         self.assertEqual(meeting.summary_agent_run, "Agent Run 1")
         self.assertEqual(meeting.status, "Completed")
+        self.assertFalse(meeting.failed_step)
+        self.assertFalse(meeting.last_error)
 
     def test_failure_sets_failed_and_preserves_transcript(self):
         transcript_before = frappe.get_doc("Meeting", self.meeting_name).transcript
 
-        with patch(
-            "huf.ai.meetings.meeting_summary.run_agent_sync",
-            return_value={"success": False, "status": "Failed", "error": "provider down"},
+        with (
+            patch("huf.ai.meetings.meeting_summary._agent_is_configured", return_value=True),
+            patch(
+                "huf.ai.meetings.meeting_summary.run_agent_sync",
+                return_value={"success": False, "status": "Failed", "error": "provider down"},
+            ),
         ):
             meeting_summary.run_meeting_summary(self.meeting_name)
 
@@ -83,14 +91,30 @@ class TestMeetingSummary(unittest.TestCase):
         self.assertEqual(meeting.status, "Failed")
         self.assertEqual(meeting.transcript, transcript_before)
         self.assertFalse(meeting.summary)
+        self.assertEqual(meeting.failed_step, "Summary")
+        self.assertEqual(meeting.last_error, "provider down")
+
+    def test_guard_skips_to_failed_when_model_not_configured(self):
+        with patch("huf.ai.meetings.meeting_summary._agent_is_configured", return_value=False):
+            meeting_summary.run_meeting_summary(self.meeting_name)
+
+        meeting = frappe.get_doc("Meeting", self.meeting_name)
+        self.assertEqual(meeting.status, "Failed")
+        self.assertEqual(meeting.failed_step, "Model Not Configured")
+        self.assertTrue(meeting.last_error)
+        self.assertTrue(meeting.error_log)
 
     def test_exception_sets_failed_and_preserves_transcript(self):
         transcript_before = frappe.get_doc("Meeting", self.meeting_name).transcript
 
-        with patch(
-            "huf.ai.meetings.meeting_summary.run_agent_sync",
-            side_effect=RuntimeError("boom"),
-        ), patch("frappe.log_error"):
+        with (
+            patch("huf.ai.meetings.meeting_summary._agent_is_configured", return_value=True),
+            patch(
+                "huf.ai.meetings.meeting_summary.run_agent_sync",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("frappe.log_error"),
+        ):
             meeting_summary.run_meeting_summary(self.meeting_name)
 
         meeting = frappe.get_doc("Meeting", self.meeting_name)
@@ -98,15 +122,18 @@ class TestMeetingSummary(unittest.TestCase):
         self.assertEqual(meeting.transcript, transcript_before)
 
     def test_retry_summary_job_reinvokes_run_meeting_summary(self):
-        with patch(
-            "huf.ai.meetings.meeting_summary.run_agent_sync",
-            return_value={
-                "success": True,
-                "status": "Success",
-                "response": "## Headline\nRetried summary.",
-                "agent_run_id": "Agent Run 2",
-            },
-        ) as mock_run:
+        with (
+            patch("huf.ai.meetings.meeting_summary._agent_is_configured", return_value=True),
+            patch(
+                "huf.ai.meetings.meeting_summary.run_agent_sync",
+                return_value={
+                    "success": True,
+                    "status": "Success",
+                    "response": "## Headline\nRetried summary.",
+                    "agent_run_id": "Agent Run 2",
+                },
+            ) as mock_run,
+        ):
             meeting_summary.retry_summary_job(self.meeting_name)
 
         mock_run.assert_called_once()

--- a/huf/ai/meetings/test_meeting_summary.py
+++ b/huf/ai/meetings/test_meeting_summary.py
@@ -29,6 +29,16 @@ class TestMeetingSummary(unittest.TestCase):
                 pass
         frappe.db.commit()
 
+    def _make_agent_run(self):
+        """
+        Meeting.summary_agent_run is a Link to Agent Run, so a fake string
+        id fails Frappe's link validation on save — create a real row so
+        tests exercise the same save() path production code does.
+        """
+        doc = frappe.get_doc({"doctype": "Agent Run"}).insert(ignore_permissions=True)
+        self.addCleanup(lambda: frappe.delete_doc("Agent Run", doc.name, ignore_permissions=True, force=True))
+        return doc.name
+
     def test_prompt_includes_full_context(self):
         meeting = frappe.get_doc("Meeting", self.meeting_name)
         meeting.title = "Launch sync"
@@ -54,6 +64,7 @@ class TestMeetingSummary(unittest.TestCase):
         self.assertNotIn("Participants", prompt)
 
     def test_success_sets_summary_and_completes(self):
+        agent_run_name = self._make_agent_run()
         with (
             patch("huf.ai.meetings.meeting_summary._agent_is_configured", return_value=True),
             patch(
@@ -62,7 +73,7 @@ class TestMeetingSummary(unittest.TestCase):
                     "success": True,
                     "status": "Success",
                     "response": "## Headline\nShipping the feature.",
-                    "agent_run_id": "Agent Run 1",
+                    "agent_run_id": agent_run_name,
                 },
             ),
         ):
@@ -70,7 +81,7 @@ class TestMeetingSummary(unittest.TestCase):
 
         meeting = frappe.get_doc("Meeting", self.meeting_name)
         self.assertEqual(meeting.summary, "## Headline\nShipping the feature.")
-        self.assertEqual(meeting.summary_agent_run, "Agent Run 1")
+        self.assertEqual(meeting.summary_agent_run, agent_run_name)
         self.assertEqual(meeting.status, "Completed")
         self.assertFalse(meeting.failed_step)
         self.assertFalse(meeting.last_error)
@@ -122,6 +133,7 @@ class TestMeetingSummary(unittest.TestCase):
         self.assertEqual(meeting.transcript, transcript_before)
 
     def test_retry_summary_job_reinvokes_run_meeting_summary(self):
+        agent_run_name = self._make_agent_run()
         with (
             patch("huf.ai.meetings.meeting_summary._agent_is_configured", return_value=True),
             patch(
@@ -130,7 +142,7 @@ class TestMeetingSummary(unittest.TestCase):
                     "success": True,
                     "status": "Success",
                     "response": "## Headline\nRetried summary.",
-                    "agent_run_id": "Agent Run 2",
+                    "agent_run_id": agent_run_name,
                 },
             ) as mock_run,
         ):

--- a/huf/ai/meetings/test_meeting_transcription.py
+++ b/huf/ai/meetings/test_meeting_transcription.py
@@ -43,9 +43,12 @@ class TestMeetingTranscription(unittest.TestCase):
     def test_successful_transcription_updates_chunk(self):
         chunk = self._make_chunk()
 
-        with patch(
-            "huf.ai.audio_service.transcribe_audio_file",
-            return_value={"success": True, "transcript": "hello world"},
+        with (
+            patch("huf.ai.meetings.meeting_transcription._agent_is_configured", return_value=True),
+            patch(
+                "huf.ai.audio_service.transcribe_audio_file",
+                return_value={"success": True, "transcript": "hello world"},
+            ),
         ):
             meeting_transcription.transcribe_meeting_chunk(chunk.name)
 
@@ -58,6 +61,7 @@ class TestMeetingTranscription(unittest.TestCase):
         chunk = self._make_chunk()
 
         with (
+            patch("huf.ai.meetings.meeting_transcription._agent_is_configured", return_value=True),
             patch(
                 "huf.ai.audio_service.transcribe_audio_file",
                 return_value={"success": False, "error": "provider down"},
@@ -73,6 +77,26 @@ class TestMeetingTranscription(unittest.TestCase):
         self.assertEqual(chunk.upload_status, "Failed")
         self.assertEqual(chunk.transcription_error, "provider down")
         self.assertEqual(mock_enqueue.call_count, meeting_transcription.MAX_RETRY_COUNT - 1)
+
+        meeting_doc = frappe.get_doc("Meeting", self.meeting["meeting_name"])
+        self.assertEqual(meeting_doc.failed_step, "Transcription")
+        self.assertEqual(meeting_doc.last_error, "provider down")
+        self.assertIn("provider down", meeting_doc.error_log)
+
+    def test_guard_skips_to_failed_when_model_not_configured(self):
+        chunk = self._make_chunk()
+
+        with patch("huf.ai.meetings.meeting_transcription._agent_is_configured", return_value=False):
+            meeting_transcription.transcribe_meeting_chunk(chunk.name)
+
+        chunk.reload()
+        self.assertEqual(chunk.upload_status, "Failed")
+
+        meeting_doc = frappe.get_doc("Meeting", self.meeting["meeting_name"])
+        self.assertEqual(meeting_doc.status, "Failed")
+        self.assertEqual(meeting_doc.failed_step, "Model Not Configured")
+        self.assertTrue(meeting_doc.last_error)
+        self.assertTrue(meeting_doc.error_log)
 
     def test_finalize_meeting_reenqueues_when_chunks_not_terminal(self):
         self._make_chunk(upload_status="Transcribing")

--- a/huf/huf/doctype/meeting/meeting.json
+++ b/huf/huf/doctype/meeting/meeting.json
@@ -22,6 +22,10 @@
   "section_break_context",
   "context_prompted_at",
   "context_completed",
+  "section_break_failure",
+  "failed_step",
+  "last_error",
+  "error_log",
   "is_system_owned"
  ],
  "fields": [
@@ -120,6 +124,32 @@
    "fieldname": "context_completed",
    "fieldtype": "Check",
    "label": "Context Completed"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:doc.status=='Failed' || doc.error_log",
+   "fieldname": "section_break_failure",
+   "fieldtype": "Section Break",
+   "label": "Failure Details"
+  },
+  {
+   "fieldname": "failed_step",
+   "fieldtype": "Select",
+   "label": "Failed Step",
+   "options": "\nModel Not Configured\nTranscription\nSummary",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_error",
+   "fieldtype": "Small Text",
+   "label": "Last Error",
+   "read_only": 1
+  },
+  {
+   "fieldname": "error_log",
+   "fieldtype": "Long Text",
+   "label": "Error Log",
+   "read_only": 1
   },
   {
    "default": "1",

--- a/huf/huf/doctype/meeting_chat_message/meeting_chat_message.json
+++ b/huf/huf/doctype/meeting_chat_message/meeting_chat_message.json
@@ -1,0 +1,134 @@
+{
+ "actions": [],
+ "creation": "2026-08-24 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "meeting",
+  "role",
+  "column_break_content",
+  "applied_to_summary",
+  "section_break_content",
+  "content",
+  "error",
+  "is_system_owned"
+ ],
+ "fields": [
+  {
+   "fieldname": "meeting",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Meeting",
+   "options": "Meeting",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "role",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Role",
+   "options": "user\nassistant",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_content",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "applied_to_summary",
+   "fieldtype": "Check",
+   "label": "Applied To Summary",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_content",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "content",
+   "fieldtype": "Long Text",
+   "label": "Content",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "error",
+   "fieldtype": "Small Text",
+   "label": "Error",
+   "read_only": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "is_system_owned",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is System Owned",
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-24 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Meeting Chat Message",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Viewer",
+   "share": 1,
+   "write": 0
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "ASC",
+ "states": []
+}

--- a/huf/huf/doctype/meeting_chat_message/meeting_chat_message.json
+++ b/huf/huf/doctype/meeting_chat_message/meeting_chat_message.json
@@ -51,8 +51,7 @@
    "fieldname": "content",
    "fieldtype": "Long Text",
    "label": "Content",
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "fieldname": "error",

--- a/huf/huf/doctype/meeting_chat_message/meeting_chat_message.py
+++ b/huf/huf/doctype/meeting_chat_message/meeting_chat_message.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class MeetingChatMessage(Document):
+	def on_trash(self):
+		if self.is_system_owned and not (
+			frappe.flags.in_install or frappe.flags.in_migrate or frappe.flags.in_uninstall
+		):
+			frappe.throw(
+				_("System-owned meeting chat messages cannot be deleted."),
+				title=_("Meeting Chat Message Protected"),
+			)

--- a/huf/huf/doctype/meeting_chat_message/test_meeting_chat_message.py
+++ b/huf/huf/doctype/meeting_chat_message/test_meeting_chat_message.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestMeetingChatMessage(FrappeTestCase):
+	def test_system_owned_message_cannot_be_deleted(self):
+		meeting = frappe.get_doc({"doctype": "Meeting", "title": "Chat delete guard", "status": "Draft"}).insert()
+		message = frappe.get_doc({
+			"doctype": "Meeting Chat Message",
+			"meeting": meeting.name,
+			"role": "user",
+			"content": "Summarize the decisions.",
+		}).insert(ignore_permissions=True)
+
+		self.assertTrue(message.is_system_owned)
+		with self.assertRaises(frappe.ValidationError):
+			message.delete()
+
+		frappe.flags.in_migrate = True
+		try:
+			message.delete()
+		finally:
+			frappe.flags.in_migrate = False
+		meeting.delete()

--- a/huf/huf/doctype/meeting_chat_message/test_meeting_chat_message.py
+++ b/huf/huf/doctype/meeting_chat_message/test_meeting_chat_message.py
@@ -22,6 +22,6 @@ class TestMeetingChatMessage(FrappeTestCase):
 		frappe.flags.in_migrate = True
 		try:
 			message.delete()
+			meeting.delete()
 		finally:
 			frappe.flags.in_migrate = False
-		meeting.delete()

--- a/huf/install.py
+++ b/huf/install.py
@@ -544,10 +544,13 @@ MEETING_SUMMARY_INSTRUCTIONS = """You turn a raw meeting transcript into a struc
 
 Output exactly these Markdown sections, in this order:
 1. `## Headline` — one sentence capturing what the meeting was about.
-2. `## Key Points` — a bullet list of the main discussion points and decisions.
-3. `## Action Items` — a bullet list of concrete follow-up actions, with an owner if the transcript names one. If there are none, write "None identified."
+2. `## Key Points` — a bullet list of the main discussion points.
+3. `## Decisions` — a bullet list of decisions that were made. If none were made, write "None identified."
+4. `## Action Items` — a bullet list of concrete follow-up actions, with an owner if the transcript names one. If there are none, write "None identified."
 
-Base the summary only on the transcript and any meeting title, description, or participants provided. Do not invent details that are not in the transcript."""
+Base the summary only on the transcript and any meeting title, description, or participants provided. Do not invent details that are not in the transcript.
+
+If asked, in a follow-up chat message, to revise the summary, output the complete revised summary again in the same four-section Markdown format — never a partial diff or just the changed section."""
 
 
 def _meeting_summary_model():


### PR DESCRIPTION
## Summary

Wave 2 on top of the Meeting Recorder feature (#649, #652, #655): failure
visibility/restart, transcript+MoM export, a minimal chat-with-your-meeting
surface, and subtitled playback.

1. **Model-config guard + failure surfacing** — a meeting no longer sits in
   Transcribing/Summarizing if the Meeting Summary Agent has no model
   configured; it fails immediately with a clear `failed_step`. A real
   model-call failure sets `failed_step`/`last_error`/`error_log` on the
   Meeting so the cause is visible, not just a generic "Failed" state.
   `retry_chunk_transcription`/`retry_summary` re-validate config before
   enqueueing and clear stale failure state on a successful kickoff.
2. **Restart + failure log UI** — `MeetingFailureCard` shows the specific
   failure reason (model-not-configured vs. a real transcription/summary
   error) with a collapsible full error log, and the existing Retry action.
3. **Download transcript / Minutes of Meeting** — `download_transcript`
   (plain text) and `download_minutes` (Markdown MoM: summary + optional
   full transcript) whitelisted endpoints, wired to two buttons on the
   Completed meeting view.
4. **Chat + revise-by-prompt** (tiny Firefly alternative) — `ask_meeting`
   answers questions grounded in the transcript/summary/chat history;
   `revise_summary` regenerates the summary from a natural-language
   instruction. Every turn, including failures, is persisted as a `Meeting
   Chat Message` so it's visible as a log, not silently swallowed.
5. **Decisions section** — the agent's summary output now has four
   sections (Headline / Key Points / Decisions / Action Items); rendered
   as its own card in `MeetingSummaryPanel`.
6. **Subtitled playback** — `MeetingRecordingPlayer` shows a toggleable
   caption bar with the currently-playing chunk's transcript text (chunk-
   level, since there's no word-level timestamp data — see code comment
   for why this is the right granularity here).

## New backend surfaces
- `huf.ai.meetings.meeting_export.{download_transcript,download_minutes}`
- `huf.ai.meetings.meeting_chat.{ask_meeting,revise_summary,get_chat_history}`
- New doctype `Meeting Chat Message` (system-owned, same delete-guard
  pattern as `Meeting Recording Chunk`)
- New `Meeting` fields: `failed_step`, `last_error`, `error_log`

## Verification
- `python -m py_compile` across every touched/new backend file — clean.
- Real frontend build gate: `tsc -b --force` (project-reference/incremental
  mode, the strict mode that actually enforces `noUnusedLocals` — see
  wave-1's #655 postmortem) and `vite build --base=/assets/huf/frontend/`,
  both run against a symlinked sibling checkout's `node_modules` — **both
  clean**, no unused-import or type errors.
- New unit tests added for every new backend module (guard/error-capture
  paths in `test_meeting_transcription.py`/`test_meeting_summary.py`/
  `test_meeting_api.py`, plus `test_meeting_export.py`, `test_meeting_chat.py`,
  `test_meeting_chat_message.py`), all mocking `run_agent_sync`/
  `audio_service` per the existing test conventions in this directory.

**Not run in this environment** (no live bench available here — same gap
wave 1 flagged before its own live-bench QA pass found 3 real bugs):
`bench migrate` (to confirm the new Meeting/Meeting Chat Message fields
apply cleanly) and `bench run-tests` for the modules above. Recommend a
live-bench pass before merge, same as wave 1's #652 fix round.

## Test plan
- [ ] `bench migrate` on a fresh site, confirm `Meeting` gains
      `failed_step`/`last_error`/`error_log` and `Meeting Chat Message` is
      created with no errors
- [ ] `bench run-tests --module huf.ai.meetings.test_meeting_transcription`
      (and the sibling `test_meeting_summary`/`test_meeting_api`/
      `test_meeting_export`/`test_meeting_chat` modules)
- [ ] Disable the Meeting Summary Agent's model, record a short meeting,
      confirm it fails immediately with "Model Not Configured" instead of
      hanging in Transcribing
- [ ] Re-enable the model, click Retry, confirm the meeting completes and
      the failure card clears
- [ ] On a Completed meeting: download transcript (.txt) and minutes
      (.md), confirm both open with correct content
- [ ] Ask the chat panel a question about a completed meeting, confirm a
      grounded answer appears and is persisted (reload the page, history
      should still be there)
- [ ] Use "Revise summary with a prompt", confirm the summary updates and
      the Decisions section still renders
- [ ] Play back a completed meeting's recording, confirm the caption bar
      shows the matching chunk's transcript text and can be toggled off