### PR TITLE
fix: live-bench QA  — agent config, knowledge embeddings, code execution

### DIFF
--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -891,6 +891,29 @@ def run_background_summarization(conversation_name, agent_name):
             "Agent Background Summarization Error"
         )
 
+
+
+def _set_conversation_title_with_retry(conversation_name, title, max_retries=2):
+    """Set conversation title, retrying on transient MariaDB deadlocks.
+
+    The title generation runs in a background job that may race with the
+    main request thread updating the same Agent Conversation row. A single
+    short retry is usually enough to land the title without surfacing a
+    non-critical error to the user.
+    """
+    import time
+
+    for attempt in range(max_retries):
+        try:
+            frappe.db.set_value("Agent Conversation", conversation_name, "title", title)
+            return
+        except frappe.QueryDeadlockError:
+            if attempt < max_retries - 1:
+                time.sleep(0.2 * (attempt + 1))
+                continue
+            raise
+
+
 @frappe.whitelist()
 def generate_conversation_title(conversation_name, agent_name):
     """
@@ -929,7 +952,7 @@ def generate_conversation_title(conversation_name, agent_name):
         )
         if title:
             title = title.strip().strip('"').strip("'")
-            frappe.db.set_value("Agent Conversation", conversation_name, "title", title)
+            _set_conversation_title_with_retry(conversation_name, title)
             frappe.db.commit()  # nosemgrep: justified background-job commit
             _emit_conversation_title_updated(conversation_name, title)
     except Exception as e:

--- a/huf/ai/agent_run_analytics_api.py
+++ b/huf/ai/agent_run_analytics_api.py
@@ -28,6 +28,14 @@ def get_execution_analytics(from_date: str | None = None, to_date: str | None = 
         frappe.throw("granularity must be 'hour' or 'day'")
     end = get_datetime(to_date) if to_date else now_datetime()
     start = get_datetime(from_date) if from_date else add_to_date(end, days=-7)
+    # from_date/to_date arrive as ISO strings (often UTC with a Z/offset suffix) from the
+    # frontend, which get_datetime parses as timezone-aware, while now_datetime()/add_to_date()
+    # return naive local datetimes. Mixing the two raises
+    # "can't compare offset-naive and offset-aware datetimes" on the next line.
+    if start.tzinfo is not None:
+        start = start.replace(tzinfo=None)
+    if end.tzinfo is not None:
+        end = end.replace(tzinfo=None)
     if start > end or (end - start).days > MAX_WINDOW_DAYS:
         frappe.throw(f"Date range must be between zero and {MAX_WINDOW_DAYS} days")
     if not frappe.db.exists("DocType", ROLLUP_DOCTYPE):

--- a/huf/ai/flow_tool_executor.py
+++ b/huf/ai/flow_tool_executor.py
@@ -183,6 +183,7 @@ def _resolve_function_path(tool_doc: dict) -> str | None:
 		"Set Conversation Data": "huf.ai.sdk_tools.handle_set_conversation_data",
 		"Load Conversation Data": "huf.ai.sdk_tools.handle_load_conversation_data",
 		"Perplexity Search": "huf.ai.tools.perplexity.handle_perplexity_search",
+		"Code Execution": "huf.ai.tools.code_execution.run_python",
 	}
 
 	return type_to_handler.get(tool_type)

--- a/huf/ai/knowledge/embedding.py
+++ b/huf/ai/knowledge/embedding.py
@@ -123,8 +123,8 @@ def resolve_embedding_config(knowledge_source: str) -> dict[str, Any]:
 	Resolve embedding configuration from a Knowledge Source document.
 
 	Reads the embedding_model, vector_dimension, and embedding_provider fields
-	from the Knowledge Source DocType and resolves the API key from the linked
-	AI Provider.
+	from the Knowledge Source DocType and resolves the API key and API base from
+	the linked AI Provider.
 
 	Args:
 		knowledge_source: Name of the Knowledge Source document.
@@ -143,17 +143,25 @@ def resolve_embedding_config(knowledge_source: str) -> dict[str, Any]:
 	if source.embedding_provider:
 		provider = frappe.get_doc("AI Provider", source.embedding_provider)
 		api_key = provider.get_password("api_key") if provider.api_key else None
-		api_base = getattr(provider, "api_base", None) or None
-		# Fallback: local LLM providers use url+port instead of api_base
+		# Precedence: api_base_url field > url+port (local LLM) > site_config fallback
+		api_base = (getattr(provider, "api_base_url", None) or "").strip() or None
 		if not api_base and getattr(provider, "is_local_llm", False):
-			url = getattr(provider, "url", None)
-			port = getattr(provider, "port", None)
+			url = (getattr(provider, "url", None) or "").strip() or None
+			port = str(getattr(provider, "port", None) or "").strip() or None
 			if url:
-				api_base = f"{url}:{port}" if port else url
+				url = url.rstrip("/")
+				api_base = f"{url}:{port}" if port and not url.endswith(f":{port}") else url
 
 	# Fallback to site_config for Ollama
 	if not api_base:
 		api_base = frappe.conf.get("ollama_api_base") or None
+
+	# LiteLLM requires a provider-prefixed model identifier (e.g. "ollama/nomic-embed-text").
+	# If the stored model name is not already prefixed, prepend the linked provider's brand.
+	if model and "/" not in model and source.embedding_provider:
+		provider_brand = frappe.db.get_value("AI Provider", source.embedding_provider, "provider_brand")
+		if provider_brand:
+			model = f"{provider_brand}/{model}"
 
 	return {
 		"model": model,

--- a/huf/ai/knowledge/tests/test_embedding_config_resolution.py
+++ b/huf/ai/knowledge/tests/test_embedding_config_resolution.py
@@ -1,0 +1,129 @@
+"""Tests for huf.ai.knowledge.embedding.resolve_embedding_config.
+
+These are isolated unit tests: the Knowledge Source and AI Provider
+documents are faked with SimpleNamespace/MagicMock stand-ins so no live
+Frappe site or database is required, following the mock-based convention
+used in huf/ai/tests/test_conversation_title_autonaming.py.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from huf.ai.knowledge.embedding import resolve_embedding_config
+
+
+def _make_provider(**overrides):
+	defaults = {
+		"api_key": None,
+		"api_base_url": None,
+		"is_local_llm": False,
+		"url": None,
+		"port": None,
+		"provider_brand": None,
+	}
+	defaults.update(overrides)
+	provider = SimpleNamespace(**defaults)
+	provider.get_password = MagicMock(return_value=defaults.get("_password"))
+	return provider
+
+
+class TestResolveEmbeddingConfig(unittest.TestCase):
+	def _run(self, source_overrides, provider=None, provider_brand=None):
+		source_defaults = {
+			"embedding_model": "text-embedding-3-small",
+			"vector_dimension": 1536,
+			"embedding_provider": "OpenAI Provider" if provider else None,
+		}
+		source_defaults.update(source_overrides)
+		source = SimpleNamespace(**source_defaults)
+
+		with patch("huf.ai.knowledge.embedding.frappe") as mock_frappe:
+			mock_frappe.conf.get.return_value = None
+
+			def get_doc(doctype, name=None):
+				if doctype == "Knowledge Source":
+					return source
+				if doctype == "AI Provider":
+					return provider
+				raise AssertionError(f"unexpected get_doc({doctype!r})")
+
+			mock_frappe.get_doc.side_effect = get_doc
+			mock_frappe.db.get_value.return_value = provider_brand
+			return resolve_embedding_config("Some Knowledge Source")
+
+	def test_reads_api_base_url_from_provider(self):
+		provider = _make_provider(api_key="secret", api_base_url="https://my-proxy.example.com/v1", _password="secret")
+		config = self._run(
+			{"embedding_provider": "Custom Provider"},
+			provider=provider,
+		)
+
+		self.assertEqual(config["api_base"], "https://my-proxy.example.com/v1")
+		self.assertEqual(config["api_key"], "secret")
+
+	def test_prefixes_model_with_provider_brand_for_litellm(self):
+		provider = _make_provider(api_key=None)
+		config = self._run(
+			{"embedding_model": "nomic-embed-text", "embedding_provider": "Ollama Provider"},
+			provider=provider,
+			provider_brand="ollama",
+		)
+
+		self.assertEqual(config["model"], "ollama/nomic-embed-text")
+
+	def test_does_not_re_prefix_an_already_prefixed_model(self):
+		provider = _make_provider(api_key=None)
+		config = self._run(
+			{"embedding_model": "openai/text-embedding-3-small", "embedding_provider": "OpenAI Provider"},
+			provider=provider,
+			provider_brand="openai",
+		)
+
+		self.assertEqual(config["model"], "openai/text-embedding-3-small")
+
+	def test_local_llm_falls_back_to_url_and_port_when_no_api_base_url(self):
+		provider = _make_provider(
+			api_key=None,
+			api_base_url="",
+			is_local_llm=True,
+			url="http://localhost",
+			port=11434,
+		)
+		config = self._run(
+			{"embedding_provider": "Local Ollama"},
+			provider=provider,
+		)
+
+		self.assertEqual(config["api_base"], "http://localhost:11434")
+
+	def test_local_llm_does_not_duplicate_port_already_in_url(self):
+		provider = _make_provider(
+			api_key=None,
+			api_base_url="",
+			is_local_llm=True,
+			url="http://localhost:11434",
+			port=11434,
+		)
+		config = self._run(
+			{"embedding_provider": "Local Ollama"},
+			provider=provider,
+		)
+
+		self.assertEqual(config["api_base"], "http://localhost:11434")
+
+	def test_no_provider_returns_none_api_key_and_base(self):
+		config = self._run({"embedding_provider": None}, provider=None)
+
+		self.assertIsNone(config["api_key"])
+		self.assertIsNone(config["api_base"])
+		self.assertEqual(config["model"], "text-embedding-3-small")
+
+	def test_falls_back_to_configured_dimension_default(self):
+		config = self._run({"vector_dimension": None, "embedding_provider": None}, provider=None)
+
+		self.assertEqual(config["dimension"], 1536)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -192,6 +192,8 @@ def create_agent_tools(agent, model_name: str = None) -> list[FunctionTool]:
                     function_path = "huf.ai.memory_tools.handle_archive_memory_record"
                 elif function_doc.types == "Promote Memory to Knowledge":
                     function_path = "huf.ai.memory_tools.handle_promote_memory_to_knowledge"
+                elif function_doc.types == "Code Execution":
+                    function_path = "huf.ai.tools.code_execution.run_python"
 
                 else:
                     continue

--- a/huf/ai/tests/test_agent_run_analytics_api_tz.py
+++ b/huf/ai/tests/test_agent_run_analytics_api_tz.py
@@ -1,0 +1,88 @@
+"""Tests for timezone handling in huf.ai.agent_run_analytics_api.get_execution_analytics.
+
+The frontend sends from_date/to_date as ISO strings (often with a Z/offset
+suffix), which frappe.utils.get_datetime parses as timezone-aware, while
+now_datetime()/add_to_date() return naive local datetimes. Mixing aware and
+naive datetimes in a comparison raises
+"TypeError: can't compare offset-naive and offset-aware datetimes". This
+test exercises the real function (unwrapped via .__wrapped__, since
+frappe.whitelist() decorates it) with frappe itself mocked out, so no live
+site/DB is required, and asserts both aware and naive inputs are handled
+without raising.
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from huf.ai import agent_run_analytics_api as api_module
+
+
+def _unwrapped(func):
+	"""Unwrap a frappe.whitelist()-decorated function down to the plain callable."""
+	while hasattr(func, "__wrapped__"):
+		func = func.__wrapped__
+	return func
+
+
+get_execution_analytics = _unwrapped(api_module.get_execution_analytics)
+
+
+class TestGetExecutionAnalyticsTimezoneHandling(unittest.TestCase):
+	def _mock_frappe(self, mock_frappe):
+		# Grant access via System Manager so _require_analytics_access short-circuits.
+		mock_frappe.session.user = "admin@example.com"
+		mock_frappe.get_roles.return_value = ["System Manager"]
+		# No rollup doctype yet -> function returns the empty-result shape
+		# immediately after the date-window validation, which is exactly the
+		# code path we need to exercise the tz-normalization logic.
+		mock_frappe.db.exists.return_value = False
+		mock_frappe.throw.side_effect = RuntimeError
+
+	@patch("huf.ai.agent_run_analytics_api.frappe")
+	def test_handles_timezone_aware_from_and_to_date(self, mock_frappe):
+		self._mock_frappe(mock_frappe)
+		aware_now = datetime.now(timezone.utc)
+		from_date = (aware_now - timedelta(days=1)).isoformat()
+		to_date = aware_now.isoformat()
+
+		# get_datetime/now_datetime/add_to_date are imported by name into the
+		# module, so they must be patched there directly rather than as
+		# attributes of the mocked `frappe` module.
+		with patch.object(api_module, "get_datetime", side_effect=lambda v: datetime.fromisoformat(v)):
+			result = get_execution_analytics(from_date=from_date, to_date=to_date, granularity="hour")
+
+		self.assertEqual(result["series"], [])
+
+	@patch("huf.ai.agent_run_analytics_api.frappe")
+	def test_handles_naive_datetimes_without_raising(self, mock_frappe):
+		self._mock_frappe(mock_frappe)
+		naive_now = datetime.now()
+
+		with patch.object(api_module, "now_datetime", return_value=naive_now), patch.object(
+			api_module, "add_to_date", return_value=naive_now - timedelta(days=7)
+		):
+			result = get_execution_analytics(granularity="hour")
+
+		self.assertEqual(result["series"], [])
+
+	@patch("huf.ai.agent_run_analytics_api.frappe")
+	def test_mixed_aware_from_date_and_naive_end_does_not_raise(self, mock_frappe):
+		# Regression check for the exact bug fix #6 addresses: from_date is
+		# tz-aware (parsed via get_datetime from an ISO string with an
+		# offset), while `end` defaults to the naive now_datetime(). Without
+		# the fix, `start > end` below would raise TypeError.
+		self._mock_frappe(mock_frappe)
+		aware_from = datetime.now(timezone.utc) - timedelta(days=1)
+		naive_end = datetime.now()
+
+		with patch.object(api_module, "get_datetime", return_value=aware_from), patch.object(
+			api_module, "now_datetime", return_value=naive_end
+		):
+			result = get_execution_analytics(from_date="irrelevant-because-mocked", granularity="hour")
+
+		self.assertEqual(result["series"], [])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_conversation_title_deadlock_retry.py
+++ b/huf/ai/tests/test_conversation_title_deadlock_retry.py
@@ -1,0 +1,68 @@
+"""Tests for the MariaDB deadlock retry wrapper around conversation title updates.
+
+See ``huf.ai.agent_integration._set_conversation_title_with_retry``: the
+background title-generation job can race the main request thread writing to
+the same ``Agent Conversation`` row, occasionally tripping a MariaDB
+deadlock. The wrapper retries once (by default) before giving up.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+
+from huf.ai.agent_integration import _set_conversation_title_with_retry
+
+
+class TestConversationTitleDeadlockRetry(unittest.TestCase):
+	@patch("time.sleep", return_value=None)
+	@patch("huf.ai.agent_integration.frappe.db.set_value")
+	def test_retries_once_on_deadlock_then_succeeds(self, mock_set_value, mock_sleep):
+		# First call raises a deadlock, second call succeeds.
+		mock_set_value.side_effect = [frappe.QueryDeadlockError("Deadlock found"), None]
+
+		_set_conversation_title_with_retry("CONV-0001", "Some Title")
+
+		self.assertEqual(mock_set_value.call_count, 2)
+		mock_set_value.assert_called_with("Agent Conversation", "CONV-0001", "title", "Some Title")
+		mock_sleep.assert_called_once()
+
+	@patch("time.sleep", return_value=None)
+	@patch("huf.ai.agent_integration.frappe.db.set_value")
+	def test_no_retry_when_first_attempt_succeeds(self, mock_set_value, mock_sleep):
+		mock_set_value.return_value = None
+
+		_set_conversation_title_with_retry("CONV-0001", "Some Title")
+
+		self.assertEqual(mock_set_value.call_count, 1)
+		mock_sleep.assert_not_called()
+
+	@patch("time.sleep", return_value=None)
+	@patch("huf.ai.agent_integration.frappe.db.set_value")
+	def test_raises_after_exhausting_retries(self, mock_set_value, mock_sleep):
+		# Every attempt deadlocks; with max_retries=2 that's exactly 2 attempts
+		# (1 initial + 1 retry) before the exception propagates.
+		mock_set_value.side_effect = frappe.QueryDeadlockError("Deadlock found")
+
+		with self.assertRaises(frappe.QueryDeadlockError):
+			_set_conversation_title_with_retry("CONV-0001", "Some Title", max_retries=2)
+
+		self.assertEqual(mock_set_value.call_count, 2)
+		mock_sleep.assert_called_once()
+
+	@patch("time.sleep", return_value=None)
+	@patch("huf.ai.agent_integration.frappe.db.set_value")
+	def test_non_deadlock_errors_are_not_retried(self, mock_set_value, mock_sleep):
+		# Any other exception type should propagate immediately without
+		# consuming a retry attempt.
+		mock_set_value.side_effect = ValueError("unrelated failure")
+
+		with self.assertRaises(ValueError):
+			_set_conversation_title_with_retry("CONV-0001", "Some Title")
+
+		self.assertEqual(mock_set_value.call_count, 1)
+		mock_sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -107,15 +107,21 @@ class PermissionAwareToolRegistry:
 
     @classmethod
     def _allows_code_execution(cls, tool_doc, agent_doc, user: str) -> bool:
-        """Additional gate for tools of type 'Code Execution'.
+        """Additional gate for the Python code execution tool.
 
-        A Code Execution tool is only returned when ALL of:
-          (a) the acting user holds the ``code_execution.run`` capability;
-          (b) the agent has ``allow_code_execution`` enabled;
-          (c) the agent references an Execution Profile that is not disabled.
-        Tools of any other type pass straight through this gate.
+        Matches the SSH/Docker gate pattern: identify the tool by function_path
+        or tool_name (registry-synced tools are App Provided, not "Code
+        Execution" type) and enforce code_execution.run capability, agent opt-in,
+        and an enabled Execution Profile.
         """
-        if tool_doc.types != "Code Execution":
+        function_path = (getattr(tool_doc, "function_path", None) or "").strip()
+        tool_name = (getattr(tool_doc, "tool_name", None) or "").strip()
+        is_code_tool = (
+            tool_doc.types == "Code Execution"
+            or function_path == "huf.ai.tools.code_execution.run_python"
+            or tool_name == "run_python"
+        )
+        if not is_code_tool:
             return True
 
         from huf.permissions import has_capability

--- a/huf/ai/tools/_registry.py
+++ b/huf/ai/tools/_registry.py
@@ -1841,6 +1841,22 @@ DOCUMENT_ARTIFACT_TOOLS = [
 	},
 ]
 
+
+CODE_EXECUTION_TOOLS = [
+	{
+		"tool_name": "run_python",
+		"description": (
+			"Execute sandboxed Python code inside a restricted subprocess. "
+			"Requires the agent to have code execution enabled and an Execution Profile selected."
+		),
+		"function_path": "huf.ai.tools.code_execution.run_python",
+		"category": "Code Execution",
+		"parameters": [
+			_p("code", required=True, description="Python source code to execute"),
+		],
+	},
+]
+
 ALL_INTEGRATION_TOOLS = (
 	# Platform capabilities — no external account to connect.
 	RECIPIENT_TOOLS
@@ -1855,6 +1871,7 @@ ALL_INTEGRATION_TOOLS = (
 	+ SSH_TOOLS
 	+ DOCKER_TOOLS
 	+ DOCUMENT_ARTIFACT_TOOLS
+	+ CODE_EXECUTION_TOOLS
 	# Tools backed by a connectable service. Keys match Integration Service
 	# docnames and the SERVICE_NAME each tool module uses for credentials.
 	+ _with_service(SLACK_TOOLS, "slack")

--- a/huf/ai/tools/code_execution.py
+++ b/huf/ai/tools/code_execution.py
@@ -31,8 +31,6 @@ from __future__ import annotations
 
 import hashlib
 import ipaddress
-
-import frappe
 import json
 import os
 import shutil
@@ -40,6 +38,7 @@ import tempfile
 from typing import Any
 from urllib.parse import urlparse
 
+import frappe
 from frappe.utils.data import add_to_date, now_datetime
 from frappe.utils.file_manager import save_file
 

--- a/huf/ai/tools/code_execution.py
+++ b/huf/ai/tools/code_execution.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 import hashlib
 import ipaddress
+
+import frappe
 import json
 import os
 import shutil

--- a/huf/hooks.py
+++ b/huf/hooks.py
@@ -279,7 +279,7 @@ scheduler_events = {
 # Testing
 # -------
 
-# before_tests = "huf.install.before_tests"
+before_tests = "huf.install.before_tests"
 
 # Overriding Methods
 # ------------------------------

--- a/huf/huf/doctype/agent/agent.json
+++ b/huf/huf/doctype/agent/agent.json
@@ -904,7 +904,8 @@
    "description": "Maximum size (in MB) for a single uploaded file. Capped by the global 25 MB limit.",
    "fieldname": "max_upload_size_mb",
    "fieldtype": "Int",
-   "label": "Max Upload Size (MB)"
+   "label": "Max Upload Size (MB)",
+   "non_negative": 1
   },
   {
    "description": "Opt-in to the elevated-risk Python Code Execution tool. Requires both this flag and a Code Execution tool assigned in the Tools tab, plus an Execution Profile below, before the tool becomes active.",

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -124,6 +124,7 @@ class Agent(Document):
             self._validate_prompt_caching()
 
         self._validate_advanced_models()
+        self._validate_voice_config()
         self._validate_skills()
         self._validate_starter_prompts()
         self._validate_allowed_users_and_roles()
@@ -363,6 +364,23 @@ class Agent(Document):
                     _("Selected STT Model does not support modality: Transcription"),
                     title=_("Invalid Model Capability"),
                 )
+
+    def _validate_voice_config(self):
+        """Ensure voice_config is valid JSON when voice is enabled."""
+        if not getattr(self, "voice_enabled", 0):
+            return
+
+        raw_config = getattr(self, "voice_config", None)
+        if not raw_config:
+            return
+
+        try:
+            json.loads(raw_config)
+        except (TypeError, ValueError):
+            frappe.throw(
+                _("Voice Configuration must be valid JSON."),
+                title=_("Invalid Voice Configuration"),
+            )
 
     def _validate_prompt_caching(self):
         if not self.model:

--- a/huf/huf/doctype/agent/agent.py
+++ b/huf/huf/doctype/agent/agent.py
@@ -125,6 +125,7 @@ class Agent(Document):
 
         self._validate_advanced_models()
         self._validate_voice_config()
+        self._validate_max_upload_size()
         self._validate_skills()
         self._validate_starter_prompts()
         self._validate_allowed_users_and_roles()
@@ -380,6 +381,31 @@ class Agent(Document):
             frappe.throw(
                 _("Voice Configuration must be valid JSON."),
                 title=_("Invalid Voice Configuration"),
+            )
+
+    def _validate_max_upload_size(self):
+        """Reject a negative Max Upload Size (MB).
+
+        The `non_negative: 1` DocType constraint on this Int field is a UI
+        hint only (grays out the minus sign / shows a warning in Desk) — it is
+        not enforced by `Document.save()` for a value set programmatically
+        (e.g. via `frappe.get_doc(...).save()` or the REST API), so an
+        explicit check is required here. This mirrors the same pattern used
+        for other `non_negative` fields in this codebase, e.g.
+        `KnowledgeSource.validate_vector_settings` and
+        `ExecutionProfile.validate`, both of which also re-check in Python
+        despite already being marked `non_negative` in their DocType JSON.
+
+        A negative value here would silently break the upload-size gate in
+        `huf.ai.agent_chat`: `min(max_upload_size_mb, 25)` would pick the
+        negative value, producing a negative byte ceiling that makes every
+        upload appear to exceed the limit.
+        """
+        max_upload_size_mb = getattr(self, "max_upload_size_mb", None)
+        if max_upload_size_mb is not None and max_upload_size_mb < 0:
+            frappe.throw(
+                _("Max Upload Size (MB) cannot be negative."),
+                title=_("Invalid Upload Size"),
             )
 
     def _validate_prompt_caching(self):

--- a/huf/install.py
+++ b/huf/install.py
@@ -99,6 +99,31 @@ def _setup_desktop_icon_as_workspace():
 	frappe.db.commit()
 
 
+def before_tests():
+	"""Clear the stale test-record cache before every `bench run-tests` invocation.
+
+	Frappe test_runner.main() calls frappe.utils.scheduler.disable_scheduler() (an
+	uncommitted write) before running any doctype/module tests. On a first run,
+	make_test_records(..., commit=True) happens to flush that write. But
+	make_test_records short-circuits per doctype once sites/<site>/.test_log
+	already lists it (see frappe/test_runner.py get_test_record_log /
+	add_to_test_record_log), so on any second-or-later run against the same site
+	no commit ever happens and the next frappe.db.begin() collides with the
+	still-uncommitted scheduler-disable write, raising
+	frappe.exceptions.ImplicitCommitError. Clearing the cache here forces
+	make_test_records to recreate (and commit) on every run, so this cannot
+	recur regardless of prior test-runner state on this site.
+	"""
+	import os
+
+	test_log_path = frappe.get_site_path(".test_log")
+	if os.path.exists(test_log_path):
+		os.remove(test_log_path)
+	frame = getattr(frappe, "flags", None)
+	if frame is not None and "test_record_log" in frame:
+		del frame["test_record_log"]
+
+
 def after_install():
     create_huf_roles()
     create_demo_ai_providers()


### PR DESCRIPTION
## What this is, plainly

Seven small, independent bugfixes found during a live-bench QA sweep of agent config, knowledge/embeddings, execution analytics, and the code-execution tool. Now with test coverage for the three that could be tested without a live Frappe site, and one additional real bug found and fixed while writing those tests.

## The seven fixes

1. **Retry once on MariaDB deadlock** when persisting a background-generated conversation title, instead of dropping the title silently.
2. **Reject invalid JSON** in `Agent.voice_config` at save time instead of persisting it and failing later at voice-session start.
3. **Enforce non-negative `Agent.max_upload_size_mb`** — a negative value was silently breaking every chat upload.
4. **Fix embedding config resolution** for knowledge sources: reads the AI Provider's `api_base_url` (the field that actually exists) instead of a nonexistent `api_base`, and provider-prefixes the model for LiteLLM so local/Ollama-backed embeddings actually reach the provider.
5. **Make the `run_python` code-execution tool reachable end-to-end**: missing import, tool-sync registration, capability-gate widening, and the "Code Execution" type mapping in two consumer modules that lacked one.
6. **Fix a naive/aware datetime comparison crash** in execution analytics when the frontend sends ISO date strings with a timezone suffix.
7. **Add a `before_tests` hook** that clears the site's stale test-record cache, fixing intermittent `ImplicitCommitError` on repeated `bench run-tests` runs.

## What changed since the last review round

The original review found all 7 fixes correct but with zero test coverage. This round closed most of that gap:

- **Added 3 real unit test files**, following this codebase's existing test conventions:
  - Deadlock retry (#1): 4 tests, syntax-checked (couldn't execute — `agent_integration.py` transitively pulls in `litellm`/the OpenAI Agents SDK, too heavy to stub quickly in an isolated clone; should run clean in CI).
  - Embedding config resolution (#4): 7 tests, **executed and passing** against a stub `frappe` module.
  - Analytics datetime fix (#6): 3 tests, **executed and passing** — and verified meaningful by reverting the fix locally, confirming the test fails with the exact `TypeError` the fix addresses, then restoring the fix.
- **Fixed the import-order nit** flagged in review (`import frappe` in `code_execution.py` was in the wrong import group — this also happened to paper over a latent pre-existing bug where the function used bare `frappe.*` calls with no top-level import at all before this PR added one, just misplaced).
- **Found and fixed a real bug while investigating fix #3**: the DocType's `"non_negative": 1` JSON flag alone does *not* enforce server-side — confirmed against this repo's own convention, where `KnowledgeSource` and `ExecutionProfile` both pair `non_negative: 1` with an explicit Python check. Traced the actual impact: without one here, a negative `max_upload_size_mb` reaches the upload-size calculation in `agent_chat.py` and produces a negative byte ceiling, silently breaking every file upload rather than just failing validation. Added the missing `frappe.throw`.

## What's still open

- **Fix #7 (`before_tests` hook) needs a live bench run** to verify — `bench run-tests` behavior isn't something a bare git clone can exercise. Flagging for whoever merges this to do one rerun before/after.
- The deadlock-retry test (#1) should be run in CI rather than trusted on syntax-check alone, given the heavy import chain prevented local execution here.

## Recommendation

Low risk, high confidence. Safe to land once CI confirms the new tests pass and someone does the one manual `bench run-tests` check for fix #7.

*Second-round fixes applied by an automated audit/fix pass over 2026-08-25's revived-branch inventory.*
