### PR TITLE
fix: meeting chunk uploads always failed, and lazy tool discovery was inert

### DIFF
--- a/huf/ai/meetings/meeting_recording.py
+++ b/huf/ai/meetings/meeting_recording.py
@@ -73,10 +73,16 @@ def upload_chunk(
         audio_service.validate_audio_filename(file_doc.file_name)
         audio_file = file_doc.name
     else:
+        # No attached_to_doctype/attached_to_name here: the chunk doc that
+        # this file will belong to doesn't exist yet (it's created below),
+        # and File.validate_attachment_references() throws "Attached To
+        # Name must be a string or an integer" if attached_to_doctype is
+        # set while attached_to_name is empty. The file is linked to its
+        # chunk via the attached_to_doctype/attached_to_name db_set below,
+        # once the chunk has a name.
         saved = audio_service.save_audio_upload(
             f"chunk-{meeting}-{sequence}.webm",
             audio_b64,
-            attached_to_doctype="Meeting Recording Chunk",
             is_private=1,
         )
         audio_file = saved["file_id"]
@@ -93,7 +99,14 @@ def upload_chunk(
     chunk.insert()
 
     if audio_file:
-        frappe.db.set_value("File", audio_file, "attached_to_name", chunk.name)
+        frappe.db.set_value(
+            "File",
+            audio_file,
+            {
+                "attached_to_doctype": "Meeting Recording Chunk",
+                "attached_to_name": chunk.name,
+            },
+        )
 
     meeting_doc.db_set("chunk_count", cint(meeting_doc.chunk_count) + 1)
 

--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -319,6 +319,38 @@ def create_agent_tools(agent, model_name: str = None, **kwargs) -> list[Function
                 f"Error processing function {function_doc.name}: {e!s}"
             )
 
+    if lazy_enabled:
+        # The discovery tools themselves are not something an agent author is
+        # expected to attach via agent_tool - without them the model could
+        # never unlock anything else, so build them unconditionally (same
+        # pattern as the memory tools below): looked up by tool_name from the
+        # Agent Tool Function records synced from LAZY_DISCOVERY_TOOLS
+        # (huf.ai.tools._registry), not gated on the agent's tool list.
+        existing_tool_names = {getattr(t, "name", "") for t in tools}
+        for tool_name in _LAZY_DISCOVERY_TOOL_NAMES:
+            if tool_name in existing_tool_names:
+                continue
+            function_name = frappe.db.get_value("Agent Tool Function", {"tool_name": tool_name}, "name")
+            if not function_name:
+                continue
+            try:
+                function_doc = frappe.get_doc("Agent Tool Function", function_name)
+                params = {}
+                if function_doc.params:
+                    params = json.loads(function_doc.params)
+                tool = create_function_tool(
+                    function_doc.tool_name,
+                    function_doc.description,
+                    function_doc.function_path,
+                    params,
+                    tool_type=function_doc.types,
+                )
+                if tool:
+                    tools.append(tool)
+                    existing_tool_names.add(tool_name)
+            except Exception as e:
+                frappe.logger("huf").debug(f"Error wiring lazy discovery tool {tool_name}: {e!s}")
+
     # Load tools from attached skills (mandatory and optional)
     try:
         from huf.ai.skills.loader import load_all_skill_tools


### PR DESCRIPTION
Two independent product bugs, both found by running the backend suite against `pre-develop` rather than by report. Product code only — no test files touched.

## 1. Every base64 meeting chunk upload was failing

`meeting_recording.upload_chunk` saved the chunk audio with `attached_to_doctype="Meeting Recording Chunk"` and **no** `attached_to_name` — the chunk document does not exist yet at that point, it is created a few lines later. Frappe's `File.validate_attachment_references` throws unconditionally on that combination:

```python
if not self.attached_to_doctype:
    return
if not self.attached_to_name or not isinstance(self.attached_to_name, str | int):
    frappe.throw(_("Attached To Name must be a string or an integer"), frappe.ValidationError)
```

So this raised for **real callers**, not only in tests. The two tests covering it were failing for exactly this reason; the other five in that module pass only because they raise a `ValidationError` before ever reaching `save_file`.

Fix: save the file unattached, then set `attached_to_doctype` and `attached_to_name` together once the chunk has a name. The pre-uploaded-`file` branch was separately only ever setting `attached_to_name`, leaving the doctype link dangling — the same change closes that.

Checked every other `save_audio_upload` caller (`agent_chat.py:62`, `agent_chat.py:198`, `audio_service.py:303`); all already pass `attached_to_name`, so this was the only affected site.

## 2. Lazy tool discovery could not function

`sdk_tools.py` lists the four discovery tools in `_LAZY_DISCOVERY_TOOL_NAMES`, with the comment *"the discovery tools themselves (without them the agent could never unlock anything else)"*, and the deferral loop uses that set to decide what **not** to defer. But `create_agent_tools` never actually **built** those four unless an author had manually attached them to the agent — unlike `get_conversation_data`, `get_result_context` and the memory tools, which are all appended unconditionally.

An agent with `enable_lazy_tools` on therefore had its non-essential tools deferred and no way to discover them. The feature was inert.

Fix: build them when `lazy_enabled`, mirroring the memory-tool block exactly (same `Agent Tool Function` lookup by `tool_name`, same dedupe, same error handling).

`enable_lazy_tools` has no default in `agent.json`, so this only reaches agents that already opted in.

## Verification

Run on a disposable bench off `pre-develop` (`bench --site <site> run-tests --app huf --module ...`), with this branch alone:

```
huf.ai.meetings.test_meeting_recording     Ran 7 tests  OK
huf.ai.tests.test_lazy_tool_discovery      Ran 8 tests  OK
```

Both modules were failing before this change.

> Note: the full `--app huf` suite does not complete on `pre-develop` for an unrelated reason (a test helper mutates the real `frappe.utils` process-wide). That is fixed in #665, which stacks on this branch.