### PR TITLE
ci(fix): frontend job run 

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -31,11 +31,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
 
+      # No dependency cache: frontend/ has no lockfile committed (neither
+      # package-lock.json nor yarn.lock), so `cache: "npm"` +
+      # cache-dependency-path pointed at a file that does not exist and
+      # actions/setup-node failed the job outright with "Some specified paths
+      # were not resolved, unable to cache dependencies" -- before typecheck,
+      # vitest or build ever ran. Restore caching once a lockfile is committed.
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Typecheck
         run: npm run typecheck


### PR DESCRIPTION
CI config only. One file.

## The problem

The `Frontend · typecheck, vitest, build` job fails in ~10 seconds on every PR.

```
##[error]Some specified paths were not resolved, unable to cache dependencies.
```

`actions/setup-node` is configured with `cache: "npm"` and `cache-dependency-path: frontend/package-lock.json`, but **`frontend/` has no lockfile committed at all** — neither `package-lock.json` nor `yarn.lock`. The cache path never resolves, and the action fails the job outright at `Setup Node`.

So typecheck, vitest and build have **never run in CI**. The frontend has had zero automated coverage this whole time, while the job sat there reporting red and being ignored.

The workflow file is byte-identical on `develop`, so this is long-standing, not a recent regression.

## The fix

Drop the cache configuration so the job proceeds, and use `npm install` instead of `npm ci` (which requires the lockfile that does not exist).

Caching should be restored once a lockfile is actually committed. I have deliberately not bundled a lockfile addition into a CI fix — that pins every transitive dependency and deserves its own PR and its own review.

## Verification

Ran all three steps locally against `pre-develop` — the three that had never executed:

```
typecheck   clean
vitest      23 files, 180 tests passed
build       succeeds
```

So this turns the job green rather than surfacing a wall of pre-existing failures. Worth stating explicitly, since "enable a CI job that has never run" is the kind of change that can do the opposite.