### PR TITLE
Meeting history: show why a meeting failed on the list, not just the detail page

### DIFF
--- a/frontend/src/components/meetings/MeetingCard.test.ts
+++ b/frontend/src/components/meetings/MeetingCard.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+// MeetingCard transitively imports @/components/dashboard -> ActiveAgentsTab
+// -> agentApi -> frappe-sdk.ts, which reads window.location at module scope
+// (same gotcha as wave-1's useMeetingRecorder.test.ts) — jsdom sidesteps it
+// without needing to mock the whole import chain for a pure-function test.
+import { describe, it, expect } from 'vitest';
+import { failureReason } from './MeetingCard';
+import type { MeetingListItem } from '@/types/meeting.types';
+
+function makeMeeting(overrides: Partial<MeetingListItem> = {}): MeetingListItem {
+  return {
+    name: 'MEETING-001',
+    status: 'Completed',
+    ...overrides,
+  };
+}
+
+describe('failureReason', () => {
+  it('returns undefined for a non-failed meeting', () => {
+    expect(failureReason(makeMeeting({ status: 'Completed' }))).toBeUndefined();
+    expect(failureReason(makeMeeting({ status: 'Recording' }))).toBeUndefined();
+  });
+
+  it('surfaces a distinct message when the model is not configured', () => {
+    expect(
+      failureReason(makeMeeting({ status: 'Failed', failed_step: 'Model Not Configured' })),
+    ).toBe('No AI model configured');
+  });
+
+  it('falls back to a truncated last_error for other failure steps', () => {
+    const longError = 'x'.repeat(200);
+    expect(failureReason(makeMeeting({ status: 'Failed', failed_step: 'Summary', last_error: longError }))).toBe(
+      longError.slice(0, 140),
+    );
+  });
+
+  it('falls back to a generic message when there is no last_error', () => {
+    expect(failureReason(makeMeeting({ status: 'Failed', failed_step: 'Transcription' }))).toBe(
+      'Failed to process',
+    );
+  });
+});

--- a/frontend/src/components/meetings/MeetingCard.tsx
+++ b/frontend/src/components/meetings/MeetingCard.tsx
@@ -29,6 +29,16 @@ function statusPresentation(status: MeetingStatus): { label: string; variant: Ba
   }
 }
 
+/** Short, list-view-appropriate failure reason — the detail page shows the
+ * full `last_error`/`error_log`, this is just enough to tell failed
+ * meetings apart at a glance without opening each one. */
+export function failureReason(meeting: MeetingListItem): string | undefined {
+  if (meeting.status !== 'Failed') return undefined;
+  if (meeting.failed_step === 'Model Not Configured') return 'No AI model configured';
+  if (meeting.last_error) return meeting.last_error.slice(0, 140);
+  return 'Failed to process';
+}
+
 function formatDuration(seconds?: number): string {
   if (!seconds || seconds <= 0) return '—';
   const minutes = Math.round(seconds / 60);
@@ -45,10 +55,13 @@ export function MeetingCard({ meeting, onClick }: MeetingCardProps) {
   const status = statusPresentation(meeting.status);
   const title = meeting.title?.trim() || `Meeting — ${formatTimeAgo(meeting.started_at || meeting.modified)}`;
 
+  const description =
+    failureReason(meeting) ?? (meeting.summary ? meeting.summary.slice(0, 140) : meeting.description?.slice(0, 140));
+
   return (
     <ItemCard
       title={title}
-      description={meeting.summary ? meeting.summary.slice(0, 140) : meeting.description?.slice(0, 140)}
+      description={description}
       status={status}
       metadata={[
         { label: 'When', value: formatTimeAgo(meeting.started_at || meeting.modified), icon: Calendar },

--- a/frontend/src/types/meeting.types.ts
+++ b/frontend/src/types/meeting.types.ts
@@ -77,6 +77,8 @@ export interface MeetingListItem {
   duration_seconds?: number;
   chunk_count?: number;
   summary?: string;
+  failed_step?: Meeting['failed_step'];
+  last_error?: string;
   modified?: string;
 }
 

--- a/huf/ai/meetings/meeting_api.py
+++ b/huf/ai/meetings/meeting_api.py
@@ -204,6 +204,8 @@ def list_meetings(start: int = 0, limit: int = 20, status: str = None, search: s
             "duration_seconds",
             "chunk_count",
             "summary",
+            "failed_step",
+            "last_error",
             "modified",
         ],
         order_by="modified desc",

--- a/huf/ai/meetings/test_meeting_api.py
+++ b/huf/ai/meetings/test_meeting_api.py
@@ -103,6 +103,19 @@ class TestMeetingApi(unittest.TestCase):
         self.assertIn("has_more", result)
         self.assertLessEqual(len(result["meetings"]), 2)
 
+    def test_list_meetings_includes_failure_reason(self):
+        name = self._create()
+        doc = frappe.get_doc("Meeting", name)
+        doc.status = "Failed"
+        doc.failed_step = "Model Not Configured"
+        doc.last_error = "No AI model is configured for the Meeting Summary Agent."
+        doc.save(ignore_permissions=True)
+
+        result = meeting_api.list_meetings(status="Failed", limit=50)
+        row = next(m for m in result["meetings"] if m["name"] == name)
+        self.assertEqual(row["failed_step"], "Model Not Configured")
+        self.assertEqual(row["last_error"], "No AI model is configured for the Meeting Summary Agent.")
+
     def test_list_meetings_filters_by_status(self):
         draft = self._create()
         recording = self._create()


### PR DESCRIPTION
## Summary

Small follow-up found during a fresh review pass after the Meeting Recorder wave 2-4 work (#657, already merged) — not a regression, a gap that review only ever exercised via the detail page.

`list_meetings` never selected `failed_step`/`last_error`, so a failed meeting's card on the history grid just showed a generic "failed" badge with no indication of why — the user had to open every single failed meeting individually to learn whether it was an unconfigured model vs. a real transcription/summary error.

Fix:
- `meeting_api.list_meetings` now also selects `failed_step`/`last_error`.
- `MeetingCard` shows a short reason in place of the summary excerpt when `status === 'Failed'`: "No AI model configured" for the config-guard case, a truncated `last_error` otherwise.

## Verification
- New backend test (`test_list_meetings_includes_failure_reason`) — ran live on a bench: **16/16 pass** (`bench run-tests --module huf.ai.meetings.test_meeting_api`).
- New frontend unit test (`MeetingCard.test.ts`, pure-function coverage of `failureReason`) — full suite **23 files / 180 tests**, all green.
- Real build gate: `tsc -b --force` + `vite build` clean, re-confirmed via `bench build --app huf` on the live bench.
- `bench migrate` applied cleanly (no schema change here — reusing existing `Meeting.failed_step`/`last_error` fields from #657).

## Test plan
- [ ] Fail a meeting with no model configured, confirm the history card shows "No AI model configured" without opening the meeting
- [ ] Fail a meeting via a real model-call error, confirm the card shows a truncated version of the actual error
- [ ] Confirm Completed/Recording/etc. cards are unaffected (still show the summary/description excerpt as before)