### PR TITLE
fix(acp-federation): scaffolding — SSRF/perm fixes, no crash 

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Upstream incident thread: https://github.com/BerriAI/litellm/issues/24518
 
 - [**Full Documentation**](https://docs.huf.ai/) — Guides, tutorials, and API reference
 - [**Bruno API Collection**](./docs/bruno/) — Ready-to-use API collection for testing and exploration
+- [**Remote Agent Federation RFC**](./docs/rfcs/huf-remote-agent-federation.md) — Protocol, schema, API & runtime specification for HUF remote agent federation.
 - [**AGENTS.md**](./AGENTS.md) — Technical context for AI agents. Adopts the [agents.md](https://agents.md) standard.
 - [**CLAUDE.md**](./CLAUDE.md) — Defines coding standards, review criteria, and project-specific rules.
 

--- a/docs/rfcs/huf-remote-agent-federation.md
+++ b/docs/rfcs/huf-remote-agent-federation.md
@@ -1,0 +1,430 @@
+# RFC: HUF Remote Agent Federation Protocol & Runtime Specification
+
+- **Status**: Proposed / Draft (Phase 1 Specification)
+- **Author**: HUF Architecture Team
+- **Created**: 2026-08-01
+- **Target Version**: V1.0
+- **RFC File**: `docs/rfcs/huf-remote-agent-federation.md`
+
+---
+
+## 1. Executive Summary
+
+HUF serves as the Frappe-native AI control plane, orchestrating AI agents, tool calls, workflow triggers, scoped memory, and enterprise data models within Frappe. To support interoperability with external agent ecosystems (e.g., ACP-compliant external tools), editor/IDE coding agents (e.g., Claude Code, Cursor, OpenCode), and satellite HUF nodes without altering or replacing HUF's native internal state machine, HUF introduces an **Adapter-based Remote Agent Federation** model.
+
+Under this architecture:
+> **HUF remains the Frappe-native AI control plane.** Protocols such as Agent Communication Protocol (ACP), Agent Client Protocol, and HUF-Native Federation act as adapter boundaries for calling remote agents, exposing local HUF agents, and linking satellite HUF instances.
+
+This specification documents Phase 1 of the federation roadmap, detailing protocol positioning, V1 scope boundaries, new Frappe DocTypes, REST APIs, the normalized event lifecycle, security governance rules, and a two-node demo rollout plan.
+
+---
+
+## 2. Protocol Positioning & Framing
+
+There are distinct protocol standards in the modern AI ecosystem. HUF positions itself cleanly across each boundary without conflating their roles:
+
+| Protocol | Purpose & Target Domain | HUF Architectural Role |
+| :--- | :--- | :--- |
+| **Model Context Protocol (MCP)** | Tool, resource, and prompt access between host and server. | HUF acts as an MCP client today (consuming external MCP tools). MCP server/gateway functionality remains a separate service boundary. |
+| **Agent Communication Protocol (ACP)** | High-level agent-to-agent interoperability via RESTful APIs, manifests, async runs, streaming, and sessions. | Supported via an adapter for delegating tasks to external ACP-compliant agents and exposing select HUF agents to external orchestrators. |
+| **Agent Client Protocol** | IDE / Editor to coding agent protocol (e.g., Claude Code, Cursor, OpenCode, Codex). | Supported via an adapter for delegating code manipulation tasks, terminal command execution, and workspace diff reviews. |
+| **HUF-Native Federation Protocol** | High-efficiency node-to-node protocol between HUF instances. | Native Frappe REST protocol preserving full Frappe session context, granular permission policies, and audit correlation IDs across nodes. |
+
+```text
+               +----------------------------------------+
+               |        HUF Core Engine (Desk/DocTypes)  |
+               +-------------------+--------------------+
+                                   |
+                     [Remote Agent Adapter Layer]
+                                   |
+         +-------------------------+-------------------------+
+         |                         |                         |
+         v                         v                         v
++------------------+     +-------------------+     +--------------------+
+|   HUF-Native     |     |   ACP Standard    |     |    Agent Client    |
+|   Federation     |     |     Adapter       |     |  Protocol Adapter  |
++--------+---------+     +---------+---------+     +----------+---------+
+         |                         |                        |
+         v                         v                        v
++------------------+     +-------------------+     +--------------------+
+| Remote HUF Node  |     | External ACP Agent|     | Local/Remote IDE   |
+| (Satellite / ERP)|     |    (Third-Party)  |     |   Coding Agent     |
++------------------+     +-------------------+     +--------------------+
+```
+
+---
+
+## 3. System Architecture Diagram
+
+The system architecture cleanly separates local agent execution from remote delegation:
+
+```mermaid
+flowchart TD
+    subgraph HUF_HQ ["HUF Central Control Plane (Node A)"]
+        Desk["HUF Agent Desk & Frontend"]
+        Core["HUF Agent Runtime\n(Agent, Run, Conversation)"]
+        ToolRegistry["Agent Tool Function Registry"]
+        RemoteToolHandler["Remote Agent Tool Handler"]
+        AdapterService["Remote Agent Adapter Service"]
+        ConnectionDocType["Remote Agent Connection Registry"]
+    end
+
+    subgraph Adapters ["Protocol Adapters"]
+        NativeAdapter["HUF-Native Adapter\n(Frappe REST)"]
+        ACPAdapter["ACP Standard Adapter\n(OpenAPI / SSE)"]
+        ACPClientAdapter["Agent Client Adapter\n(JSON-RPC / stdio / WS)"]
+    end
+
+    subgraph RemoteNodes ["Target Execution Plane"]
+        NodeB["Satellite HUF Instance B\n(Remote ERP Site)"]
+        ExternalAgent["External ACP Agent\n(Third-Party Platform)"]
+        CodingAgent["Coding Agent\n(Claude Code / Cursor / OpenCode)"]
+    end
+
+    Desk --> Core
+    Core --> ToolRegistry
+    ToolRegistry --> RemoteToolHandler
+    RemoteToolHandler --> ConnectionDocType
+    RemoteToolHandler --> AdapterService
+    AdapterService --> NativeAdapter
+    AdapterService --> ACPAdapter
+    AdapterService --> ACPClientAdapter
+
+    NativeAdapter <-->|"Frappe REST / Site Token"| NodeB
+    ACPAdapter <-->|"ACP Spec / SSE"| ExternalAgent
+    ACPClientAdapter <-->|"JSON-RPC / stdio / WS"| CodingAgent
+```
+
+---
+
+## 4. V1 Implementation Scope
+
+To ensure a rapid, high-quality, and robust initial rollout, V1 focuses on establishing the core federation primitives and proving HUF-to-HUF delegation.
+
+### 4.1 In-Scope (V1)
+1. **Remote Connection Registry**: A dedicated `Remote Agent Connection` DocType to store endpoints, transport settings, credentials, and cached manifests.
+2. **Normalized Remote Capability Cache**: A `Remote Agent Capability` child/related table caching capabilities advertised by remote agents.
+3. **HUF-Native Adapter**: Complete Python adapter layer for calling and exposing remote agents between HUF instances.
+4. **Manifest & Remote Run REST APIs**: Standardized server methods for listing exposed agents and managing remote agent runs (`create_run`, `get_run`, `get_run_events`, `cancel_run`).
+5. **`Remote Agent` Tool Type**: Extending `Agent Tool Function` types so any local HUF agent can invoke a remote agent as a standard tool call.
+6. **Delegated Run Audit Trail**: A durable `Delegated Agent Run` DocType linking local `Agent Run` instances to remote executions with status and response tracking.
+7. **Security & Governance Controls**: SSRF protection (blocking private IPs by default), credential masking in logs/REST APIs, role/user capability policies, and execution timeouts.
+
+### 4.2 Out-of-Scope (Deferred to V2+)
+- Public multi-tenant agent registry or dynamic service-mesh discovery.
+- OAuth 2.0 PKCE / OIDC flow UI (V1 uses API Keys, Site Tokens, or Bearer Passwords).
+- Complex coding-agent workspace diff UI and file tree synchronization.
+- Direct Visual Flow Builder drag-and-drop nodes for remote agents (handled seamlessly via standard `Remote Agent` tools in V1).
+- Real-time WebSocket/SSE streaming infrastructure (V1 uses cursor-based polling with synchronous fallback).
+
+---
+
+## 5. Backend Schema & DocType Definitions
+
+### 5.1 Remote Agent Connection (`Remote Agent Connection`)
+Stores endpoint connections, transport configurations, authentication credentials, and diagnostic metadata.
+
+- **Module**: `huf`
+- **DocType Name**: `Remote Agent Connection`
+
+| Fieldname | Field Type | Label | Options / Rules | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `connection_name` | Data | Connection Name | **Required**, Primary Key | Unique user-facing identifier. |
+| `protocol_type` | Select | Protocol Type | `huf_native` (default)<br>`agent_communication_protocol`<br>`agent_client_protocol` | Protocol standard used by target endpoint. |
+| `transport` | Select | Transport Mode | `http` (default)<br>`websocket`<br>`stdio` | Network transport mode. |
+| `base_url` | Data | Base URL | Required if transport is `http` or `websocket` | Base endpoint URL (e.g. `https://erp.site.com`). |
+| `stdio_command` | Small Text | Stdio Command | Optional | Command string for local stdio coding agents. |
+| `auth_type` | Select | Auth Type | `none`<br>`bearer_token`<br>`site_token`<br>`api_key` | Authentication mechanism. |
+| `auth_secret` | Password | Auth Secret | Encrypted | API key, token, or password. Excluded from JSON APIs. |
+| `enabled` | Check | Enabled | Default: `1` | Operational toggle to enable/disable connection. |
+| `allow_local_network` | Check | Allow Local Network | Default: `0` | If checked, bypasses SSRF loopback/private IP block. |
+| `health_status` | Select | Health Status | `Unknown` (default)<br>`Healthy`<br>`Degraded`<br>`Failed` | Diagnostics status auto-updated on health check. |
+| `last_health_check` | Datetime | Last Health Check | Read-only | Timestamp of most recent ping/manifest refresh. |
+| `manifest_json` | JSON | Cached Manifest | Read-only | Cached JSON manifest from remote agent endpoint. |
+| `last_error` | Small Text | Last Error Log | Read-only | Diagnostic error log from last failed attempt. |
+
+---
+
+### 5.2 Remote Agent Capability (`Remote Agent Capability`)
+Normalized local record of capabilities offered by a specific remote agent connection.
+
+- **Module**: `huf`
+- **DocType Name**: `Remote Agent Capability`
+
+| Fieldname | Field Type | Label | Description |
+| :--- | :--- | :--- | :--- |
+| `connection` | Link | Connection | Link to parent `Remote Agent Connection`. |
+| `remote_agent_id` | Data | Remote Agent ID | Opaque agent ID specified by remote host. |
+| `display_name` | Data | Display Name | Human-readable title of the remote agent. |
+| `description` | Small Text | Description | Functional summary from remote manifest. |
+| `input_modes` | JSON | Input Modes | Supported content formats (e.g., `["text/markdown", "application/json"]`). |
+| `output_modes` | JSON | Output Modes | Supported response formats. |
+| `capabilities` | JSON | Capabilities | Declared feature tags (e.g., `["chat", "knowledge_search"]`). |
+| `stateful` | Check | Stateful | Indicates if target supports session continuity. |
+| `long_running` | Check | Long Running | Indicates support for asynchronous execution. |
+| `supports_streaming` | Check | Supports Streaming | Indicates support for incremental chunk updates. |
+| `enabled_for_delegation` | Check | Enabled for Delegation | Local gate allowing HUF agents to invoke this capability. |
+
+---
+
+### 5.3 Delegated Agent Run (`Delegated Agent Run`)
+Tracks the execution lifecycle of a local run delegated to a remote agent.
+
+- **Module**: `huf`
+- **DocType Name**: `Delegated Agent Run`
+
+| Fieldname | Field Type | Label | Options / Rules | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| `local_agent_run` | Link | Local Agent Run | Link to `Agent Run` | Parent local run initiating the delegation. |
+| `connection` | Link | Remote Connection | Link to `Remote Agent Connection` | Target connection used for delegation. |
+| `remote_agent_id` | Data | Remote Agent ID | Data | Remote agent identifier. |
+| `remote_run_id` | Data | Remote Run ID | Data | Remote run reference ID returned by endpoint. |
+| `remote_session_id` | Data | Remote Session ID | Data | Remote session reference if stateful. |
+| `status` | Select | Status | `queued`<br>`running`<br>`needs_approval`<br>`completed`<br>`failed`<br>`cancelled`<br>`timeout` | Current state of delegated execution. |
+| `started_at` | Datetime | Started At | Datetime | Local timestamp when delegation was dispatched. |
+| `completed_at` | Datetime | Completed At | Datetime | Local timestamp when run reached terminal state. |
+| `request_json` | JSON | Request Payload | JSON (Redacted) | Sanitized request payload sent to remote node. |
+| `response_json` | JSON | Response Data | JSON | Normalized response payload or event summary. |
+| `event_cursor` | Data | Event Cursor | Data | Polling cursor mark for incremental updates. |
+| `error` | Small Text | Error Log | Small Text | Redacted error description if execution failed. |
+
+---
+
+### 5.4 Remote Agent Policy (`Remote Agent Policy`)
+Controls which local agents and roles may delegate actions to remote connections, along with operational limits.
+
+- **Module**: `huf`
+- **DocType Name**: `Remote Agent Policy`
+
+| Fieldname | Field Type | Label | Description |
+| :--- | :--- | :--- | :--- |
+| `connection` | Link | Connection | Target `Remote Agent Connection`. |
+| `allowed_agents` | JSON | Allowed HUF Agents | List of local HUF Agent names authorized to call this connection. Empty = all permitted. |
+| `allowed_roles` | JSON | Allowed Roles | System user roles authorized to initiate delegation. |
+| `max_timeout_seconds` | Int | Max Timeout (Sec) | Wall-clock timeout limit (Default: `120`). |
+| `max_tokens` | Int | Max Tokens Limit | Upper bound on token budget sent in request hints. |
+| `allow_files` | Check | Allow File Transmission | Controls whether file attachments can be sent to target. Default: `0`. |
+| `requires_human_approval` | Check | Force Human Approval | Halts execution until a local user approves the action. Default: `0`. |
+| `audit_level` | Select | Audit Logging Level | Options: `metadata`, `messages`, `messages_and_events`. |
+
+---
+
+## 6. Proposed V1 APIs
+
+### 6.1 HUF Agent Manifest & Discovery API
+Exposes allowlisted local HUF agents to remote callers or peer HUF nodes.
+
+```text
+GET /.well-known/huf-agent.json
+GET /api/method/huf.api.remote_agents.list_agents
+GET /api/method/huf.api.remote_agents.get_agent_manifest
+```
+
+#### Sample Response (`/.well-known/huf-agent.json`)
+```json
+{
+  "server_name": "Dubai Operations HUF Node",
+  "protocol_versions": ["huf-native-v1"],
+  "agents": [
+    {
+      "id": "erp_support_agent",
+      "name": "ERP Support Agent",
+      "description": "Answers ERP support queries, checks order status, and generates support tickets.",
+      "input_modes": ["text/markdown", "application/json"],
+      "output_modes": ["text/markdown", "application/json"],
+      "capabilities": ["chat", "knowledge_search", "ticket_create"],
+      "stateful": true,
+      "long_running": true,
+      "streaming": true
+    }
+  ]
+}
+```
+
+---
+
+### 6.2 Remote Run Management API
+Allows federated callers to initiate, poll, monitor, and cancel agent runs.
+
+```text
+POST /api/method/huf.api.remote_agents.create_run
+GET  /api/method/huf.api.remote_agents.get_run
+GET  /api/method/huf.api.remote_agents.get_run_events
+POST /api/method/huf.api.remote_agents.cancel_run
+```
+
+#### Request Payload (`create_run`)
+```json
+{
+  "agent_id": "erp_support_agent",
+  "prompt": "Check status of Purchase Order PO-2026-0089 and summarize line item delays.",
+  "session_id": "session_conv_12345",
+  "parameters": {
+    "include_supplier_details": true
+  }
+}
+```
+
+#### Response Payload (`create_run`)
+```json
+{
+  "status": "success",
+  "data": {
+    "run_id": "run_huf_remote_98765",
+    "status": "running",
+    "started_at": "2026-08-01 03:30:00"
+  }
+}
+```
+
+---
+
+### 6.3 Local Delegation Tool (`Remote Agent` Tool Type)
+Integration into HUF's existing tool function architecture by registering `Remote Agent` as a native Tool Type in `Agent Tool Function`.
+
+#### Tool Input Schema (Passed by Local Calling Agent)
+```json
+{
+  "remote_agent": "erp_support_agent",
+  "task": "Retrieve outstanding balance for Customer CUST-4029 and check active tickets.",
+  "context": {
+    "conversation_id": "conv_88123",
+    "reference_doctype": "Sales Order",
+    "reference_name": "SO-2026-0012"
+  }
+}
+```
+
+#### Tool Output Schema (Returned to Local Calling Agent)
+```json
+{
+  "status": "completed",
+  "remote_run_id": "run_huf_remote_98765",
+  "content": "Customer CUST-4029 has an outstanding balance of $3,450.00 across 2 unpaid invoices. No open critical support tickets.",
+  "events_summary": [
+    {"event": "run.started", "timestamp": "2026-08-01T03:30:00Z"},
+    {"event": "tool.completed", "tool_name": "get_customer_invoices", "timestamp": "2026-08-01T03:30:02Z"},
+    {"event": "run.completed", "timestamp": "2026-08-01T03:30:03Z"}
+  ]
+}
+```
+
+---
+
+## 7. Event Model
+
+All remote execution events are translated into a standardized, internal event lifecycle:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Queued: create_run
+    Queued --> Running: run.started
+    Running --> NeedsApproval: approval.required
+    NeedsApproval --> Running: approval.granted
+    NeedsApproval --> Cancelled: approval.rejected
+    Running --> Completed: run.completed
+    Running --> Failed: run.failed
+    Running --> Cancelled: run.cancelled
+    Completed --> [*]
+    Failed --> [*]
+    Cancelled --> [*]
+```
+
+### Event Specification Table
+
+| Event Type | Category | Meaning & Trigger | Payload Attributes |
+| :--- | :--- | :--- | :--- |
+| `run.started` | Lifecycle | Remote execution accepted and initialized by host. | `run_id`, `timestamp` |
+| `message.delta` | Stream | Incremental response text chunk. | `chunk`, `delta_index` |
+| `message.completed` | Message | Full user/assistant/tool message block finalized. | `role`, `content`, `tokens` |
+| `tool.started` | Tool | Remote agent initiated a local/external tool execution. | `tool_name`, `tool_args` |
+| `tool.completed` | Tool | Remote tool execution finished successfully. | `tool_name`, `status`, `result_summary` |
+| `approval.required` | Governance | Remote run paused pending human confirmation. | `action_id`, `reason`, `preview` |
+| `run.completed` | Lifecycle | Run reached successful terminal state. | `final_content`, `total_tokens`, `cost` |
+| `run.failed` | Error | Execution aborted due to unhandled error. | `error_code`, `message` |
+| `run.cancelled` | Lifecycle | Execution aborted via caller request or timeout. | `cancelled_by`, `timestamp` |
+
+---
+
+## 8. Security & Governance Rules
+
+Remote agent delegation establishes cross-boundary communication. Strict security controls are enforced:
+
+1. **Explicit Permission Gating**: Remote calls are gated by Frappe's permission system. Calling agents operate under the permissions of the initiating user or explicit API key context.
+2. **SSRF & Private IP Protection**:
+   - Remote target URLs undergo strict network resolution checks.
+   - Outbound connections to private IP spaces (RFC 1918: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) and loopback (`127.0.0.1`, `::1`) are **blocked by default**, unless `allow_local_network` is explicitly set on the `Remote Agent Connection`.
+3. **Secret Storage & Redaction**:
+   - Authentication tokens/keys are stored solely in Frappe `Password` fields or `site_config.json`.
+   - Headers containing `Authorization`, `Bearer`, `Cookie`, or API keys are stripped prior to logging requests in `Delegated Agent Run` or system traces.
+4. **Strict Request Timeouts**: Remote executions enforce `max_timeout_seconds` (default: 120s) to safeguard local WSGI/Gunicorn workers against hanging connections.
+5. **Untrusted Input Treatment**: Remote manifests and agent responses are validated against strict JSON schemas before being parsed by internal handlers.
+6. **Approval Controls**: Actions with side effects (document creation, updates, deletes) can be forced into a `needs_approval` state based on `Remote Agent Policy`.
+
+---
+
+## 9. Rollout Roadmap & Demo Plan
+
+### 9.1 Phase Breakdown & PR Plan
+
+```mermaid
+gantt
+    title HUF Remote Agent Federation Rollout
+    dateFormat  YYYY-MM-DD
+    section Phase 1
+    RFC Specification (docs/rfcs/huf-remote-agent-federation.md) :active, p1, 2026-08-01, 2026-08-02
+    section Phase 2
+    DocTypes (Connection, Capability, Delegated Run, Policy) :p2, 2026-08-03, 2026-08-05
+    section Phase 3
+    Remote Agent Adapter Service Framework :p3, 2026-08-06, 2026-08-08
+    section Phase 4
+    Manifest & Remote Execution REST APIs :p4, 2026-08-09, 2026-08-11
+    section Phase 5
+    Remote Agent Tool Handler Integration :p5, 2026-08-12, 2026-08-14
+    section Phase 6
+    End-to-End HUF-to-HUF Demo & Smoke Test :p6, 2026-08-15, 2026-08-17
+```
+
+| PR Sequence | Target Scope | Key Deliverables | Risk Level |
+| :--- | :--- | :--- | :--- |
+| **PR 1 (Current)** | RFC Specification | `docs/rfcs/huf-remote-agent-federation.md` | Low |
+| **PR 2** | Connection & Schema | `Remote Agent Connection`, `Capability`, `Delegated Agent Run`, `Policy` DocTypes | Medium |
+| **PR 3** | Adapter Layer | `huf/ai/remote_agents/` Python package & mock adapter test suite | Medium |
+| **PR 4** | Exposed Manifest & Run API | `huf/api/remote_agents.py` REST API endpoints | Medium-High |
+| **PR 5** | Tool Integration | `Remote Agent` Tool Type handler in `huf/ai/sdk_tools.py` | High |
+| **PR 6** | E2E Demo & Validation | Demo scripts, integration test suite, documentation update | Medium |
+
+---
+
+### 9.2 End-to-End HUF-to-HUF Demo Plan (Phase 6)
+
+The demonstration will feature two local HUF bench sites:
+
+- **HUF Central (Node A)**: `http://localhost:8000` (Main Orchestration Plane)
+- **HUF Satellite (Node B)**: `http://localhost:8001` (ERP Operations Node)
+
+#### Step-by-Step Scenario
+1. **Setup**:
+   - Node B configures and allowlists `erp_support_agent`.
+   - Node A creates a `Remote Agent Connection` pointing to `http://localhost:8001` with `allow_local_network=1` and credentials.
+   - Node A clicks **Refresh Manifest**; `Remote Agent Capability` records automatically populate Node B's advertised capabilities.
+2. **Delegation Execution**:
+   - User opens Node A Agent Chat and prompts the Orchestration Agent: *"Ask the ERP Support Agent on Node B to inspect stock for item ITEM-9901 and report any pending purchase orders."*
+   - Node A Orchestration Agent selects the `Remote Agent` tool configured for Node B.
+   - Node A creates a local `Delegated Agent Run` record, then dispatches a POST request to Node B's `/api/method/huf.api.remote_agents.create_run`.
+   - Node B receives the request, executes its local `Agent Run`, queries MariaDB, and returns the result.
+   - Node A receives the response payload, updates `Delegated Agent Run` to `completed`, and streams the final synthesis back to the user.
+3. **Audit Verification**:
+   - Inspect `Delegated Agent Run` on Node A to verify correlation between `local_agent_run` and `remote_run_id`.
+   - Verify secrets were masked and non-permitted actions were rejected.
+4. **Negative Case Testing**:
+   - Temporarily disable Node B connection or alter permission policy on Node A. Verify that Node A Orchestration Agent handles tool error gracefully without throwing an unhandled exception.
+
+---
+
+## 10. References & Further Reading
+
+- [Agent Communication Protocol (ACP) Specification](https://agentcommunicationprotocol.dev/introduction/welcome)
+- [Agent Client Protocol Specification](https://agentclientprotocol.com/get-started/architecture)
+- [Model Context Protocol (MCP) Overview](https://modelcontextprotocol.io/)
+- [HUF Repository & System Prompts](../../AGENTS.md)

--- a/huf/ai/remote_agents/__init__.py
+++ b/huf/ai/remote_agents/__init__.py
@@ -1,0 +1,32 @@
+"""
+HUF Remote Agent Integration Package.
+Provides protocol adapter interfaces and implementations for remote agent federation.
+"""
+
+from huf.ai.remote_agents.adapter import (
+    AgentClientProtocolAdapter,
+    AgentCommunicationProtocolAdapter,
+    HufNativeAdapter,
+    RemoteAgentAdapter,
+    RemoteAgentAdapterError,
+    RemoteAgentAuthError,
+    RemoteAgentConnectionError,
+    RemoteAgentNotImplementedError,
+    RemoteAgentResponseError,
+    RemoteAgentTimeoutError,
+    get_adapter,
+)
+
+__all__ = [
+    "RemoteAgentAdapter",
+    "HufNativeAdapter",
+    "AgentCommunicationProtocolAdapter",
+    "AgentClientProtocolAdapter",
+    "RemoteAgentAdapterError",
+    "RemoteAgentConnectionError",
+    "RemoteAgentAuthError",
+    "RemoteAgentTimeoutError",
+    "RemoteAgentResponseError",
+    "RemoteAgentNotImplementedError",
+    "get_adapter",
+]

--- a/huf/ai/remote_agents/adapter.py
+++ b/huf/ai/remote_agents/adapter.py
@@ -396,6 +396,11 @@ class HufNativeAdapter(RemoteAgentAdapter):
 class AgentCommunicationProtocolAdapter(RemoteAgentAdapter):
     """
     Placeholder adapter implementation for Agent Communication Protocol (ACP).
+
+    NOT YET IMPLEMENTED: this class exists to reserve the shape of a future
+    standard-ACP integration. Every method below unconditionally raises
+    RemoteAgentNotImplementedError. It does not perform real ACP interop
+    of any kind — do not mistake its presence for working support.
     """
 
     def __init__(self, base_url: str = "", **kwargs):
@@ -431,6 +436,11 @@ class AgentCommunicationProtocolAdapter(RemoteAgentAdapter):
 class AgentClientProtocolAdapter(RemoteAgentAdapter):
     """
     Placeholder adapter implementation for Agent Client Protocol (coding agents / IDE bridge).
+
+    NOT YET IMPLEMENTED: this class exists to reserve the shape of a future
+    standard-ACP integration. Every method below unconditionally raises
+    RemoteAgentNotImplementedError. It does not perform real ACP interop
+    of any kind — do not mistake its presence for working support.
     """
 
     def __init__(self, base_url: str = "", **kwargs):

--- a/huf/ai/remote_agents/adapter.py
+++ b/huf/ai/remote_agents/adapter.py
@@ -1,0 +1,485 @@
+"""
+Remote Agent Adapter Service.
+
+Provides a protocol-agnostic abstraction layer (RemoteAgentAdapter) for invoking
+and managing remote agents over various protocol standards (HUF-native, ACP, Agent Client Protocol).
+"""
+
+from abc import ABC, abstractmethod
+import ipaddress
+import json
+import socket
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10MB
+DEFAULT_TIMEOUT = 30
+
+
+# Exception Hierarchy
+class RemoteAgentAdapterError(Exception):
+    """Base exception for remote agent adapter errors."""
+
+    pass
+
+
+class RemoteAgentConnectionError(RemoteAgentAdapterError):
+    """Raised when connecting to a remote endpoint fails or URL validation fails."""
+
+    pass
+
+
+class RemoteAgentAuthError(RemoteAgentAdapterError):
+    """Raised when authentication with the remote endpoint fails (401/403)."""
+
+    pass
+
+
+class RemoteAgentTimeoutError(RemoteAgentAdapterError):
+    """Raised when a request to a remote endpoint times out."""
+
+    pass
+
+
+class RemoteAgentResponseError(RemoteAgentAdapterError):
+    """Raised when a remote agent endpoint returns an error status or invalid payload."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class RemoteAgentNotImplementedError(RemoteAgentAdapterError, NotImplementedError):
+    """Raised when an adapter action or protocol is not yet implemented."""
+
+    pass
+
+
+def _is_public_ip(ip_str: str) -> bool:
+    """Return True if ip_str is a routable public address."""
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        addr = mapped
+
+    return not (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+def validate_remote_url(url: str, allow_local_network: bool = False) -> tuple[bool, str | None]:
+    """
+    Validate remote URL to prevent SSRF while allowing optional local/satellite setups.
+    Returns (is_valid, error_message).
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        return False, "Only HTTP and HTTPS schemes are allowed"
+
+    if not parsed.hostname:
+        return False, "Invalid URL: missing hostname"
+
+    if not allow_local_network:
+        try:
+            addr_info = socket.getaddrinfo(parsed.hostname, None)
+            ips = {info[4][0] for info in addr_info}
+        except socket.gaierror:
+            return False, f"Cannot resolve hostname: {parsed.hostname}"
+
+        for ip in ips:
+            if not _is_public_ip(ip):
+                return False, "Requests to private/internal addresses are not allowed"
+
+    return True, None
+
+
+class RemoteAgentAdapter(ABC):
+    """Abstract base class for all remote agent adapters."""
+
+    @abstractmethod
+    def fetch_manifest(self) -> dict:
+        """
+        Fetch and normalize remote agent manifest.
+
+        Returns:
+            dict: Normalized manifest containing server_name, protocol_version, and agents list.
+        """
+        pass
+
+    @abstractmethod
+    def create_run(self, agent_id: str, payload: dict) -> dict:
+        """
+        Initiate a run on the remote agent.
+
+        Args:
+            agent_id (str): Remote agent identifier.
+            payload (dict): Run payload (prompt, inputs, context).
+
+        Returns:
+            dict: Normalized run details (run_id, status, response, etc.).
+        """
+        pass
+
+    @abstractmethod
+    def get_run(self, run_id: str) -> dict:
+        """
+        Fetch details and status of an existing remote run.
+
+        Args:
+            run_id (str): Remote run identifier.
+
+        Returns:
+            dict: Normalized run details.
+        """
+        pass
+
+    @abstractmethod
+    def get_events(self, run_id: str, cursor: str | None = None) -> dict:
+        """
+        Fetch execution events for a remote run.
+
+        Args:
+            run_id (str): Remote run identifier.
+            cursor (str | None): Optional event cursor for pagination/resume.
+
+        Returns:
+            dict: Normalized events list and pagination cursor.
+        """
+        pass
+
+    @abstractmethod
+    def cancel_run(self, run_id: str) -> dict:
+        """
+        Cancel an ongoing remote run.
+
+        Args:
+            run_id (str): Remote run identifier.
+
+        Returns:
+            dict: Normalized cancellation confirmation.
+        """
+        pass
+
+
+class HufNativeAdapter(RemoteAgentAdapter):
+    """
+    Adapter implementation for HUF-native federation.
+
+    Interacts with another HUF instance using Frappe RPC endpoints and standard
+    HUF remote agent endpoints.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        auth_type: str = "none",
+        auth_secret: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        allow_local_network: bool = False,
+        headers: dict | None = None,
+    ):
+        self.base_url = base_url.rstrip("/") if base_url else ""
+        self.auth_type = auth_type or "none"
+        self.auth_secret = auth_secret
+        self.timeout = timeout
+        self.allow_local_network = allow_local_network
+        self.custom_headers = headers or {}
+
+    @classmethod
+    def from_config(cls, config: dict | object) -> "HufNativeAdapter":
+        """Construct adapter instance from a dict or DocType/namespace object."""
+        def get_val(key: str, default=None):
+            if isinstance(config, dict):
+                return config.get(key, default)
+            return getattr(config, key, default)
+
+        base_url = get_val("base_url", "")
+        auth_type = get_val("auth_type", "none")
+        auth_secret = get_val("auth_secret") or get_val("api_key") or get_val("token")
+        timeout = get_val("timeout", DEFAULT_TIMEOUT)
+        allow_local_network = get_val("allow_local_network", False) or get_val("allow_local_ips", False)
+        headers = get_val("headers", None)
+
+        return cls(
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_secret=auth_secret,
+            timeout=timeout,
+            allow_local_network=allow_local_network,
+            headers=headers,
+        )
+
+    def _get_headers(self) -> dict:
+        headers = dict(self.custom_headers)
+        if self.auth_type == "bearer_token" and self.auth_secret:
+            headers["Authorization"] = f"Bearer {self.auth_secret}"
+        elif self.auth_type == "site_token" and self.auth_secret:
+            headers["X-Site-Token"] = self.auth_secret
+        elif self.auth_type == "api_key" and self.auth_secret:
+            headers["Authorization"] = f"token {self.auth_secret}"
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict | None = None,
+        json_data: dict | None = None,
+        allow_404: bool = False,
+    ) -> dict:
+        if not self.base_url:
+            raise RemoteAgentConnectionError("Remote connection base_url is not configured")
+
+        full_url = urljoin(self.base_url + "/", path.lstrip("/"))
+
+        is_valid, error_msg = validate_remote_url(full_url, allow_local_network=self.allow_local_network)
+        if not is_valid:
+            raise RemoteAgentConnectionError(f"URL validation failed: {error_msg}")
+
+        req_headers = self._get_headers()
+
+        try:
+            response = requests.request(
+                method=method.upper(),
+                url=full_url,
+                headers=req_headers,
+                params=params,
+                json=json_data,
+                timeout=self.timeout,
+                allow_redirects=False,
+            )
+        except requests.exceptions.Timeout:
+            raise RemoteAgentTimeoutError(f"Request to {full_url} timed out after {self.timeout}s")
+        except requests.exceptions.ConnectionError as e:
+            raise RemoteAgentConnectionError(f"Failed to connect to {full_url}: {e!s}")
+        except requests.exceptions.RequestException as e:
+            raise RemoteAgentConnectionError(f"HTTP request error for {full_url}: {e!s}")
+
+        if response.status_code in (401, 403):
+            raise RemoteAgentAuthError(
+                f"Authentication failed ({response.status_code}): {response.text}"
+            )
+
+        if response.status_code == 404 and allow_404:
+            return {"_status_code": 404}
+
+        if response.status_code >= 400:
+            raise RemoteAgentResponseError(
+                f"Remote endpoint error ({response.status_code}): {response.text[:500]}",
+                status_code=response.status_code,
+            )
+
+        if len(response.content) > MAX_RESPONSE_SIZE:
+            raise RemoteAgentResponseError(
+                "Response size exceeds maximum allowed limit (10MB)",
+                status_code=response.status_code,
+            )
+
+        try:
+            data = response.json()
+        except ValueError:
+            raise RemoteAgentResponseError(
+                f"Invalid JSON response from remote endpoint: {response.text[:200]}",
+                status_code=response.status_code,
+            )
+
+        # Unpack standard Frappe RPC envelope {"message": ...}
+        if isinstance(data, dict) and "message" in data:
+            unpacked = data["message"]
+            if isinstance(unpacked, (dict, list)):
+                return unpacked
+
+        return data if isinstance(data, dict) else {"data": data}
+
+    def fetch_manifest(self) -> dict:
+        path = "/api/method/huf.api.remote_agents.get_agent_manifest"
+        res = self._request("GET", path, allow_404=True)
+
+        # Fallback to standard well-known location if method endpoint is 404
+        if res.get("_status_code") == 404:
+            res = self._request("GET", "/.well-known/huf-agent.json")
+
+        agents_list = res.get("agents", []) if isinstance(res, dict) else []
+
+        return {
+            "server_name": res.get("server_name", "Remote HUF"),
+            "protocol_version": res.get("protocol_version") or "huf-native-v1",
+            "agents": agents_list,
+            "raw_manifest": res,
+        }
+
+    def create_run(self, agent_id: str, payload: dict) -> dict:
+        path = "/api/method/huf.api.remote_agents.create_run"
+        body = {
+            "agent_id": agent_id,
+            "payload": payload,
+        }
+        res = self._request("POST", path, json_data=body)
+
+        run_id = res.get("run_id") or res.get("name") or res.get("id") or ""
+        status = res.get("status", "queued")
+        response_text = res.get("response") or res.get("content") or ""
+        error = res.get("error") or res.get("error_message")
+
+        return {
+            "run_id": run_id,
+            "status": status,
+            "response": response_text,
+            "error": error,
+            "raw_response": res,
+        }
+
+    def get_run(self, run_id: str) -> dict:
+        path = "/api/method/huf.api.remote_agents.get_run"
+        res = self._request("GET", path, params={"run_id": run_id})
+
+        status = res.get("status", "unknown")
+        response_text = res.get("response") or res.get("content") or ""
+        error = res.get("error") or res.get("error_message")
+
+        return {
+            "run_id": run_id,
+            "status": status,
+            "response": response_text,
+            "error": error,
+            "completed_at": res.get("completed_at"),
+            "raw_response": res,
+        }
+
+    def get_events(self, run_id: str, cursor: str | None = None) -> dict:
+        path = "/api/method/huf.api.remote_agents.get_run_events"
+        params = {"run_id": run_id}
+        if cursor:
+            params["cursor"] = cursor
+
+        res = self._request("GET", path, params=params)
+
+        events = res.get("events", []) if isinstance(res, dict) else []
+        next_cursor = res.get("cursor") if isinstance(res, dict) else None
+        has_more = bool(res.get("has_more", False)) if isinstance(res, dict) else False
+
+        return {
+            "run_id": run_id,
+            "events": events,
+            "cursor": next_cursor,
+            "has_more": has_more,
+            "raw_response": res,
+        }
+
+    def cancel_run(self, run_id: str) -> dict:
+        path = "/api/method/huf.api.remote_agents.cancel_run"
+        body = {"run_id": run_id}
+        res = self._request("POST", path, json_data=body)
+
+        status = res.get("status", "cancelled") if isinstance(res, dict) else "cancelled"
+        msg = res.get("message", "Run cancelled") if isinstance(res, dict) else "Run cancelled"
+
+        return {
+            "run_id": run_id,
+            "status": status,
+            "message": msg,
+            "raw_response": res,
+        }
+
+
+class AgentCommunicationProtocolAdapter(RemoteAgentAdapter):
+    """
+    Placeholder adapter implementation for Agent Communication Protocol (ACP).
+    """
+
+    def __init__(self, base_url: str = "", **kwargs):
+        self.base_url = base_url
+        self.kwargs = kwargs
+
+    def fetch_manifest(self) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Communication Protocol (ACP) adapter is not yet implemented."
+        )
+
+    def create_run(self, agent_id: str, payload: dict) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Communication Protocol (ACP) adapter is not yet implemented."
+        )
+
+    def get_run(self, run_id: str) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Communication Protocol (ACP) adapter is not yet implemented."
+        )
+
+    def get_events(self, run_id: str, cursor: str | None = None) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Communication Protocol (ACP) adapter is not yet implemented."
+        )
+
+    def cancel_run(self, run_id: str) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Communication Protocol (ACP) adapter is not yet implemented."
+        )
+
+
+class AgentClientProtocolAdapter(RemoteAgentAdapter):
+    """
+    Placeholder adapter implementation for Agent Client Protocol (coding agents / IDE bridge).
+    """
+
+    def __init__(self, base_url: str = "", **kwargs):
+        self.base_url = base_url
+        self.kwargs = kwargs
+
+    def fetch_manifest(self) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Client Protocol adapter is not yet implemented."
+        )
+
+    def create_run(self, agent_id: str, payload: dict) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Client Protocol adapter is not yet implemented."
+        )
+
+    def get_run(self, run_id: str) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Client Protocol adapter is not yet implemented."
+        )
+
+    def get_events(self, run_id: str, cursor: str | None = None) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Client Protocol adapter is not yet implemented."
+        )
+
+    def cancel_run(self, run_id: str) -> dict:
+        raise RemoteAgentNotImplementedError(
+            "Agent Client Protocol adapter is not yet implemented."
+        )
+
+
+def get_adapter(protocol_type: str, **kwargs) -> RemoteAgentAdapter:
+    """
+    Factory function to obtain a RemoteAgentAdapter instance by protocol name.
+
+    Supported protocol_types:
+      - 'huf_native'
+      - 'agent_communication_protocol'
+      - 'agent_client_protocol'
+    """
+    if protocol_type == "huf_native":
+        if len(kwargs) == 1 and ("config" in kwargs or "connection" in kwargs):
+            cfg = kwargs.get("config") or kwargs.get("connection")
+            return HufNativeAdapter.from_config(cfg)
+        return HufNativeAdapter(**kwargs)
+    elif protocol_type == "agent_communication_protocol":
+        return AgentCommunicationProtocolAdapter(**kwargs)
+    elif protocol_type == "agent_client_protocol":
+        return AgentClientProtocolAdapter(**kwargs)
+    else:
+        raise ValueError(f"Unsupported protocol type: '{protocol_type}'")

--- a/huf/ai/remote_agents/tool_handler.py
+++ b/huf/ai/remote_agents/tool_handler.py
@@ -1,0 +1,58 @@
+import frappe
+from huf.ai.remote_agents.adapter import get_adapter
+
+def execute_remote_tool(agent_run, tool_call, parameters):
+    """
+    Executes a remote agent tool.
+    Creates a Delegated Agent Run and delegates to the remote adapter.
+    """
+    connection_name = parameters.get("connection_name")
+    remote_agent_id = parameters.get("remote_agent_id")
+    prompt = parameters.get("prompt")
+    
+    if not connection_name or not remote_agent_id:
+        return {"status": "failed", "error": "Missing connection_name or remote_agent_id"}
+        
+    connection = frappe.get_doc("Remote Agent Connection", connection_name)
+    
+    if not connection.enabled:
+        return {"status": "failed", "error": "Remote Agent Connection is disabled"}
+        
+    # Check basic permissions (placeholder)
+    if not frappe.has_permission("Remote Agent Connection", "read", doc=connection):
+        return {"status": "failed", "error": "Permission denied for remote connection"}
+        
+    # Create local Delegated Agent Run
+    delegated_run = frappe.get_doc({
+        "doctype": "Delegated Agent Run",
+        "local_agent_run": agent_run.name,
+        "connection": connection.name,
+        "remote_agent_id": remote_agent_id,
+        "status": "queued",
+        "request_json": frappe.as_json({"prompt": prompt})
+    })
+    delegated_run.insert(ignore_permissions=True)
+    
+    try:
+        adapter = get_adapter(connection.protocol_type, connection=connection)
+        
+        # Initiate remote run
+        delegated_run.db_set("status", "running")
+        remote_response = adapter.create_run(remote_agent_id, {"prompt": prompt})
+        
+        # In a real implementation we would stream/poll, for v1 we just get result
+        delegated_run.db_set("remote_run_id", remote_response.get("run_id"))
+        delegated_run.db_set("status", "completed")
+        delegated_run.db_set("response_json", frappe.as_json(remote_response))
+        
+        return {
+            "status": "completed",
+            "remote_run_id": remote_response.get("run_id"),
+            "content": remote_response.get("content", "Remote execution completed successfully."),
+            "events_summary": []
+        }
+        
+    except Exception as e:
+        delegated_run.db_set("status", "failed")
+        delegated_run.db_set("error", str(e))
+        return {"status": "failed", "error": str(e)}

--- a/huf/ai/remote_agents/tool_handler.py
+++ b/huf/ai/remote_agents/tool_handler.py
@@ -1,5 +1,5 @@
 import frappe
-from huf.ai.remote_agents.adapter import get_adapter
+from huf.ai.remote_agents.adapter import RemoteAgentNotImplementedError, get_adapter
 
 def execute_remote_tool(agent_run, tool_call, parameters):
     """
@@ -23,6 +23,12 @@ def execute_remote_tool(agent_run, tool_call, parameters):
         return {"status": "failed", "error": "Permission denied for remote connection"}
         
     # Create local Delegated Agent Run
+    if not frappe.db.exists("DocType", "Delegated Agent Run"):
+        raise RemoteAgentNotImplementedError(
+            "Delegated Agent Run tracking is not yet implemented — remote tool-call "
+            "execution is not available in this release."
+        )
+
     delegated_run = frappe.get_doc({
         "doctype": "Delegated Agent Run",
         "local_agent_run": agent_run.name,

--- a/huf/ai/tests/test_remote_agent_adapter.py
+++ b/huf/ai/tests/test_remote_agent_adapter.py
@@ -1,0 +1,348 @@
+"""
+Unit tests for Remote Agent Adapter Service (Phase 3).
+"""
+
+from types import SimpleNamespace
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from huf.ai.remote_agents.adapter import (
+    AgentClientProtocolAdapter,
+    AgentCommunicationProtocolAdapter,
+    HufNativeAdapter,
+    RemoteAgentAdapter,
+    RemoteAgentAdapterError,
+    RemoteAgentAuthError,
+    RemoteAgentConnectionError,
+    RemoteAgentNotImplementedError,
+    RemoteAgentResponseError,
+    RemoteAgentTimeoutError,
+    get_adapter,
+    validate_remote_url,
+)
+
+
+class TestRemoteUrlValidation(unittest.TestCase):
+    @patch("huf.ai.remote_agents.adapter.socket.getaddrinfo")
+    def test_valid_http_and_https(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("93.184.216.34", 80))]
+        is_valid, err = validate_remote_url("https://example.com/api", allow_local_network=False)
+        self.assertTrue(is_valid)
+        self.assertIsNone(err)
+
+    def test_invalid_scheme(self):
+        is_valid, err = validate_remote_url("ftp://example.com/api", allow_local_network=False)
+        self.assertFalse(is_valid)
+        self.assertIn("HTTP and HTTPS", err)
+
+    def test_missing_hostname(self):
+        is_valid, err = validate_remote_url("http://", allow_local_network=False)
+        self.assertFalse(is_valid)
+        self.assertIn("missing hostname", err)
+
+    @patch("huf.ai.remote_agents.adapter.socket.getaddrinfo")
+    def test_ssrf_blocks_private_ips(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (None, None, None, None, ("127.0.0.1", 80))
+        ]
+        is_valid, err = validate_remote_url("http://localhost/api", allow_local_network=False)
+        self.assertFalse(is_valid)
+        self.assertIn("private/internal addresses are not allowed", err)
+
+    @patch("huf.ai.remote_agents.adapter.socket.getaddrinfo")
+    def test_ssrf_allows_private_ips_when_configured(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (None, None, None, None, ("127.0.0.1", 80))
+        ]
+        is_valid, err = validate_remote_url("http://localhost/api", allow_local_network=True)
+        self.assertTrue(is_valid)
+        self.assertIsNone(err)
+
+
+class TestHufNativeAdapterAuth(unittest.TestCase):
+    def test_bearer_token_header(self):
+        adapter = HufNativeAdapter(
+            base_url="https://remote.example.com",
+            auth_type="bearer_token",
+            auth_secret="my-token",
+        )
+        headers = adapter._get_headers()
+        self.assertEqual(headers.get("Authorization"), "Bearer my-token")
+
+    def test_site_token_header(self):
+        adapter = HufNativeAdapter(
+            base_url="https://remote.example.com",
+            auth_type="site_token",
+            auth_secret="site-secret-123",
+        )
+        headers = adapter._get_headers()
+        self.assertEqual(headers.get("X-Site-Token"), "site-secret-123")
+
+    def test_api_key_header(self):
+        adapter = HufNativeAdapter(
+            base_url="https://remote.example.com",
+            auth_type="api_key",
+            auth_secret="key:secret",
+        )
+        headers = adapter._get_headers()
+        self.assertEqual(headers.get("Authorization"), "token key:secret")
+
+    def test_custom_headers_merged(self):
+        adapter = HufNativeAdapter(
+            base_url="https://remote.example.com",
+            auth_type="bearer_token",
+            auth_secret="token",
+            headers={"X-Custom-Header": "custom-val"},
+        )
+        headers = adapter._get_headers()
+        self.assertEqual(headers.get("Authorization"), "Bearer token")
+        self.assertEqual(headers.get("X-Custom-Header"), "custom-val")
+
+
+class TestHufNativeAdapterFromConfig(unittest.TestCase):
+    def test_from_dict_config(self):
+        cfg = {
+            "base_url": "https://remote.example.com",
+            "auth_type": "bearer_token",
+            "auth_secret": "sec123",
+            "timeout": 45,
+            "allow_local_network": True,
+        }
+        adapter = HufNativeAdapter.from_config(cfg)
+        self.assertEqual(adapter.base_url, "https://remote.example.com")
+        self.assertEqual(adapter.auth_type, "bearer_token")
+        self.assertEqual(adapter.auth_secret, "sec123")
+        self.assertEqual(adapter.timeout, 45)
+        self.assertTrue(adapter.allow_local_network)
+
+    def test_from_object_config(self):
+        cfg = SimpleNamespace(
+            base_url="https://remote.example.com",
+            auth_type="api_key",
+            api_key="key:sec",
+            timeout=15,
+            allow_local_ips=True,
+        )
+        adapter = HufNativeAdapter.from_config(cfg)
+        self.assertEqual(adapter.base_url, "https://remote.example.com")
+        self.assertEqual(adapter.auth_type, "api_key")
+        self.assertEqual(adapter.auth_secret, "key:sec")
+        self.assertEqual(adapter.timeout, 15)
+        self.assertTrue(adapter.allow_local_network)
+
+
+class TestHufNativeAdapterOperations(unittest.TestCase):
+    def setUp(self):
+        self.adapter = HufNativeAdapter(
+            base_url="https://remote.example.com",
+            auth_type="bearer_token",
+            auth_secret="test-secret",
+            allow_local_network=True,
+        )
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_fetch_manifest_success(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b'{"message": {"server_name": "Test Server", "agents": [{"id": "agent_1"}]}}'
+        mock_resp.json.return_value = {
+            "message": {
+                "server_name": "Test Server",
+                "agents": [{"id": "agent_1"}],
+            }
+        }
+        mock_request.return_value = mock_resp
+
+        manifest = self.adapter.fetch_manifest()
+
+        self.assertEqual(manifest["server_name"], "Test Server")
+        self.assertEqual(manifest["protocol_version"], "huf-native-v1")
+        self.assertEqual(len(manifest["agents"]), 1)
+        self.assertEqual(manifest["agents"][0]["id"], "agent_1")
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_fetch_manifest_fallback_to_well_known(self, mock_request, mock_val):
+        resp_404 = MagicMock()
+        resp_404.status_code = 404
+
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        resp_200.content = b'{"server_name": "Fallback Server", "agents": []}'
+        resp_200.json.return_value = {"server_name": "Fallback Server", "agents": []}
+
+        mock_request.side_effect = [resp_404, resp_200]
+
+        manifest = self.adapter.fetch_manifest()
+
+        self.assertEqual(manifest["server_name"], "Fallback Server")
+        self.assertEqual(mock_request.call_count, 2)
+        self.assertIn(".well-known/huf-agent.json", mock_request.call_args_list[1].kwargs["url"])
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_create_run_success(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b'{"message": {"run_id": "run_001", "status": "completed", "response": "Done"}}'
+        mock_resp.json.return_value = {
+            "message": {"run_id": "run_001", "status": "completed", "response": "Done"}
+        }
+        mock_request.return_value = mock_resp
+
+        res = self.adapter.create_run("agent_1", {"prompt": "Hello"})
+
+        self.assertEqual(res["run_id"], "run_001")
+        self.assertEqual(res["status"], "completed")
+        self.assertEqual(res["response"], "Done")
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_get_run_success(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b'{"message": {"status": "running", "response": "In progress"}}'
+        mock_resp.json.return_value = {
+            "message": {"status": "running", "response": "In progress"}
+        }
+        mock_request.return_value = mock_resp
+
+        res = self.adapter.get_run("run_001")
+
+        self.assertEqual(res["run_id"], "run_001")
+        self.assertEqual(res["status"], "running")
+        self.assertEqual(res["response"], "In progress")
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_get_events_success(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b'{"message": {"events": [{"type": "message.delta"}], "cursor": "c2", "has_more": true}}'
+        mock_resp.json.return_value = {
+            "message": {
+                "events": [{"type": "message.delta"}],
+                "cursor": "c2",
+                "has_more": True,
+            }
+        }
+        mock_request.return_value = mock_resp
+
+        res = self.adapter.get_events("run_001", cursor="c1")
+
+        self.assertEqual(res["run_id"], "run_001")
+        self.assertEqual(len(res["events"]), 1)
+        self.assertEqual(res["cursor"], "c2")
+        self.assertTrue(res["has_more"])
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_cancel_run_success(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b'{"message": {"status": "cancelled", "message": "Stopped"}}'
+        mock_resp.json.return_value = {
+            "message": {"status": "cancelled", "message": "Stopped"}
+        }
+        mock_request.return_value = mock_resp
+
+        res = self.adapter.cancel_run("run_001")
+
+        self.assertEqual(res["run_id"], "run_001")
+        self.assertEqual(res["status"], "cancelled")
+        self.assertEqual(res["message"], "Stopped")
+
+
+class TestHufNativeAdapterErrors(unittest.TestCase):
+    def setUp(self):
+        self.adapter = HufNativeAdapter(
+            base_url="https://remote.example.com",
+            auth_type="bearer_token",
+            auth_secret="test-secret",
+            allow_local_network=True,
+        )
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request", side_effect=requests.exceptions.Timeout("Connection timed out"))
+    def test_timeout_raises_remote_agent_timeout_error(self, mock_request, mock_val):
+        with self.assertRaises(RemoteAgentTimeoutError):
+            self.adapter.get_run("run_001")
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request", side_effect=requests.exceptions.ConnectionError("DNS failure"))
+    def test_connection_failure_raises_remote_agent_connection_error(self, mock_request, mock_val):
+        with self.assertRaises(RemoteAgentConnectionError):
+            self.adapter.get_run("run_001")
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_401_raises_remote_agent_auth_error(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.text = "Unauthorized"
+        mock_request.return_value = mock_resp
+
+        with self.assertRaises(RemoteAgentAuthError):
+            self.adapter.get_run("run_001")
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_500_raises_remote_agent_response_error(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Server Error"
+        mock_request.return_value = mock_resp
+
+        with self.assertRaises(RemoteAgentResponseError) as ctx:
+            self.adapter.get_run("run_001")
+        self.assertEqual(ctx.exception.status_code, 500)
+
+    @patch("huf.ai.remote_agents.adapter.validate_remote_url", return_value=(True, None))
+    @patch("requests.request")
+    def test_invalid_json_raises_remote_agent_response_error(self, mock_request, mock_val):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"Not JSON content"
+        mock_resp.text = "Not JSON content"
+        mock_resp.json.side_effect = ValueError("Invalid JSON")
+        mock_request.return_value = mock_resp
+
+        with self.assertRaises(RemoteAgentResponseError):
+            self.adapter.get_run("run_001")
+
+
+class TestPlaceholderAdaptersAndFactory(unittest.TestCase):
+    def test_acp_adapter_raises_not_implemented(self):
+        adapter = AgentCommunicationProtocolAdapter("https://acp.example.com")
+        self.assertIsInstance(adapter, RemoteAgentAdapter)
+        with self.assertRaises(RemoteAgentNotImplementedError):
+            adapter.fetch_manifest()
+
+    def test_agent_client_protocol_adapter_raises_not_implemented(self):
+        adapter = AgentClientProtocolAdapter("https://client.example.com")
+        self.assertIsInstance(adapter, RemoteAgentAdapter)
+        with self.assertRaises(RemoteAgentNotImplementedError):
+            adapter.fetch_manifest()
+
+    def test_get_adapter_huf_native(self):
+        adapter = get_adapter("huf_native", base_url="https://remote.example.com")
+        self.assertIsInstance(adapter, HufNativeAdapter)
+
+    def test_get_adapter_acp(self):
+        adapter = get_adapter("agent_communication_protocol", base_url="https://acp.example.com")
+        self.assertIsInstance(adapter, AgentCommunicationProtocolAdapter)
+
+    def test_get_adapter_client_protocol(self):
+        adapter = get_adapter("agent_client_protocol", base_url="https://acp.example.com")
+        self.assertIsInstance(adapter, AgentClientProtocolAdapter)
+
+    def test_get_adapter_unknown_protocol(self):
+        with self.assertRaises(ValueError):
+            get_adapter("unknown_protocol", base_url="https://example.com")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/api/remote_agents.py
+++ b/huf/api/remote_agents.py
@@ -5,6 +5,9 @@ from frappe import _
 def list_agents():
     # Only return agents that are enabled for remote delegation
     # Placeholder implementation
+    if not frappe.has_permission("Agent", "read"):
+        frappe.throw(_("Not permitted"), frappe.PermissionError)
+
     agents = frappe.get_all("Agent", filters={"disabled": 0}, fields=["name", "agent_name", "description"])
     return {
         "server_name": frappe.local.site,
@@ -15,6 +18,9 @@ def list_agents():
 @frappe.whitelist(allow_guest=False)
 def get_agent_manifest(agent_name):
     agent = frappe.get_doc("Agent", agent_name)
+    if not frappe.has_permission("Agent", "read", doc=agent):
+        frappe.throw(_("Not permitted"), frappe.PermissionError)
+
     return {
         "id": agent.name,
         "name": agent.agent_name,
@@ -24,7 +30,8 @@ def get_agent_manifest(agent_name):
         "capabilities": ["chat"],
         "stateful": True,
         "long_running": True,
-        "streaming": True
+        # V1 does not support streaming; deferred to V2 per RFC §4.2.
+        "streaming": False
     }
 
 @frappe.whitelist(allow_guest=False)

--- a/huf/api/remote_agents.py
+++ b/huf/api/remote_agents.py
@@ -1,0 +1,61 @@
+import frappe
+from frappe import _
+
+@frappe.whitelist(allow_guest=False)
+def list_agents():
+    # Only return agents that are enabled for remote delegation
+    # Placeholder implementation
+    agents = frappe.get_all("Agent", filters={"disabled": 0}, fields=["name", "agent_name", "description"])
+    return {
+        "server_name": frappe.local.site,
+        "protocol_versions": ["huf-native-v1"],
+        "agents": agents
+    }
+
+@frappe.whitelist(allow_guest=False)
+def get_agent_manifest(agent_name):
+    agent = frappe.get_doc("Agent", agent_name)
+    return {
+        "id": agent.name,
+        "name": agent.agent_name,
+        "description": agent.description,
+        "input_modes": ["text/markdown", "application/json"],
+        "output_modes": ["text/markdown", "application/json"],
+        "capabilities": ["chat"],
+        "stateful": True,
+        "long_running": True,
+        "streaming": True
+    }
+
+@frappe.whitelist(allow_guest=False)
+def create_run(agent_id, prompt, session_id=None, parameters=None):
+    # Map to local Agent Run
+    return {
+        "status": "success",
+        "data": {
+            "run_id": "dummy_run_123",
+            "status": "running",
+            "started_at": frappe.utils.now()
+        }
+    }
+
+@frappe.whitelist(allow_guest=False)
+def get_run(run_id):
+    return {
+        "status": "success",
+        "data": {
+            "run_id": run_id,
+            "status": "completed"
+        }
+    }
+
+@frappe.whitelist(allow_guest=False)
+def get_run_events(run_id, cursor=None):
+    return {
+        "events": [],
+        "next_cursor": None
+    }
+
+@frappe.whitelist(allow_guest=False)
+def cancel_run(run_id):
+    return {"status": "cancelled"}

--- a/huf/huf/doctype/remote_agent_connection/__init__.py
+++ b/huf/huf/doctype/remote_agent_connection/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt

--- a/huf/huf/doctype/remote_agent_connection/remote_agent_connection.js
+++ b/huf/huf/doctype/remote_agent_connection/remote_agent_connection.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Remote Agent Connection", {
+	refresh(frm) {
+		if (!frm.is_new()) {
+			frm.add_custom_button(__("Test Connection"), function () {
+				frm.events.test_connection(frm);
+			}, __("Actions"));
+
+			frm.add_custom_button(__("Refresh Manifest"), function () {
+				frm.events.refresh_manifest(frm);
+			}, __("Actions"));
+		}
+	},
+
+	test_connection(frm) {
+		frappe.call({
+			method: "test_connection_cmd",
+			doc: frm.doc,
+			args: {
+				connection_name: frm.doc.name
+			},
+			freeze: true,
+			freeze_message: __("Testing remote agent connection..."),
+			callback: function (r) {
+				if (r.message && r.message.status === "healthy") {
+					frappe.msgprint({
+						title: __("Connection Successful"),
+						message: __("Successfully connected to remote agent."),
+						indicator: "green"
+					});
+				} else {
+					frappe.msgprint({
+						title: __("Connection Failed"),
+						message: r.message ? r.message.message : __("Unknown error"),
+						indicator: "red"
+					});
+				}
+				frm.reload_doc();
+			}
+		});
+	},
+
+	refresh_manifest(frm) {
+		frappe.call({
+			method: "refresh_manifest_cmd",
+			doc: frm.doc,
+			args: {
+				connection_name: frm.doc.name
+			},
+			freeze: true,
+			freeze_message: __("Refreshing remote agent manifest..."),
+			callback: function (r) {
+				if (!r.exc) {
+					frappe.show_alert({
+						message: __("Manifest refreshed successfully"),
+						indicator: "green"
+					});
+					frm.reload_doc();
+				}
+			}
+		});
+	}
+});

--- a/huf/huf/doctype/remote_agent_connection/remote_agent_connection.json
+++ b/huf/huf/doctype/remote_agent_connection/remote_agent_connection.json
@@ -1,0 +1,181 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:connection_name",
+ "creation": "2026-08-01 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "connection_name",
+  "protocol_type",
+  "enabled",
+  "column_break_1",
+  "transport",
+  "base_url",
+  "auth_section",
+  "auth_type",
+  "auth_secret",
+  "status_section",
+  "health_status",
+  "last_health_check",
+  "last_error",
+  "manifest_section",
+  "manifest_json"
+ ],
+ "fields": [
+  {
+   "fieldname": "connection_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Connection Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "default": "huf_native",
+   "fieldname": "protocol_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Protocol Type",
+   "options": "agent_communication_protocol\nagent_client_protocol\nhuf_native",
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "http",
+   "fieldname": "transport",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Transport",
+   "options": "http\nwebsocket\nstdio",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.transport !== 'stdio'",
+   "description": "Required for HTTP and WebSocket transports (e.g., https://remote-huf.example.com)",
+   "fieldname": "base_url",
+   "fieldtype": "Data",
+   "label": "Base URL"
+  },
+  {
+   "fieldname": "auth_section",
+   "fieldtype": "Section Break",
+   "label": "Authentication"
+  },
+  {
+   "default": "none",
+   "fieldname": "auth_type",
+   "fieldtype": "Select",
+   "label": "Auth Type",
+   "options": "none\nbearer_token\nsite_token",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.auth_type !== 'none'",
+   "description": "Stored encrypted in database. Never exposed in API responses.",
+   "fieldname": "auth_secret",
+   "fieldtype": "Password",
+   "label": "Auth Secret"
+  },
+  {
+   "fieldname": "status_section",
+   "fieldtype": "Section Break",
+   "label": "Health & Diagnostic Status"
+  },
+  {
+   "default": "unknown",
+   "fieldname": "health_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Health Status",
+   "options": "unknown\nhealthy\ndegraded\nfailed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_health_check",
+   "fieldtype": "Datetime",
+   "label": "Last Health Check",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_error",
+   "fieldtype": "Small Text",
+   "label": "Last Error",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "manifest_section",
+   "fieldtype": "Section Break",
+   "label": "Cached Manifest"
+  },
+  {
+   "fieldname": "manifest_json",
+   "fieldtype": "Code",
+   "label": "Manifest JSON",
+   "options": "JSON"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-01 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "Remote Agent Connection",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "select": 1,
+   "share": 1,
+   "write": 0
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/huf/huf/doctype/remote_agent_connection/remote_agent_connection.py
+++ b/huf/huf/doctype/remote_agent_connection/remote_agent_connection.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import json
+from urllib.parse import urlparse
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+
+class RemoteAgentConnection(Document):
+	def validate(self):
+		self.validate_transport_and_url()
+		self.validate_auth()
+		self.validate_manifest_json()
+
+	def validate_transport_and_url(self):
+		if self.transport in ("http", "websocket"):
+			if not self.base_url:
+				frappe.throw(_("Base URL is required when transport is {0}.").format(self.transport))
+
+			clean_url = self.base_url.strip()
+			parsed = urlparse(clean_url)
+			if not parsed.scheme or parsed.scheme.lower() not in ("http", "https", "ws", "wss"):
+				frappe.throw(_("Invalid Base URL scheme. Must start with http://, https://, ws://, or wss://."))
+			if not parsed.netloc:
+				frappe.throw(_("Invalid Base URL format."))
+			self.base_url = clean_url
+
+	def validate_auth(self):
+		if self.auth_type != "none":
+			# Frappe Password fields encrypt secret automatically.
+			# If creating new record or setting auth_type without secret, ensure a password exists.
+			if not self.auth_secret and not self.get_password("auth_secret"):
+				frappe.throw(_("Auth Secret is required when Auth Type is {0}.").format(self.auth_type))
+
+	def validate_manifest_json(self):
+		if self.manifest_json:
+			try:
+				if isinstance(self.manifest_json, str):
+					json.loads(self.manifest_json)
+			except Exception as e:
+				frappe.throw(_("Invalid JSON in manifest_json: {0}").format(str(e)))
+
+	def get_auth_secret(self) -> str | None:
+		"""
+		Securely retrieve the decrypted auth secret.
+		Never log or return this value in API responses.
+		"""
+		if self.auth_type == "none":
+			return None
+		return self.get_password("auth_secret")
+
+	def as_dict(self, no_nulls=False, no_default_fields=False, convert_dates_to_gstr=False, no_private_properties=False):
+		"""
+		Override as_dict to ensure auth_secret is never returned or leaked in dict form.
+		"""
+		d = super().as_dict(
+			no_nulls=no_nulls,
+			no_default_fields=no_default_fields,
+			convert_dates_to_gstr=convert_dates_to_gstr,
+			no_private_properties=no_private_properties,
+		)
+		if "auth_secret" in d:
+			d.pop("auth_secret", None)
+		return d
+
+	@frappe.whitelist()
+	def test_connection(self):
+		"""
+		Test reachable connection status.
+		"""
+		if not self.enabled:
+			return {"status": "disabled", "message": _("Connection is disabled.")}
+
+		if self.transport not in ("http", "websocket"):
+			return {"status": "unknown", "message": _("Transport type '{0}' test not supported.").format(self.transport)}
+
+		try:
+			import requests
+
+			headers = {}
+			secret = self.get_auth_secret()
+			if self.auth_type == "bearer_token" and secret:
+				headers["Authorization"] = f"Bearer {secret}"
+			elif self.auth_type == "site_token" and secret:
+				headers["X-Site-Token"] = secret
+
+			url = self.base_url.rstrip("/")
+			response = requests.get(f"{url}/.well-known/huf-agent.json", headers=headers, timeout=5)
+			if response.status_code == 200:
+				self.health_status = "healthy"
+				self.last_error = ""
+				self.last_health_check = frappe.utils.now_datetime()
+				self.save(ignore_permissions=True)
+				return {"status": "healthy", "message": _("Connection successful.")}
+			else:
+				self.health_status = "degraded"
+				self.last_error = f"HTTP {response.status_code}: {response.text[:200]}"
+				self.last_health_check = frappe.utils.now_datetime()
+				self.save(ignore_permissions=True)
+				return {"status": "degraded", "message": self.last_error}
+		except Exception as e:
+			err_msg = str(e)
+			self.health_status = "failed"
+			self.last_error = err_msg[:500]
+			self.last_health_check = frappe.utils.now_datetime()
+			self.save(ignore_permissions=True)
+			return {"status": "failed", "message": err_msg}
+
+	@frappe.whitelist()
+	def refresh_manifest(self):
+		"""
+		Fetch and cache the manifest JSON from remote agent.
+		"""
+		if not self.enabled:
+			frappe.throw(_("Cannot refresh manifest on a disabled connection."))
+
+		if not self.base_url:
+			frappe.throw(_("Base URL is required to refresh manifest."))
+
+		try:
+			import requests
+
+			headers = {}
+			secret = self.get_auth_secret()
+			if self.auth_type == "bearer_token" and secret:
+				headers["Authorization"] = f"Bearer {secret}"
+			elif self.auth_type == "site_token" and secret:
+				headers["X-Site-Token"] = secret
+
+			url = self.base_url.rstrip("/")
+			response = requests.get(f"{url}/.well-known/huf-agent.json", headers=headers, timeout=10)
+			response.raise_for_status()
+
+			manifest_data = response.json()
+			self.manifest_json = json.dumps(manifest_data, indent=2)
+			self.health_status = "healthy"
+			self.last_error = ""
+			self.last_health_check = frappe.utils.now_datetime()
+			self.save(ignore_permissions=True)
+			return manifest_data
+		except Exception as e:
+			err_msg = str(e)
+			self.health_status = "failed"
+			self.last_error = f"Manifest refresh failed: {err_msg[:500]}"
+			self.last_health_check = frappe.utils.now_datetime()
+			self.save(ignore_permissions=True)
+			frappe.throw(_("Failed to refresh manifest: {0}").format(err_msg))
+
+
+@frappe.whitelist()
+def test_connection_cmd(connection_name):
+	doc = frappe.get_doc("Remote Agent Connection", connection_name)
+	doc.check_permission("read")
+	return doc.test_connection()
+
+
+@frappe.whitelist()
+def refresh_manifest_cmd(connection_name):
+	doc = frappe.get_doc("Remote Agent Connection", connection_name)
+	doc.check_permission("write")
+	return doc.refresh_manifest()

--- a/huf/huf/doctype/remote_agent_connection/remote_agent_connection.py
+++ b/huf/huf/doctype/remote_agent_connection/remote_agent_connection.py
@@ -8,6 +8,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from huf.ai.remote_agents.adapter import HufNativeAdapter, RemoteAgentAdapterError
+
 
 class RemoteAgentConnection(Document):
 	def validate(self):
@@ -24,6 +26,17 @@ class RemoteAgentConnection(Document):
 			parsed = urlparse(clean_url)
 			if not parsed.scheme or parsed.scheme.lower() not in ("http", "https", "ws", "wss"):
 				frappe.throw(_("Invalid Base URL scheme. Must start with http://, https://, ws://, or wss://."))
+			# Websocket transport is not implemented: HufNativeAdapter._request() (adapter.py)
+			# only accepts http/https via validate_remote_url(), so a ws:// or wss:// URL would
+			# save successfully here but always fail at request time with no clear reason why.
+			# Reject it up front instead.
+			if parsed.scheme.lower() in ("ws", "wss"):
+				frappe.throw(
+					_(
+						"WebSocket transport (ws:// or wss://) is not yet implemented. "
+						"Please use an http:// or https:// Base URL."
+					)
+				)
 			if not parsed.netloc:
 				frappe.throw(_("Invalid Base URL format."))
 			self.base_url = clean_url
@@ -78,29 +91,28 @@ class RemoteAgentConnection(Document):
 			return {"status": "unknown", "message": _("Transport type '{0}' test not supported.").format(self.transport)}
 
 		try:
-			import requests
+			adapter = HufNativeAdapter(
+				base_url=self.base_url,
+				auth_type=self.auth_type,
+				auth_secret=self.get_auth_secret(),
+				timeout=5,
+			)
+			# Goes through adapter._request(), which runs validate_remote_url() (SSRF
+			# protection) and sends allow_redirects=False, same as every other adapter call.
+			adapter._request("GET", "/.well-known/huf-agent.json")
 
-			headers = {}
-			secret = self.get_auth_secret()
-			if self.auth_type == "bearer_token" and secret:
-				headers["Authorization"] = f"Bearer {secret}"
-			elif self.auth_type == "site_token" and secret:
-				headers["X-Site-Token"] = secret
-
-			url = self.base_url.rstrip("/")
-			response = requests.get(f"{url}/.well-known/huf-agent.json", headers=headers, timeout=5)
-			if response.status_code == 200:
-				self.health_status = "healthy"
-				self.last_error = ""
-				self.last_health_check = frappe.utils.now_datetime()
-				self.save(ignore_permissions=True)
-				return {"status": "healthy", "message": _("Connection successful.")}
-			else:
-				self.health_status = "degraded"
-				self.last_error = f"HTTP {response.status_code}: {response.text[:200]}"
-				self.last_health_check = frappe.utils.now_datetime()
-				self.save(ignore_permissions=True)
-				return {"status": "degraded", "message": self.last_error}
+			self.health_status = "healthy"
+			self.last_error = ""
+			self.last_health_check = frappe.utils.now_datetime()
+			self.save(ignore_permissions=True)
+			return {"status": "healthy", "message": _("Connection successful.")}
+		except RemoteAgentAdapterError as e:
+			err_msg = str(e)
+			self.health_status = "degraded"
+			self.last_error = err_msg[:500]
+			self.last_health_check = frappe.utils.now_datetime()
+			self.save(ignore_permissions=True)
+			return {"status": "degraded", "message": self.last_error}
 		except Exception as e:
 			err_msg = str(e)
 			self.health_status = "failed"
@@ -121,20 +133,16 @@ class RemoteAgentConnection(Document):
 			frappe.throw(_("Base URL is required to refresh manifest."))
 
 		try:
-			import requests
+			adapter = HufNativeAdapter(
+				base_url=self.base_url,
+				auth_type=self.auth_type,
+				auth_secret=self.get_auth_secret(),
+				timeout=10,
+			)
+			# Goes through adapter._request(), which runs validate_remote_url() (SSRF
+			# protection) and sends allow_redirects=False, same as every other adapter call.
+			manifest_data = adapter._request("GET", "/.well-known/huf-agent.json")
 
-			headers = {}
-			secret = self.get_auth_secret()
-			if self.auth_type == "bearer_token" and secret:
-				headers["Authorization"] = f"Bearer {secret}"
-			elif self.auth_type == "site_token" and secret:
-				headers["X-Site-Token"] = secret
-
-			url = self.base_url.rstrip("/")
-			response = requests.get(f"{url}/.well-known/huf-agent.json", headers=headers, timeout=10)
-			response.raise_for_status()
-
-			manifest_data = response.json()
 			self.manifest_json = json.dumps(manifest_data, indent=2)
 			self.health_status = "healthy"
 			self.last_error = ""
@@ -153,7 +161,9 @@ class RemoteAgentConnection(Document):
 @frappe.whitelist()
 def test_connection_cmd(connection_name):
 	doc = frappe.get_doc("Remote Agent Connection", connection_name)
-	doc.check_permission("read")
+	# test_connection() persists health-status fields via self.save(ignore_permissions=True),
+	# so this action mutates state and requires write permission, not just read.
+	doc.check_permission("write")
 	return doc.test_connection()
 
 

--- a/huf/huf/doctype/remote_agent_connection/test_remote_agent_connection.py
+++ b/huf/huf/doctype/remote_agent_connection/test_remote_agent_connection.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import json
+import unittest
+import frappe
+from frappe.tests import IntegrationTestCase
+from huf.huf.doctype.remote_agent_connection.remote_agent_connection import RemoteAgentConnection
+
+
+class TestRemoteAgentConnection(IntegrationTestCase):
+	def setUp(self):
+		frappe.db.rollback()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_validations(self):
+		# Base URL missing for HTTP
+		doc = frappe.get_doc({
+			"doctype": "Remote Agent Connection",
+			"connection_name": "Test Connection Invalid URL",
+			"protocol_type": "huf_native",
+			"transport": "http",
+			"auth_type": "none",
+			"enabled": 1,
+		})
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+		# Invalid scheme
+		doc.base_url = "ftp://invalid-url.com"
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+		# Invalid Auth secret missing
+		doc.base_url = "https://valid-url.com"
+		doc.auth_type = "bearer_token"
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+		# Invalid manifest JSON
+		doc.auth_type = "none"
+		doc.manifest_json = "{ invalid json }"
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_auth_secret_security(self):
+		conn_name = "Test Secret Connection"
+		if frappe.db.exists("Remote Agent Connection", conn_name):
+			frappe.delete_doc("Remote Agent Connection", conn_name)
+
+		doc = frappe.get_doc({
+			"doctype": "Remote Agent Connection",
+			"connection_name": conn_name,
+			"protocol_type": "huf_native",
+			"transport": "http",
+			"base_url": "https://secure-agent.example.com",
+			"auth_type": "bearer_token",
+			"auth_secret": "super_secret_token_123",
+			"enabled": 1,
+		})
+		doc.insert()
+
+		# Verify auth_secret is not returned in as_dict()
+		doc_dict = doc.as_dict()
+		self.assertNotIn("auth_secret", doc_dict)
+
+		# Verify secret can be safely fetched internally via get_auth_secret()
+		retrieved_secret = doc.get_auth_secret()
+		self.assertEqual(retrieved_secret, "super_secret_token_123")
+
+		frappe.delete_doc("Remote Agent Connection", conn_name)


### PR DESCRIPTION


Backend scaffolding for a future "one Huf agent calls an agent on another Huf instance over HTTP" feature. **This is not a complete feature and should not be read as one** — see "what's still missing" below. What it does provide, safely: the DocType, the SSRF-hardened HTTP client, and the discovery/connection-test flow.

## What changed since the last review round

A second, deeper review pass found this PR was less complete than its name suggested — most of the RFC it's based on (`docs/rfcs/huf-remote-agent-federation.md`) was never finished. Rather than try to complete the whole RFC (real net-new feature work — 3 more DocTypes, a full run lifecycle, a frontend page), this round made what's *actually here* honest and non-crashing:

1. **Closed the SSRF bypass** — `test_connection()`/`refresh_manifest()` on the DocType previously called `requests.get()` directly, skipping all the SSRF hardening. They now go through the same validated `HufNativeAdapter._request()` path everything else uses.
2. **Manifest no longer lies about streaming** — it advertised `"streaming": true`; the RFC itself says V1 has none. Fixed to `false`.
3. **Added the missing permission checks** on `list_agents`/`get_agent_manifest` — every other whitelisted method in this PR already checked permissions, these two didn't.
4. **Fixed a read-permission-triggers-a-write bug** — a read-only role could hit `test_connection_cmd` and have it silently persist health-status fields via `ignore_permissions=True`. Now requires write permission, matching what the action actually does.
5. **Replaced a crash with an honest error** — the one code path that would actually execute a remote tool call (`tool_handler.py`) references a `Delegated Agent Run` doctype that was never built (it's one of the 3 missing RFC doctypes). It would have thrown an opaque `DoctypeNotFoundError`. It now checks first and raises a clear `RemoteAgentNotImplementedError` explaining remote tool-call execution isn't available yet.
6. **Fixed a silently-broken config option** — the DocType accepted `ws://`/`wss://` URLs, but the HTTP-only adapter would always reject them at request time with no clue why. Now rejected at save time with a clear message.
7. **Labeled the fake standards support clearly** — `AgentCommunicationProtocolAdapter` and `AgentClientProtocolAdapter` (meant for future real-ACP/A2A-standard interop) are pure `NotImplementedError` stubs. They now say so in their docstrings, so nobody mistakes this for real ACP interop.

## What's still missing (confirmed via interop testing, see below)

- **3 of 4 RFC doctypes were never built**: `Delegated Agent Run`, `Remote Agent Capability`, `Remote Agent Policy`. Without them, remote tool-calling from an agent's tool-call loop doesn't work — `tool_handler.py` now fails cleanly instead of crashing, but it still doesn't *do* anything.
- **`huf/api/remote_agents.py`'s `get_run`/`get_run_events`/`cancel_run`/`create_run` are stub endpoints** that don't touch any real run record — untouched in this pass, since fixing them needs the missing doctypes too.
- **No frontend UI exists** — configuration is desk-form-only.
- **This is not real ACP.** Tested directly: the actual Agent Client Protocol (used by e.g. `kimi-code acp`, Zed's agent integration) is JSON-RPC 2.0 over stdio with a rich capabilities handshake. What's implemented here (`HufNativeAdapter`) is a Huf-proprietary HTTP+manifest protocol that only borrows the "ACP" name — confirmed by directly running `kimi acp` and diffing its wire protocol against `adapter.py`'s.
- **What DOES work, verified**: wrote a standalone functional test (`test_huf_federation_interop.py`) against a mock second-Huf-instance HTTP server, exercising `HufNativeAdapter` directly (it has no Frappe dependency, so this is testable outside a bench). All 6 checks passed: manifest discovery, Frappe-RPC-envelope unwrapping, a full remote-agent-invocation round trip, the SSRF guard correctly rejecting loopback when `allow_local_network=False`, and bearer-token auth header construction. **The transport/adapter layer is solid** — what's broken is everything above it (missing doctypes, stub endpoints, no UI).

## Recommendation

Land this as what it honestly is: a safe, tested HTTP client + connection-management DocType for a federation feature that isn't finished. Rename/re-scope expectations before merge (title/description already reflect this). Follow-up work needed before "remote agent tool-calling" is real: the 3 missing doctypes, real `remote_agents.py` endpoints, `Agent Tool Function`'s "Remote Agent" tool_type wiring, and a frontend config page.

*Second-round fixes applied by an automated audit/fix pass over 2026-08-25's revived-branch inventory.*
