### PR TITLE
test: make the backend suite run again on pre-develop (it currently aborts before reporting a single test)

### DIFF
--- a/huf/ai/automation_runtime_flag.py
+++ b/huf/ai/automation_runtime_flag.py
@@ -7,9 +7,17 @@ Stage 2 hard-cuts ``hooks.py``'s scheduler/doc-event registrations onto the
 new ``automation_scheduler.py`` / ``automation_hooks.py`` entrypoints, but
 keeps a one-line rollback available without a code revert: setting
 ``automation_trigger_runtime`` to ``"legacy"`` in ``site_config.json`` makes
-every new entrypoint that checks this flag act as disabled, while the
-untouched legacy ``agent_scheduler.py`` / ``agent_hooks.py`` files keep
-working unconditionally (they never check this flag).
+every new entrypoint that checks this flag act as disabled and hands the work
+back to the legacy ``agent_scheduler.py`` / ``agent_hooks.py`` entrypoints.
+
+Both sides check this flag, with opposite polarity: the new entrypoints
+return early when the mode is *not* ``"new"``, the legacy ones return early
+when it *is*. ``hooks.py`` registers both, so exactly one of each pair ever
+executes. The default is ``"new"``, which means the legacy scheduler and doc
+hooks are inert on any site that has not explicitly opted into ``"legacy"``
+-- tests that exercise them must patch ``automation_runtime_is_new`` rather
+than only the calling module's ``frappe``, since this module holds its own
+``frappe`` reference.
 
 Webhook and App Event trigger types have no legacy counterpart (confirmed
 by grep across the whole ``huf/`` tree -- see

--- a/huf/ai/knowledge/tests/test_faiss_backend.py
+++ b/huf/ai/knowledge/tests/test_faiss_backend.py
@@ -29,8 +29,12 @@ class TestFaissBackend(unittest.TestCase):
 
 		self._previous_site = getattr(frappe.local, "site", None)
 		frappe.local.site = "test_site"
-		# frappe.throw/msgprint and logging need these bound outside a site context.
+		# frappe.throw/msgprint and logging need these bound outside a site context;
+		# restored in tearDown because bench run-tests runs inside a real process with
+		# a real frappe.local.flags that the rest of the suite depends on.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
+		self._previous_message_log = getattr(frappe.local, "message_log", None)
 		frappe.local.message_log = []
 
 		self.patcher_config = patch("huf.ai.knowledge.embedding.resolve_embedding_config")
@@ -60,6 +64,18 @@ class TestFaissBackend(unittest.TestCase):
 				del frappe.local.site
 		else:
 			frappe.local.site = self._previous_site
+
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
+		if self._previous_message_log is None:
+			if hasattr(frappe.local, "message_log"):
+				del frappe.local.message_log
+		else:
+			frappe.local.message_log = self._previous_message_log
 
 	def _initialize(self, config=None, index_exists=False, sidecar=None):
 		"""Initialize the backend with faiss, FaissVectorStore, and the FS mocked."""
@@ -440,10 +456,19 @@ class TestFaissBackendRegistry(unittest.TestCase):
 
 	def setUp(self):
 		self._clear_registry_cache()
-		# frappe.get_attr consults local.flags outside install/uninstall.
+		# frappe.get_attr consults local.flags outside install/uninstall; restored in
+		# tearDown because bench run-tests runs inside a real process with a real
+		# frappe.local.flags that the rest of the suite depends on.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
 
 	def tearDown(self):
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
 		self._clear_registry_cache()
 
 	def test_faiss_is_builtin(self):

--- a/huf/ai/knowledge/tests/test_pinecone_backend.py
+++ b/huf/ai/knowledge/tests/test_pinecone_backend.py
@@ -46,8 +46,12 @@ class TestPineconeBackend(unittest.TestCase):
 
 		self._previous_site = getattr(frappe.local, "site", None)
 		frappe.local.site = "test_site"
-		# frappe.throw/msgprint and logging need these bound outside a site context.
+		# frappe.throw/msgprint and logging need these bound outside a site context;
+		# restored in tearDown because bench run-tests runs inside a real process with
+		# a real frappe.local.flags that the rest of the suite depends on.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
+		self._previous_message_log = getattr(frappe.local, "message_log", None)
 		frappe.local.message_log = []
 
 		self.patcher_config = patch("huf.ai.knowledge.embedding.resolve_embedding_config")
@@ -77,6 +81,18 @@ class TestPineconeBackend(unittest.TestCase):
 				del frappe.local.site
 		else:
 			frappe.local.site = self._previous_site
+
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
+		if self._previous_message_log is None:
+			if hasattr(frappe.local, "message_log"):
+				del frappe.local.message_log
+		else:
+			frappe.local.message_log = self._previous_message_log
 
 	def _config(self, **overrides):
 		config = {
@@ -508,10 +524,19 @@ class TestPineconeBackendRegistry(unittest.TestCase):
 
 	def setUp(self):
 		self._clear_registry_cache()
-		# frappe.get_attr consults local.flags outside install/uninstall.
+		# frappe.get_attr consults local.flags outside install/uninstall; restored in
+		# tearDown because bench run-tests runs inside a real process with a real
+		# frappe.local.flags that the rest of the suite depends on.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
 
 	def tearDown(self):
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
 		self._clear_registry_cache()
 
 	def test_pinecone_is_builtin(self):

--- a/huf/ai/knowledge/tests/test_redis_backend.py
+++ b/huf/ai/knowledge/tests/test_redis_backend.py
@@ -25,8 +25,12 @@ class TestRedisBackend(unittest.TestCase):
 
 		self._previous_site = getattr(frappe.local, "site", None)
 		frappe.local.site = "test_site"
-		# frappe.throw/msgprint and logging need these bound outside a site context.
+		# frappe.throw/msgprint and logging need these bound outside a site context,
+		# and restored because bench run-tests runs inside a real frappe process
+		# whose frappe.local.flags carries state the rest of the suite depends on.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
+		self._previous_message_log = getattr(frappe.local, "message_log", None)
 		frappe.local.message_log = []
 
 		self.patcher_config = patch("huf.ai.knowledge.embedding.resolve_embedding_config")
@@ -56,6 +60,18 @@ class TestRedisBackend(unittest.TestCase):
 				del frappe.local.site
 		else:
 			frappe.local.site = self._previous_site
+
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
+		if self._previous_message_log is None:
+			if hasattr(frappe.local, "message_log"):
+				del frappe.local.message_log
+		else:
+			frappe.local.message_log = self._previous_message_log
 
 	def _initialize(self, config=None):
 		"""Initialize the backend with the redis client and SearchIndex mocked."""
@@ -372,10 +388,18 @@ class TestRedisBackendRegistry(unittest.TestCase):
 
 	def setUp(self):
 		self._clear_registry_cache()
-		# frappe.get_attr consults local.flags outside install/uninstall.
+		# frappe.get_attr consults local.flags outside install/uninstall,
+		# and restored because bench run-tests runs inside a real frappe process.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
 
 	def tearDown(self):
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
 		self._clear_registry_cache()
 
 	@patch("huf.ai.knowledge.backends.frappe.get_installed_apps")

--- a/huf/ai/knowledge/tests/test_weaviate_backend.py
+++ b/huf/ai/knowledge/tests/test_weaviate_backend.py
@@ -114,8 +114,12 @@ class TestWeaviateBackend(unittest.TestCase):
 
 		self._previous_site = getattr(frappe.local, "site", None)
 		frappe.local.site = "test_site"
-		# frappe.throw/msgprint and logging need these bound outside a site context.
+		# frappe.throw/msgprint and logging need these bound outside a site context,
+		# and restored because bench run-tests runs inside a real frappe process
+		# whose frappe.local.flags carries state the rest of the suite depends on.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
+		self._previous_message_log = getattr(frappe.local, "message_log", None)
 		frappe.local.message_log = []
 
 		self.patcher_config = patch("huf.ai.knowledge.embedding.resolve_embedding_config")
@@ -145,6 +149,18 @@ class TestWeaviateBackend(unittest.TestCase):
 				del frappe.local.site
 		else:
 			frappe.local.site = self._previous_site
+
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
+		if self._previous_message_log is None:
+			if hasattr(frappe.local, "message_log"):
+				del frappe.local.message_log
+		else:
+			frappe.local.message_log = self._previous_message_log
 
 	def _initialize(self, config=None, knowledge_source="test_source"):
 		"""Initialize the backend with weaviate-client and the adapter mocked."""
@@ -521,10 +537,18 @@ class TestWeaviateBackendRegistry(unittest.TestCase):
 
 	def setUp(self):
 		self._clear_registry_cache()
-		# frappe.get_attr consults local.flags outside install/uninstall.
+		# frappe.get_attr consults local.flags outside install/uninstall,
+		# and restored because bench run-tests runs inside a real frappe process.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
 
 	def tearDown(self):
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
 		self._clear_registry_cache()
 
 	def test_weaviate_is_builtin(self):

--- a/huf/ai/knowledge/tests/test_zvec_backend.py
+++ b/huf/ai/knowledge/tests/test_zvec_backend.py
@@ -27,8 +27,12 @@ class TestZvecBackend(unittest.TestCase):
 
 		self._previous_site = getattr(frappe.local, "site", None)
 		frappe.local.site = "test_site"
-		# frappe.throw/msgprint and logging need these bound outside a site context.
+		# frappe.throw/msgprint and logging need these bound outside a site context,
+		# and restored because bench run-tests runs inside a real frappe process
+		# whose frappe.local.flags carries state the rest of the suite depends on.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
+		self._previous_message_log = getattr(frappe.local, "message_log", None)
 		frappe.local.message_log = []
 
 		self.patcher_config = patch("huf.ai.knowledge.embedding.resolve_embedding_config")
@@ -58,6 +62,18 @@ class TestZvecBackend(unittest.TestCase):
 				del frappe.local.site
 		else:
 			frappe.local.site = self._previous_site
+
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
+		if self._previous_message_log is None:
+			if hasattr(frappe.local, "message_log"):
+				del frappe.local.message_log
+		else:
+			frappe.local.message_log = self._previous_message_log
 
 	def _initialize(self, config=None, collection_exists=False):
 		"""Initialize the backend with the zvec module and Collection mocked."""
@@ -406,10 +422,18 @@ class TestZvecBackendRegistry(unittest.TestCase):
 
 	def setUp(self):
 		self._clear_registry_cache()
-		# frappe.get_attr consults local.flags outside install/uninstall.
+		# frappe.get_attr consults local.flags outside install/uninstall,
+		# and restored because bench run-tests runs inside a real frappe process.
+		self._previous_flags = getattr(frappe.local, "flags", None)
 		frappe.local.flags = frappe._dict()
 
 	def tearDown(self):
+		if self._previous_flags is None:
+			if hasattr(frappe.local, "flags"):
+				del frappe.local.flags
+		else:
+			frappe.local.flags = self._previous_flags
+
 		self._clear_registry_cache()
 
 	def test_zvec_is_builtin(self):

--- a/huf/ai/tests/_stub_env.py
+++ b/huf/ai/tests/_stub_env.py
@@ -20,8 +20,19 @@ and the `litellm` package resolves to a broken/partial namespace install (see
 
 Call `install()` before importing any `huf.ai.*` module. Safe to call multiple
 times (idempotent — checks `sys.modules` first).
+
+Every stub here is gated on the corresponding real package being absent. That
+gate is not a nicety: these test modules are also collected by `bench run-tests
+--app huf`, in a process that has the real frappe, litellm and agents packages
+loaded and a live site connected. Stubbing unconditionally used to reach into
+the *real* `frappe.utils` and replace `now_datetime`/`now`/`add_to_date` with
+MagicMocks for the rest of the process, which aborted the whole run the next
+time frappe did date arithmetic against the database (`throttle_user_creation`
+-> `get_creation_count`), and swapped the real `frappe.tests.UnitTestCase` for
+an empty class, silently de-registering every test that subclassed it.
 """
 
+import importlib.util
 import json
 import sys
 import types
@@ -36,91 +47,115 @@ def _make_module(name):
     return module
 
 
+def _is_real_package(name):
+    """True when `name` resolves to a genuinely installed package.
+
+    A module we (or conftest) put in `sys.modules` ourselves is a MagicMock or
+    a bare `types.ModuleType` with no `__file__`; a real installed package has
+    one. A package that only resolves as an empty namespace (the broken local
+    `litellm` install this module exists to work around) also counts as absent.
+    """
+    module = sys.modules.get(name)
+    if module is not None:
+        return not isinstance(module, MagicMock) and getattr(module, "__file__", None) is not None
+    try:
+        spec = importlib.util.find_spec(name)
+    except (ImportError, ValueError):
+        return False
+    return spec is not None and spec.origin is not None
+
+
 def install():
-    # --- frappe -------------------------------------------------------
-    if "frappe" not in sys.modules or not hasattr(sys.modules["frappe"], "__path__"):
-        frappe = MagicMock(name="frappe")
-        frappe.__path__ = []  # makes `frappe` importable as a package
-        sys.modules["frappe"] = frappe
-    frappe = sys.modules["frappe"]
-    # `frappe.as_json` is used by huf.ai.context_segments to serialize tool
-    # calls before token-counting them. A bare MagicMock return value has no
-    # real length/content, which silently zeroes out any test relying on the
-    # serialized text -- wire it to the real json.dumps so counting behaves
-    # like it does in production.
-    frappe.as_json = lambda obj, **kwargs: json.dumps(obj)
+    # Each section is skipped outright when the real package is installed --
+    # under `bench run-tests` these stubs would otherwise mutate the live
+    # modules for the whole process. See the module docstring.
+    if not _is_real_package("frappe"):
+        # --- frappe -------------------------------------------------------
+        if "frappe" not in sys.modules or not hasattr(sys.modules["frappe"], "__path__"):
+            frappe = MagicMock(name="frappe")
+            frappe.__path__ = []  # makes `frappe` importable as a package
+            sys.modules["frappe"] = frappe
+        frappe = sys.modules["frappe"]
+        # `frappe.as_json` is used by huf.ai.context_segments to serialize tool
+        # calls before token-counting them. A bare MagicMock return value has no
+        # real length/content, which silently zeroes out any test relying on the
+        # serialized text -- wire it to the real json.dumps so counting behaves
+        # like it does in production.
+        frappe.as_json = lambda obj, **kwargs: json.dumps(obj)
 
-    frappe_utils = _make_module("frappe.utils")
-    frappe_utils.now = MagicMock(return_value="2026-01-01 00:00:00")
-    frappe_utils.add_to_date = MagicMock()
-    frappe_utils.get_datetime = MagicMock(side_effect=lambda v: v)
-    frappe_utils.now_datetime = MagicMock()
-    # Identity passthrough is enough for tests that never exercise the
-    # aware/naive normalisation itself (agent_run_analytics_api.py imports
-    # this at module level, so it must exist for the module to import at
-    # all) -- tests that actually need real tz-conversion behaviour talk to
-    # a live bench instead, since pytz's tzdata isn't available here.
-    frappe_utils.convert_utc_to_system_timezone = MagicMock(side_effect=lambda v: v)
-    frappe.utils = frappe_utils
+        frappe_utils = _make_module("frappe.utils")
+        frappe_utils.now = MagicMock(return_value="2026-01-01 00:00:00")
+        frappe_utils.add_to_date = MagicMock()
+        frappe_utils.get_datetime = MagicMock(side_effect=lambda v: v)
+        frappe_utils.now_datetime = MagicMock()
+        # Identity passthrough is enough for tests that never exercise the
+        # aware/naive normalisation itself (agent_run_analytics_api.py imports
+        # this at module level, so it must exist for the module to import at
+        # all) -- tests that actually need real tz-conversion behaviour talk to
+        # a live bench instead, since pytz's tzdata isn't available here.
+        frappe_utils.convert_utc_to_system_timezone = MagicMock(side_effect=lambda v: v)
+        frappe.utils = frappe_utils
 
-    frappe_tests = _make_module("frappe.tests")
+        frappe_tests = _make_module("frappe.tests")
 
-    class UnitTestCase:
-        pass
-
-    frappe_tests.UnitTestCase = UnitTestCase
-    frappe.tests = frappe_tests
-
-    # --- litellm --------------------------------------------------------
-    # The real `litellm` package (pip-installed, version 1.95.0) is shadowed in
-    # this environment by an unrelated broken namespace package at
-    # /private/tmp/litellm_work — `import litellm` succeeds but exposes no
-    # attributes at all. Stub it fully rather than depending on that install.
-    if "litellm" not in sys.modules or not isinstance(sys.modules["litellm"], MagicMock):
-        litellm_mock = MagicMock(name="litellm")
-
-        class InternalServerError(Exception):
+        class UnitTestCase:
             pass
 
-        class RateLimitError(Exception):
+        frappe_tests.UnitTestCase = UnitTestCase
+        frappe.tests = frappe_tests
+
+    if not _is_real_package("litellm"):
+        # --- litellm --------------------------------------------------------
+        # The real `litellm` package (pip-installed, version 1.95.0) is shadowed in
+        # this environment by an unrelated broken namespace package at
+        # /private/tmp/litellm_work — `import litellm` succeeds but exposes no
+        # attributes at all. Stub it fully rather than depending on that install.
+        if "litellm" not in sys.modules or not isinstance(sys.modules["litellm"], MagicMock):
+            litellm_mock = MagicMock(name="litellm")
+
+            class InternalServerError(Exception):
+                pass
+
+            class RateLimitError(Exception):
+                pass
+
+            class APIError(Exception):
+                pass
+
+            class BadRequestError(Exception):
+                pass
+
+            class ContextWindowExceededError(Exception):
+                pass
+
+            litellm_mock.InternalServerError = InternalServerError
+            litellm_mock.RateLimitError = RateLimitError
+            litellm_mock.APIError = APIError
+            litellm_mock.BadRequestError = BadRequestError
+            litellm_mock.ContextWindowExceededError = ContextWindowExceededError
+            litellm_mock.token_counter = MagicMock(return_value=0)
+            sys.modules["litellm"] = litellm_mock
+
+        litellm_utils = _make_module("litellm.utils")
+        litellm_utils.trim_messages = MagicMock()
+
+    if not _is_real_package("agents"):
+        # --- agents (OpenAI Agents SDK) --------------------------------------
+        _make_module("agents")
+        agents_tool_context = _make_module("agents.tool_context")
+
+        class ToolContext:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        agents_tool_context.ToolContext = ToolContext
+
+        agents_usage = _make_module("agents.usage")
+
+        class Usage:
             pass
 
-        class APIError(Exception):
-            pass
-
-        class BadRequestError(Exception):
-            pass
-
-        class ContextWindowExceededError(Exception):
-            pass
-
-        litellm_mock.InternalServerError = InternalServerError
-        litellm_mock.RateLimitError = RateLimitError
-        litellm_mock.APIError = APIError
-        litellm_mock.BadRequestError = BadRequestError
-        litellm_mock.ContextWindowExceededError = ContextWindowExceededError
-        litellm_mock.token_counter = MagicMock(return_value=0)
-        sys.modules["litellm"] = litellm_mock
-
-    litellm_utils = _make_module("litellm.utils")
-    litellm_utils.trim_messages = MagicMock()
-
-    # --- agents (OpenAI Agents SDK) --------------------------------------
-    _make_module("agents")
-    agents_tool_context = _make_module("agents.tool_context")
-
-    class ToolContext:
-        def __init__(self, *args, **kwargs):
-            pass
-
-    agents_tool_context.ToolContext = ToolContext
-
-    agents_usage = _make_module("agents.usage")
-
-    class Usage:
-        pass
-
-    agents_usage.Usage = Usage
+        agents_usage.Usage = Usage
 
     # --- huf / huf.ai / huf.ai.providers packages ------------------------
     # sys.path already has the repo root on it when tests are run from there;

--- a/huf/ai/tests/_stub_env.py
+++ b/huf/ai/tests/_stub_env.py
@@ -60,7 +60,9 @@ def _is_real_package(name):
         return not isinstance(module, MagicMock) and getattr(module, "__file__", None) is not None
     try:
         spec = importlib.util.find_spec(name)
-    except (ImportError, ValueError):
+    except Exception:
+        # find_spec imports parent packages, and a parent may itself blow up in
+        # a stubbed environment. Treat anything unresolvable as absent.
         return False
     return spec is not None and spec.origin is not None
 
@@ -161,14 +163,19 @@ def install():
     # sys.path already has the repo root on it when tests are run from there;
     # these just need to exist as importable packages pointing at the real
     # on-disk source so `import huf.ai.providers.litellm` etc. resolve normally.
-    repo_pkg = _make_module("huf")
-    if not hasattr(repo_pkg, "__path__"):
-        repo_pkg.__path__ = ["huf"]
-
-    ai_pkg = _make_module("huf.ai")
-    if not hasattr(ai_pkg, "__path__"):
-        ai_pkg.__path__ = ["huf/ai"]
-
-    providers_pkg = _make_module("huf.ai.providers")
-    if not hasattr(providers_pkg, "__path__"):
-        providers_pkg.__path__ = ["huf/ai/providers"]
+    #
+    # Gated the same way as the sections above. Under a bench, `huf` is a real
+    # installed package but its subpackages are often not imported yet, so an
+    # ungated `_make_module("huf.ai.providers")` inserts a bare module with a
+    # repo-relative `__path__` ahead of the real one, and every later
+    # `import huf.ai.providers.litellm` fails with ModuleNotFoundError.
+    for name, rel_path in (
+        ("huf", "huf"),
+        ("huf.ai", "huf/ai"),
+        ("huf.ai.providers", "huf/ai/providers"),
+    ):
+        if _is_real_package(name):
+            continue
+        pkg = _make_module(name)
+        if not hasattr(pkg, "__path__"):
+            pkg.__path__ = [rel_path]

--- a/huf/ai/tests/test_automation_scheduler.py
+++ b/huf/ai/tests/test_automation_scheduler.py
@@ -1,0 +1,241 @@
+"""
+Tests for the live automation scheduler entrypoint, run_due_automations.
+
+Covers:
+- No-op when automation_runtime_is_new() is False (legacy runtime active).
+- No-op when the Automation Trigger DocType does not exist.
+- A due trigger fires run_automation with the automation name, now=True,
+  and a trigger_context of type "schedule".
+- The per-trigger cache lock short-circuits a second fire.
+- The stale-batch re-check: a fresh next_execution read in the future
+  prevents execution even if the trigger was due in the initial batch.
+- next_execution is claimed (advanced) before run_automation executes,
+  and the advanced value matches the trigger's interval.
+- A trigger that raises is swallowed, logged via frappe.log_error, and
+  does not stop the remaining triggers in the batch from firing.
+
+Run with: bench --site <site> run-tests --app huf --module huf.ai.tests.test_automation_scheduler
+"""
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from huf.ai import automation_scheduler
+
+
+class TestRunDueAutomations(unittest.TestCase):
+    @patch("huf.ai.automation_scheduler.automation_runtime_is_new", return_value=False)
+    @patch("huf.ai.automation_scheduler.frappe")
+    @patch("huf.ai.automation_scheduler.run_automation")
+    def test_no_op_under_legacy_runtime(self, mock_run_automation, mock_frappe, mock_runtime_is_new):
+        automation_scheduler.run_due_automations()
+
+        mock_frappe.db.exists.assert_not_called()
+        mock_frappe.get_all.assert_not_called()
+        mock_run_automation.assert_not_called()
+
+    @patch("huf.ai.automation_scheduler.automation_runtime_is_new", return_value=True)
+    @patch("huf.ai.automation_scheduler.frappe")
+    @patch("huf.ai.automation_scheduler.run_automation")
+    def test_no_op_when_doctype_missing(self, mock_run_automation, mock_frappe, mock_runtime_is_new):
+        mock_frappe.db.exists.return_value = False
+
+        automation_scheduler.run_due_automations()
+
+        mock_frappe.get_all.assert_not_called()
+        mock_run_automation.assert_not_called()
+
+    @patch("huf.ai.automation_scheduler.now_datetime")
+    @patch("huf.ai.automation_scheduler.automation_runtime_is_new", return_value=True)
+    @patch("huf.ai.automation_scheduler.frappe")
+    @patch("huf.ai.automation_scheduler.run_automation")
+    def test_due_trigger_fires(self, mock_run_automation, mock_frappe, mock_runtime_is_new, mock_now_datetime):
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        mock_now_datetime.return_value = now
+
+        mock_frappe.db.exists.return_value = True
+        trigger = {
+            "name": "AT-001",
+            "automation": "My Automation",
+            "scheduled_interval": "Hourly",
+            "interval_count": 1,
+            "next_execution": now,
+            "last_execution": None,
+        }
+        mock_frappe.get_all.return_value = [trigger]
+
+        cache = MagicMock()
+        cache.get_value.return_value = None
+        mock_frappe.cache.return_value = cache
+        mock_frappe.db.get_value.return_value = now
+
+        automation_scheduler.run_due_automations()
+
+        mock_run_automation.assert_called_once()
+        args, kwargs = mock_run_automation.call_args
+        self.assertEqual(args[0], "My Automation")
+        self.assertTrue(kwargs.get("now"))
+        self.assertEqual(kwargs.get("trigger_context", {}).get("type"), "schedule")
+
+    @patch("huf.ai.automation_scheduler.now_datetime")
+    @patch("huf.ai.automation_scheduler.automation_runtime_is_new", return_value=True)
+    @patch("huf.ai.automation_scheduler.frappe")
+    @patch("huf.ai.automation_scheduler.run_automation")
+    def test_cache_lock_short_circuits_second_fire(
+        self, mock_run_automation, mock_frappe, mock_runtime_is_new, mock_now_datetime
+    ):
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        mock_now_datetime.return_value = now
+
+        mock_frappe.db.exists.return_value = True
+        trigger = {
+            "name": "AT-001",
+            "automation": "My Automation",
+            "scheduled_interval": "Hourly",
+            "interval_count": 1,
+            "next_execution": now,
+            "last_execution": None,
+        }
+        mock_frappe.get_all.return_value = [trigger]
+
+        cache = MagicMock()
+        cache.get_value.return_value = "already-locked"
+        mock_frappe.cache.return_value = cache
+
+        automation_scheduler.run_due_automations()
+
+        mock_frappe.db.get_value.assert_not_called()
+        mock_run_automation.assert_not_called()
+
+    @patch("huf.ai.automation_scheduler.now_datetime")
+    @patch("huf.ai.automation_scheduler.automation_runtime_is_new", return_value=True)
+    @patch("huf.ai.automation_scheduler.frappe")
+    @patch("huf.ai.automation_scheduler.run_automation")
+    def test_stale_batch_recheck_prevents_execution(
+        self, mock_run_automation, mock_frappe, mock_runtime_is_new, mock_now_datetime
+    ):
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        mock_now_datetime.return_value = now
+
+        mock_frappe.db.exists.return_value = True
+        trigger = {
+            "name": "AT-001",
+            "automation": "My Automation",
+            "scheduled_interval": "Hourly",
+            "interval_count": 1,
+            "next_execution": now,
+            "last_execution": None,
+        }
+        mock_frappe.get_all.return_value = [trigger]
+
+        cache = MagicMock()
+        cache.get_value.return_value = None
+        mock_frappe.cache.return_value = cache
+        # Fresh read under the lock shows next_execution has already moved
+        # into the future (another tick beat us to it).
+        mock_frappe.db.get_value.return_value = now + timedelta(hours=1)
+
+        automation_scheduler.run_due_automations()
+
+        mock_run_automation.assert_not_called()
+
+    @patch("huf.ai.automation_scheduler.add_to_date")
+    @patch("huf.ai.automation_scheduler.now_datetime")
+    @patch("huf.ai.automation_scheduler.automation_runtime_is_new", return_value=True)
+    @patch("huf.ai.automation_scheduler.frappe")
+    @patch("huf.ai.automation_scheduler.run_automation")
+    def test_next_execution_claimed_before_execution(
+        self, mock_run_automation, mock_frappe, mock_runtime_is_new, mock_now_datetime, mock_add_to_date
+    ):
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        mock_now_datetime.return_value = now
+        advanced = now + timedelta(hours=2)
+        mock_add_to_date.return_value = advanced
+
+        mock_frappe.db.exists.return_value = True
+        trigger = {
+            "name": "AT-001",
+            "automation": "My Automation",
+            "scheduled_interval": "Hourly",
+            "interval_count": 2,
+            "next_execution": now,
+            "last_execution": None,
+        }
+        mock_frappe.get_all.return_value = [trigger]
+
+        cache = MagicMock()
+        cache.get_value.return_value = None
+        mock_frappe.cache.return_value = cache
+        mock_frappe.db.get_value.return_value = now
+
+        call_order = []
+        mock_frappe.db.set_value.side_effect = lambda *a, **kw: call_order.append("set_value")
+        mock_run_automation.side_effect = lambda *a, **kw: call_order.append("run_automation")
+
+        automation_scheduler.run_due_automations()
+
+        mock_add_to_date.assert_called_once_with(now, hours=2, days=0, weeks=0, months=0, years=0)
+
+        set_value_calls = [
+            c for c in mock_frappe.db.set_value.call_args_list
+            if c.args[:2] == ("Automation Trigger", "AT-001") and "next_execution" in c.args[2]
+        ]
+        self.assertEqual(len(set_value_calls), 1)
+        self.assertEqual(set_value_calls[0].args[2]["next_execution"], advanced)
+
+        self.assertIn("set_value", call_order)
+        self.assertIn("run_automation", call_order)
+        self.assertLess(call_order.index("set_value"), call_order.index("run_automation"))
+
+    @patch("huf.ai.automation_scheduler.now_datetime")
+    @patch("huf.ai.automation_scheduler.automation_runtime_is_new", return_value=True)
+    @patch("huf.ai.automation_scheduler.frappe")
+    @patch("huf.ai.automation_scheduler.run_automation")
+    def test_raising_trigger_is_swallowed_and_does_not_block_batch(
+        self, mock_run_automation, mock_frappe, mock_runtime_is_new, mock_now_datetime
+    ):
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        mock_now_datetime.return_value = now
+
+        mock_frappe.db.exists.return_value = True
+        trigger_a = {
+            "name": "AT-A",
+            "automation": "Automation A",
+            "scheduled_interval": "Hourly",
+            "interval_count": 1,
+            "next_execution": now,
+            "last_execution": None,
+        }
+        trigger_b = {
+            "name": "AT-B",
+            "automation": "Automation B",
+            "scheduled_interval": "Hourly",
+            "interval_count": 1,
+            "next_execution": now,
+            "last_execution": None,
+        }
+        mock_frappe.get_all.return_value = [trigger_a, trigger_b]
+
+        cache = MagicMock()
+        cache.get_value.return_value = None
+        mock_frappe.cache.return_value = cache
+        mock_frappe.db.get_value.return_value = now
+
+        def run_side_effect(automation_name, **kwargs):
+            if automation_name == "Automation A":
+                raise RuntimeError("boom")
+            return None
+
+        mock_run_automation.side_effect = run_side_effect
+
+        automation_scheduler.run_due_automations()
+
+        self.assertEqual(mock_run_automation.call_count, 2)
+        called_names = [c.args[0] for c in mock_run_automation.call_args_list]
+        self.assertIn("Automation A", called_names)
+        self.assertIn("Automation B", called_names)
+        mock_frappe.log_error.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_context_segments_reconcile.py
+++ b/huf/ai/tests/test_context_segments_reconcile.py
@@ -16,6 +16,7 @@ propagation rules documented in its docstring:
 import sys
 import os
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import _stub_env  # noqa: E402
@@ -79,13 +80,12 @@ class TestReconcileCompositionUnknownPropagation(unittest.TestCase):
         # sum(segments) = 50, tool_exchange = 0 -> counted = 50 vs reported = 100
         # delta_ratio = 0.5, well beyond the default 0.15 tolerance
         segments = {"system": 20, "tools": 10, "knowledge": 0, "history": 15, "message": 5}
-        result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100)
+        with patch("huf.ai.context_segments.frappe.logger") as mock_logger:
+            result = reconcile_composition(segments, tool_exchange_tokens=0, provider_prompt_tokens=100)
         self.assertFalse(result["within_tolerance"])
         self.assertAlmostEqual(result["delta_ratio"], 0.5)
 
-        import frappe
-
-        self.assertTrue(frappe.logger.called or frappe.logger("huf").warning.called)
+        mock_logger.return_value.warning.assert_called_once()
 
     def test_within_tolerance_boundary_is_inclusive(self):
         # delta_ratio exactly equal to tolerance (0.15) must count as within

--- a/huf/ai/tests/test_context_segments_tool_exchange.py
+++ b/huf/ai/tests/test_context_segments_tool_exchange.py
@@ -11,15 +11,19 @@ Tests for huf.ai.context_segments.count_tool_exchange_tokens:
   - returns None if any message's count fails
   - handles both string and list-of-content-block `content` shapes
 
-`_count()` (the module's shared token counter) calls `litellm.token_counter`,
-which is stubbed in this environment (see huf/ai/tests/_stub_env.py) to
-return a deterministic value via a side_effect keyed on text length, so
-these tests can assert on exact counted totals rather than "it ran".
+`_count()` (the module's shared token counter) calls `token_counter`, which
+`huf.ai.context_segments` imports by name from litellm. This module patches
+`huf.ai.context_segments.token_counter` directly (via `unittest.mock.patch`)
+with a deterministic side_effect keyed on text length, so these tests can
+assert on exact counted totals rather than "it ran" -- and the patch works
+the same way whether litellm is real (under a bench) or stubbed (see
+huf/ai/tests/_stub_env.py for the frappe-less standalone environment).
 """
 
 import sys
 import os
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import _stub_env  # noqa: E402
@@ -28,7 +32,6 @@ _stub_env.install()
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
 
-import litellm  # noqa: E402
 from huf.ai.context_segments import count_tool_exchange_tokens  # noqa: E402
 
 
@@ -36,12 +39,12 @@ class TestCountToolExchangeTokens(unittest.TestCase):
     def setUp(self):
         # Deterministic per-call token count: 1 "token" per character. Lets
         # tests assert exact totals without depending on a real tokenizer.
-        litellm.token_counter.side_effect = lambda model, text: len(text)
-        litellm.token_counter.return_value = None
-
-    def tearDown(self):
-        litellm.token_counter.side_effect = None
-        litellm.token_counter.return_value = 0
+        patcher = patch(
+            "huf.ai.context_segments.token_counter",
+            side_effect=lambda model, text: len(text),
+        )
+        self.mock_token_counter = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_empty_or_none_messages_returns_zero(self):
         self.assertEqual(count_tool_exchange_tokens("gpt-4", []), 0)
@@ -147,7 +150,7 @@ class TestCountToolExchangeTokens(unittest.TestCase):
                 raise RuntimeError("tokenizer exploded")
             return len(text)
 
-        litellm.token_counter.side_effect = flaky_counter
+        self.mock_token_counter.side_effect = flaky_counter
         messages = [{"role": "tool", "content": "will fail"}]
         result = count_tool_exchange_tokens("gpt-4", messages)
         self.assertIsNone(result)

--- a/huf/ai/tests/test_gateway_service.py
+++ b/huf/ai/tests/test_gateway_service.py
@@ -11,6 +11,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime
 
 from huf.ai import gateway_service
+from huf.ai.gateway_adapters.types import GatewayReply
 
 
 def gateway(**overrides):
@@ -299,12 +300,20 @@ class TestPairingReplyEnabled(unittest.TestCase):
         mock_frappe.get_all.return_value = []
         mock_frappe.get_doc.side_effect = self._get_doc_side_effect
         adapter = MagicMock()
-        mock_adapter_cls.return_value = adapter
+        # Two-level wiring: _adapter_class_for_provider returns a class,
+        # the code instantiates it, so the returned instance must be adapter.
+        mock_adapter_cls.return_value.return_value = adapter
 
         gw = gateway(direct_policy="Pairing", integration_settings="INT-001", pairing_reply_enabled=1)
-        gateway_service._create_pairing_request(gw, "42")
+        code = gateway_service._create_pairing_request(gw, "42")
 
+        mock_adapter_cls.assert_called_once_with("Telegram")
         adapter.send_reply.assert_called_once()
+        call_args = adapter.send_reply.call_args
+        reply = call_args[0][0]
+        assert isinstance(reply, GatewayReply)
+        assert reply.conversation_id == "42"
+        assert code in reply.text
 
     @patch("huf.ai.gateway_webhook._adapter_class_for_provider")
     @patch("huf.ai.gateway_service.frappe")
@@ -332,13 +341,21 @@ class TestPairingReplyEnabled(unittest.TestCase):
         mock_frappe.get_all.return_value = []
         mock_frappe.get_doc.side_effect = self._get_doc_side_effect
         adapter = MagicMock()
-        mock_adapter_cls.return_value = adapter
+        # Two-level wiring: _adapter_class_for_provider returns a class,
+        # the code instantiates it, so the returned instance must be adapter.
+        mock_adapter_cls.return_value.return_value = adapter
 
         gw = gateway(direct_policy="Pairing", integration_settings="INT-001")
         assert not hasattr(gw, "pairing_reply_enabled")
-        gateway_service._create_pairing_request(gw, "42")
+        code = gateway_service._create_pairing_request(gw, "42")
 
+        mock_adapter_cls.assert_called_once_with("Telegram")
         adapter.send_reply.assert_called_once()
+        call_args = adapter.send_reply.call_args
+        reply = call_args[0][0]
+        assert isinstance(reply, GatewayReply)
+        assert reply.conversation_id == "42"
+        assert code in reply.text
 
 
 class TestApproveGatewayPairing(unittest.TestCase):
@@ -353,7 +370,9 @@ class TestApproveGatewayPairing(unittest.TestCase):
         `expires_at`, so `_has_access_entry`'s `expires_at >= now` filter made
         an approved entry silently stop matching once that TTL elapsed."""
         entry = access_entry(expires_at=None)
-        mock_frappe.get_all.return_value = [{"name": entry.name, "pairing_code": "PAIR-7A9K"}]
+        # frappe.get_all returns frappe._dict rows, and _find_pending_entry_by_code
+        # reads row.pairing_code by attribute -- a plain dict here would raise.
+        mock_frappe.get_all.return_value = [frappe._dict({"name": entry.name, "pairing_code": "PAIR-7A9K"})]
         mock_frappe.get_doc.return_value = entry
         mock_frappe.has_permission.return_value = True
         mock_frappe.session.user = "admin@example.com"
@@ -401,7 +420,9 @@ class TestApproveGatewayPairing(unittest.TestCase):
     @patch("huf.ai.gateway_service.frappe")
     def test_expired_entry_is_rejected(self, mock_frappe):
         entry = access_entry(expires_at=datetime(2020, 1, 1))
-        mock_frappe.get_all.return_value = [{"name": entry.name, "pairing_code": "PAIR-7A9K"}]
+        # frappe.get_all returns frappe._dict rows, and _find_pending_entry_by_code
+        # reads row.pairing_code by attribute -- a plain dict here would raise.
+        mock_frappe.get_all.return_value = [frappe._dict({"name": entry.name, "pairing_code": "PAIR-7A9K"})]
         mock_frappe.get_doc.return_value = entry
         mock_frappe.has_permission.return_value = True
         mock_frappe.ValidationError = ValueError
@@ -414,7 +435,9 @@ class TestApproveGatewayPairing(unittest.TestCase):
     @patch("huf.ai.gateway_service.frappe")
     def test_already_approved_entry_is_rejected(self, mock_frappe):
         entry = access_entry(state="Approved")
-        mock_frappe.get_all.return_value = [{"name": entry.name, "pairing_code": "PAIR-7A9K"}]
+        # frappe.get_all returns frappe._dict rows, and _find_pending_entry_by_code
+        # reads row.pairing_code by attribute -- a plain dict here would raise.
+        mock_frappe.get_all.return_value = [frappe._dict({"name": entry.name, "pairing_code": "PAIR-7A9K"})]
         mock_frappe.get_doc.return_value = entry
         mock_frappe.has_permission.return_value = True
         mock_frappe.ValidationError = ValueError

--- a/huf/ai/tests/test_queue_first_runs.py
+++ b/huf/ai/tests/test_queue_first_runs.py
@@ -489,11 +489,13 @@ class TestQueueFirstRuns(unittest.TestCase):
         mock_run.assert_called_once()
         self.assertTrue(mock_run.call_args.kwargs.get("now"))
 
+    @patch("huf.ai.agent_scheduler.automation_runtime_is_new", return_value=False)
     @patch("huf.ai.prompt_resolver.resolve_prompt")
     @patch("huf.ai.agent_scheduler.frappe")
     @patch("huf.ai.agent_scheduler.run_agent_sync")
-    def test_scheduler_submits_queued_run(self, mock_run, mock_frappe, mock_resolve_prompt):
-        """Scheduled triggers are background workers; they hand runs to the queue."""
+    def test_scheduler_submits_queued_run(self, mock_run, mock_frappe, mock_resolve_prompt, mock_runtime_is_new):
+        """Legacy scheduler (site pins automation_trigger_runtime to "legacy"):
+        scheduled triggers are background workers; they hand runs to the queue."""
         mock_frappe.session.user = "Administrator"
         mock_frappe.has_permission.return_value = True
         mock_frappe.db.exists.return_value = True
@@ -528,6 +530,17 @@ class TestQueueFirstRuns(unittest.TestCase):
         mock_run.assert_called_once()
         self.assertNotIn("now", mock_run.call_args.kwargs)
         self.assertEqual(mock_run.call_args.args, ("Scheduled Agent", "scheduled prompt", "Test Provider", "test-model"))
+
+    @patch("huf.ai.agent_scheduler.automation_runtime_is_new", return_value=True)
+    @patch("huf.ai.agent_scheduler.frappe")
+    @patch("huf.ai.agent_scheduler.run_agent_sync")
+    def test_legacy_scheduler_no_ops_under_new_runtime(self, mock_run, mock_frappe, mock_runtime_is_new):
+        """Legacy scheduler no-ops under the default "new" automation runtime,
+        leaving run_due_automations (huf.ai.automation_scheduler) as the sole executor."""
+        agent_scheduler.run_scheduled_agents()
+
+        mock_run.assert_not_called()
+        mock_frappe.get_all.assert_not_called()
 
 
     # ------------------------------------------------------------------

--- a/huf/ai/tests/test_render_tools.py
+++ b/huf/ai/tests/test_render_tools.py
@@ -209,6 +209,15 @@ class TestPromptInstructionSelection(unittest.TestCase):
 		manager.agent_doc.agent_name = "test-agent"
 		manager.effective_model = "test-model"
 		manager.effective_provider = "test-provider"
+		# create_agent() calls self.provider.get_model(...) - production callers
+		# always go through AgentManager.__init__ -> _setup_client(), which sets
+		# this up from the Agent's configured AI Provider. This test builds the
+		# manager via __new__() to skip all of that DB/network-touching setup,
+		# so the seam has to be stubbed by hand here.
+		manager.provider = mock.MagicMock()
+		# The Agents SDK validates this: Agent(model=...) rejects anything that
+		# isn't a string, a Model, or None, so a bare MagicMock will not do.
+		manager.provider.get_model.return_value = "test-model"
 		manager.tools = [mock.MagicMock(name=n, description="d") for n in tool_names]
 		for tool, n in zip(manager.tools, tool_names):
 			tool.name = n


### PR DESCRIPTION
Stacked on #664 — review that first; this PR's diff is test files only (plus one docstring correction). **Retarget to `pre-develop` once #664 merges.**

## The headline

On a clean bench off `pre-develop`, `bench --site <site> run-tests --app huf` **does not fail — it aborts**, before reporting a single test:

```
frappe/core/doctype/user/user.py:1237  throttle_user_creation()
frappe/database/database.py:1313       get_creation_count()
pymysql.err.ProgrammingError: (1064, "... near '<MagicMock name='mock().__sub__()'>'")
"SELECT COUNT(`name`) FROM `tabUser` WHERE `creation`>=<MagicMock ...>"
```

With this branch (and #664 beneath it): **1102 tests, OK, 144 skipped**, confirmed stable across two consecutive runs.

## What was actually wrong

**1. `_stub_env.install()` poisoned the real frappe for the whole process.** It is imported and `install()`-ed at module import by 9 test files. Its only guard protected `sys.modules["frappe"]` itself; everything after reached into whatever `frappe.utils` already was — under a bench, the *real* module — and overwrote `now`, `now_datetime`, `add_to_date`, `get_datetime` and `convert_utc_to_system_timezone` with MagicMocks, permanently. That is the abort above. It also replaced the real `frappe.tests.UnitTestCase` with an empty class (silently de-registering every test subclassing it), swapped real `litellm` for a mock (its guard was inverted), and shadowed `huf.ai.providers` so three modules could not be collected at all. Every stub is now gated on the real package being absent, so it is a no-op under a bench and unchanged standalone.

**2. The knowledge backend suites destroyed `frappe.local.flags`.** All five fake a site context in `setUp` and restore only `frappe.local.site` — never `flags` or `message_log`. That wipes `currently_saving` for the rest of the process, so every later document insert dies with `AttributeError: 'NoneType' object has no attribute 'append'`. Bisected by running each module in order inside a live frappe context: `test_faiss_backend` is the first offender. **This is the cause behind the quarantine note already sitting in `test_code_execution_broker_permissions.py:28`** — that note records the symptom; the source had not been found. Both attributes are now saved and restored, mirroring the existing `_previous_site` handling.

**3. `test_scheduler_submits_queued_run` was stale.** `agent_scheduler.run_scheduled_agents()` has been gated behind `automation_runtime_is_new()` since the Stage 2 hard cut (`4c04c396`). That flag defaults to `"new"`, and `automation_runtime_flag` holds its own `frappe` reference, so patching `agent_scheduler.frappe` never reached the guard — `run_agent_sync` was called 0 times. Product code is correct; the test now patches the flag explicitly, with a mirror test for the default runtime.

**4. `TestPairingReplyEnabled` wired its mock one level too shallow.** `_create_pairing_request` resolves an adapter *class* then instantiates it; the tests set `mock_adapter_cls.return_value = adapter`, so `send_reply` landed on `adapter.return_value` and the assertion checked a mock nothing ever touched.

**5. Three `TestApproveGatewayPairing` errors.** `frappe.get_all` returns `frappe._dict` rows and `_find_pending_entry_by_code` reads them by attribute; the tests mocked plain dicts.

**6. The two `context_segments` suites only worked against the stubs.** They mutated `litellm.token_counter.side_effect` and read `frappe.logger.called` — silent no-ops against the real function objects a bench provides. Now patched by name (`huf.ai.context_segments.token_counter`, `.frappe.logger`): scoped, always restored, correct in either environment.

## New coverage

`huf/ai/tests/test_automation_scheduler.py` — `run_due_automations`, the entrypoint that actually runs today, had **zero** coverage anywhere in the repo. 7 tests: flag gating, missing-DocType no-op, a due trigger firing, the per-trigger cache lock, the stale-batch re-check, `next_execution` being claimed *before* execution, and a raising trigger not stopping the rest of the batch.

## Not addressed here

- **144 skipped tests** — 54 `@unittest.skip("quarantined pending RegressionCI triage")` across 25 files. Un-skipping the one that blamed the flags leak shows it now fails for its own unrelated reason, so that backlog needs a dedicated pass.
- **CI never sees any of this.** `.github/workflows/server-tests.yml` triggers only on `develop`, so work merging into `pre-develop` gets no backend run at all — which is how a suite that cannot start reached this state.
- `automation_scheduler._fire_due_trigger` advances and commits `next_execution` *before* checking `automation_name`, so a trigger with no automation set has its schedule advanced forever, silently. Reported, not fixed.