### PR TITLE
fix: Automations list card had two confusing play-like icons

### DIFF
--- a/frontend/src/pages/AutomationsPage.tsx
+++ b/frontend/src/pages/AutomationsPage.tsx
@@ -199,7 +199,6 @@ export function AutomationsPage() {
                   onClick: () => handleRunNow(automation),
                 },
               ]}
-              menuIcon={isActive ? Pause : Play}
               menuActions={[
                 {
                   icon: isActive ? Pause : Play,


### PR DESCRIPTION
## Summary
Follow-up to #656. The new Automations list page (`AutomationsPage.tsx`) rendered two
play-triangle-looking icons per card: the dedicated "Run now" button, and the "More
actions" dropdown trigger -- which had incorrectly been given a state-dependent
`Play`/`Pause` icon instead of the standard neutral menu icon every other list page
uses (`SkillsPage.tsx`, `DataPage.tsx` both use a plain icon, defaulting to
`MoreVertical`). For a Draft automation both icons were literally identical play
triangles side by side; for Active ones it looked like a broken play/pause toggle.

## Fix
Removed the `menuIcon` override so it falls back to `MoreVertical` (the standard
three-dot "more actions" affordance). Pause/Resume stays exactly where it was --
a labeled item inside the dropdown.

## Test plan
- [x] `yarn typecheck` clean
- [x] Real `yarn build` clean
- [x] Live-verified on a running bench (screenshot before/after) -- card now shows one
      Play (Run now) icon + a standard three-dot menu, no more duplicate icons