### PR TITLE
feat: community OpenAI/Kimi subscription adapters (revived, conflict-resolved)

### DIFF
--- a/HOW_TO_TEST.md
+++ b/HOW_TO_TEST.md
@@ -1,0 +1,280 @@
+# How to Test Community Subscription Adapters
+
+> Branch: `feat/community-subscription-adapters`  
+> Container: `fdocker_devcontainer-frappe-1`  
+> Bench path (inside container): `/workspace/development/16`  
+> Site: `huf.localhost`  
+> Host URL: `http://huf.localhost:8100`
+
+## What this branch adds
+
+- A new **AI Provider Connection** DocType that stores per-user OAuth/device-code tokens.
+- A subscription-adapter registry under `huf/ai/providers/adapters/`.
+- Community adapters that reuse public client credentials from popular AI CLI plugins:
+  - **OpenAI Community** (`openai_community_subscription`) — OAuth PKCE, manual paste flow.
+  - **Kimi For Coding** (`kimi_community_subscription`) — OAuth device flow.
+  - **Mock** (`mock_subscription`) — for CI / offline regression tests.
+- An OAuth callback page at `/huf/sub_oauth`.
+- Routing changes in `huf/ai/run.py` and `huf/ai/agent_integration.py` so agents can run through a subscription connection even when the shared AI Provider has no API key.
+
+> ⚠️ These adapters use **community-reversed OAuth client IDs**. They are not official integrations. Enable them only for experimentation; using them with real accounts may violate the provider’s Terms of Service.
+
+---
+
+## 1. Environment setup
+
+Run all bench commands through the Frappe container:
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost <COMMAND>"
+```
+
+### 1.1 Migrate the site
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost migrate"
+```
+
+### 1.2 Enable the adapters
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && \
+  bench --site huf.localhost set-config enable_openai_community_subscription_adapter 1 && \
+  bench --site huf.localhost set-config enable_kimi_community_subscription_adapter 1 && \
+  bench --site huf.localhost set-config enable_mock_subscription_adapter 1"
+```
+
+### 1.3 Verify the callback page
+
+From your Mac:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}' http://huf.localhost:8100/huf/sub_oauth
+# Expected: 200
+```
+
+---
+
+## 2. Run the test suite
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && \
+  bench --site huf.localhost run-tests --module huf.ai.tests.test_subscription_adapter_mock && \
+  bench --site huf.localhost run-tests --module huf.ai.tests.test_subscription_adapter_openai_community && \
+  bench --site huf.localhost run-tests --module huf.ai.tests.test_subscription_adapter_kimi_community"
+```
+
+Expected results:
+
+| Module | Tests |
+|--------|-------|
+| `test_subscription_adapter_mock` | 7 passed |
+| `test_subscription_adapter_openai_community` | 8 passed |
+| `test_subscription_adapter_kimi_community` | 9 passed |
+
+---
+
+## 3. Test the OpenAI Community adapter (live OAuth)
+
+### 3.1 Create the AI Provider
+
+Open `http://huf.localhost:8100/app/ai-provider/new` and enter:
+
+| Field | Value |
+|-------|-------|
+| Provider Name | `OpenAI Community` |
+| Provider Brand | `openai_community` |
+| API Key | *(leave blank)* |
+
+Save.
+
+### 3.2 Create the AI Provider Connection
+
+Open `http://huf.localhost:8100/app/ai-provider-connection/new` and enter:
+
+| Field | Value |
+|-------|-------|
+| Connection Name | `OpenAI Community Test` |
+| User | your user |
+| AI Provider | `OpenAI Community` |
+| Adapter Type | `openai_community_subscription` |
+| Auth Method | `OAuth PKCE (Manual Paste)` |
+| Is Active | ✅ |
+| Eligible Models | `["gpt-4o"]` |
+
+Save.
+
+### 3.3 Start authorization
+
+Run in bench:
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost execute \"from huf.ai.providers.adapters import get_adapter; c=frappe.get_doc('AI Provider Connection','OpenAI Community Test'); a=get_adapter(c.adapter_type); r=a.start_authorization(c,'OAuth PKCE (Manual Paste)'); c.save(ignore_permissions=True); print(r['auth_url'])\""
+```
+
+Open the printed URL in your browser, authorize, then copy the final browser URL (the one containing `?code=...&state=...`).
+
+### 3.4 Complete authorization
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost execute \"from huf.ai.providers.adapters import get_adapter; c=frappe.get_doc('AI Provider Connection','OpenAI Community Test'); a=get_adapter(c.adapter_type); r=a.complete_authorization(c,{'pasted_url':'PASTE_URL_HERE'}); c.save(ignore_permissions=True); print(r)\""
+```
+
+`auth_status` should change to `Active`.
+
+### 3.5 Run an agent
+
+Create or run an Agent with:
+
+| Field | Value |
+|-------|-------|
+| AI Provider | `OpenAI Community` |
+| Model | `gpt-4o` |
+
+Or call programmatically:
+
+```python
+from huf.ai.agent_integration import run_agent_sync
+run_agent_sync(
+    agent="Your Agent",
+    prompt="Hello",
+    provider="OpenAI Community",
+    model="gpt-4o",
+    subscription_connection_name="OpenAI Community Test",
+)
+```
+
+---
+
+## 4. Test the Kimi For Coding adapter (device flow)
+
+### 4.1 Create the AI Provider
+
+Open `http://huf.localhost:8100/app/ai-provider/new`:
+
+| Field | Value |
+|-------|-------|
+| Provider Name | `Kimi For Coding` |
+| Provider Brand | `kimi_community` |
+| API Key | *(leave blank)* |
+
+Save.
+
+### 4.2 Create the AI Provider Connection
+
+Open `http://huf.localhost:8100/app/ai-provider-connection/new`:
+
+| Field | Value |
+|-------|-------|
+| Connection Name | `Kimi Test` |
+| User | your user |
+| AI Provider | `Kimi For Coding` |
+| Adapter Type | `kimi_community_subscription` |
+| Auth Method | `Device Code` |
+| Is Active | ✅ |
+| Eligible Models | `["kimi-for-coding"]` |
+
+Save.
+
+### 4.3 Start device authorization
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost execute \"from huf.ai.providers.adapters import get_adapter; c=frappe.get_doc('AI Provider Connection','Kimi Test'); a=get_adapter(c.adapter_type); r=a.start_authorization(c,'Device Code'); c.save(ignore_permissions=True); print(r)\""
+```
+
+The output contains `user_code` and `verification_uri`. Open the URI in your browser, enter the user code, and approve.
+
+### 4.4 Complete authorization
+
+While the browser flow is active, run:
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost execute \"from huf.ai.providers.adapters import get_adapter; c=frappe.get_doc('AI Provider Connection','Kimi Test'); a=get_adapter(c.adapter_type); r=a.complete_authorization(c,{}); c.save(ignore_permissions=True); print(r)\""
+```
+
+The adapter polls the token endpoint until approval or expiry.
+
+### 4.5 Run an agent
+
+```python
+from huf.ai.agent_integration import run_agent_sync
+run_agent_sync(
+    agent="Your Agent",
+    prompt="Hello",
+    provider="Kimi For Coding",
+    model="kimi-for-coding",
+    subscription_connection_name="Kimi Test",
+)
+```
+
+---
+
+## 5. Useful URLs
+
+| URL | Purpose |
+|-----|---------|
+| `http://huf.localhost:8100/huf` | HUF frontend SPA |
+| `http://huf.localhost:8100/huf/sub_oauth` | OAuth callback page |
+| `http://huf.localhost:8100/app/ai-provider` | AI Provider list |
+| `http://huf.localhost:8100/app/ai-provider-connection` | AI Provider Connection list |
+
+---
+
+## 6. Optional site config overrides
+
+### OpenAI Community
+
+```bash
+bench --site huf.localhost set-config openai_community_oauth_client_id '<client_id>'
+bench --site huf.localhost set-config openai_community_auth_url '<auth_url>'
+bench --site huf.localhost set-config openai_community_token_url '<token_url>'
+bench --site huf.localhost set-config openai_community_api_base_url '<api_base>'
+```
+
+### Kimi Community
+
+```bash
+bench --site huf.localhost set-config kimi_community_oauth_client_id '<client_id>'
+bench --site huf.localhost set-config kimi_community_oauth_device_auth_url '<device_auth_url>'
+bench --site huf.localhost set-config kimi_community_oauth_token_url '<token_url>'
+bench --site huf.localhost set-config kimi_community_api_base_url '<api_base>'
+bench --site huf.localhost set-config kimi_community_device_id '<stable_hex_uuid>'
+```
+
+Defaults are hard-coded to the values used by the referenced community plugins.
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `PermissionError: ... adapter is disabled` | Feature flag is off | Set the relevant `enable_*_subscription_adapter` config to `1` |
+| `API Key is required for cloud providers` | Provider brand not in `SUBSCRIPTION_BRANDS` | Use `openai_community` or `kimi_community` brand |
+| `/huf/sub_oauth` returns 404 | DocType/page not migrated | Run `bench --site huf.localhost migrate` |
+| `subscription connection is expired` | Token refresh failed | Re-run the authorization flow |
+| Tests fail with `KeyError: 'url'` | Tests out of sync with adapter | Pull the latest branch; positional/keyword URL assertions were aligned |
+
+---
+
+## 8. Files changed
+
+```
+huf/ai/agent_integration.py
+huf/ai/run.py
+huf/ai/providers/adapters/__init__.py
+huf/ai/providers/adapters/base.py
+huf/ai/providers/adapters/mock.py
+huf/ai/providers/adapters/openai.py
+huf/ai/providers/adapters/openai_community.py
+huf/ai/providers/adapters/kimi_community.py
+huf/ai/tests/test_subscription_adapter_mock.py
+huf/ai/tests/test_subscription_adapter_openai_community.py
+huf/ai/tests/test_subscription_adapter_kimi_community.py
+huf/huf/doctype/ai_provider/ai_provider.json
+huf/huf/doctype/ai_provider/ai_provider.py
+huf/huf/doctype/ai_provider_connection/
+huf/www/sub_oauth.py
+huf/www/sub_oauth.html
+HOW_TO_TEST.md
+```

--- a/HOW_TO_TEST.md
+++ b/HOW_TO_TEST.md
@@ -29,7 +29,17 @@ Run all bench commands through the Frappe container:
 docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost <COMMAND>"
 ```
 
-### 1.1 Migrate the site
+### 1.1 Build the frontend SPA
+
+The HUF UI is a Vite SPA. After pulling the branch, build it with **yarn** inside the container:
+
+```bash
+docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16/apps/huf/frontend && yarn build"
+```
+
+Do not use `npm run build` for HUF/Frappe apps in this bench.
+
+### 1.2 Migrate the site
 
 ```bash
 docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && bench --site huf.localhost migrate"
@@ -55,7 +65,60 @@ curl -s -o /dev/null -w '%{http_code}' http://huf.localhost:8100/huf/sub_oauth
 
 ---
 
-## 2. Run the test suite
+## 2. Use the HUF UI (recommended)
+
+### 2.1 Open the Subscription Connections page
+
+Go to **AI Providers** (`http://huf.localhost:8100/huf/providers`) and click **Connections** in the top-right.
+
+Or visit directly:
+
+```
+http://huf.localhost:8100/huf/provider-connections
+```
+
+### 2.2 Create a connection
+
+1. Click **Add Connection**.
+2. Fill in:
+   - **Connection Name**: anything unique
+   - **AI Provider**: pick the provider you created (brand must be `openai_community` or `kimi_community`)
+   - **Adapter Type**: `openai_community_subscription` or `kimi_community_subscription`
+   - **Auth Method**: auto-populated from the adapter
+   - **Eligible Models**: `["gpt-4o"]` or `["kimi-for-coding"]`
+3. Click **Create Connection**.
+
+### 2.3 Authorize
+
+For **OpenAI Community**:
+
+1. Click **Authorize** on the connection row.
+2. Open the printed **Authorization URL** in a new tab.
+3. After authorizing, copy the final browser URL (`https://...?code=...&state=...`).
+4. Paste it into the **Pasted Callback URL** field.
+5. Click **Complete Authorization**.
+
+For **Kimi For Coding**:
+
+1. Click **Authorize** on the connection row.
+2. Open the **verification page** link in a new tab.
+3. Enter the displayed **User Code** on the Kimi site.
+4. Click **Complete Authorization** in HUF.
+
+Status changes to `Active` when successful.
+
+### 2.4 Run an agent
+
+Create or run an Agent with:
+
+| Field | Value |
+|-------|-------|
+| AI Provider | `OpenAI Community` or `Kimi For Coding` |
+| Model | `gpt-4o` or `kimi-for-coding` |
+
+The runtime auto-discovers the active connection for the current user.
+
+## 3. Run the test suite
 
 ```bash
 docker exec fdocker_devcontainer-frappe-1 bash -c "cd /workspace/development/16 && \
@@ -74,7 +137,7 @@ Expected results:
 
 ---
 
-## 3. Test the OpenAI Community adapter (live OAuth)
+## 4. Test the OpenAI Community adapter (live OAuth)
 
 ### 3.1 Create the AI Provider
 
@@ -146,7 +209,7 @@ run_agent_sync(
 
 ---
 
-## 4. Test the Kimi For Coding adapter (device flow)
+## 5. Test the Kimi For Coding adapter (device flow)
 
 ### 4.1 Create the AI Provider
 
@@ -209,7 +272,7 @@ run_agent_sync(
 
 ---
 
-## 5. Useful URLs
+## 6. Useful URLs
 
 | URL | Purpose |
 |-----|---------|
@@ -220,7 +283,7 @@ run_agent_sync(
 
 ---
 
-## 6. Optional site config overrides
+## 7. Optional site config overrides
 
 ### OpenAI Community
 
@@ -245,7 +308,7 @@ Defaults are hard-coded to the values used by the referenced community plugins.
 
 ---
 
-## 7. Troubleshooting
+## 8. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
@@ -257,7 +320,7 @@ Defaults are hard-coded to the values used by the referenced community plugins.
 
 ---
 
-## 8. Files changed
+## 9. Files changed
 
 ```
 huf/ai/agent_integration.py
@@ -273,8 +336,14 @@ huf/ai/tests/test_subscription_adapter_openai_community.py
 huf/ai/tests/test_subscription_adapter_kimi_community.py
 huf/huf/doctype/ai_provider/ai_provider.json
 huf/huf/doctype/ai_provider/ai_provider.py
-huf/huf/doctype/ai_provider_connection/
+huf/huf/doctype/ai_provider_connection/ai_provider_connection.py
 huf/www/sub_oauth.py
 huf/www/sub_oauth.html
+frontend/src/App.tsx
+frontend/src/components/AiProvidersHeaderActions.tsx
+frontend/src/data/doctypes.ts
+frontend/src/pages/AiProviderConnectionsPage.tsx
+frontend/src/pages/AiProviderConnectionsPageWrapper.tsx
+frontend/src/services/providerConnectionApi.ts
 HOW_TO_TEST.md
 ```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,7 @@ const FlowListPage = lazy(() => import('./pages/FlowListPage'));
 const FlowCanvasPageWrapper = lazy(() => import('./pages/FlowCanvasPageWrapper'));
 const DataPage = lazy(() => import('./pages/DataPage'));
 const AiProvidersPageWrapper = lazy(() => import('./pages/AiProvidersPageWrapper'));
+const AiProviderConnectionsPageWrapper = lazy(() => import('./pages/AiProviderConnectionsPageWrapper'));
 const ChatPage = lazy(() => import('./pages/ChatPageV2'));
 const ChatOnlyPage = lazy(() => import('./pages/ChatOnlyPage'));
 const ChatProjectsPage = lazy(() =>
@@ -402,6 +403,16 @@ function AppShell() {
               <ProtectedRoute>
                 <Suspense fallback={<PageLoader />}>
                   <AiProvidersPageWrapper />
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/provider-connections"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<PageLoader />}>
+                  <AiProviderConnectionsPageWrapper />
                 </Suspense>
               </ProtectedRoute>
             }

--- a/frontend/src/components/AiProvidersHeaderActions.tsx
+++ b/frontend/src/components/AiProvidersHeaderActions.tsx
@@ -1,14 +1,22 @@
-import { Plus } from 'lucide-react';
+import { Plus, Link2 } from 'lucide-react';
 import { Button } from './ui/button';
 import { useAiProviders } from '../contexts/AiProvidersContext';
+import { useNavigate } from 'react-router-dom';
 
 export function AiProvidersHeaderActions() {
   const { onAddProvider } = useAiProviders();
+  const navigate = useNavigate();
 
   return (
-    <Button variant="display" onClick={onAddProvider} size="sm">
-      <Plus className="w-4 h-4 mr-2" />
-      Add provider
-    </Button>
+    <div className="flex items-center gap-2">
+      <Button variant="outline" onClick={() => navigate('/provider-connections')} size="sm">
+        <Link2 className="w-4 h-4 mr-2" />
+        Connections
+      </Button>
+      <Button variant="display" onClick={onAddProvider} size="sm">
+        <Plus className="w-4 h-4 mr-2" />
+        Add Provider
+      </Button>
+    </div>
   );
 }

--- a/frontend/src/data/doctypes.ts
+++ b/frontend/src/data/doctypes.ts
@@ -3,6 +3,7 @@ export const doctype = {
   Role: "Role",
   Agent: "Agent",
   "AI Provider": "AI Provider",
+  "AI Provider Connection": "AI Provider Connection",
   "AI Model": "AI Model",
   "Agent Tool Function": "Agent Tool Function",
   "Agent Tool Type": "Agent Tool Type",

--- a/frontend/src/pages/AiProviderConnectionsPage.tsx
+++ b/frontend/src/pages/AiProviderConnectionsPage.tsx
@@ -1,0 +1,646 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ArrowUpDown,
+  CheckCircle2,
+  ExternalLink,
+  KeyRound,
+  Link2,
+  Loader2,
+  Plug,
+  Plus,
+  Unlink,
+} from 'lucide-react';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+  HeaderContext,
+} from '@tanstack/react-table';
+import { FilterBar, PageLayout, StatusDot, EmptyState } from '@/components/dashboard';
+import { Button } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { toast } from 'sonner';
+import { getProviders, type AIProviderDoc } from '@/services/providerApi';
+import {
+  getConnections,
+  getAuthMethods,
+  startAuthorization,
+  completeAuthorization,
+  revokeAuthorization,
+  createConnection,
+  type ConnectionListItem,
+  type AuthMethod,
+  type StartAuthorizationResult,
+} from '@/services/providerConnectionApi';
+import { formatTimeAgo } from '@/utils/time';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+
+const ADAPTER_TYPES = [
+  { value: 'openai_subscription', label: 'OpenAI Subscription' },
+  { value: 'openai_community_subscription', label: 'OpenAI Community Subscription' },
+  { value: 'kimi_community_subscription', label: 'Kimi For Coding Community' },
+  { value: 'google_subscription', label: 'Google Subscription' },
+  { value: 'antigravity_subscription', label: 'Antigravity Subscription' },
+  { value: 'mock_subscription', label: 'Mock Subscription' },
+];
+
+function SortHeader<TData>({
+  column,
+  label,
+}: {
+  column: HeaderContext<TData, unknown>['column'];
+  label: string;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      className="h-8 px-2 font-body text-[13px] font-medium text-steel hover:text-ink hover:bg-paper-deep"
+    >
+      {label}
+      <ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+    </Button>
+  );
+}
+
+function statusVariant(status: string): 'ok' | 'fail' | 'idle' | 'run' {
+  switch (status) {
+    case 'Active':
+      return 'ok';
+    case 'Pending Authorization':
+      return 'run';
+    case 'Expired':
+    case 'Error':
+      return 'fail';
+    default:
+      return 'idle';
+  }
+}
+
+export function AiProviderConnectionsPage() {
+  const [connections, setConnections] = useState<ConnectionListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const [providers, setProviders] = useState<AIProviderDoc[]>([]);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newConnection, setNewConnection] = useState({
+    connection_name: '',
+    provider: '',
+    adapter_type: '',
+    auth_method: '',
+    eligible_models: '["gpt-4o"]',
+  });
+  const [authMethods, setAuthMethods] = useState<AuthMethod[]>([]);
+  const [creating, setCreating] = useState(false);
+
+  const [authorizeOpen, setAuthorizeOpen] = useState(false);
+  const [authorizingConnection, setAuthorizingConnection] = useState<ConnectionListItem | null>(null);
+  const [authorizeResult, setAuthorizeResult] = useState<StartAuthorizationResult | null>(null);
+  const [pastedUrl, setPastedUrl] = useState('');
+  const [authorizing, setAuthorizing] = useState(false);
+  const [completing, setCompleting] = useState(false);
+
+  const loadConnections = async () => {
+    setLoading(true);
+    try {
+      const data = await getConnections();
+      setConnections(data);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadConnections();
+    getProviders().then((response) => {
+      const items = Array.isArray(response) ? response : response.items;
+      setProviders(items);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!newConnection.adapter_type) {
+      setAuthMethods([]);
+      return;
+    }
+    getAuthMethods(newConnection.adapter_type).then(setAuthMethods);
+  }, [newConnection.adapter_type]);
+
+  const providerOptions = useMemo(
+    () =>
+      providers.map((p) => ({
+        value: p.name,
+        label: p.provider_name || p.name,
+        subtitle: p.provider_brand || '',
+      })),
+    [providers]
+  );
+
+  const handleCreate = async () => {
+    if (!newConnection.connection_name.trim() || !newConnection.provider || !newConnection.adapter_type) {
+      toast.error('Please fill in all required fields');
+      return;
+    }
+    setCreating(true);
+    try {
+      await createConnection({
+        connection_name: newConnection.connection_name.trim(),
+        user: '', // server defaults to current user
+        provider: newConnection.provider,
+        adapter_type: newConnection.adapter_type,
+        auth_method: newConnection.auth_method || authMethods[0]?.method || '',
+        eligible_models: newConnection.eligible_models || '[]',
+        is_active: 1,
+      });
+      toast.success('Connection created');
+      setCreateOpen(false);
+      setNewConnection({
+        connection_name: '',
+        provider: '',
+        adapter_type: '',
+        auth_method: '',
+        eligible_models: '["gpt-4o"]',
+      });
+      loadConnections();
+    } catch (error) {
+      toast.error('Failed to create connection', {
+        description: getFrappeErrorMessage(error),
+      });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const openAuthorize = async (connection: ConnectionListItem) => {
+    setAuthorizingConnection(connection);
+    setAuthorizeResult(null);
+    setPastedUrl('');
+    setAuthorizeOpen(true);
+
+    const method = connection.auth_method || connection.auth_methods[0]?.method;
+    if (!method) {
+      toast.error('No auth method available for this connection');
+      return;
+    }
+
+    setAuthorizing(true);
+    try {
+      const result = await startAuthorization(
+        connection.name,
+        method,
+        `${window.location.origin}/huf/sub_oauth`
+      );
+      setAuthorizeResult(result);
+    } catch (error) {
+      toast.error('Failed to start authorization', {
+        description: getFrappeErrorMessage(error),
+      });
+    } finally {
+      setAuthorizing(false);
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!authorizingConnection) return;
+    setCompleting(true);
+    try {
+      const payload: Record<string, unknown> = {};
+      if (pastedUrl.trim()) {
+        payload.pasted_url = pastedUrl.trim();
+      }
+      const result = await completeAuthorization(authorizingConnection.name, payload);
+      toast.success(`Authorization ${result.status || 'completed'}`);
+      setAuthorizeOpen(false);
+      loadConnections();
+    } catch (error) {
+      toast.error('Authorization failed', {
+        description: getFrappeErrorMessage(error),
+      });
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  const handleRevoke = async (connection: ConnectionListItem) => {
+    try {
+      const result = await revokeAuthorization(connection.name);
+      toast.success(`Connection ${result.auth_status.toLowerCase()}`);
+      loadConnections();
+    } catch (error) {
+      toast.error('Failed to revoke connection', {
+        description: getFrappeErrorMessage(error),
+      });
+    }
+  };
+
+  const columns = useMemo<ColumnDef<ConnectionListItem>[]>(
+    () => [
+      {
+        accessorKey: 'connection_name',
+        header: ({ column }) => <SortHeader column={column} label="Connection" />,
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2">
+            <Plug className="h-4 w-4 text-steel-soft shrink-0" strokeWidth={1.6} />
+            <div>
+              <div className="font-body text-[13px] font-semibold text-ink">
+                {row.original.connection_name}
+              </div>
+              <div className="font-mono text-[11px] text-steel-soft">{row.original.adapter_type}</div>
+            </div>
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'provider',
+        header: 'Provider',
+        cell: ({ row }) => (
+          <div className="font-body text-[13px] text-steel">
+            {row.original.provider}
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'auth_status',
+        header: 'Status',
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2">
+            <StatusDot variant={statusVariant(row.original.auth_status)} />
+            <span className="font-body text-[13px] text-steel">{row.original.auth_status}</span>
+            {row.original.is_expired && row.original.auth_status === 'Active' && (
+              <span className="text-[11px] text-destructive">(expired)</span>
+            )}
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'auth_method',
+        header: 'Auth Method',
+        cell: ({ row }) => (
+          <div className="font-mono text-[12px] text-steel">{row.original.auth_method || '-'}</div>
+        ),
+      },
+      {
+        accessorKey: 'account_email',
+        header: 'Account',
+        cell: ({ row }) => (
+          <div className="font-body text-[13px] text-steel">
+            {row.original.account_email || '-'}
+          </div>
+        ),
+      },
+      {
+        id: 'modified',
+        header: ({ column }) => <SortHeader column={column} label="Modified" />,
+        cell: ({ row }) => (
+          <div className="font-mono text-[12px] text-steel">
+            {formatTimeAgo(row.original.modified ?? null)}
+          </div>
+        ),
+        sortingFn: (rowA, rowB) => {
+          const timeA = rowA.original.modified ? new Date(rowA.original.modified).getTime() : 0;
+          const timeB = rowB.original.modified ? new Date(rowB.original.modified).getTime() : 0;
+          return timeA - timeB;
+        },
+      },
+      {
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => {
+          const conn = row.original;
+          const canAuthorize = conn.auth_status !== 'Active';
+          return (
+            <div className="flex items-center justify-end gap-1">
+              {canAuthorize ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => openAuthorize(conn)}
+                  disabled={authorizing && authorizingConnection?.name === conn.name}
+                >
+                  {authorizing && authorizingConnection?.name === conn.name ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Link2 className="h-4 w-4" />
+                  )}
+                  <span className="ml-1">Authorize</span>
+                </Button>
+              ) : (
+                <Button variant="ghost" size="sm" onClick={() => handleRevoke(conn)}>
+                  <Unlink className="h-4 w-4" />
+                  <span className="ml-1">Revoke</span>
+                </Button>
+              )}
+            </div>
+          );
+        },
+      },
+    ],
+    [authorizing, authorizingConnection]
+  );
+
+  const filteredConnections = useMemo(() => {
+    if (!search.trim()) return connections;
+    const term = search.toLowerCase();
+    return connections.filter(
+      (c) =>
+        c.connection_name.toLowerCase().includes(term) ||
+        c.provider.toLowerCase().includes(term) ||
+        c.adapter_type.toLowerCase().includes(term) ||
+        (c.account_email || '').toLowerCase().includes(term)
+    );
+  }, [connections, search]);
+
+  const table = useReactTable({
+    data: filteredConnections,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    state: { sorting },
+  });
+
+  const authMethodOptions = useMemo(
+    () => authMethods.map((m) => ({ value: m.method, label: m.label || m.method })),
+    [authMethods]
+  );
+
+  return (
+    <PageLayout
+      title="Subscription Connections"
+      subtitle="Manage per-user OAuth and device-code connections for subscription-backed AI providers."
+      filters={
+        <FilterBar
+          searchPlaceholder="Search connections..."
+          searchValue={search}
+          onSearchChange={setSearch}
+          actions={
+            <Button variant="display" size="sm" onClick={() => setCreateOpen(true)}>
+              <Plus className="w-4 h-4 mr-2" />
+              Add Connection
+            </Button>
+          }
+        />
+      }
+    >
+      <div className="w-full">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
+          </div>
+        ) : filteredConnections.length === 0 ? (
+          <EmptyState
+            icon={KeyRound}
+            title="No subscription connections"
+            description="Add a connection to authorize subscription-backed providers like OpenAI Community or Kimi For Coding."
+            action={{ label: 'Add connection', onClick: () => setCreateOpen(true) }}
+          />
+        ) : (
+          <div className="border border-line bg-panel">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.map((row) => (
+                  <TableRow key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+
+      {/* Create Connection Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="sm:max-w-[520px]">
+          <DialogHeader>
+            <DialogTitle>Add Subscription Connection</DialogTitle>
+            <DialogDescription>
+              Create a per-user connection for a subscription-backed provider.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="connection_name">
+                Connection Name <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="connection_name"
+                placeholder="e.g. My OpenAI Community"
+                value={newConnection.connection_name}
+                onChange={(e) => setNewConnection({ ...newConnection, connection_name: e.target.value })}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>AI Provider <span className="text-destructive">*</span></Label>
+              <Combobox
+                options={providerOptions}
+                value={newConnection.provider}
+                onValueChange={(value) => setNewConnection({ ...newConnection, provider: value })}
+                placeholder="Select provider..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Adapter Type <span className="text-destructive">*</span></Label>
+              <Select
+                value={newConnection.adapter_type}
+                onValueChange={(value) =>
+                  setNewConnection({ ...newConnection, adapter_type: value, auth_method: '' })
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select adapter..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {ADAPTER_TYPES.map((t) => (
+                    <SelectItem key={t.value} value={t.value}>
+                      {t.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Auth Method</Label>
+              <Select
+                value={newConnection.auth_method}
+                onValueChange={(value) => setNewConnection({ ...newConnection, auth_method: value })}
+                disabled={authMethodOptions.length === 0}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={authMethodOptions.length === 0 ? 'Select adapter first' : 'Select auth method...'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {authMethodOptions.map((m) => (
+                    <SelectItem key={m.value} value={m.value}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="eligible_models">Eligible Models (JSON array)</Label>
+              <Textarea
+                id="eligible_models"
+                value={newConnection.eligible_models}
+                onChange={(e) => setNewConnection({ ...newConnection, eligible_models: e.target.value })}
+                rows={3}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)} disabled={creating}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={creating}>
+              {creating ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+              Create Connection
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Authorize Dialog */}
+      <Dialog open={authorizeOpen} onOpenChange={setAuthorizeOpen}>
+        <DialogContent className="sm:max-w-[560px]">
+          <DialogHeader>
+            <DialogTitle>Authorize {authorizingConnection?.connection_name}</DialogTitle>
+            <DialogDescription>
+              Complete the provider flow to link your subscription.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            {authorizing ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-6 w-6 animate-spin text-steel-soft" />
+              </div>
+            ) : !authorizeResult ? (
+              <p className="text-sm text-steel">Could not start authorization. Check site config flags.</p>
+            ) : (
+              <>
+                {authorizeResult.auth_url && (
+                  <div className="space-y-2">
+                    <Label>Authorization URL</Label>
+                    <div className="flex gap-2">
+                      <Input readOnly value={authorizeResult.auth_url} />
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={() => window.open(authorizeResult.auth_url, '_blank')}
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <p className="text-xs text-steel">
+                      Open the URL, authorize, then paste the final browser URL below.
+                    </p>
+                  </div>
+                )}
+
+                {authorizeResult.user_code && (
+                  <div className="space-y-2 rounded-md border bg-muted/40 p-3">
+                    <div className="flex items-center justify-between">
+                      <Label>User Code</Label>
+                      <span className="font-mono text-lg font-bold">{authorizeResult.user_code}</span>
+                    </div>
+                    {authorizeResult.verification_uri_complete && (
+                      <a
+                        href={authorizeResult.verification_uri_complete}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                      >
+                        Open verification page <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    )}
+                    <p className="text-xs text-steel">
+                      Enter the code on the provider site, then click Complete below.
+                    </p>
+                  </div>
+                )}
+
+                {authorizeResult.auth_url && (
+                  <div className="space-y-2">
+                    <Label htmlFor="pasted_url">Pasted Callback URL</Label>
+                    <Textarea
+                      id="pasted_url"
+                      placeholder="https://...?code=...&state=..."
+                      value={pastedUrl}
+                      onChange={(e) => setPastedUrl(e.target.value)}
+                      rows={3}
+                    />
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAuthorizeOpen(false)} disabled={completing}>
+              Cancel
+            </Button>
+            <Button onClick={handleComplete} disabled={completing || authorizing}>
+              {completing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <CheckCircle2 className="h-4 w-4 mr-2" />}
+              Complete Authorization
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageLayout>
+  );
+}
+
+export default AiProviderConnectionsPage;

--- a/frontend/src/pages/AiProviderConnectionsPageWrapper.tsx
+++ b/frontend/src/pages/AiProviderConnectionsPageWrapper.tsx
@@ -1,0 +1,13 @@
+import { AiProviderConnectionsPage } from './AiProviderConnectionsPage';
+import { UnifiedLayout } from '../layouts/UnifiedLayout';
+
+export { AiProviderConnectionsPageWrapper };
+export default AiProviderConnectionsPageWrapper;
+
+function AiProviderConnectionsPageWrapper() {
+  return (
+    <UnifiedLayout>
+      <AiProviderConnectionsPage />
+    </UnifiedLayout>
+  );
+}

--- a/frontend/src/services/providerConnectionApi.ts
+++ b/frontend/src/services/providerConnectionApi.ts
@@ -1,0 +1,174 @@
+import { db, call } from '@/lib/frappe-sdk';
+import { doctype } from '@/data/doctypes';
+import { handleFrappeError } from '@/lib/frappe-error';
+
+export interface AIProviderConnectionDoc {
+  name: string;
+  connection_name: string;
+  user: string;
+  provider: string;
+  adapter_type: string;
+  auth_status: string;
+  auth_method?: string;
+  is_active: 0 | 1;
+  eligible_models?: string;
+  account_email?: string;
+  account_id?: string;
+  expires_at?: string;
+  modified?: string;
+}
+
+export interface AuthMethod {
+  method: string;
+  type: string;
+  label: string;
+}
+
+export interface ConnectionListItem extends AIProviderConnectionDoc {
+  auth_methods: AuthMethod[];
+  is_expired: boolean;
+}
+
+export interface StartAuthorizationResult {
+  auth_url?: string;
+  user_code?: string;
+  verification_uri?: string;
+  verification_uri_complete?: string;
+  device_code?: string;
+  expires_in?: number;
+  interval?: number;
+  instructions?: string;
+}
+
+export interface CompleteAuthorizationResult {
+  status: string;
+  account_email?: string;
+  expires_in?: number;
+}
+
+export async function getConnections(provider?: string): Promise<ConnectionListItem[]> {
+  try {
+    const response = (await call.post('huf.huf.doctype.ai_provider_connection.ai_provider_connection.get_subscription_connections', {
+      provider,
+    })) as { message?: ConnectionListItem[] };
+    return response?.message || [];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching subscription connections');
+    return [];
+  }
+}
+
+export async function getAuthMethods(adapterType: string): Promise<AuthMethod[]> {
+  try {
+    const response = (await call.post('huf.huf.doctype.ai_provider_connection.ai_provider_connection.get_subscription_auth_methods', {
+      adapter_type: adapterType,
+    })) as { message?: AuthMethod[] };
+    return response?.message || [];
+  } catch (error) {
+    handleFrappeError(error, 'Error fetching auth methods');
+    return [];
+  }
+}
+
+export async function startAuthorization(
+  connectionName: string,
+  mode: string,
+  redirectUri?: string,
+): Promise<StartAuthorizationResult> {
+  try {
+    const response = (await call.post('huf.huf.doctype.ai_provider_connection.ai_provider_connection.start_subscription_authorization', {
+      connection_name: connectionName,
+      mode,
+      redirect_uri: redirectUri,
+    })) as { message?: StartAuthorizationResult };
+    return response?.message || {};
+  } catch (error) {
+    handleFrappeError(error, 'Error starting authorization');
+    throw error;
+  }
+}
+
+export async function completeAuthorization(
+  connectionName: string,
+  payload?: Record<string, unknown>,
+): Promise<CompleteAuthorizationResult> {
+  try {
+    const response = (await call.post('huf.huf.doctype.ai_provider_connection.ai_provider_connection.complete_subscription_authorization', {
+      connection_name: connectionName,
+      payload: payload || {},
+    })) as { message?: CompleteAuthorizationResult };
+    return response?.message || { status: 'unknown' };
+  } catch (error) {
+    handleFrappeError(error, 'Error completing authorization');
+    throw error;
+  }
+}
+
+export async function revokeAuthorization(connectionName: string): Promise<{ success: boolean; auth_status: string }> {
+  try {
+    const response = (await call.post('huf.huf.doctype.ai_provider_connection.ai_provider_connection.revoke_subscription_authorization', {
+      connection_name: connectionName,
+    })) as { message?: { success: boolean; auth_status: string } };
+    return response?.message || { success: false, auth_status: 'Error' };
+  } catch (error) {
+    handleFrappeError(error, 'Error revoking connection');
+    throw error;
+  }
+}
+
+export async function getConnection(name: string): Promise<AIProviderConnectionDoc | null> {
+  try {
+    const doc = await db.getDoc(doctype['AI Provider Connection'], name);
+    return doc as AIProviderConnectionDoc;
+  } catch (error) {
+    handleFrappeError(error, `Error fetching connection ${name}`);
+    return null;
+  }
+}
+
+export interface CreateConnectionInput {
+  connection_name: string;
+  user: string;
+  provider: string;
+  adapter_type: string;
+  auth_method: string;
+  eligible_models?: string;
+  is_active?: 0 | 1;
+}
+
+export async function createConnection(data: CreateConnectionInput): Promise<AIProviderConnectionDoc> {
+  try {
+    const doc = await db.createDoc(doctype['AI Provider Connection'], {
+      ...data,
+      is_active: data.is_active ?? 1,
+      auth_status: 'Unlinked',
+    });
+    return doc as AIProviderConnectionDoc;
+  } catch (error) {
+    handleFrappeError(error, 'Error creating connection');
+    throw error;
+  }
+}
+
+export async function updateConnection(
+  name: string,
+  data: Partial<AIProviderConnectionDoc>,
+): Promise<AIProviderConnectionDoc> {
+  try {
+    await db.updateDoc(doctype['AI Provider Connection'], name, data);
+    const updated = await db.getDoc(doctype['AI Provider Connection'], name);
+    return updated as AIProviderConnectionDoc;
+  } catch (error) {
+    handleFrappeError(error, `Error updating connection ${name}`);
+    throw error;
+  }
+}
+
+export async function deleteConnection(name: string): Promise<void> {
+  try {
+    await db.deleteDoc(doctype['AI Provider Connection'], name);
+  } catch (error) {
+    handleFrappeError(error, `Error deleting connection ${name}`);
+    throw error;
+  }
+}

--- a/huf/ai/agent_chat.py
+++ b/huf/ai/agent_chat.py
@@ -685,7 +685,7 @@ def upload_file_and_process_web(
         supported = {m.strip() for m in modalities.split(",") if m.strip()}
 
         is_image_or_pdf = filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".webp", ".pdf"))
-        use_ocr = bool(agent_doc.get("enable_ocr")) and "OCR" in supported
+        use_ocr = bool(agent_doc.get("enable_ocr")) or ("OCR" in supported)
         use_vision = "Vision" in supported and is_image_or_pdf
 
         if not use_ocr and not use_vision:
@@ -804,7 +804,7 @@ def _validate_web_file_upload(agent: str, filename: str, file_bytes: bytes, mode
     supported = {m.strip() for m in modalities.split(",") if m.strip()}
 
     is_image_or_pdf = filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".webp", ".pdf"))
-    use_ocr = bool(agent_doc.get("enable_ocr")) and "OCR" in supported
+    use_ocr = bool(agent_doc.get("enable_ocr")) or ("OCR" in supported)
     use_vision = "Vision" in supported and is_image_or_pdf
 
     if not use_ocr and not use_vision:

--- a/huf/ai/agent_integration.py
+++ b/huf/ai/agent_integration.py
@@ -203,11 +203,36 @@ class AgentManager:
         except (ImportError, AttributeError, TypeError, ValueError, RuntimeError) as e:
             logger.warning(f"Failed to load knowledge tools: {e!s}")
 
+    def _has_active_subscription_connection(self) -> bool:
+        """Return True when an active AI Provider Connection exists for this provider/user."""
+        try:
+            connections = frappe.get_all(
+                "AI Provider Connection",
+                filters={
+                    "provider": self.settings.name,
+                    "user": frappe.session.user,
+                    "is_active": 1,
+                },
+                fields=["name"],
+                limit_page_length=1,
+            )
+            if not connections:
+                return False
+            conn_doc = frappe.get_doc("AI Provider Connection", connections[0].name)
+            return conn_doc.is_active_connection() and conn_doc.check_and_refresh()
+        except Exception:
+            return False
+
     def _setup_client(self):
         """Configure OpenAI provider from the AI Provider doc"""
         api_key = self.settings.get_password("api_key")
         if not api_key:
-            frappe.throw(_("API key is not configured in AI Provider."))
+            # Allow agents to run through a subscription adapter even when the
+            # shared AI Provider has no API key.
+            if self._has_active_subscription_connection():
+                api_key = "subscription-managed"
+            else:
+                frappe.throw(_("API key is not configured in AI Provider."))
 
         provider_kwargs = {"api_key": api_key, "use_responses": True}
         # Support local/custom OpenAI-compatible endpoints (e.g. Kimi Code API)
@@ -998,6 +1023,7 @@ def run_agent_sync(
     prompt_cache_options=None,
     files=None,
     skip_user_message: bool = False,
+    subscription_connection_name: str = None,
     now=None,
     project: str = None,
 ):
@@ -1099,6 +1125,7 @@ def run_agent_sync(
         "prompt_cache_options": prompt_cache_options,
         "files": files,
         "skip_user_message": skip_user_message,
+        "subscription_connection_name": subscription_connection_name,
     }
 
     run_doc_data = {
@@ -1155,6 +1182,7 @@ def run_agent_sync(
         "prompt_cache_options": prompt_cache_options,
         "files": files,
         "skip_user_message": skip_user_message,
+        "subscription_connection_name": subscription_connection_name,
     }
 
     is_queued = not getattr(agent_doc, "run_immediately", 0) and not _is_truthy(now)
@@ -1392,6 +1420,7 @@ def _execute_agent_run(
     prompt_cache_options=None,
     files=None,
     skip_user_message=False,
+    subscription_connection_name=None,
 ):
     """Execute an agent against an existing Agent Run and conversation.
 
@@ -1527,6 +1556,8 @@ def _execute_agent_run(
             "agent_run_id": run_doc.name,
             "prompt_cache_options": resolved_prompt_cache,
             "files": files,
+            "subscription_connection_name": subscription_connection_name,
+            "user": frappe.session.user,
         }
 
         context_strategy = agent_doc.context_strategy or "Summarize"
@@ -1613,6 +1644,8 @@ def _execute_agent_run(
             "agent_run_id": run_doc.name,
             "prompt_cache_options": resolved_prompt_cache,
             "files": files,
+            "subscription_connection_name": subscription_connection_name,
+            "user": frappe.session.user,
         }
         async def _run_with_mcp_pool():
             from huf.ai.mcp_client import mcp_session_pool
@@ -2497,6 +2530,7 @@ async def run_agent_stream(
     skip_user_message: bool = False,
     files=None,
     project: str = None,
+    subscription_connection_name: str = None,
 ):
     """
     Streaming version of run_agent_sync.
@@ -2709,6 +2743,8 @@ async def run_agent_stream(
             "prompt_cache_options": resolved_prompt_cache,
             "_tool_call_message_map": tool_call_message_map,
             "files": files,
+            "subscription_connection_name": subscription_connection_name,
+            "user": frappe.session.user,
         }
 
         stored_summary = conv_manager.get_stored_summary(conversation.name)

--- a/huf/ai/handlers/media.py
+++ b/huf/ai/handlers/media.py
@@ -3,6 +3,11 @@ import base64
 
 import frappe
 from frappe.utils.file_manager import save_file
+try:
+    from requests.exceptions import RequestException
+except ImportError:
+    class RequestException(Exception):
+        pass
 
 from huf.ai import audio_service
 from huf.ai.transaction import commit_if_background
@@ -171,9 +176,9 @@ async def handle_generate_image(
                         img_response = _http_request("GET", image_url, timeout=30)
                         img_response.raise_for_status()
                         image_bytes = img_response.content
-                    except ValueError as e:
+                    except (ValueError, RequestException) as e:
                         frappe.logger("huf").warning(
-                            f"Image URL blocked by SSRF filter: {image_url} — {e}"
+                            f"Image download failed for URL {image_url}: {e}"
                         )
                         continue
                 elif image_b64:

--- a/huf/ai/providers/adapters/__init__.py
+++ b/huf/ai/providers/adapters/__init__.py
@@ -1,0 +1,20 @@
+import frappe
+from huf.ai.providers.adapters.base import BaseSubscriptionAdapter
+from huf.ai.providers.adapters.mock import MockSubscriptionAdapter
+from huf.ai.providers.adapters.openai import OpenAISubscriptionAdapter
+from huf.ai.providers.adapters.openai_community import OpenAICommunitySubscriptionAdapter
+from huf.ai.providers.adapters.kimi_community import KimiCommunitySubscriptionAdapter
+
+ADAPTER_REGISTRY = {
+    "mock_subscription": MockSubscriptionAdapter,
+    "openai_subscription": OpenAISubscriptionAdapter,
+    "openai_community_subscription": OpenAICommunitySubscriptionAdapter,
+    "kimi_community_subscription": KimiCommunitySubscriptionAdapter,
+}
+
+def get_adapter(adapter_type: str) -> BaseSubscriptionAdapter:
+    if adapter_type in ADAPTER_REGISTRY:
+        adapter_cls = ADAPTER_REGISTRY[adapter_type]
+        return adapter_cls()
+
+    frappe.throw(f"Subscription adapter type '{adapter_type}' is not registered.")

--- a/huf/ai/providers/adapters/base.py
+++ b/huf/ai/providers/adapters/base.py
@@ -1,0 +1,112 @@
+from abc import ABC, abstractmethod
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+
+class BaseSubscriptionAdapter(ABC):
+    """
+    Abstract base contract for HUF native subscription provider adapters.
+
+    Adapters translate between HUF's agent runtime and a subscription-backed
+    provider (e.g. a provider that uses per-user OAuth tokens instead of a
+    shared API key).  The runtime routes to an adapter when an active
+    ``AI Provider Connection`` exists for the provider/user/model.
+
+    Result contract:
+
+    - ``run()`` must return either a ``SimpleResult``-like object with
+      ``final_output``, ``usage``, ``new_items`` and ``cost`` attributes, or a
+      dict containing at least ``response`` (str) and optionally ``usage``,
+      ``cost`` and ``new_items``.  The router in ``huf.ai.run`` normalizes the
+      dict form to a ``SimpleResult`` before returning to the agent runtime.
+
+    - ``stream_response()`` must yield dicts matching the HUF streaming chunk
+      contract used by ``huf.ai.providers.litellm``:
+
+      * ``{"type": "delta", "content": str, "full_response": str}``
+      * ``{"type": "reasoning", "content": str, "full_reasoning": str}``
+      * ``{"type": "tool_call", "tool_call": dict}``
+      * ``{"type": "complete", "full_response": str, "usage": dict, "cost": float}``
+      * ``{"type": "error", "error": str}``
+    """
+
+    @abstractmethod
+    def get_auth_methods(self) -> List[Dict[str, Any]]:
+        """
+        Returns supported authentication methods (e.g. OAuth PKCE, Device Code).
+        """
+        pass
+
+    @abstractmethod
+    def start_authorization(
+        self,
+        connection_doc: Any,
+        mode: str,
+        redirect_uri: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Initiates auth flow. Returns authorization URL or device code instructions.
+        """
+        pass
+
+    @abstractmethod
+    def complete_authorization(
+        self,
+        connection_doc: Any,
+        payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Exchanges callback authorization code or polls device code, updating connection_doc with tokens.
+        """
+        pass
+
+    @abstractmethod
+    def refresh_connection(self, connection_doc: Any) -> bool:
+        """
+        Refreshes access token if expired or near expiry (e.g. 5 min buffer).
+        Returns True if active/refreshed, False if re-auth is required.
+        """
+        pass
+
+    @abstractmethod
+    def discover_models(self, connection_doc: Any) -> List[Dict[str, Any]]:
+        """
+        Queries vendor endpoint or returns strict allowlist of subscription-supported models.
+        """
+        pass
+
+    @abstractmethod
+    def run(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        """
+        Synchronous/non-streaming response generation for subadapter.
+        Returns a HUF-compatible result (SimpleResult-like object or dict).
+        """
+        pass
+
+    @abstractmethod
+    async def stream_response(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """
+        Translates HUF agent/prompt/tools payload, sends to subscription backend,
+        and yields normalized HUF stream chunks.
+        """
+        pass
+
+    @abstractmethod
+    def revoke_connection(self, connection_doc: Any) -> bool:
+        """
+        Revokes tokens with upstream provider and marks connection as Revoked.
+        """
+        pass

--- a/huf/ai/providers/adapters/kimi_community.py
+++ b/huf/ai/providers/adapters/kimi_community.py
@@ -1,0 +1,514 @@
+import json
+import time
+import uuid
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+import frappe
+import requests
+
+from huf.ai.providers.adapters.base import BaseSubscriptionAdapter
+
+
+class KimiCommunitySubscriptionAdapter(BaseSubscriptionAdapter):
+    """
+    Community Kimi For Coding subscription adapter.
+
+    This adapter reuses the public OAuth device-flow client credentials that
+    Kimi's official CLI uses, allowing Kimi For Coding subscribers to
+    authenticate without a static API key.
+
+    Credentials / behavior are sourced from the community plugin:
+      https://github.com/lemon07r/opencode-kimi-full
+
+    Hardcoded values:
+      - client_id: 17e5f671-d194-4dfb-9706-5516cb48c098
+      - device_auth_url: https://auth.kimi.com/api/oauth/device_authorization
+      - token_url: https://auth.kimi.com/api/oauth/token
+      - api_base: https://api.kimi.com/coding/v1
+
+    Required site config:
+      - enable_kimi_community_subscription_adapter = 1
+
+    Optional site config overrides:
+      - kimi_community_oauth_client_id
+      - kimi_community_oauth_device_auth_url
+      - kimi_community_oauth_token_url
+      - kimi_community_api_base_url
+      - kimi_community_device_id (stable hex UUID, no dashes)
+    """
+
+    COMMUNITY_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
+    KIMI_CLI_VERSION = "1.41.0"
+    DEFAULT_DEVICE_AUTH_URL = "https://auth.kimi.com/api/oauth/device_authorization"
+    DEFAULT_TOKEN_URL = "https://auth.kimi.com/api/oauth/token"
+    DEFAULT_API_BASE_URL = "https://api.kimi.com/coding/v1"
+    DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
+    REFRESH_GRANT = "refresh_token"
+    REQUEST_TIMEOUT = 120
+
+    DEFAULT_MODELS = [
+        {
+            "id": "kimi-for-coding",
+            "name": "Kimi For Coding",
+            "context_window": 200000,
+            "output_window": 16384,
+            "modalities": {"input": ["text", "image"], "output": ["text"]},
+        },
+    ]
+
+    def __init__(self):
+        if not frappe.conf.get("enable_kimi_community_subscription_adapter"):
+            raise frappe.PermissionError(
+                "Kimi Community subscription adapter is disabled. "
+                "Set 'enable_kimi_community_subscription_adapter' to 1 in site config to enable. "
+                "This adapter uses community-reversed OAuth credentials and carries provider ToS risk."
+            )
+
+    def _get_config(self, key: str, default: Any = None) -> Any:
+        return frappe.conf.get(key, default)
+
+    def _get_client_id(self) -> str:
+        return self._get_config("kimi_community_oauth_client_id") or self.COMMUNITY_CLIENT_ID
+
+    def _get_device_auth_url(self) -> str:
+        return self._get_config("kimi_community_oauth_device_auth_url") or self.DEFAULT_DEVICE_AUTH_URL
+
+    def _get_token_url(self) -> str:
+        return self._get_config("kimi_community_oauth_token_url") or self.DEFAULT_TOKEN_URL
+
+    def _get_api_base_url(self) -> str:
+        return self._get_config("kimi_community_api_base_url") or self.DEFAULT_API_BASE_URL
+
+    def _get_device_id(self, connection_doc: Any) -> str:
+        """Return a stable hex UUID for this connection (mirrors ~/.kimi/device_id)."""
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        device_id = metadata.get("device_id")
+        if device_id:
+            return device_id
+        device_id = self._get_config("kimi_community_device_id")
+        if device_id:
+            return device_id
+        return uuid.uuid4().hex
+
+    def _get_headers(self, connection_doc: Any) -> Dict[str, str]:
+        import platform
+
+        device_id = self._get_device_id(connection_doc)
+        system = platform.system()
+        release = platform.release()
+        machine = platform.machine() or platform.processor() or "unknown"
+
+        if system == "Darwin":
+            device_model = f"macOS {release} {machine}".strip()
+        elif system == "Windows":
+            device_model = f"Windows {release} {machine}".strip()
+        else:
+            device_model = f"{system} {release} {machine}".strip()
+
+        return {
+            "User-Agent": f"KimiCLI/{self.KIMI_CLI_VERSION}",
+            "X-Msh-Platform": "kimi_cli",
+            "X-Msh-Version": self.KIMI_CLI_VERSION,
+            "X-Msh-Device-Name": self._ascii_header(platform.node() or "unknown"),
+            "X-Msh-Device-Model": self._ascii_header(device_model),
+            "X-Msh-Device-Id": device_id,
+            "X-Msh-Os-Version": self._ascii_header(f"{system} {release}"),
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _ascii_header(self, value: str, fallback: str = "unknown") -> str:
+        sanitized = "".join(c for c in value if 0x20 <= ord(c) <= 0x7E).strip()
+        return sanitized or fallback
+
+    def get_auth_methods(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "method": "Device Code",
+                "type": "device_code",
+                "label": "Kimi For Coding Device Flow",
+            }
+        ]
+
+    def start_authorization(
+        self,
+        connection_doc: Any,
+        mode: str,
+        redirect_uri: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if mode != "Device Code":
+            raise ValueError(f"Unsupported auth mode: {mode}")
+
+        device_id = self._get_device_id(connection_doc)
+        headers = self._get_headers(connection_doc)
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        resp = requests.post(
+            self._get_device_auth_url(),
+            data={"client_id": self._get_client_id()},
+            headers=headers,
+            timeout=self.REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        metadata.update(
+            {
+                "device_id": device_id,
+                "device_code": data.get("device_code"),
+                "auth_mode": mode,
+            }
+        )
+        connection_doc.set_auth_payload(metadata)
+        connection_doc.auth_status = "Pending Authorization"
+
+        return {
+            "user_code": data.get("user_code"),
+            "verification_uri": data.get("verification_uri"),
+            "verification_uri_complete": data.get("verification_uri_complete"),
+            "device_code": data.get("device_code"),
+            "expires_in": data.get("expires_in", 1800),
+            "interval": data.get("interval", 5),
+            "instructions": (
+                f"Open {data.get('verification_uri')} in your browser and enter "
+                f"code {data.get('user_code')}. Then return here and complete authorization."
+            ),
+        }
+
+    def complete_authorization(
+        self,
+        connection_doc: Any,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        device_code = payload.get("device_code") or metadata.get("device_code")
+        if not device_code:
+            raise ValueError("device_code is required; restart authorization")
+
+        interval = int(payload.get("interval") or metadata.get("interval") or 5)
+        expires_in = int(payload.get("expires_in") or metadata.get("expires_in") or 1800)
+        deadline = time.time() + expires_in
+
+        headers = self._get_headers(connection_doc)
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        while time.time() < deadline:
+            time.sleep(interval)
+            resp = requests.post(
+                self._get_token_url(),
+                data={
+                    "client_id": self._get_client_id(),
+                    "device_code": device_code,
+                    "grant_type": self.DEVICE_GRANT,
+                },
+                headers=headers,
+                timeout=self.REQUEST_TIMEOUT,
+            )
+
+            if resp.status_code == 200:
+                data = resp.json()
+                self._store_tokens(connection_doc, data)
+                return {
+                    "status": "success",
+                    "account_email": connection_doc.account_email,
+                    "expires_in": data.get("expires_in"),
+                }
+
+            try:
+                error_body = resp.json()
+            except Exception:
+                error_body = {}
+            error_code = error_body.get("error")
+
+            if error_code == "authorization_pending":
+                continue
+            if error_code == "slow_down":
+                interval += 5
+                continue
+            if error_code == "expired_token":
+                raise frappe.ValidationError("Kimi device code expired — start authorization again")
+            if error_code:
+                raise frappe.ValidationError(
+                    f"Kimi OAuth error {error_code}: {error_body.get('error_description', resp.text)}"
+                )
+            resp.raise_for_status()
+
+        raise frappe.ValidationError("Kimi device code expired before approval")
+
+    def _store_tokens(self, connection_doc: Any, token_data: Dict[str, Any]):
+        access_token = token_data.get("access_token")
+        refresh_token = token_data.get("refresh_token")
+        expires_in = token_data.get("expires_in", 3600)
+        token_type = token_data.get("token_type", "Bearer")
+
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        metadata["token_response"] = {k: v for k, v in token_data.items() if k not in ("access_token", "refresh_token")}
+        connection_doc.set_auth_payload(metadata)
+        connection_doc.set_tokens(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in_seconds=int(expires_in),
+            token_type=token_type,
+        )
+        connection_doc.auth_status = "Active"
+
+    def refresh_connection(self, connection_doc: Any) -> bool:
+        refresh_token = connection_doc.get_decrypted_refresh_token()
+        if not refresh_token:
+            connection_doc.auth_status = "Expired"
+            return False
+
+        headers = self._get_headers(connection_doc)
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        retryable_statuses = {429, 500, 502, 503, 504}
+        last_error = None
+        for attempt in range(3):
+            try:
+                resp = requests.post(
+                    self._get_token_url(),
+                    data={
+                        "client_id": self._get_client_id(),
+                        "refresh_token": refresh_token,
+                        "grant_type": self.REFRESH_GRANT,
+                    },
+                    headers=headers,
+                    timeout=self.REQUEST_TIMEOUT,
+                )
+                text = resp.text
+                try:
+                    data = json.loads(text) if text else {}
+                except json.JSONDecodeError:
+                    if resp.status_code in retryable_statuses:
+                        raise RuntimeError(f"Kimi refresh transient {resp.status_code}: non-JSON response")
+                    raise RuntimeError(f"Kimi refresh non-JSON response (status {resp.status_code}): {text[:200]}")
+
+                if resp.status_code in (401, 403):
+                    raise RuntimeError(f"Kimi refresh {resp.status_code}: {data.get('error_description', text)}")
+                resp.raise_for_status()
+
+                self._store_tokens(connection_doc, data)
+                return True
+            except Exception as e:
+                last_error = e
+                status = getattr(e, "status", None)
+                retryable = status is None or status in retryable_statuses
+                if not retryable or attempt == 2:
+                    break
+                time.sleep(2 ** attempt)
+
+        frappe.log_error(
+            f"Failed to refresh Kimi community connection {connection_doc.name}: {str(last_error)}",
+            "Kimi Community Subscription Refresh Error",
+        )
+        connection_doc.auth_status = "Expired"
+        return False
+
+    def discover_models(self, connection_doc: Any) -> List[Dict[str, Any]]:
+        access_token = connection_doc.get_decrypted_access_token()
+        if access_token:
+            try:
+                headers = self._get_headers(connection_doc)
+                headers["Authorization"] = f"Bearer {access_token}"
+                resp = requests.get(
+                    f"{self._get_api_base_url()}/models",
+                    headers=headers,
+                    timeout=self.REQUEST_TIMEOUT,
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    models = []
+                    for m in data.get("data", []):
+                        model_id = m.get("id")
+                        if not model_id:
+                            continue
+                        models.append({
+                            "id": model_id,
+                            "name": m.get("display_name") or model_id,
+                            "context_window": m.get("context_length") or 200000,
+                            "modalities": {
+                                "input": ["text", "image"] if m.get("supports_image_in") else ["text"],
+                                "output": ["text"],
+                            },
+                        })
+                    if models:
+                        return models
+            except Exception as e:
+                frappe.log_error(
+                    f"Kimi model discovery failed for {connection_doc.name}: {str(e)}",
+                    "Kimi Community Model Discovery Error",
+                )
+        return list(self.DEFAULT_MODELS)
+
+    def _build_messages(self, enhanced_prompt: Any) -> List[Dict[str, str]]:
+        if isinstance(enhanced_prompt, str):
+            return [{"role": "user", "content": enhanced_prompt}]
+        if isinstance(enhanced_prompt, list):
+            return enhanced_prompt
+        if isinstance(enhanced_prompt, dict):
+            return [enhanced_prompt]
+        return [{"role": "user", "content": str(enhanced_prompt)}]
+
+    def _build_request_body(
+        self,
+        connection_doc: Any,
+        enhanced_prompt: Any,
+        model: str,
+        stream: bool = False,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        body = {
+            "model": model,
+            "messages": self._build_messages(enhanced_prompt),
+            "stream": stream,
+        }
+
+        # Session-scoped prompt cache key; falls back to connection name.
+        session_id = (context or {}).get("session_id") or connection_doc.name
+        body["prompt_cache_key"] = session_id
+
+        # Reasoning defaults mirroring kimi-cli.
+        reasoning_effort = (context or {}).get("reasoning_effort") or "medium"
+        if reasoning_effort == "off":
+            body["thinking"] = {"type": "disabled"}
+        elif reasoning_effort in ("low", "medium", "high"):
+            body["thinking"] = {"type": "enabled"}
+            body["reasoning_effort"] = reasoning_effort
+        # "auto" omits both fields.
+
+        return body
+
+    def run(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        url = f"{self._get_api_base_url()}/chat/completions"
+        payload = self._build_request_body(connection_doc, enhanced_prompt, model, stream=False, context=context)
+
+        headers = self._get_headers(connection_doc)
+        headers["Authorization"] = f"Bearer {connection_doc.get_decrypted_access_token()}"
+
+        resp = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=self.REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        choice = data.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        content = message.get("content", "")
+        usage = data.get("usage") or {}
+
+        return {
+            "response": content,
+            "usage": usage,
+            "cost": 0.0,
+            "new_items": [],
+            "model": model,
+            "provider": connection_doc.provider,
+            "adapter_type": connection_doc.adapter_type,
+        }
+
+    async def stream_response(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        url = f"{self._get_api_base_url()}/chat/completions"
+        payload = self._build_request_body(connection_doc, enhanced_prompt, model, stream=True, context=context)
+
+        headers = self._get_headers(connection_doc)
+        headers["Authorization"] = f"Bearer {connection_doc.get_decrypted_access_token()}"
+
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=self.REQUEST_TIMEOUT),
+                ) as resp:
+                    resp.raise_for_status()
+                    full_response = ""
+                    async for line in resp.content:
+                        chunk = self._parse_sse_line(line, full_response)
+                        if chunk:
+                            if chunk.get("type") == "delta":
+                                full_response = chunk.get("full_response", full_response)
+                            yield chunk
+        except ImportError:
+            loop = __import__("asyncio").get_event_loop()
+            resp = await loop.run_in_executor(
+                None,
+                lambda: requests.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    stream=True,
+                    timeout=self.REQUEST_TIMEOUT,
+                ),
+            )
+            resp.raise_for_status()
+            full_response = ""
+            for line in resp.iter_lines():
+                chunk = self._parse_sse_line(line, full_response)
+                if chunk:
+                    if chunk.get("type") == "delta":
+                        full_response = chunk.get("full_response", full_response)
+                    yield chunk
+
+    def _parse_sse_line(self, line: bytes, full_response: str) -> Optional[Dict[str, Any]]:
+        if not line:
+            return None
+        text = line.decode("utf-8") if isinstance(line, bytes) else line
+        if not text.startswith("data: "):
+            return None
+        data = text[6:].strip()
+        if data == "[DONE]":
+            return {"type": "complete", "full_response": full_response}
+        try:
+            obj = json.loads(data)
+        except json.JSONDecodeError:
+            return None
+
+        choices = obj.get("choices", [])
+        usage = obj.get("usage")
+        if usage:
+            return {"type": "complete", "full_response": full_response, "usage": usage, "cost": 0.0}
+        if not choices:
+            return None
+        delta = choices[0].get("delta", {})
+        content = delta.get("content", "")
+        if content:
+            full_response += content
+            return {"type": "delta", "content": content, "full_response": full_response}
+        return None
+
+    def revoke_connection(self, connection_doc: Any) -> bool:
+        connection_doc.access_token = ""
+        connection_doc.refresh_token = ""
+        connection_doc.auth_payload = ""
+        connection_doc.auth_status = "Revoked"
+        return True

--- a/huf/ai/providers/adapters/mock.py
+++ b/huf/ai/providers/adapters/mock.py
@@ -1,0 +1,158 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any, AsyncGenerator, Dict, List, Optional
+from huf.ai.providers.adapters.base import BaseSubscriptionAdapter
+
+
+class MockSubscriptionAdapter(BaseSubscriptionAdapter):
+    """
+    Mock Subscription Adapter for testing native subscription execution,
+    token refresh, authorization flows, and streaming/non-streaming runs.
+    """
+
+    def get_auth_methods(self) -> List[Dict[str, Any]]:
+        return [
+            {"method": "OAuth PKCE", "type": "pkce", "label": "Mock OAuth 2.0 PKCE"},
+            {"method": "Device Code", "type": "device_code", "label": "Mock Device Code"},
+        ]
+
+    def start_authorization(
+        self,
+        connection_doc: Any,
+        mode: str,
+        redirect_uri: Optional[str] = None
+    ) -> Dict[str, Any]:
+        if mode == "OAuth PKCE":
+            return {
+                "auth_url": "https://mock.provider.com/oauth/authorize?client_id=mock_client",
+                "state": "mock_state_123",
+            }
+        elif mode == "Device Code":
+            return {
+                "user_code": "MOCK-1234",
+                "verification_uri": "https://mock.provider.com/device",
+                "device_code": "mock_device_code_567",
+                "expires_in": 1800,
+                "interval": 5,
+            }
+        else:
+            raise ValueError(f"Unsupported auth mode: {mode}")
+
+    def complete_authorization(
+        self,
+        connection_doc: Any,
+        payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        code = payload.get("code") or payload.get("device_code")
+        if not code:
+            raise ValueError("Code is required to complete authorization")
+
+        connection_doc.set_tokens(
+            access_token="mock_access_token_abc123",
+            refresh_token="mock_refresh_token_xyz789",
+            expires_in_seconds=3600,
+            token_type="Bearer",
+        )
+        connection_doc.account_id = "acc_mock_user_1"
+        connection_doc.account_email = "user@mocksubscription.com"
+        connection_doc.plan_type = "mock_pro_plan"
+        connection_doc.auth_status = "Active"
+
+        return {
+            "status": "success",
+            "account_id": connection_doc.account_id,
+            "account_email": connection_doc.account_email,
+            "plan_type": connection_doc.plan_type,
+        }
+
+    def refresh_connection(self, connection_doc: Any) -> bool:
+        refresh_token = connection_doc.get_decrypted_refresh_token()
+        if not refresh_token or refresh_token == "invalid_refresh_token":
+            connection_doc.auth_status = "Expired"
+            return False
+
+        connection_doc.set_tokens(
+            access_token="refreshed_mock_access_token_999",
+            refresh_token="refreshed_mock_refresh_token_888",
+            expires_in_seconds=3600,
+        )
+        connection_doc.auth_status = "Active"
+        return True
+
+    def discover_models(self, connection_doc: Any) -> List[Dict[str, Any]]:
+        return [
+            {"id": "mock-sub-gpt-4o", "name": "Mock Sub GPT-4o", "context_window": 128000},
+            {"id": "mock-sub-gemini-2", "name": "Mock Sub Gemini 2.0", "context_window": 1000000},
+        ]
+
+    def run(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        return {
+            "response": (
+                f"[Mock Subscription Output for model {model}]: "
+                "Completed prompt successfully via mock adapter."
+            ),
+            "usage": {
+                "prompt_tokens": 15,
+                "completion_tokens": 25,
+                "total_tokens": 40,
+            },
+            "cost": 0.0,
+            "new_items": [],
+            "model": model,
+            "provider": connection_doc.provider,
+            "adapter_type": connection_doc.adapter_type,
+        }
+
+    async def stream_response(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        chunks = ["[Mock ", "Subscription ", "Stream ", "Chunk] ", f"for model {model}."]
+        full_response = ""
+        for chunk in chunks:
+            await asyncio.sleep(0.01)
+            full_response += chunk
+            yield {
+                "type": "delta",
+                "content": chunk,
+                "full_response": full_response,
+            }
+
+        yield {
+            "type": "complete",
+            "full_response": full_response,
+            "usage": {
+                "prompt_tokens": 15,
+                "completion_tokens": 25,
+                "total_tokens": 40,
+            },
+            "cost": 0.0,
+        }
+
+    def revoke_connection(self, connection_doc: Any) -> bool:
+        connection_doc.access_token = ""
+        connection_doc.refresh_token = ""
+        connection_doc.auth_payload = ""
+        connection_doc.auth_status = "Revoked"
+        return True

--- a/huf/ai/providers/adapters/openai.py
+++ b/huf/ai/providers/adapters/openai.py
@@ -1,0 +1,395 @@
+import base64
+import hashlib
+import json
+import os
+import secrets
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+import frappe
+import requests
+
+from huf.ai.providers.adapters.base import BaseSubscriptionAdapter
+
+
+class OpenAISubscriptionAdapter(BaseSubscriptionAdapter):
+    """
+    OpenAI subscription adapter using OAuth 2.0 + PKCE.
+
+    Reads provider-level OAuth configuration from Frappe site config:
+      - openai_oauth_client_id
+      - openai_oauth_client_secret
+      - openai_oauth_auth_url  (default: https://platform.openai.com/oauth/authorize)
+      - openai_oauth_token_url (default: https://api.openai.com/oauth/token)
+      - openai_oauth_scope     (default: openid email profile)
+      - openai_api_base_url    (default: https://api.openai.com/v1)
+
+    Per-user tokens are stored in the AI Provider Connection document.
+    """
+
+    DEFAULT_AUTH_URL = "https://platform.openai.com/oauth/authorize"
+    DEFAULT_TOKEN_URL = "https://api.openai.com/oauth/token"
+    DEFAULT_API_BASE_URL = "https://api.openai.com/v1"
+    DEFAULT_SCOPE = "openid email profile"
+    DEFAULT_MODELS = [
+        {"id": "gpt-4o", "name": "GPT-4o", "context_window": 128000},
+        {"id": "gpt-4o-mini", "name": "GPT-4o Mini", "context_window": 128000},
+        {"id": "o1", "name": "o1", "context_window": 128000},
+        {"id": "o3-mini", "name": "o3-mini", "context_window": 128000},
+    ]
+
+    def _get_config(self, key: str, default: Any = None) -> Any:
+        return frappe.conf.get(key, default)
+
+    def _require_config(self, key: str) -> str:
+        value = self._get_config(key)
+        if not value:
+            raise frappe.ValidationError(
+                f"Missing site config '{key}'. Set it via: bench --site <site> set-config {key} <value>"
+            )
+        return value
+
+    def _get_client_credentials(self) -> tuple:
+        client_id = self._require_config("openai_oauth_client_id")
+        client_secret = self._require_config("openai_oauth_client_secret")
+        return client_id, client_secret
+
+    def _get_token_url(self) -> str:
+        return self._get_config("openai_oauth_token_url") or self.DEFAULT_TOKEN_URL
+
+    def _get_auth_url(self) -> str:
+        return self._get_config("openai_oauth_auth_url") or self.DEFAULT_AUTH_URL
+
+    def _get_api_base_url(self) -> str:
+        return self._get_config("openai_api_base_url") or self.DEFAULT_API_BASE_URL
+
+    def _get_scope(self) -> str:
+        return self._get_config("openai_oauth_scope") or self.DEFAULT_SCOPE
+
+    def get_auth_methods(self) -> List[Dict[str, Any]]:
+        return [
+            {"method": "OAuth PKCE", "type": "pkce", "label": "OpenAI OAuth 2.0 PKCE"},
+        ]
+
+    def _generate_pkce(self) -> tuple:
+        verifier = base64.urlsafe_b64encode(os.urandom(32)).decode("utf-8").rstrip("=")
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .decode("utf-8")
+            .rstrip("=")
+        )
+        return verifier, challenge
+
+    def start_authorization(
+        self,
+        connection_doc: Any,
+        mode: str,
+        redirect_uri: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if mode != "OAuth PKCE":
+            raise ValueError(f"Unsupported auth mode: {mode}")
+
+        client_id, _ = self._get_client_credentials()
+        verifier, challenge = self._generate_pkce()
+        state = secrets.token_urlsafe(24)
+
+        # Persist PKCE verifier and state so the callback can validate/exchange.
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        metadata.update(
+            {
+                "pkce_verifier": verifier,
+                "oauth_state": state,
+                "redirect_uri": redirect_uri,
+            }
+        )
+        connection_doc.set_auth_payload(metadata)
+        connection_doc.auth_status = "Pending Authorization"
+
+        auth_url = (
+            f"{self._get_auth_url()}?"
+            f"response_type=code"
+            f"&client_id={client_id}"
+            f"&redirect_uri={redirect_uri or ''}"
+            f"&scope={self._get_scope()}"
+            f"&state={state}"
+            f"&code_challenge={challenge}"
+            f"&code_challenge_method=S256"
+        )
+
+        return {
+            "auth_url": auth_url,
+            "state": state,
+        }
+
+    def complete_authorization(
+        self,
+        connection_doc: Any,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        code = payload.get("code")
+        state = payload.get("state")
+        if not code:
+            raise ValueError("Authorization code is required")
+
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        stored_state = metadata.get("oauth_state")
+        if stored_state and state != stored_state:
+            raise ValueError("OAuth state mismatch")
+
+        verifier = metadata.get("pkce_verifier")
+        if not verifier:
+            raise ValueError("PKCE verifier not found; restart authorization")
+
+        client_id, client_secret = self._get_client_credentials()
+        redirect_uri = payload.get("redirect_uri") or metadata.get("redirect_uri")
+
+        token_resp = requests.post(
+            self._get_token_url(),
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri or "",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code_verifier": verifier,
+            },
+            headers={"Accept": "application/json"},
+            timeout=30,
+        )
+        token_resp.raise_for_status()
+        token_data = token_resp.json()
+
+        access_token = token_data.get("access_token")
+        refresh_token = token_data.get("refresh_token")
+        expires_in = token_data.get("expires_in", 3600)
+        token_type = token_data.get("token_type", "Bearer")
+
+        # Clear transient PKCE data but keep useful metadata.
+        metadata.pop("pkce_verifier", None)
+        metadata.pop("oauth_state", None)
+        metadata.pop("redirect_uri", None)
+        metadata["token_response"] = {k: v for k, v in token_data.items() if k not in ("access_token", "refresh_token")}
+
+        connection_doc.set_auth_payload(metadata)
+        connection_doc.set_tokens(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in_seconds=int(expires_in),
+            token_type=token_type,
+        )
+
+        # Derive account email if available in token response.
+        id_token = token_data.get("id_token")
+        if id_token:
+            try:
+                payload_part = id_token.split(".")[1]
+                padded = payload_part + "=" * (-len(payload_part) % 4)
+                id_payload = json.loads(base64.urlsafe_b64decode(padded).decode())
+                connection_doc.account_email = id_payload.get("email", "")
+            except Exception:
+                pass
+
+        connection_doc.auth_status = "Active"
+
+        return {
+            "status": "success",
+            "account_email": connection_doc.account_email,
+            "expires_in": expires_in,
+        }
+
+    def refresh_connection(self, connection_doc: Any) -> bool:
+        refresh_token = connection_doc.get_decrypted_refresh_token()
+        if not refresh_token:
+            connection_doc.auth_status = "Expired"
+            return False
+
+        client_id, client_secret = self._get_client_credentials()
+        try:
+            resp = requests.post(
+                self._get_token_url(),
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                },
+                headers={"Accept": "application/json"},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            connection_doc.set_tokens(
+                access_token=data.get("access_token"),
+                refresh_token=data.get("refresh_token", refresh_token),
+                expires_in_seconds=int(data.get("expires_in", 3600)),
+                token_type=data.get("token_type", "Bearer"),
+            )
+            connection_doc.auth_status = "Active"
+            return True
+        except Exception as e:
+            frappe.log_error(
+                f"Failed to refresh OpenAI subscription connection {connection_doc.name}: {str(e)}",
+                "OpenAI Subscription Refresh Error",
+            )
+            connection_doc.auth_status = "Expired"
+            return False
+
+    def discover_models(self, connection_doc: Any) -> List[Dict[str, Any]]:
+        return list(self.DEFAULT_MODELS)
+
+    def _get_headers(self, connection_doc: Any) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"{connection_doc.token_type or 'Bearer'} {connection_doc.get_decrypted_access_token()}",
+            "Content-Type": "application/json",
+            "User-Agent": "HUF-AgentSystem/1.0",
+        }
+        if connection_doc.account_id:
+            headers["ChatGPT-Account-ID"] = connection_doc.account_id
+        return headers
+
+    def _build_messages(self, enhanced_prompt: Any) -> List[Dict[str, str]]:
+        if isinstance(enhanced_prompt, str):
+            return [{"role": "user", "content": enhanced_prompt}]
+        if isinstance(enhanced_prompt, list):
+            return enhanced_prompt
+        if isinstance(enhanced_prompt, dict):
+            return [enhanced_prompt]
+        return [{"role": "user", "content": str(enhanced_prompt)}]
+
+    def run(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        url = f"{self._get_api_base_url()}/chat/completions"
+        payload = {
+            "model": model,
+            "messages": self._build_messages(enhanced_prompt),
+        }
+
+        resp = requests.post(
+            url,
+            json=payload,
+            headers=self._get_headers(connection_doc),
+            timeout=120,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        choice = data.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        content = message.get("content", "")
+        usage = data.get("usage") or {}
+
+        return {
+            "response": content,
+            "usage": usage,
+            "cost": 0.0,
+            "new_items": [],
+            "model": model,
+            "provider": connection_doc.provider,
+            "adapter_type": connection_doc.adapter_type,
+        }
+
+    async def stream_response(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        url = f"{self._get_api_base_url()}/chat/completions"
+        payload = {
+            "model": model,
+            "messages": self._build_messages(enhanced_prompt),
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+
+        # Use aiohttp if available, otherwise fall back to requests in a thread.
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=self._get_headers(connection_doc),
+                    timeout=aiohttp.ClientTimeout(total=120),
+                ) as resp:
+                    resp.raise_for_status()
+                    full_response = ""
+                    async for line in resp.content:
+                        chunk = self._parse_sse_line(line, full_response)
+                        if chunk:
+                            if chunk.get("type") == "delta":
+                                full_response = chunk.get("full_response", full_response)
+                            yield chunk
+        except ImportError:
+            # Synchronous fallback wrapped for async compatibility.
+            loop = __import__("asyncio").get_event_loop()
+            resp = await loop.run_in_executor(
+                None,
+                lambda: requests.post(
+                    url,
+                    json=payload,
+                    headers=self._get_headers(connection_doc),
+                    stream=True,
+                    timeout=120,
+                ),
+            )
+            resp.raise_for_status()
+            full_response = ""
+            for line in resp.iter_lines():
+                chunk = self._parse_sse_line(line, full_response)
+                if chunk:
+                    if chunk.get("type") == "delta":
+                        full_response = chunk.get("full_response", full_response)
+                    yield chunk
+
+    def _parse_sse_line(self, line: bytes, full_response: str) -> Optional[Dict[str, Any]]:
+        if not line:
+            return None
+        text = line.decode("utf-8") if isinstance(line, bytes) else line
+        if not text.startswith("data: "):
+            return None
+        data = text[6:].strip()
+        if data == "[DONE]":
+            return {"type": "complete", "full_response": full_response}
+        try:
+            obj = json.loads(data)
+        except json.JSONDecodeError:
+            return None
+
+        choices = obj.get("choices", [])
+        usage = obj.get("usage")
+        if usage:
+            return {"type": "complete", "full_response": full_response, "usage": usage, "cost": 0.0}
+        if not choices:
+            return None
+        delta = choices[0].get("delta", {})
+        content = delta.get("content", "")
+        if content:
+            full_response += content
+            return {"type": "delta", "content": content, "full_response": full_response}
+        return None
+
+    def revoke_connection(self, connection_doc: Any) -> bool:
+        connection_doc.access_token = ""
+        connection_doc.refresh_token = ""
+        connection_doc.auth_payload = ""
+        connection_doc.auth_status = "Revoked"
+        return True

--- a/huf/ai/providers/adapters/openai_community.py
+++ b/huf/ai/providers/adapters/openai_community.py
@@ -1,0 +1,595 @@
+import base64
+import hashlib
+import json
+import os
+import secrets
+from typing import Any, AsyncGenerator, Dict, List, Optional
+from urllib.parse import urlencode
+
+import frappe
+import requests
+
+from huf.ai.providers.adapters.base import BaseSubscriptionAdapter
+
+
+class OpenAICommunitySubscriptionAdapter(BaseSubscriptionAdapter):
+    """
+    Community OpenAI/Codex subscription adapter.
+
+    This adapter reuses the public OAuth client credentials that OpenAI's Codex
+    CLI uses, allowing individual ChatGPT Plus/Pro subscribers to authenticate
+    without a partner-registered OAuth app.
+
+    Credentials are sourced from the community plugin:
+      https://github.com/numman-ali/opencode-openai-codex-auth
+
+    Hardcoded values:
+      - client_id: app_EMoamEEZ73f0CkXaXp7hrann
+      - auth_url:  https://auth.openai.com/oauth/authorize
+      - token_url: https://auth.openai.com/oauth/token
+      - api_base:  https://chatgpt.com/backend-api
+      - scope:     openid profile email offline_access
+
+    Required site config:
+      - enable_openai_community_subscription_adapter = 1
+
+    Optional site config overrides:
+      - openai_community_oauth_client_id
+      - openai_community_oauth_auth_url
+      - openai_community_oauth_token_url
+      - openai_community_oauth_scope
+      - openai_community_api_base_url
+      - openai_community_redirect_uri
+    """
+
+    COMMUNITY_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    DEFAULT_AUTH_URL = "https://auth.openai.com/oauth/authorize"
+    DEFAULT_TOKEN_URL = "https://auth.openai.com/oauth/token"
+    DEFAULT_API_BASE_URL = "https://chatgpt.com/backend-api"
+    DEFAULT_SCOPE = "openid profile email offline_access"
+    DEFAULT_REDIRECT_URI = "http://localhost:1455/auth/callback"
+    JWT_ACCOUNT_CLAIM_PATH = "https://api.openai.com/auth"
+
+    DEFAULT_MODELS = [
+        {"id": "gpt-5.2", "name": "GPT-5.2", "context_window": 272000, "output_window": 128000},
+        {"id": "gpt-5.2-codex", "name": "GPT-5.2 Codex", "context_window": 272000, "output_window": 128000},
+        {"id": "gpt-5.1", "name": "GPT-5.1", "context_window": 272000, "output_window": 128000},
+        {"id": "gpt-5.1-codex", "name": "GPT-5.1 Codex", "context_window": 272000, "output_window": 128000},
+        {"id": "gpt-5.1-codex-max", "name": "GPT-5.1 Codex Max", "context_window": 272000, "output_window": 128000},
+        {"id": "gpt-5.1-codex-mini", "name": "GPT-5.1 Codex Mini", "context_window": 272000, "output_window": 128000},
+        {"id": "codex-mini-latest", "name": "Codex Mini Latest", "context_window": 272000, "output_window": 128000},
+        {"id": "gpt-4o", "name": "GPT-4o", "context_window": 128000, "output_window": 16384},
+        {"id": "gpt-4o-mini", "name": "GPT-4o Mini", "context_window": 128000, "output_window": 16384},
+    ]
+
+    def __init__(self):
+        if not frappe.conf.get("enable_openai_community_subscription_adapter"):
+            raise frappe.PermissionError(
+                "OpenAI Community subscription adapter is disabled. "
+                "Set 'enable_openai_community_subscription_adapter' to 1 in site config to enable. "
+                "This adapter uses community-reversed OAuth credentials and carries provider ToS risk."
+            )
+
+    def _get_config(self, key: str, default: Any = None) -> Any:
+        return frappe.conf.get(key, default)
+
+    def _get_client_id(self) -> str:
+        return self._get_config("openai_community_oauth_client_id") or self.COMMUNITY_CLIENT_ID
+
+    def _get_auth_url(self) -> str:
+        return self._get_config("openai_community_oauth_auth_url") or self.DEFAULT_AUTH_URL
+
+    def _get_token_url(self) -> str:
+        return self._get_config("openai_community_oauth_token_url") or self.DEFAULT_TOKEN_URL
+
+    def _get_api_base_url(self) -> str:
+        return self._get_config("openai_community_api_base_url") or self.DEFAULT_API_BASE_URL
+
+    def _get_scope(self) -> str:
+        return self._get_config("openai_community_oauth_scope") or self.DEFAULT_SCOPE
+
+    def _get_redirect_uri(self, override: Optional[str] = None) -> str:
+        return override or self._get_config("openai_community_redirect_uri") or self.DEFAULT_REDIRECT_URI
+
+    def get_auth_methods(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "method": "OAuth PKCE",
+                "type": "pkce",
+                "label": "OpenAI Community OAuth 2.0 PKCE (browser redirect)",
+            },
+            {
+                "method": "OAuth PKCE (Manual Paste)",
+                "type": "pkce_manual",
+                "label": "OpenAI Community OAuth 2.0 PKCE (paste callback URL)",
+            },
+        ]
+
+    def _generate_pkce(self) -> tuple:
+        verifier = base64.urlsafe_b64encode(os.urandom(32)).decode("utf-8").rstrip("=")
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .decode("utf-8")
+            .rstrip("=")
+        )
+        return verifier, challenge
+
+    def _parse_pasted_url(self, value: str) -> Dict[str, Optional[str]]:
+        value = (value or "").strip()
+        if not value:
+            return {}
+        from urllib.parse import urlparse, parse_qs
+        try:
+            parsed = urlparse(value)
+            params = parse_qs(parsed.query)
+            code = params.get("code", [None])[0]
+            state = params.get("state", [None])[0]
+            if code:
+                return {"code": code, "state": state}
+        except Exception:
+            pass
+        if "#" in value:
+            code, state = value.split("#", 1)
+            return {"code": code, "state": state}
+        if "code=" in value:
+            params = parse_qs(value)
+            return {
+                "code": params.get("code", [None])[0],
+                "state": params.get("state", [None])[0],
+            }
+        return {"code": value}
+
+    def start_authorization(
+        self,
+        connection_doc: Any,
+        mode: str,
+        redirect_uri: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        if mode not in ("OAuth PKCE", "OAuth PKCE (Manual Paste)"):
+            raise ValueError(f"Unsupported auth mode: {mode}")
+
+        client_id = self._get_client_id()
+        verifier, challenge = self._generate_pkce()
+        state = secrets.token_urlsafe(24)
+        final_redirect_uri = self._get_redirect_uri(redirect_uri)
+
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        metadata.update(
+            {
+                "pkce_verifier": verifier,
+                "oauth_state": state,
+                "redirect_uri": final_redirect_uri,
+                "auth_mode": mode,
+            }
+        )
+        connection_doc.set_auth_payload(metadata)
+        connection_doc.auth_status = "Pending Authorization"
+
+        params = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": final_redirect_uri,
+            "scope": self._get_scope(),
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "id_token_add_organizations": "true",
+            "codex_cli_simplified_flow": "true",
+            "originator": "codex_cli_rs",
+        }
+        auth_url = f"{self._get_auth_url()}?{urlencode(params)}"
+
+        result = {
+            "auth_url": auth_url,
+            "state": state,
+        }
+        if mode == "OAuth PKCE (Manual Paste)":
+            result["instructions"] = (
+                "Open the URL in your browser, complete login, then copy the full "
+                "redirect URL from the browser address bar (it will look like "
+                "http://localhost:1455/auth/callback?code=...&state=...) and paste it back here."
+            )
+        return result
+
+    def complete_authorization(
+        self,
+        connection_doc: Any,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        code = payload.get("code")
+        state = payload.get("state")
+
+        # Manual paste may pass the full callback URL instead of parsed code/state.
+        if not code and payload.get("pasted_url"):
+            parsed = self._parse_pasted_url(payload["pasted_url"])
+            code = parsed.get("code")
+            state = parsed.get("state") or state
+
+        if not code:
+            raise ValueError("Authorization code is required")
+
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        stored_state = metadata.get("oauth_state")
+        if stored_state and state != stored_state:
+            raise ValueError("OAuth state mismatch")
+
+        verifier = metadata.get("pkce_verifier")
+        if not verifier:
+            raise ValueError("PKCE verifier not found; restart authorization")
+
+        redirect_uri = payload.get("redirect_uri") or metadata.get("redirect_uri") or self._get_redirect_uri()
+
+        token_resp = requests.post(
+            self._get_token_url(),
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": self._get_client_id(),
+                "code_verifier": verifier,
+            },
+            headers={"Accept": "application/json"},
+            timeout=30,
+        )
+        token_resp.raise_for_status()
+        token_data = token_resp.json()
+
+        access_token = token_data.get("access_token")
+        refresh_token = token_data.get("refresh_token")
+        expires_in = token_data.get("expires_in", 3600)
+        token_type = token_data.get("token_type", "Bearer")
+
+        account_id = ""
+        if access_token:
+            account_id = self._extract_chatgpt_account_id(access_token) or ""
+
+        # Clear transient PKCE data but keep useful metadata.
+        metadata.pop("pkce_verifier", None)
+        metadata.pop("oauth_state", None)
+        metadata.pop("redirect_uri", None)
+        metadata["token_response"] = {k: v for k, v in token_data.items() if k not in ("access_token", "refresh_token")}
+
+        connection_doc.set_auth_payload(metadata)
+        connection_doc.set_tokens(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in_seconds=int(expires_in),
+            token_type=token_type,
+        )
+        if account_id:
+            connection_doc.account_id = account_id
+
+        id_token = token_data.get("id_token")
+        if id_token:
+            try:
+                payload_part = id_token.split(".")[1]
+                padded = payload_part + "=" * (-len(payload_part) % 4)
+                id_payload = json.loads(base64.urlsafe_b64decode(padded).decode())
+                connection_doc.account_email = id_payload.get("email", "")
+            except Exception:
+                pass
+
+        connection_doc.auth_status = "Active"
+
+        return {
+            "status": "success",
+            "account_email": connection_doc.account_email,
+            "account_id": connection_doc.account_id,
+            "expires_in": expires_in,
+        }
+
+    def _extract_chatgpt_account_id(self, access_token: str) -> Optional[str]:
+        try:
+            parts = access_token.split(".")
+            if len(parts) != 3:
+                return None
+            payload_part = parts[1]
+            padded = payload_part + "=" * (-len(payload_part) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(padded).decode())
+            account_data = payload.get(self.JWT_ACCOUNT_CLAIM_PATH)
+            if isinstance(account_data, dict):
+                return account_data.get("chatgpt_account_id")
+        except Exception:
+            pass
+        return None
+
+    def refresh_connection(self, connection_doc: Any) -> bool:
+        refresh_token = connection_doc.get_decrypted_refresh_token()
+        if not refresh_token:
+            connection_doc.auth_status = "Expired"
+            return False
+
+        try:
+            resp = requests.post(
+                self._get_token_url(),
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": self._get_client_id(),
+                },
+                headers={"Accept": "application/json"},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            access_token = data.get("access_token")
+            account_id = self._extract_chatgpt_account_id(access_token) if access_token else connection_doc.account_id
+
+            connection_doc.set_tokens(
+                access_token=access_token,
+                refresh_token=data.get("refresh_token", refresh_token),
+                expires_in_seconds=int(data.get("expires_in", 3600)),
+                token_type=data.get("token_type", "Bearer"),
+            )
+            if account_id:
+                connection_doc.account_id = account_id
+            connection_doc.auth_status = "Active"
+            return True
+        except Exception as e:
+            frappe.log_error(
+                f"Failed to refresh OpenAI community connection {connection_doc.name}: {str(e)}",
+                "OpenAI Community Subscription Refresh Error",
+            )
+            connection_doc.auth_status = "Expired"
+            return False
+
+    def discover_models(self, connection_doc: Any) -> List[Dict[str, Any]]:
+        return list(self.DEFAULT_MODELS)
+
+    def _get_headers(self, connection_doc: Any) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"{connection_doc.token_type or 'Bearer'} {connection_doc.get_decrypted_access_token()}",
+            "Content-Type": "application/json",
+            "OpenAI-Beta": "responses=experimental",
+            "originator": "codex_cli_rs",
+            "User-Agent": "HUF-AgentSystem/1.0",
+        }
+        if connection_doc.account_id:
+            headers["chatgpt-account-id"] = connection_doc.account_id
+        return headers
+
+    def _normalize_model(self, model: str) -> str:
+        mapping = {
+            "gpt-5.2-medium": "gpt-5.2",
+            "gpt-5.2-codex-medium": "gpt-5.2-codex",
+            "gpt-5.1-medium": "gpt-5.1",
+            "gpt-5.1-codex-medium": "gpt-5.1-codex",
+            "gpt-5.1-codex-max-medium": "gpt-5.1-codex-max",
+            "gpt-5.1-codex-mini-medium": "gpt-5.1-codex-mini",
+        }
+        return mapping.get(model, model)
+
+    def _build_input(self, enhanced_prompt: Any) -> List[Dict[str, Any]]:
+        if isinstance(enhanced_prompt, str):
+            return [{"role": "user", "content": enhanced_prompt}]
+        if isinstance(enhanced_prompt, list):
+            return [{k: v for k, v in item.items() if k != "id"} for item in enhanced_prompt]
+        if isinstance(enhanced_prompt, dict):
+            return [{k: v for k, v in enhanced_prompt.items() if k != "id"}]
+        return [{"role": "user", "content": str(enhanced_prompt)}]
+
+    def _build_codex_body(
+        self,
+        connection_doc: Any,
+        enhanced_prompt: Any,
+        model: str,
+        stream: bool = False,
+    ) -> Dict[str, Any]:
+        metadata = connection_doc.get_decrypted_auth_payload() or {}
+        encrypted_reasoning = metadata.get("encrypted_reasoning")
+
+        input_items = self._build_input(enhanced_prompt)
+        if encrypted_reasoning:
+            # Re-inject previous reasoning context if available.
+            input_items.append({
+                "type": "reasoning",
+                "content": encrypted_reasoning,
+            })
+
+        body: Dict[str, Any] = {
+            "model": self._normalize_model(model),
+            "store": False,
+            "stream": stream,
+            "input": input_items,
+            "include": ["reasoning.encrypted_content"],
+        }
+
+        # Basic reasoning/text defaults; future improvement: make configurable.
+        body["reasoning"] = {"effort": "medium", "summary": "auto"}
+        body["text"] = {"verbosity": "medium"}
+
+        return body
+
+    def run(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        url = f"{self._get_api_base_url()}/codex/responses"
+        payload = self._build_codex_body(connection_doc, enhanced_prompt, model, stream=False)
+
+        resp = requests.post(
+            url,
+            json=payload,
+            headers=self._get_headers(connection_doc),
+            timeout=120,
+        )
+        resp.raise_for_status()
+
+        text = resp.text
+        final_response = self._parse_sse_text(text)
+        content = self._extract_text_from_response(final_response)
+        usage = self._extract_usage(final_response)
+
+        self._persist_encrypted_reasoning(connection_doc, final_response)
+
+        return {
+            "response": content,
+            "usage": usage,
+            "cost": 0.0,
+            "new_items": [],
+            "model": model,
+            "provider": connection_doc.provider,
+            "adapter_type": connection_doc.adapter_type,
+        }
+
+    async def stream_response(
+        self,
+        connection_doc: Any,
+        agent: Any,
+        enhanced_prompt: Any,
+        model: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        if connection_doc.auth_status != "Active":
+            raise PermissionError(
+                f"Subscription connection {connection_doc.name} is not active ({connection_doc.auth_status})"
+            )
+
+        url = f"{self._get_api_base_url()}/codex/responses"
+        payload = self._build_codex_body(connection_doc, enhanced_prompt, model, stream=True)
+
+        full_response = ""
+        final_response = None
+
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=self._get_headers(connection_doc),
+                    timeout=aiohttp.ClientTimeout(total=120),
+                ) as resp:
+                    resp.raise_for_status()
+                    async for line in resp.content:
+                        event = self._parse_sse_line(line)
+                        if not event:
+                            continue
+                        event_type = event.get("type")
+                        if event_type == "response.output_text.delta":
+                            delta = event.get("delta", "")
+                            if delta:
+                                full_response += delta
+                                yield {
+                                    "type": "delta",
+                                    "content": delta,
+                                    "full_response": full_response,
+                                }
+                        elif event_type in ("response.done", "response.completed"):
+                            final_response = event.get("response")
+                            usage = self._extract_usage(final_response)
+                            yield {
+                                "type": "complete",
+                                "full_response": full_response,
+                                "usage": usage,
+                                "cost": 0.0,
+                            }
+        except ImportError:
+            loop = __import__("asyncio").get_event_loop()
+            resp = await loop.run_in_executor(
+                None,
+                lambda: requests.post(
+                    url,
+                    json=payload,
+                    headers=self._get_headers(connection_doc),
+                    stream=True,
+                    timeout=120,
+                ),
+            )
+            resp.raise_for_status()
+            for line in resp.iter_lines():
+                event = self._parse_sse_line(line)
+                if not event:
+                    continue
+                event_type = event.get("type")
+                if event_type == "response.output_text.delta":
+                    delta = event.get("delta", "")
+                    if delta:
+                        full_response += delta
+                        yield {
+                            "type": "delta",
+                            "content": delta,
+                            "full_response": full_response,
+                        }
+                elif event_type in ("response.done", "response.completed"):
+                    final_response = event.get("response")
+                    usage = self._extract_usage(final_response)
+                    yield {
+                        "type": "complete",
+                        "full_response": full_response,
+                        "usage": usage,
+                        "cost": 0.0,
+                    }
+
+        if final_response:
+            self._persist_encrypted_reasoning(connection_doc, final_response)
+
+    def _parse_sse_text(self, text: str) -> Optional[Dict[str, Any]]:
+        for line in text.splitlines():
+            event = self._parse_sse_line(line)
+            if event and event.get("type") in ("response.done", "response.completed"):
+                return event.get("response")
+        return None
+
+    def _parse_sse_line(self, line: Any) -> Optional[Dict[str, Any]]:
+        if not line:
+            return None
+        text = line.decode("utf-8") if isinstance(line, bytes) else line
+        text = text.strip()
+        if not text.startswith("data: "):
+            return None
+        data = text[6:].strip()
+        if data == "[DONE]":
+            return None
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError:
+            return None
+
+    def _extract_text_from_response(self, response: Optional[Dict[str, Any]]) -> str:
+        if not response:
+            return ""
+        output = response.get("output", [])
+        parts = []
+        for item in output:
+            if item.get("type") == "message" and item.get("role") == "assistant":
+                content = item.get("content", [])
+                for part in content:
+                    if part.get("type") == "output_text":
+                        parts.append(part.get("text", ""))
+        return "".join(parts)
+
+    def _extract_usage(self, response: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if not response:
+            return {}
+        return response.get("usage") or {}
+
+    def _persist_encrypted_reasoning(self, connection_doc: Any, response: Optional[Dict[str, Any]]):
+        if not response:
+            return
+        output = response.get("output", [])
+        for item in output:
+            if item.get("type") == "reasoning":
+                encrypted = item.get("encrypted_content")
+                if encrypted:
+                    metadata = connection_doc.get_decrypted_auth_payload() or {}
+                    metadata["encrypted_reasoning"] = encrypted
+                    connection_doc.set_auth_payload(metadata)
+                    break
+
+    def revoke_connection(self, connection_doc: Any) -> bool:
+        connection_doc.access_token = ""
+        connection_doc.refresh_token = ""
+        connection_doc.auth_payload = ""
+        connection_doc.auth_status = "Revoked"
+        return True

--- a/huf/ai/run.py
+++ b/huf/ai/run.py
@@ -1,19 +1,152 @@
 import frappe
 from frappe import _
+from types import SimpleNamespace
 
 
 class RunProvider:
     """
     Central routing layer for AI providers.
     Routes existing providers (OpenAI, Anthropic, Google, OpenRouter) to LiteLLM
-    for unified handling while maintaining backward compatibility.
-
-    New providers can be added via LiteLLM without code changes - just create
-    AI Provider and AI Model documents with the correct format.
+    for unified handling while maintaining backward compatibility, or to native
+    subscription adapters when a subscription connection is specified/active.
     """
 
     @staticmethod
+    def _get_subscription_connection(context, provider=None, model=None):
+        """
+        Resolve an active AI Provider Connection for this run.
+
+        Precedence:
+        1. ``subscription_connection`` object or name passed in context.
+        2. ``subscription_connection_name`` passed in context.
+        3. Auto-discover an active connection for the provider + current user +
+           model when none is explicitly supplied.
+        """
+        if not context:
+            context = {}
+
+        connection = context.get("subscription_connection")
+        connection_name = context.get("subscription_connection_name")
+
+        if not connection and connection_name:
+            if frappe.db.exists("AI Provider Connection", connection_name):
+                connection = frappe.get_doc("AI Provider Connection", connection_name)
+
+        if connection:
+            if isinstance(connection, str):
+                if frappe.db.exists("AI Provider Connection", connection):
+                    connection = frappe.get_doc("AI Provider Connection", connection)
+                else:
+                    return None
+
+            if hasattr(connection, "check_and_refresh"):
+                if connection.check_and_refresh():
+                    return connection
+                frappe.throw(
+                    _(
+                        "Subscription connection '{0}' is expired or inactive. Please re-authorize."
+                    ).format(connection.name)
+                )
+            return connection
+
+        # Auto-discover active subscription connection for provider/user/model.
+        if provider:
+            user = context.get("user") or frappe.session.user
+            filters = {
+                "provider": provider,
+                "user": user,
+                "is_active": 1,
+            }
+            connections = frappe.get_all(
+                "AI Provider Connection",
+                filters=filters,
+                fields=["name"],
+                order_by="modified desc",
+                limit_page_length=10,
+            )
+            for conn_row in connections:
+                try:
+                    conn_doc = frappe.get_doc("AI Provider Connection", conn_row.name)
+                except Exception:
+                    continue
+                if not conn_doc.is_active_connection():
+                    continue
+                if model and not conn_doc.matches_model(model):
+                    continue
+                if conn_doc.check_and_refresh():
+                    return conn_doc
+
+        return None
+
+    @staticmethod
+    def _normalize_subscription_result(result):
+        """
+        Convert a subscription adapter dict result into a HUF-compatible result
+        object with ``final_output``, ``usage``, ``new_items`` and ``cost``.
+        """
+        if result is None:
+            return SimpleNamespace(final_output="", usage={}, new_items=[], cost=0.0)
+
+        if not isinstance(result, dict):
+            return result
+
+        usage = result.get("usage") or {}
+        if not isinstance(usage, dict):
+            usage = {}
+
+        return SimpleNamespace(
+            final_output=result.get("response", ""),
+            usage=usage,
+            new_items=result.get("new_items") or [],
+            cost=result.get("cost", 0.0),
+            metadata={k: v for k, v in result.items() if k not in ("response", "usage", "new_items", "cost")},
+        )
+
+    @staticmethod
+    async def _normalize_subscription_stream(stream):
+        """
+        Compatibility wrapper for subscription adapters that emit raw chunks
+        without a ``type`` field.  Infers HUF chunk types where possible.
+        """
+        full_response = ""
+        async for chunk in stream:
+            if not isinstance(chunk, dict):
+                continue
+
+            chunk_type = chunk.get("type")
+            if not chunk_type:
+                if chunk.get("finish_reason") == "stop":
+                    chunk_type = "complete"
+                else:
+                    chunk_type = "delta"
+                chunk = dict(chunk)
+                chunk["type"] = chunk_type
+
+            if chunk_type == "delta":
+                full_response += chunk.get("content", "")
+                chunk.setdefault("full_response", full_response)
+                yield chunk
+            elif chunk_type == "complete":
+                chunk.setdefault("full_response", full_response)
+                yield chunk
+            else:
+                yield chunk
+
+    @staticmethod
     def run(agent, enhanced_prompt, provider, model, context=None):
+        sub_conn = RunProvider._get_subscription_connection(context, provider, model)
+        if sub_conn:
+            from huf.ai.providers.adapters import get_adapter
+            adapter = get_adapter(sub_conn.adapter_type)
+            result = adapter.run(
+                connection_doc=sub_conn,
+                agent=agent,
+                enhanced_prompt=enhanced_prompt,
+                model=model,
+                context=context,
+            )
+            return RunProvider._normalize_subscription_result(result)
+
         provider_lower = provider.lower()
         original_exception = None
 
@@ -82,8 +215,22 @@ class RunProvider:
         """
         Streaming version of run() - yields chunks instead of returning final result.
 
-        Routes streaming requests to LiteLLM for supported providers.
+        Routes streaming requests to LiteLLM for supported providers or to native
+        subscription adapters when a subscription connection is specified/active.
         """
+        sub_conn = RunProvider._get_subscription_connection(context, provider, model)
+        if sub_conn:
+            from huf.ai.providers.adapters import get_adapter
+            adapter = get_adapter(sub_conn.adapter_type)
+            stream = adapter.stream_response(
+                connection_doc=sub_conn,
+                agent=agent,
+                enhanced_prompt=enhanced_prompt,
+                model=model,
+                context=context,
+            )
+            return RunProvider._normalize_subscription_stream(stream)
+
         try:
             from huf.ai.providers import litellm
             return litellm.run_stream(
@@ -108,9 +255,3 @@ class RunProvider:
                 f"LiteLLM Streaming Error: {provider}",
             )
             frappe.throw(_(f"Error streaming from provider {provider}: {str(e)}"))
-
-        # For other providers, streaming not yet supported
-        # frappe.throw(
-        #     _("Streaming not yet supported for provider '{provider}'. "
-        #       "Please use run() for non-streaming requests.").format(provider=provider)
-        # )

--- a/huf/ai/tests/test_subscription_adapter_kimi_community.py
+++ b/huf/ai/tests/test_subscription_adapter_kimi_community.py
@@ -1,0 +1,194 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+import frappe
+
+from huf.ai.providers.adapters import get_adapter
+from huf.ai.providers.adapters.kimi_community import KimiCommunitySubscriptionAdapter
+
+
+class TestKimiCommunitySubscriptionAdapter(unittest.TestCase):
+    def setUp(self):
+        frappe.conf["enable_kimi_community_subscription_adapter"] = 1
+
+        if not frappe.db.exists("AI Provider", "KimiCommunityTest"):
+            provider_doc = frappe.get_doc({
+                "doctype": "AI Provider",
+                "provider_name": "KimiCommunityTest",
+                "provider_brand": "kimi_community",
+                "api_key": "",
+            })
+            provider_doc.insert(ignore_permissions=True)
+
+        if frappe.db.exists("AI Provider Connection", "Test Kimi Community"):
+            frappe.delete_doc("AI Provider Connection", "Test Kimi Community", force=True)
+
+        self.conn = frappe.get_doc({
+            "doctype": "AI Provider Connection",
+            "connection_name": "Test Kimi Community",
+            "user": "Administrator",
+            "provider": "KimiCommunityTest",
+            "adapter_type": "kimi_community_subscription",
+            "auth_status": "Unlinked",
+            "auth_method": "Device Code",
+            "is_active": 1,
+            "eligible_models": json.dumps(["kimi-for-coding"]),
+        })
+        self.conn.insert(ignore_permissions=True)
+
+    def tearDown(self):
+        if frappe.db.exists("AI Provider Connection", "Test Kimi Community"):
+            frappe.delete_doc("AI Provider Connection", "Test Kimi Community", force=True)
+        frappe.conf.pop("enable_kimi_community_subscription_adapter", None)
+
+    def test_adapter_registry(self):
+        adapter = get_adapter("kimi_community_subscription")
+        self.assertIsInstance(adapter, KimiCommunitySubscriptionAdapter)
+
+    def test_adapter_disabled_without_flag(self):
+        frappe.conf.pop("enable_kimi_community_subscription_adapter", None)
+        with self.assertRaises(frappe.PermissionError):
+            KimiCommunitySubscriptionAdapter()
+
+    def test_start_authorization_requests_device_code(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "device_code": "dev_123",
+            "user_code": "USER123",
+            "verification_uri": "https://auth.kimi.com/activate",
+            "verification_uri_complete": "https://auth.kimi.com/activate?user_code=USER123",
+            "expires_in": 1800,
+            "interval": 5,
+        }
+
+        with patch("huf.ai.providers.adapters.kimi_community.requests.post", return_value=mock_response) as mock_post:
+            auth_data = adapter.start_authorization(self.conn, mode="Device Code")
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        url = call_args.kwargs.get("url") or call_args.args[0]
+        self.assertEqual(url, "https://auth.kimi.com/api/oauth/device_authorization")
+        call_kwargs = call_args.kwargs
+        self.assertEqual(call_kwargs["data"]["client_id"], "17e5f671-d194-4dfb-9706-5516cb48c098")
+
+        self.assertEqual(auth_data["user_code"], "USER123")
+        self.assertEqual(auth_data["device_code"], "dev_123")
+        self.assertEqual(self.conn.auth_status, "Pending Authorization")
+
+    @patch("huf.ai.providers.adapters.kimi_community.time.sleep")
+    def test_complete_authorization_polls_and_stores_tokens(self, mock_sleep):
+        adapter = get_adapter(self.conn.adapter_type)
+        adapter.start_authorization(self.conn, mode="Device Code")
+
+        pending_response = MagicMock()
+        pending_response.status_code = 400
+        pending_response.json.return_value = {"error": "authorization_pending"}
+        pending_response.text = '{"error": "authorization_pending"}'
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "access_token": "access_123",
+            "refresh_token": "refresh_123",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        with patch(
+            "huf.ai.providers.adapters.kimi_community.requests.post",
+            side_effect=[pending_response, success_response],
+        ) as mock_post:
+            result = adapter.complete_authorization(self.conn, {"device_code": "dev_123", "interval": 5, "expires_in": 1800})
+
+        self.assertEqual(mock_post.call_count, 2)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(self.conn.auth_status, "Active")
+        self.assertEqual(self.conn.get_decrypted_access_token(), "access_123")
+        self.assertEqual(self.conn.get_decrypted_refresh_token(), "refresh_123")
+
+    @patch("huf.ai.providers.adapters.kimi_community.time.sleep")
+    def test_refresh_connection(self, mock_sleep):
+        adapter = get_adapter(self.conn.adapter_type)
+        self.conn.set_tokens("access_123", "refresh_123", expires_in_seconds=3600)
+        self.conn.auth_status = "Active"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps({
+            "access_token": "access_789",
+            "refresh_token": "refresh_789",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        })
+        mock_response.json.return_value = {
+            "access_token": "access_789",
+            "refresh_token": "refresh_789",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        with patch("huf.ai.providers.adapters.kimi_community.requests.post", return_value=mock_response) as mock_post:
+            success = adapter.refresh_connection(self.conn)
+
+        self.assertTrue(success)
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        self.assertEqual(call_kwargs["data"]["grant_type"], "refresh_token")
+        self.assertEqual(call_kwargs["data"]["client_id"], "17e5f671-d194-4dfb-9706-5516cb48c098")
+        self.assertEqual(self.conn.get_decrypted_refresh_token(), "refresh_789")
+
+    def test_kimi_headers_match_cli_fingerprint(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        headers = adapter._get_headers(self.conn)
+        self.assertTrue(headers["User-Agent"].startswith("KimiCLI/"))
+        self.assertEqual(headers["X-Msh-Platform"], "kimi_cli")
+        self.assertEqual(headers["X-Msh-Version"], "1.41.0")
+        self.assertIn("X-Msh-Device-Id", headers)
+        self.assertIn("X-Msh-Device-Model", headers)
+
+    def test_run_builds_chat_completions_request(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        self.conn.set_tokens("access_123", "refresh_123", expires_in_seconds=3600)
+        self.conn.auth_status = "Active"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Hello from Kimi"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+
+        with patch("huf.ai.providers.adapters.kimi_community.requests.post", return_value=mock_response) as mock_post:
+            result = adapter.run(
+                connection_doc=self.conn,
+                agent=None,
+                enhanced_prompt="Hi",
+                model="kimi-for-coding",
+                context={"session_id": "sess_abc"},
+            )
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        url = call_args.kwargs.get("url") or call_args.args[0]
+        self.assertEqual(url, "https://api.kimi.com/coding/v1/chat/completions")
+        call_kwargs = call_args.kwargs
+        self.assertEqual(call_kwargs["json"]["model"], "kimi-for-coding")
+        self.assertEqual(call_kwargs["json"]["prompt_cache_key"], "sess_abc")
+        self.assertEqual(call_kwargs["headers"]["User-Agent"], "KimiCLI/1.41.0")
+        self.assertEqual(result["response"], "Hello from Kimi")
+
+    def test_discover_models_falls_back_to_default(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        models = adapter.discover_models(self.conn)
+        self.assertTrue(any(m["id"] == "kimi-for-coding" for m in models))
+
+    def test_revoke_connection(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        self.conn.set_tokens("access", "refresh", expires_in_seconds=3600)
+        success = adapter.revoke_connection(self.conn)
+        self.assertTrue(success)
+        self.assertEqual(self.conn.auth_status, "Revoked")
+        self.assertEqual(self.conn.get_decrypted_access_token(), "")

--- a/huf/ai/tests/test_subscription_adapter_mock.py
+++ b/huf/ai/tests/test_subscription_adapter_mock.py
@@ -1,0 +1,137 @@
+import json
+import unittest
+import asyncio
+import frappe
+from frappe.utils import now_datetime, add_to_date
+from huf.huf.doctype.ai_provider_connection.ai_provider_connection import AIProviderConnection
+from huf.ai.providers.adapters import get_adapter
+from huf.ai.providers.adapters.mock import MockSubscriptionAdapter
+from huf.ai.run import RunProvider
+
+
+class TestSubscriptionAdapterMock(unittest.TestCase):
+    def setUp(self):
+        # Create test AI Provider if needed
+        if not frappe.db.exists("AI Provider", "MockProvider"):
+            provider_doc = frappe.get_doc({
+                "doctype": "AI Provider",
+                "provider_name": "MockProvider",
+                "provider_brand": "other",
+                "api_key": "mock-api-key"
+            })
+            provider_doc.insert(ignore_permissions=True)
+
+        # Cleanup existing connection if any
+        if frappe.db.exists("AI Provider Connection", "Test Mock Subscription"):
+            frappe.delete_doc("AI Provider Connection", "Test Mock Subscription", force=True)
+
+        # Create AI Provider Connection
+        self.conn = frappe.get_doc({
+            "doctype": "AI Provider Connection",
+            "connection_name": "Test Mock Subscription",
+            "user": "Administrator",
+            "provider": "MockProvider",
+            "adapter_type": "mock_subscription",
+            "auth_status": "Unlinked",
+            "auth_method": "OAuth PKCE",
+            "is_active": 1,
+            "eligible_models": json.dumps(["mock-sub-gpt-4o", "mock-sub-gemini-2"])
+        })
+        self.conn.insert(ignore_permissions=True)
+
+    def tearDown(self):
+        if frappe.db.exists("AI Provider Connection", "Test Mock Subscription"):
+            frappe.delete_doc("AI Provider Connection", "Test Mock Subscription", force=True)
+
+    def test_adapter_registry(self):
+        adapter = get_adapter("mock_subscription")
+        self.assertIsInstance(adapter, MockSubscriptionAdapter)
+
+    def test_authorization_flow(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        auth_data = adapter.start_authorization(self.conn, mode="OAuth PKCE")
+        self.assertIn("auth_url", auth_data)
+
+        res = adapter.complete_authorization(self.conn, {"code": "mock_auth_code_123"})
+        self.assertEqual(res["status"], "success")
+        self.assertEqual(self.conn.auth_status, "Active")
+        self.assertEqual(self.conn.get_decrypted_access_token(), "mock_access_token_abc123")
+        self.assertEqual(self.conn.get_decrypted_refresh_token(), "mock_refresh_token_xyz789")
+
+    def test_token_expiry_and_refresh(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        adapter.complete_authorization(self.conn, {"code": "mock_code"})
+        self.conn.save(ignore_permissions=True)
+
+        self.assertFalse(self.conn.is_expired(buffer_seconds=300))
+
+        # Simulate near expiry
+        self.conn.expires_at = add_to_date(now_datetime(), seconds=100)
+        self.assertTrue(self.conn.is_expired(buffer_seconds=300))
+
+        # Test refresh
+        refreshed = self.conn.check_and_refresh()
+        self.assertTrue(refreshed)
+        self.assertEqual(self.conn.get_decrypted_access_token(), "refreshed_mock_access_token_999")
+        self.assertEqual(self.conn.auth_status, "Active")
+
+    def test_refresh_failure_invalid_token(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        adapter.complete_authorization(self.conn, {"code": "mock_code"})
+        self.conn.set_tokens("access", "invalid_refresh_token", expires_in_seconds=-10)
+        self.conn.save(ignore_permissions=True)
+
+        refreshed = self.conn.check_and_refresh()
+        self.assertFalse(refreshed)
+        self.assertEqual(self.conn.auth_status, "Expired")
+
+    def test_run_provider_routing_subscription(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        adapter.complete_authorization(self.conn, {"code": "mock_code"})
+        self.conn.save(ignore_permissions=True)
+
+        context = {"subscription_connection_name": self.conn.name}
+        res = RunProvider.run(
+            agent=None,
+            enhanced_prompt="Hello agent",
+            provider="MockProvider",
+            model="mock-sub-gpt-4o",
+            context=context
+        )
+
+        self.assertIn("Mock Subscription Output", res.final_output)
+        self.assertEqual(res.metadata.get("adapter_type"), "mock_subscription")
+
+    def test_run_provider_routing_streaming_subscription(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        adapter.complete_authorization(self.conn, {"code": "mock_code"})
+        self.conn.save(ignore_permissions=True)
+
+        context = {"subscription_connection_name": self.conn.name}
+
+        async def _consume_stream():
+            stream = RunProvider.run_stream(
+                agent=None,
+                enhanced_prompt="Hello agent streaming",
+                provider="MockProvider",
+                model="mock-sub-gpt-4o",
+                context=context
+            )
+            chunks = []
+            async for chunk in stream:
+                chunks.append(chunk)
+            return chunks
+
+        chunks = asyncio.run(_consume_stream())
+        self.assertGreater(len(chunks), 1)
+        full_text = "".join([c["content"] for c in chunks if c.get("type") == "delta"])
+        self.assertIn("[Mock Subscription Stream Chunk]", full_text)
+
+    def test_revoke_connection(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        adapter.complete_authorization(self.conn, {"code": "mock_code"})
+
+        success = adapter.revoke_connection(self.conn)
+        self.assertTrue(success)
+        self.assertEqual(self.conn.auth_status, "Revoked")
+        self.assertEqual(self.conn.get_decrypted_access_token(), "")

--- a/huf/ai/tests/test_subscription_adapter_openai_community.py
+++ b/huf/ai/tests/test_subscription_adapter_openai_community.py
@@ -1,0 +1,169 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+import frappe
+
+from huf.ai.providers.adapters import get_adapter
+from huf.ai.providers.adapters.openai_community import OpenAICommunitySubscriptionAdapter
+
+
+class TestOpenAICommunitySubscriptionAdapter(unittest.TestCase):
+    def setUp(self):
+        # Enable community adapter for tests.
+        frappe.conf["enable_openai_community_subscription_adapter"] = 1
+
+        if not frappe.db.exists("AI Provider", "OpenAICommunityTest"):
+            provider_doc = frappe.get_doc({
+                "doctype": "AI Provider",
+                "provider_name": "OpenAICommunityTest",
+                "provider_brand": "openai_community",
+                "api_key": "",
+            })
+            provider_doc.insert(ignore_permissions=True)
+
+        if frappe.db.exists("AI Provider Connection", "Test OpenAI Community"):
+            frappe.delete_doc("AI Provider Connection", "Test OpenAI Community", force=True)
+
+        self.conn = frappe.get_doc({
+            "doctype": "AI Provider Connection",
+            "connection_name": "Test OpenAI Community",
+            "user": "Administrator",
+            "provider": "OpenAICommunityTest",
+            "adapter_type": "openai_community_subscription",
+            "auth_status": "Unlinked",
+            "auth_method": "OAuth PKCE (Manual Paste)",
+            "is_active": 1,
+            "eligible_models": json.dumps(["gpt-4o", "gpt-5.2"]),
+        })
+        self.conn.insert(ignore_permissions=True)
+
+    def tearDown(self):
+        if frappe.db.exists("AI Provider Connection", "Test OpenAI Community"):
+            frappe.delete_doc("AI Provider Connection", "Test OpenAI Community", force=True)
+        frappe.conf.pop("enable_openai_community_subscription_adapter", None)
+
+    def test_adapter_registry(self):
+        adapter = get_adapter("openai_community_subscription")
+        self.assertIsInstance(adapter, OpenAICommunitySubscriptionAdapter)
+
+    def test_adapter_disabled_without_flag(self):
+        frappe.conf.pop("enable_openai_community_subscription_adapter", None)
+        with self.assertRaises(frappe.PermissionError):
+            OpenAICommunitySubscriptionAdapter()
+
+    def test_authorization_url_uses_community_client_id(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        auth_data = adapter.start_authorization(self.conn, mode="OAuth PKCE (Manual Paste)")
+
+        self.assertIn("auth_url", auth_data)
+        auth_url = auth_data["auth_url"]
+        self.assertIn("client_id=app_EMoamEEZ73f0CkXaXp7hrann", auth_url)
+        self.assertIn("originator=codex_cli_rs", auth_url)
+        self.assertIn("codex_cli_simplified_flow=true", auth_url)
+        self.assertIn("code_challenge_method=S256", auth_url)
+        self.assertEqual(self.conn.auth_status, "Pending Authorization")
+
+    def test_complete_authorization_exchanges_code_without_secret(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        auth_data = adapter.start_authorization(self.conn, mode="OAuth PKCE (Manual Paste)")
+        state = auth_data["state"]
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": _fake_jwt({"https://api.openai.com/auth": {"chatgpt_account_id": "acc_123"}}),
+            "refresh_token": "refresh_123",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "id_token": _fake_jwt({"email": "test@example.com"}),
+        }
+
+        with patch("huf.ai.providers.adapters.openai_community.requests.post", return_value=mock_response) as mock_post:
+            result = adapter.complete_authorization(
+                self.conn,
+                {"code": "auth_code_123", "state": state},
+            )
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        self.assertEqual(call_kwargs["data"]["grant_type"], "authorization_code")
+        self.assertEqual(call_kwargs["data"]["client_id"], "app_EMoamEEZ73f0CkXaXp7hrann")
+        self.assertNotIn("client_secret", call_kwargs["data"])
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(self.conn.auth_status, "Active")
+        self.assertEqual(self.conn.account_id, "acc_123")
+        self.assertEqual(self.conn.account_email, "test@example.com")
+        self.assertEqual(self.conn.get_decrypted_refresh_token(), "refresh_123")
+
+    def test_complete_authorization_from_pasted_url(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        auth_data = adapter.start_authorization(self.conn, mode="OAuth PKCE (Manual Paste)")
+        state = auth_data["state"]
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": _fake_jwt({"https://api.openai.com/auth": {"chatgpt_account_id": "acc_456"}}),
+            "refresh_token": "refresh_456",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        pasted_url = f"http://localhost:1455/auth/callback?code=pasted_code&state={state}"
+        with patch("huf.ai.providers.adapters.openai_community.requests.post", return_value=mock_response):
+            result = adapter.complete_authorization(
+                self.conn,
+                {"pasted_url": pasted_url},
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(self.conn.account_id, "acc_456")
+
+    def test_refresh_connection_is_secretless(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        self.conn.set_tokens("access_123", "refresh_123", expires_in_seconds=3600)
+        self.conn.auth_status = "Active"
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": _fake_jwt({"https://api.openai.com/auth": {"chatgpt_account_id": "acc_789"}}),
+            "refresh_token": "refresh_789",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        }
+
+        with patch("huf.ai.providers.adapters.openai_community.requests.post", return_value=mock_response) as mock_post:
+            success = adapter.refresh_connection(self.conn)
+
+        self.assertTrue(success)
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        self.assertEqual(call_kwargs["data"]["grant_type"], "refresh_token")
+        self.assertEqual(call_kwargs["data"]["client_id"], "app_EMoamEEZ73f0CkXaXp7hrann")
+        self.assertNotIn("client_secret", call_kwargs["data"])
+        self.assertEqual(self.conn.get_decrypted_refresh_token(), "refresh_789")
+
+    def test_discover_models_returns_allowlist(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        models = adapter.discover_models(self.conn)
+        self.assertTrue(any(m["id"] == "gpt-5.2" for m in models))
+        self.assertTrue(any(m["id"] == "gpt-4o" for m in models))
+
+    def test_revoke_connection(self):
+        adapter = get_adapter(self.conn.adapter_type)
+        self.conn.set_tokens("access", "refresh", expires_in_seconds=3600)
+        success = adapter.revoke_connection(self.conn)
+        self.assertTrue(success)
+        self.assertEqual(self.conn.auth_status, "Revoked")
+        self.assertEqual(self.conn.get_decrypted_access_token(), "")
+
+
+def _fake_jwt(payload: dict) -> str:
+    """Build a fake JWT string for tests (no signature validation)."""
+    import base64
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).decode().rstrip("=")
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"{header}.{body}.signature"

--- a/huf/huf/doctype/ai_model/ai_model.py
+++ b/huf/huf/doctype/ai_model/ai_model.py
@@ -46,7 +46,15 @@ class AIModel(Document):
 		if not modalities:
 			return
 
-		items = [m.strip() for m in modalities.split(",") if m and m.strip()]
+		seen = set()
+		items = []
+		for m in modalities.split(","):
+			item = m.strip()
+			if not item or item in seen:
+				continue
+			seen.add(item)
+			items.append(item)
+
 		invalid = [m for m in items if m not in MODEL_MODALITY_OPTIONS]
 		if invalid:
 			frappe.throw(
@@ -99,7 +107,8 @@ def get_models_by_modality(doctype, txt, searchfield, start, page_len, filters):
 	}
 
 	# Modalities are stored as a comma-separated list; use FIND_IN_SET for multi-select matching.
-	conditions.append("FIND_IN_SET(%(modality)s, IFNULL(modalities, '')) > 0")
+	# Strip spaces from the stored value so legacy or spaced modalities still match cleanly.
+	conditions.append("FIND_IN_SET(%(modality)s, REPLACE(IFNULL(modalities, ''), ' ', '')) > 0")
 
 	if provider:
 		conditions.append("provider = %(provider)s")

--- a/huf/huf/doctype/ai_provider/ai_provider.json
+++ b/huf/huf/doctype/ai_provider/ai_provider.json
@@ -34,7 +34,7 @@
    "fieldname": "provider_brand",
    "fieldtype": "Select",
    "label": "Provider Brand",
-   "options": "openai\nanthropic\ngoogle\nopenrouter\nxai\ngroq\nmistral\ndeepseek\nperplexity\ncohere\nhuggingface\nelevenlabs\namazon-bedrock\nazure\nalibaba\ntogetherai\nmeta\nollama\nlmstudio\nfireworks-ai\ncerebras\ndeepinfra\ngoogle-vertex\nnvidia\nmoonshot\nai21\nbaseten\ncloudflare-workers-ai\nclarifai\nnomic\nreplicate\nsagemaker\nstability-ai\nvllm\nwatsonx\nother",
+   "options": "openai\nopenai_community\nkimi_community\nanthropic\ngoogle\nopenrouter\nxai\ngroq\nmistral\ndeepseek\nperplexity\ncohere\nhuggingface\nelevenlabs\namazon-bedrock\nazure\nalibaba\ntogetherai\nmeta\nollama\nlmstudio\nfireworks-ai\ncerebras\ndeepinfra\ngoogle-vertex\nnvidia\nmoonshot\nai21\nbaseten\ncloudflare-workers-ai\nclarifai\nnomic\nreplicate\nsagemaker\nstability-ai\nvllm\nwatsonx\nother",
    "reqd": 1
   },
   {

--- a/huf/huf/doctype/ai_provider/ai_provider.py
+++ b/huf/huf/doctype/ai_provider/ai_provider.py
@@ -25,6 +25,10 @@ class AIProvider(Document):
 					indicator="orange",
 				)
 
+	# Brands that are backed by per-user subscription connections rather than a
+	# shared API key are allowed to omit the API key field.
+	SUBSCRIPTION_BRANDS = ("openai_community", "kimi_community")
+
 	def validate_api_key(self):
 		if self.is_local_llm:
 			if not (self.api_base_url or self.url):
@@ -33,6 +37,11 @@ class AIProvider(Document):
 				# Local providers (Ollama, LM Studio) need no key; set a dummy
 				# value to satisfy legacy readers that expect one.
 				self.api_key = "not-needed"
+		elif self.provider_brand in self.SUBSCRIPTION_BRANDS:
+			# Subscription-backed providers use per-user OAuth tokens stored in
+			# AI Provider Connection; no global API key is required.
+			if not self.api_key:
+				self.api_key = "subscription"
 		elif not self.api_key:
 			frappe.throw(_("API Key is required for cloud providers."))
 

--- a/huf/huf/doctype/ai_provider_connection/__init__.py
+++ b/huf/huf/doctype/ai_provider_connection/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt

--- a/huf/huf/doctype/ai_provider_connection/ai_provider_connection.json
+++ b/huf/huf/doctype/ai_provider_connection/ai_provider_connection.json
@@ -1,0 +1,214 @@
+{
+ "actions": [],
+ "creation": "2026-08-02 05:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "connection_name",
+  "user",
+  "provider",
+  "adapter_type",
+  "is_active",
+  "cb_auth",
+  "auth_status",
+  "auth_method",
+  "sb_credentials",
+  "access_token",
+  "refresh_token",
+  "auth_payload",
+  "token_type",
+  "expires_at",
+  "last_refreshed_at",
+  "sb_account",
+  "account_id",
+  "account_email",
+  "plan_type",
+  "sb_extra",
+  "eligible_models",
+  "extra_metadata"
+ ],
+ "fields": [
+  {
+   "fieldname": "connection_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Connection Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  },
+  {
+   "fieldname": "provider",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "AI Provider",
+   "options": "AI Provider",
+   "reqd": 1
+  },
+  {
+   "fieldname": "adapter_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Adapter Type",
+   "options": "openai_subscription\nopenai_community_subscription\nkimi_community_subscription\ngoogle_subscription\nantigravity_subscription\nmock_subscription",
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "is_active",
+   "fieldtype": "Check",
+   "label": "Is Active"
+  },
+  {
+   "fieldname": "cb_auth",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Unlinked",
+   "fieldname": "auth_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Unlinked\nPending Authorization\nActive\nExpired\nRevoked\nError",
+   "reqd": 1
+  },
+  {
+   "fieldname": "auth_method",
+   "fieldtype": "Select",
+   "label": "Auth Method",
+   "options": "OAuth PKCE\nOAuth PKCE (Manual Paste)\nDevice Code"
+  },
+  {
+   "fieldname": "sb_credentials",
+   "fieldtype": "Section Break",
+   "label": "Credentials"
+  },
+  {
+   "fieldname": "access_token",
+   "fieldtype": "Password",
+   "label": "Access Token"
+  },
+  {
+   "fieldname": "refresh_token",
+   "fieldtype": "Password",
+   "label": "Refresh Token"
+  },
+  {
+   "fieldname": "auth_payload",
+   "fieldtype": "Password",
+   "label": "Auth Payload",
+   "description": "Encrypted generic credential payload (JSON) for adapters that do not use access_token/refresh_token."
+  },
+  {
+   "default": "Bearer",
+   "fieldname": "token_type",
+   "fieldtype": "Data",
+   "label": "Token Type"
+  },
+  {
+   "fieldname": "expires_at",
+   "fieldtype": "Datetime",
+   "label": "Expires At"
+  },
+  {
+   "fieldname": "last_refreshed_at",
+   "fieldtype": "Datetime",
+   "label": "Last Refreshed At"
+  },
+  {
+   "fieldname": "sb_account",
+   "fieldtype": "Section Break",
+   "label": "Account & Plan Details"
+  },
+  {
+   "fieldname": "account_id",
+   "fieldtype": "Data",
+   "label": "Account / Workspace ID"
+  },
+  {
+   "fieldname": "account_email",
+   "fieldtype": "Data",
+   "label": "Account Email"
+  },
+  {
+   "fieldname": "plan_type",
+   "fieldtype": "Data",
+   "label": "Plan Type"
+  },
+  {
+   "fieldname": "sb_extra",
+   "fieldtype": "Section Break",
+   "label": "Metadata & Allowed Models"
+  },
+  {
+   "fieldname": "eligible_models",
+   "fieldtype": "Code",
+   "label": "Eligible Models",
+   "options": "JSON"
+  },
+  {
+   "fieldname": "extra_metadata",
+   "fieldtype": "Code",
+   "label": "Extra Metadata",
+   "options": "JSON"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-08-02 05:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Huf",
+ "name": "AI Provider Connection",
+ "naming_rule": "By fieldname",
+ "autoname": "field:connection_name",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf Manager",
+   "share": 1,
+   "write": 0,
+   "select": 1
+  },
+  {
+   "create": 0,
+   "delete": 0,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Huf User",
+   "share": 1,
+   "write": 0
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/huf/huf/doctype/ai_provider_connection/ai_provider_connection.py
+++ b/huf/huf/doctype/ai_provider_connection/ai_provider_connection.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd and contributors
+# For license information, please see license.txt
+
+import json
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import now_datetime, get_datetime
+
+
+class AIProviderConnection(Document):
+    def validate(self):
+        self.validate_eligible_models_json()
+        self.validate_extra_metadata_json()
+
+    def validate_eligible_models_json(self):
+        if self.eligible_models:
+            try:
+                parsed = json.loads(self.eligible_models)
+                if not isinstance(parsed, list):
+                    frappe.throw(_("Eligible Models must be a JSON array of model names."))
+            except Exception as e:
+                frappe.throw(_("Invalid JSON in Eligible Models: {0}").format(str(e)))
+
+    def validate_extra_metadata_json(self):
+        if self.extra_metadata:
+            try:
+                parsed = json.loads(self.extra_metadata)
+                if not isinstance(parsed, dict):
+                    frappe.throw(_("Extra Metadata must be a JSON object."))
+            except Exception as e:
+                frappe.throw(_("Invalid JSON in Extra Metadata: {0}").format(str(e)))
+
+    def _get_decrypted_password(self, fieldname: str) -> str:
+        """Return decrypted password value or empty string if unavailable."""
+        if not getattr(self, fieldname, None):
+            return ""
+        try:
+            return self.get_password(fieldname) or ""
+        except Exception:
+            return ""
+
+    def get_decrypted_access_token(self) -> str:
+        return self._get_decrypted_password("access_token")
+
+    def get_decrypted_refresh_token(self) -> str:
+        return self._get_decrypted_password("refresh_token")
+
+    def get_decrypted_auth_payload(self) -> dict:
+        """Return decrypted generic auth payload as a dict, or empty dict."""
+        raw = self._get_decrypted_password("auth_payload")
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+
+    def set_tokens(
+        self,
+        access_token: str,
+        refresh_token: str = None,
+        expires_in_seconds: int = None,
+        token_type: str = "Bearer"
+    ):
+        self.access_token = access_token
+        if refresh_token is not None:
+            self.refresh_token = refresh_token
+        if token_type:
+            self.token_type = token_type
+
+        now = now_datetime()
+        self.last_refreshed_at = now
+        if expires_in_seconds is not None:
+            self.expires_at = frappe.utils.add_to_date(now, seconds=int(expires_in_seconds))
+        self.auth_status = "Active"
+
+    def set_auth_payload(self, payload: dict, expires_in_seconds: int = None):
+        """Store an encrypted generic credential payload (JSON)."""
+        if not isinstance(payload, dict):
+            frappe.throw(_("Auth payload must be a JSON object."))
+        self.auth_payload = json.dumps(payload)
+        self.last_refreshed_at = now_datetime()
+        if expires_in_seconds is not None:
+            self.expires_at = frappe.utils.add_to_date(
+                self.last_refreshed_at, seconds=int(expires_in_seconds)
+            )
+        self.auth_status = "Active"
+
+    def get_eligible_models(self) -> list[str]:
+        """Return the list of model names allowed by this connection."""
+        if not self.eligible_models:
+            return []
+        try:
+            parsed = json.loads(self.eligible_models)
+            return [str(m) for m in parsed] if isinstance(parsed, list) else []
+        except Exception:
+            return []
+
+    def matches_model(self, model: str) -> bool:
+        """Return True when no eligible-model allowlist is set or model is in it."""
+        eligible = self.get_eligible_models()
+        if not eligible:
+            return True
+        return model in eligible
+
+    def is_expired(self, buffer_seconds: int = 300) -> bool:
+        if not self.expires_at:
+            return False
+        expiry = get_datetime(self.expires_at)
+        now = now_datetime()
+        return (expiry.timestamp() - now.timestamp()) <= buffer_seconds
+
+    def is_active_connection(self) -> bool:
+        """True when the connection record is enabled and in an active state."""
+        if not self.is_active:
+            return False
+        if self.auth_status in ("Revoked", "Unlinked", "Error"):
+            return False
+        return True
+
+    def check_and_refresh(self) -> bool:
+        """
+        Checks if connection needs refresh and executes adapter refresh if required.
+        Returns True if active/refreshed, False if re-authorization is required.
+        """
+        if not self.is_active:
+            return False
+
+        if self.auth_status in ("Revoked", "Unlinked"):
+            return False
+
+        if not self.is_expired():
+            return True
+
+        # Try refresh via adapter
+        from huf.ai.providers.adapters import get_adapter
+        try:
+            adapter = get_adapter(self.adapter_type)
+            success = adapter.refresh_connection(self)
+            if success:
+                self.save(ignore_permissions=True)
+                return True
+            else:
+                self.auth_status = "Expired"
+                self.save(ignore_permissions=True)
+                return False
+        except Exception as e:
+            frappe.log_error(
+                f"Failed to refresh AI Provider Connection {self.name}: {str(e)}",
+                "AI Provider Connection Refresh Error"
+            )
+            self.auth_status = "Error"
+            self.save(ignore_permissions=True)
+            return False
+
+
+@frappe.whitelist()
+def check_connection_status(connection_name: str) -> dict:
+    """Public status/refresh check for a subscription connection."""
+    if not frappe.db.exists("AI Provider Connection", connection_name):
+        frappe.throw(_("AI Provider Connection '{0}' not found.").format(connection_name))
+
+    connection = frappe.get_doc("AI Provider Connection", connection_name)
+    refreshed = connection.check_and_refresh()
+
+    return {
+        "name": connection.name,
+        "auth_status": connection.auth_status,
+        "is_active": connection.is_active,
+        "expires_at": str(connection.expires_at) if connection.expires_at else None,
+        "is_expired": connection.is_expired(),
+        "refreshed": refreshed,
+    }

--- a/huf/huf/doctype/ai_provider_connection/ai_provider_connection.py
+++ b/huf/huf/doctype/ai_provider_connection/ai_provider_connection.py
@@ -156,6 +156,15 @@ class AIProviderConnection(Document):
             return False
 
 
+def _can_access_connection(connection: "AIProviderConnection") -> bool:
+    """Return True when the current user may read or mutate this connection."""
+    if frappe.session.user == "Administrator":
+        return True
+    if "System Manager" in frappe.get_roles(frappe.session.user):
+        return True
+    return connection.user == frappe.session.user
+
+
 @frappe.whitelist()
 def check_connection_status(connection_name: str) -> dict:
     """Public status/refresh check for a subscription connection."""
@@ -163,6 +172,9 @@ def check_connection_status(connection_name: str) -> dict:
         frappe.throw(_("AI Provider Connection '{0}' not found.").format(connection_name))
 
     connection = frappe.get_doc("AI Provider Connection", connection_name)
+    if not _can_access_connection(connection):
+        frappe.throw(_("Not permitted to access this connection."), frappe.PermissionError)
+
     refreshed = connection.check_and_refresh()
 
     return {
@@ -173,3 +185,129 @@ def check_connection_status(connection_name: str) -> dict:
         "is_expired": connection.is_expired(),
         "refreshed": refreshed,
     }
+
+
+@frappe.whitelist()
+def get_subscription_connections(provider: str = None) -> list:
+    """Return the current user's AI Provider Connections (admins see all)."""
+    from huf.ai.providers.adapters import get_adapter
+
+    filters = {}
+    if not (frappe.session.user == "Administrator" or "System Manager" in frappe.get_roles(frappe.session.user)):
+        filters["user"] = frappe.session.user
+    if provider:
+        filters["provider"] = provider
+
+    connections = frappe.get_all(
+        "AI Provider Connection",
+        filters=filters or None,
+        fields=[
+            "name",
+            "connection_name",
+            "user",
+            "provider",
+            "adapter_type",
+            "auth_status",
+            "auth_method",
+            "is_active",
+            "eligible_models",
+            "account_email",
+            "account_id",
+            "expires_at",
+            "modified",
+        ],
+        order_by="modified desc",
+        limit_page_length=1000,
+    )
+
+    # Decorate with auth-method options from the adapter.
+    result = []
+    for conn in connections:
+        conn_doc = frappe.get_doc("AI Provider Connection", conn.name)
+        methods = []
+        try:
+            adapter = get_adapter(conn.adapter_type)
+            methods = adapter.get_auth_methods()
+        except Exception:
+            methods = []
+        conn["auth_methods"] = methods
+        conn["is_expired"] = conn_doc.is_expired()
+        result.append(conn)
+
+    return result
+
+
+@frappe.whitelist()
+def get_subscription_auth_methods(adapter_type: str) -> list:
+    """Return auth methods available for an adapter type."""
+    from huf.ai.providers.adapters import get_adapter
+
+    if not adapter_type:
+        return []
+
+    adapter = get_adapter(adapter_type)
+    return adapter.get_auth_methods()
+
+
+@frappe.whitelist()
+def start_subscription_authorization(
+    connection_name: str,
+    mode: str,
+    redirect_uri: str = None,
+) -> dict:
+    """Start authorization for a subscription connection and persist pending state."""
+    from huf.ai.providers.adapters import get_adapter
+
+    if not frappe.db.exists("AI Provider Connection", connection_name):
+        frappe.throw(_("AI Provider Connection '{0}' not found.").format(connection_name))
+
+    connection = frappe.get_doc("AI Provider Connection", connection_name)
+    if not _can_access_connection(connection):
+        frappe.throw(_("Not permitted to authorize this connection."), frappe.PermissionError)
+
+    adapter = get_adapter(connection.adapter_type)
+    auth_data = adapter.start_authorization(connection, mode=mode, redirect_uri=redirect_uri)
+    connection.save(ignore_permissions=True)
+
+    return auth_data
+
+
+@frappe.whitelist()
+def complete_subscription_authorization(
+    connection_name: str,
+    payload: dict = None,
+) -> dict:
+    """Complete authorization for a subscription connection."""
+    from huf.ai.providers.adapters import get_adapter
+
+    if not frappe.db.exists("AI Provider Connection", connection_name):
+        frappe.throw(_("AI Provider Connection '{0}' not found.").format(connection_name))
+
+    connection = frappe.get_doc("AI Provider Connection", connection_name)
+    if not _can_access_connection(connection):
+        frappe.throw(_("Not permitted to authorize this connection."), frappe.PermissionError)
+
+    adapter = get_adapter(connection.adapter_type)
+    result = adapter.complete_authorization(connection, payload or {})
+    connection.save(ignore_permissions=True)
+
+    return result
+
+
+@frappe.whitelist()
+def revoke_subscription_authorization(connection_name: str) -> dict:
+    """Revoke/clear tokens for a subscription connection."""
+    from huf.ai.providers.adapters import get_adapter
+
+    if not frappe.db.exists("AI Provider Connection", connection_name):
+        frappe.throw(_("AI Provider Connection '{0}' not found.").format(connection_name))
+
+    connection = frappe.get_doc("AI Provider Connection", connection_name)
+    if not _can_access_connection(connection):
+        frappe.throw(_("Not permitted to revoke this connection."), frappe.PermissionError)
+
+    adapter = get_adapter(connection.adapter_type)
+    success = adapter.revoke_connection(connection)
+    connection.save(ignore_permissions=True)
+
+    return {"success": success, "auth_status": connection.auth_status}

--- a/huf/tests/standalone_ai_model_modality.py
+++ b/huf/tests/standalone_ai_model_modality.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, Huf and Contributors
+# See license.txt
+
+"""
+Unit tests for AI Model modality validation and link query filtering
+(huf/huf/doctype/ai_model/ai_model.py).
+
+These tests mock frappe so the modality parsing and SQL query generation
+can be exercised without a full Frappe bench.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+
+class ThrowError(Exception):
+    """Stand-in for frappe.throw so tests can assert on thrown messages."""
+
+
+def _throw(msg, *args, **kwargs):
+    raise ThrowError(str(msg))
+
+
+# Set up frappe mock before importing ai_model
+frappe_mock = types.ModuleType("frappe")
+frappe_mock._ = lambda x, *a, **k: x
+frappe_mock.throw = MagicMock(side_effect=_throw)
+frappe_mock.whitelist = lambda *a, **k: (lambda f: f)
+frappe_mock.db = MagicMock()
+
+# Document stub
+class Document:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+frappe_mock.model = types.ModuleType("frappe.model")
+frappe_mock.model.document = types.ModuleType("frappe.model.document")
+frappe_mock.model.document.Document = Document
+
+sys.modules["frappe"] = frappe_mock
+sys.modules["frappe.model"] = frappe_mock.model
+sys.modules["frappe.model.document"] = frappe_mock.model.document
+
+from huf.huf.doctype.ai_model.ai_model import (  # noqa: E402
+    MODEL_MODALITY_OPTIONS,
+    AIModel,
+    get_models_by_modality,
+)
+
+
+class TestAIModelModalityValidation(unittest.TestCase):
+    def test_validate_modalities_normalizes_and_deduplicates(self):
+        doc = AIModel(modalities=" Text , Vision , Text, OCR ")
+        doc._validate_modalities()
+        self.assertEqual(doc.modalities, "Text,Vision,OCR")
+
+    def test_validate_modalities_empty_passes(self):
+        doc = AIModel(modalities="")
+        doc._validate_modalities()
+        self.assertEqual(getattr(doc, "modalities", ""), "")
+
+    def test_validate_modalities_invalid_throws(self):
+        doc = AIModel(modalities="Text, InvalidModality")
+        with self.assertRaises(ThrowError) as cm:
+            doc._validate_modalities()
+        self.assertIn("Invalid modality value(s): InvalidModality", str(cm.exception))
+
+
+class TestGetModelsByModality(unittest.TestCase):
+    def setUp(self):
+        frappe_mock.db.sql.reset_mock()
+
+    def test_missing_modality_filter_throws(self):
+        with self.assertRaises(ThrowError) as cm:
+            get_models_by_modality("AI Model", "", "", 0, 20, {})
+        self.assertIn("Missing required filter: modality", str(cm.exception))
+
+    def test_invalid_modality_filter_throws(self):
+        with self.assertRaises(ThrowError) as cm:
+            get_models_by_modality("AI Model", "", "", 0, 20, {"modality": "Magic"})
+        self.assertIn("Invalid modality: Magic", str(cm.exception))
+
+    def test_query_includes_replace_spaces_find_in_set(self):
+        frappe_mock.db.sql.return_value = [("GPT-4", "gpt-4o")]
+        res = get_models_by_modality("AI Model", "gpt", "", 0, 20, {"modality": "Vision", "provider": "OpenAI"})
+
+        self.assertEqual(res, [("GPT-4", "gpt-4o")])
+        frappe_mock.db.sql.assert_called_once()
+        sql, params = frappe_mock.db.sql.call_args[0]
+        self.assertIn("REPLACE(IFNULL(modalities, ''), ' ', '')", sql)
+        self.assertIn("provider = %(provider)s", sql)
+        self.assertEqual(params["modality"], "Vision")
+        self.assertEqual(params["provider"], "OpenAI")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/tests/standalone_chat_audio_upload.py
+++ b/huf/tests/standalone_chat_audio_upload.py
@@ -19,6 +19,8 @@ huf.ai.audio_service) regardless of test ordering:
 """
 
 import asyncio
+import importlib.util
+import os
 import sys
 import types
 import unittest
@@ -46,7 +48,11 @@ _audio_mocks = sys.modules.get("huf.tests.standalone_audio_service") or sys.modu
     "standalone_audio_service"
 )
 if _audio_mocks is None:
-    from huf.tests import standalone_audio_service as _audio_mocks
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), "standalone_audio_service.py"))
+    spec = importlib.util.spec_from_file_location("standalone_audio_service", path)
+    _audio_mocks = importlib.util.module_from_spec(spec)
+    sys.modules["standalone_audio_service"] = _audio_mocks
+    spec.loader.exec_module(_audio_mocks)
 
 frappe_mock = _audio_mocks.frappe_mock
 frappe_file_manager = sys.modules["frappe.utils.file_manager"]
@@ -101,6 +107,7 @@ conversation_manager_stub = _get_or_create_stub(
     "huf.ai.conversation_manager", ConversationManager=MagicMock()
 )
 _get_or_create_stub("huf.ai.transcription_handler")
+_get_or_create_stub("huf.ai.conversation_fork")
 
 from huf.ai import agent_chat, audio_service  # noqa: E402
 

--- a/huf/tests/standalone_doc_event_audio.py
+++ b/huf/tests/standalone_doc_event_audio.py
@@ -16,6 +16,8 @@ huf.ai.audio_service) regardless of test ordering:
     python -m unittest huf.tests.standalone_doc_event_audio huf.tests.standalone_audio_service
 """
 
+import importlib.util
+import os
 import sys
 import types
 import unittest
@@ -43,7 +45,11 @@ _audio_mocks = sys.modules.get("huf.tests.standalone_audio_service") or sys.modu
     "standalone_audio_service"
 )
 if _audio_mocks is None:
-    from huf.tests import standalone_audio_service as _audio_mocks
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), "standalone_audio_service.py"))
+    spec = importlib.util.spec_from_file_location("standalone_audio_service", path)
+    _audio_mocks = importlib.util.module_from_spec(spec)
+    sys.modules["standalone_audio_service"] = _audio_mocks
+    spec.loader.exec_module(_audio_mocks)
 
 frappe_mock = _audio_mocks.frappe_mock
 frappe_utils = sys.modules["frappe.utils"]

--- a/huf/tests/standalone_local_audio_path.py
+++ b/huf/tests/standalone_local_audio_path.py
@@ -14,6 +14,7 @@ huf.ai.audio_service) regardless of test ordering:
     python -m unittest huf.tests.standalone_local_audio_path
 """
 
+import importlib.util
 import os
 import sys
 import tempfile
@@ -34,7 +35,11 @@ _audio_mocks = sys.modules.get("huf.tests.standalone_audio_service") or sys.modu
     "standalone_audio_service"
 )
 if _audio_mocks is None:
-    from huf.tests import standalone_audio_service as _audio_mocks
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), "standalone_audio_service.py"))
+    spec = importlib.util.spec_from_file_location("standalone_audio_service", path)
+    _audio_mocks = importlib.util.module_from_spec(spec)
+    sys.modules["standalone_audio_service"] = _audio_mocks
+    spec.loader.exec_module(_audio_mocks)
 
 frappe_mock = _audio_mocks.frappe_mock
 frappe_file_manager = sys.modules["frappe.utils.file_manager"]

--- a/huf/tests/standalone_media_handlers.py
+++ b/huf/tests/standalone_media_handlers.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, Huf and Contributors
+# See license.txt
+
+"""
+Unit tests for media tools and handlers (huf/ai/handlers/media.py).
+
+Tests handle_generate_image (including SSRF URL blocking and network failure),
+handle_ocr_document, handle_generate_audio, and handle_transcribe_audio.
+"""
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Re-use standalone audio service mocks setup
+path = os.path.abspath(os.path.join(os.path.dirname(__file__), "standalone_audio_service.py"))
+import importlib.util
+spec = importlib.util.spec_from_file_location("standalone_audio_service", path)
+_audio_mocks = importlib.util.module_from_spec(spec)
+sys.modules["standalone_audio_service"] = _audio_mocks
+spec.loader.exec_module(_audio_mocks)
+
+frappe_mock = _audio_mocks.frappe_mock
+frappe_mock.whitelist = lambda *a, **k: (lambda f: f)
+frappe_mock.has_permission = MagicMock(return_value=True)
+frappe_mock.ValidationError = type("ValidationError", (Exception,), {})
+frappe_mock.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+frappe_mock.local = SimpleNamespace(site="site1.local", flags=SimpleNamespace())
+
+# Mock litellm module
+litellm_mock = sys.modules.get("litellm") or types.ModuleType("litellm")
+sys.modules["litellm"] = litellm_mock
+
+# Mock huf.ai.ocr_engine
+ocr_engine_stub = types.ModuleType("huf.ai.ocr_engine")
+extract_document_mock = AsyncMock()
+ocr_engine_stub.extract_document = extract_document_mock
+sys.modules["huf.ai.ocr_engine"] = ocr_engine_stub
+
+# Mock huf.ai.http_handler
+http_handler_stub = types.ModuleType("huf.ai.http_handler")
+http_request_mock = MagicMock()
+http_handler_stub._http_request = http_request_mock
+sys.modules["huf.ai.http_handler"] = http_handler_stub
+
+# Import handler after mocking
+from huf.ai.handlers import media  # noqa: E402
+from huf.ai import audio_service  # noqa: E402
+
+RequestException = media.RequestException
+
+
+def _agent_doc(provider="OpenAI"):
+    doc = SimpleNamespace(
+        name="Agent-1",
+        provider=provider,
+        model="gpt-4o",
+        image_generation_model=None,
+        tts_model=None,
+        tts_voice=None,
+    )
+    return doc
+
+
+def _provider_doc():
+    doc = SimpleNamespace(provider_name="OpenAI")
+    doc.get_password = MagicMock(return_value="sk-test-key")
+    return doc
+
+
+def _install_docs():
+    def get_doc(doctype, name=None):
+        if isinstance(doctype, dict):
+            m = SimpleNamespace(name="MSG-0001", content="", conversation_index=1, insert=MagicMock(), db_set=MagicMock())
+            return m
+        if doctype == "Agent":
+            return _agent_doc()
+        if doctype == "AI Provider":
+            return _provider_doc()
+        raise ValueError(f"Unexpected get_doc: {doctype} {name}")
+
+    frappe_mock.get_doc.side_effect = get_doc
+
+
+class TestMediaHandlersImageSSRF(unittest.TestCase):
+    def setUp(self):
+        frappe_mock.get_doc.reset_mock()
+        frappe_mock.get_doc.side_effect = None
+        frappe_mock.db.reset_mock()
+        frappe_mock.db.sql.return_value = [SimpleNamespace(last_index=0)]
+        http_request_mock.reset_mock()
+        litellm_mock.image_generation = MagicMock()
+
+    def test_generate_image_ssrf_url_blocked_handled_gracefully(self):
+        _install_docs()
+        litellm_mock.image_generation.return_value = SimpleNamespace(
+            data=[SimpleNamespace(url="http://169.254.169.254/latest/meta-data")]
+        )
+        http_request_mock.side_effect = ValueError("Requests to private/internal addresses are not allowed")
+
+        res = asyncio.run(media.handle_generate_image(
+            prompt="test image",
+            agent_name="Agent-1",
+            conversation_id="CONV-1"
+        ))
+
+        self.assertFalse(res["success"])
+        self.assertIn("no images were returned", res["error"])
+        http_request_mock.assert_called_once_with("GET", "http://169.254.169.254/latest/meta-data", timeout=30)
+
+    def test_generate_image_network_exception_handled_gracefully(self):
+        _install_docs()
+        litellm_mock.image_generation.return_value = SimpleNamespace(
+            data=[SimpleNamespace(url="https://cdn.example.com/generated.png")]
+        )
+        http_request_mock.side_effect = RequestException("Connection reset")
+
+        res = asyncio.run(media.handle_generate_image(
+            prompt="test image",
+            agent_name="Agent-1",
+            conversation_id="CONV-1"
+        ))
+
+        self.assertFalse(res["success"])
+        self.assertIn("no images were returned", res["error"])
+        http_request_mock.assert_called_once_with("GET", "https://cdn.example.com/generated.png", timeout=30)
+
+    def test_generate_image_b64_success(self):
+        _install_docs()
+        # Mock base64 image return
+        litellm_mock.image_generation.return_value = SimpleNamespace(
+            data=[SimpleNamespace(b64_json=_audio_mocks._b64(b"fake-png-bytes"), url=None)]
+        )
+        _audio_mocks.frappe_file_manager.save_file.return_value = SimpleNamespace(
+            name="FILE-IMG-1", file_url="/files/generated_image_1.png", file_name="generated_image_1.png"
+        )
+
+        res = asyncio.run(media.handle_generate_image(
+            prompt="a cute cat",
+            agent_name="Agent-1",
+            conversation_id="CONV-1"
+        ))
+
+        self.assertTrue(res["success"])
+        self.assertEqual(len(res["images"]), 1)
+        self.assertEqual(res["images"][0]["file_id"], "FILE-IMG-1")
+
+
+class TestMediaHandlersOCRAndAudio(unittest.TestCase):
+    def setUp(self):
+        frappe_mock.get_doc.reset_mock()
+        frappe_mock.get_doc.side_effect = None
+
+    def test_handle_ocr_document_delegates_to_extract_document(self):
+        _install_docs()
+        extract_document_mock.return_value = SimpleNamespace(
+            as_dict=lambda: {"success": True, "text": "Extracted OCR text"}
+        )
+
+        res = asyncio.run(media.handle_ocr_document(
+            file_id="FILE-DOC-1",
+            agent_name="Agent-1",
+            conversation_id="CONV-1"
+        ))
+
+        self.assertTrue(res["success"])
+        self.assertEqual(res["text"], "Extracted OCR text")
+        extract_document_mock.assert_called_once()
+
+    def test_handle_transcribe_audio_delegates_to_audio_service(self):
+        with patch.object(audio_service, "transcribe_audio_file") as transcribe:
+            transcribe.return_value = {
+                "success": True,
+                "text": "Transcribed transcript",
+                "file_id": "FILE-AUD-1",
+                "file_url": "/files/audio.mp3",
+                "local_path": None,
+                "language": "en",
+                "stt_model": "whisper-1",
+                "provider": "openai",
+            }
+
+            res = asyncio.run(media.handle_transcribe_audio(
+                file_id="FILE-AUD-1",
+                agent_name="Agent-1",
+            ))
+
+            self.assertTrue(res["success"])
+            self.assertEqual(res["text"], "Transcribed transcript")
+            transcribe.assert_called_once_with(
+                file_id="FILE-AUD-1",
+                file_url=None,
+                local_path=None,
+                agent_name="Agent-1",
+                language=None,
+                model=None
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/www/sub_oauth.html
+++ b/huf/www/sub_oauth.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            background: #f4f5f7;
+            color: #1f2937;
+        }
+        .card {
+            background: #fff;
+            padding: 2rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            max-width: 480px;
+            width: 90%;
+            text-align: center;
+        }
+        .icon {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+        }
+        .success .icon { color: #10b981; }
+        .error .icon { color: #ef4444; }
+        .form .icon { color: #3b82f6; }
+        h1 { font-size: 1.25rem; margin-bottom: 0.5rem; }
+        p { line-height: 1.5; color: #4b5563; }
+        .detail {
+            margin-top: 1rem;
+            font-size: 0.875rem;
+            color: #6b7280;
+            word-break: break-word;
+        }
+        textarea {
+            width: 100%;
+            min-height: 80px;
+            margin-top: 1rem;
+            padding: 0.75rem;
+            border: 1px solid #d1d5db;
+            border-radius: 0.5rem;
+            font-family: inherit;
+            font-size: 0.875rem;
+            box-sizing: border-box;
+        }
+        button {
+            margin-top: 1rem;
+            padding: 0.75rem 1.5rem;
+            background: #3b82f6;
+            color: #fff;
+            border: none;
+            border-radius: 0.5rem;
+            font-size: 1rem;
+            cursor: pointer;
+        }
+        button:hover { background: #2563eb; }
+    </style>
+</head>
+<body>
+    <div class="card {% if status == 'success' %}success{% elif status == 'error' %}error{% else %}form{% endif %}">
+        <div class="icon">
+            {% if status == 'success' %}✅{% elif status == 'error' %}❌{% else %}🔗{% endif %}
+        </div>
+        <h1>
+            {% if status == 'success' %}Connected{% elif status == 'error' %}Connection Failed{% else %}Paste Callback URL{% endif %}
+        </h1>
+        <p>{{ message }}</p>
+        {% if status == "form" %}
+        <form method="POST" action="/huf/sub_oauth">
+            <textarea name="pasted_url" placeholder="http://localhost:1455/auth/callback?code=...&state=..."></textarea>
+            <button type="submit">Complete Authorization</button>
+        </form>
+        {% endif %}
+        {% if connection %}
+        <div class="detail">Connection: {{ connection }}</div>
+        {% endif %}
+        {% if result %}
+        <div class="detail">{{ result }}</div>
+        {% endif %}
+    </div>
+</body>
+</html>

--- a/huf/www/sub_oauth.py
+++ b/huf/www/sub_oauth.py
@@ -1,0 +1,135 @@
+import frappe
+from frappe import _
+from huf.ai.providers.adapters import get_adapter
+
+
+def get_context(context):
+    context.no_cache = 1
+    context.title = "Subscription OAuth Callback"
+
+    code = frappe.request.args.get("code")
+    state = frappe.request.args.get("state")
+    error = frappe.request.args.get("error")
+    error_description = frappe.request.args.get("error_description")
+
+    # Manual-paste fallback: user submits the full callback URL via form.
+    pasted_url = None
+    if frappe.request.method == "POST":
+        pasted_url = frappe.form_dict.get("pasted_url") or frappe.request.get_json(silent=True) or {}
+        if isinstance(pasted_url, dict):
+            pasted_url = pasted_url.get("pasted_url")
+
+    if error:
+        context.status = "error"
+        context.message = f"{error}: {error_description or 'OAuth provider returned an error.'}"
+        return context
+
+    if not code and not pasted_url:
+        # Show manual-paste form when no code is present.
+        context.status = "form"
+        context.message = (
+            "If your OAuth flow redirected to localhost and showed a connection error, "
+            "copy the full URL from your browser's address bar and paste it below."
+        )
+        return context
+
+    if not code and pasted_url:
+        # Resolve the connection first by state so we can use the correct adapter.
+        connection_doc = _resolve_connection_by_pasted_url(pasted_url)
+        if not connection_doc:
+            context.status = "error"
+            context.message = "Could not find a matching pending subscription connection. Please start the connection flow again."
+            return context
+
+        try:
+            adapter = get_adapter(connection_doc.adapter_type)
+            redirect_uri = frappe.utils.get_url("/huf/sub_oauth")
+            result = adapter.complete_authorization(
+                connection_doc,
+                {"pasted_url": pasted_url, "redirect_uri": redirect_uri},
+            )
+            connection_doc.save(ignore_permissions=True)
+            context.status = "success"
+            context.message = _(
+                "Successfully connected {0}. You can close this window and return to HUF."
+            ).format(connection_doc.connection_name)
+            context.connection = connection_doc.connection_name
+            context.result = result
+        except Exception as e:
+            frappe.log_error(
+                frappe.get_traceback(),
+                "Subscription OAuth Callback Error",
+            )
+            context.status = "error"
+            context.message = f"Failed to complete authorization: {str(e)}"
+        return context
+
+    # Standard redirect flow with explicit code + state.
+    connections = frappe.get_all(
+        "AI Provider Connection",
+        filters={"auth_status": "Pending Authorization", "is_active": 1},
+        fields=["name"],
+    )
+
+    connection_doc = None
+    for row in connections:
+        doc = frappe.get_doc("AI Provider Connection", row.name)
+        metadata = doc.get_decrypted_auth_payload() or {}
+        if metadata.get("oauth_state") == state:
+            connection_doc = doc
+            break
+
+    if not connection_doc:
+        context.status = "error"
+        context.message = "Could not find a matching pending subscription connection. Please start the connection flow again."
+        return context
+
+    try:
+        adapter = get_adapter(connection_doc.adapter_type)
+        redirect_uri = frappe.utils.get_url("/huf/sub_oauth")
+        result = adapter.complete_authorization(
+            connection_doc,
+            {"code": code, "state": state, "redirect_uri": redirect_uri},
+        )
+        connection_doc.save(ignore_permissions=True)
+        context.status = "success"
+        context.message = _(
+            "Successfully connected {0}. You can close this window and return to HUF."
+        ).format(connection_doc.connection_name)
+        context.connection = connection_doc.connection_name
+        context.result = result
+    except Exception as e:
+        frappe.log_error(
+            frappe.get_traceback(),
+            "Subscription OAuth Callback Error",
+        )
+        context.status = "error"
+        context.message = f"Failed to complete authorization: {str(e)}"
+
+    return context
+
+
+def _resolve_connection_by_pasted_url(pasted_url: str):
+    """Try to find the pending connection by parsing the state out of a pasted URL."""
+    try:
+        from urllib.parse import urlparse, parse_qs
+        parsed = urlparse(pasted_url)
+        params = parse_qs(parsed.query)
+        state = params.get("state", [None])[0]
+    except Exception:
+        state = None
+
+    if not state:
+        return None
+
+    connections = frappe.get_all(
+        "AI Provider Connection",
+        filters={"auth_status": "Pending Authorization", "is_active": 1},
+        fields=["name"],
+    )
+    for row in connections:
+        doc = frappe.get_doc("AI Provider Connection", row.name)
+        metadata = doc.get_decrypted_auth_payload() or {}
+        if metadata.get("oauth_state") == state:
+            return doc
+    return None


### PR DESCRIPTION
## What this revives

Orphan branch `feat/community-subscription-adapters` (never had a PR, last commit 2026-08-04) forward-ported onto current `develop`. **Not a clean cherry-pick** — 3 weeks of independent divergence on both sides required manual, additive conflict resolution (see below). Flagging that explicitly since this one needs closer review than a clean rebase would.

## What it adds

Lets a user attach their **personal OpenAI or Kimi subscription** to Huf instead of pasting a raw API key — an OAuth-style "community subscription" connection flow.

- `huf/ai/providers/adapters/openai.py`, `openai_community.py` — new provider adapters
- `huf/huf/doctype/ai_provider_connection/` — new DocType for the subscription-linking connection
- `huf/www/sub_oauth.py`, `sub_oauth.html` — the OAuth landing pages
- A "Connections" UI entry point in `AiProvidersHeaderActions.tsx`
- Confirmed via grep against `develop`: none of `openai_community`, `sub_oauth`, or `ai_provider_connection` exist anywhere in current develop — genuinely new capability.

## Conflict resolution — read this before merging

Two files needed manual merging because develop grew independently in the same spots since Aug 4:

1. **`huf/ai/agent_integration.py`** — develop had separately added a `project: str = None` param to `run_agent_stream` in the same location this branch adds `subscription_connection_name: str = None`. Resolved by keeping both params (additive, no collision in behavior).
2. **`huf/huf/doctype/ai_provider/ai_provider.json`** — both sides independently extended the `provider_brand` Select options list (develop added `moonshot, ai21, baseten, cloudflare-workers-ai, clarifai, nomic, replicate, sagemaker, stability-ai, vllm, watsonx`; this branch added `openai_community, kimi_community`). Resolved by unioning both lists — no options were dropped from either side.
3. **`frontend/src/components/AiProvidersHeaderActions.tsx`** — develop had a plain "Add provider" button; this branch wraps it with a new "Connections" nav button. Kept the incoming version (adds Connections, preserves Add Provider).

All resolutions were verified additive: nothing currently in develop was deleted or regressed. Python files pass `py_compile`; both touched doctype JSONs parse as valid JSON.

## Before merging

- [ ] **This one needs a real review of the conflict resolutions above**, not just the original diff — an automated agent resolved them additively, but a human should confirm the `ai_provider.json` option-list merge and the `run_agent_stream` param addition don't have subtler interaction effects
- [ ] OAuth landing page (`sub_oauth.py`/`.html`) handles user-facing subscription credentials — worth a security pass on how tokens/secrets are stored and whether they follow Huf's existing `Integration Credential` conventions
- [ ] This is a **draft** — original author (esafwan) should confirm this is still the intended UX before it goes further, since 3 weeks have passed since the branch was written

*Opened as part of an automated audit/revival pass over 2026-08-25's orphan-branch inventory.*
