### PR TITLE
security: enforce File read permission in transcribe_audio_file

### DIFF
--- a/huf/ai/audio_service.py
+++ b/huf/ai/audio_service.py
@@ -454,18 +454,34 @@ def resolve_stt_config(agent_name: str = None, model: str = None) -> dict:
 
 
 def _resolve_file_doc(file_id: str = None, file_url: str = None):
-    """Resolve a Frappe File document from an ID or URL."""
-    if file_id:
-        return frappe.get_doc("File", file_id)
+    """
+    Resolve a Frappe File document from an ID or URL.
 
+    Enforces the caller's read permission on the resolved File so a
+    ``file_id``/``file_url`` referencing a File the caller cannot read
+    (e.g. a private file owned by another user) is never handed back for
+    transcription. Callers that need an existing File document must go
+    through this function rather than calling ``frappe.get_doc("File", ...)``
+    directly.
+    """
     file_doc = None
-    if file_url:
+
+    if file_id:
+        file_doc = frappe.get_doc("File", file_id)
+    elif file_url:
         try:
             file_doc = frappe.get_doc("File", {"file_url": file_url})
         except (frappe.DoesNotExistError, frappe.DataError):
             # Try alternative lookup
             file_name = file_url.replace("/files/", "")
             file_doc = frappe.get_doc("File", {"file_name": file_name})
+
+    if file_doc and not frappe.has_permission("File", "read", doc=file_doc):
+        frappe.throw(
+            _("Not permitted to read File {0}").format(file_doc.name),
+            frappe.PermissionError,
+        )
+
     return file_doc
 
 
@@ -515,6 +531,8 @@ def transcribe_audio_file(
         elif file_id:
             try:
                 file_doc = _resolve_file_doc(file_id=file_id)
+            except frappe.PermissionError:
+                raise
             except Exception as e:
                 return {"success": False, "error": f"File not found: {e!s}"}
         elif file_url:
@@ -568,6 +586,10 @@ def transcribe_audio_file(
             "stt_source": stt_config["source"],
         }
 
+    except frappe.PermissionError:
+        # Let permission failures propagate as a real 403, not a
+        # success:False payload indistinguishable from a provider error.
+        raise
     except Exception as e:
         frappe.log_error(title="Audio Transcription Service", message=f"Audio transcription error: {e!s}")
         return {"success": False, "error": str(e)}

--- a/huf/ai/tests/test_transcribe_file_permission.py
+++ b/huf/ai/tests/test_transcribe_file_permission.py
@@ -57,6 +57,7 @@ class TestTranscribeFilePermission(IntegrationTestCase):
 				"doctype": "Agent",
 				"agent_name": f"huf-transcribe-perm-test-agent-{frappe.generate_hash(length=8)}",
 				"agent_modality": "Text",
+				"instructions": "You are a test agent used only for permission regression tests.",
 			}
 		)
 		agent.insert(ignore_permissions=True)

--- a/huf/ai/tests/test_transcribe_file_permission.py
+++ b/huf/ai/tests/test_transcribe_file_permission.py
@@ -1,0 +1,122 @@
+"""
+Regression test for the transcribe-audio file-permission bypass.
+
+``huf.ai.audio_service._resolve_file_doc`` (used by both
+``transcribe_audio_file`` and the whitelisted ``huf.ai.audio_api.transcribe``
+entrypoint) used to resolve any ``file_id``/``file_url`` straight to a
+``File`` document with no permission check. Any authenticated user could
+pass another user's private File id and get its contents transcribed back
+to them.
+
+Proves:
+- A user without read permission on another user's private File is denied
+  (``frappe.PermissionError``) when resolving/transcribing that file.
+- The file's owner (who does have read permission) is NOT denied by the
+  permission check itself.
+
+Run with:
+    bench --site <site> run-tests --app huf --module huf.ai.tests.test_transcribe_file_permission
+"""
+import frappe
+from frappe.utils.file_manager import save_file
+
+from frappe.tests import IntegrationTestCase
+
+from huf.ai import audio_service
+
+
+class TestTranscribeFilePermission(IntegrationTestCase):
+	def setUp(self):
+		self._users = []
+		self._files = []
+		self._agents = []
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for name in self._files:
+			try:
+				frappe.delete_doc("File", name, ignore_permissions=True, force=True)
+			except Exception:
+				pass
+		for name in self._agents:
+			try:
+				frappe.delete_doc("Agent", name, ignore_permissions=True, force=True)
+			except Exception:
+				pass
+		for name in self._users:
+			try:
+				frappe.delete_doc("User", name, ignore_permissions=True, force=True)
+			except Exception:
+				pass
+		frappe.db.commit()
+
+	def _make_agent(self):
+		frappe.set_user("Administrator")
+		agent = frappe.get_doc(
+			{
+				"doctype": "Agent",
+				"agent_name": f"huf-transcribe-perm-test-agent-{frappe.generate_hash(length=8)}",
+				"agent_modality": "Text",
+			}
+		)
+		agent.insert(ignore_permissions=True)
+		self._agents.append(agent.name)
+		return agent.name
+
+	def _make_user(self):
+		email = f"huf-transcribe-perm-test-{frappe.generate_hash(length=10)}@example.com"
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "TranscribePermTest",
+				"send_welcome_email": 0,
+			}
+		)
+		user.insert(ignore_permissions=True)
+		self._users.append(user.name)
+		return user.name
+
+	def _make_private_file_as(self, user):
+		frappe.set_user(user)
+		file_doc = save_file(
+			"secret-audio-owner-only.txt",
+			b"private transcript-worthy content",
+			None,
+			None,
+			is_private=1,
+		)
+		self._files.append(file_doc.name)
+		frappe.set_user("Administrator")
+		return file_doc.name
+
+	def test_other_user_cannot_resolve_private_file_owned_by_someone_else(self):
+		user_a = self._make_user()
+		user_b = self._make_user()
+		file_id = self._make_private_file_as(user_a)
+
+		frappe.set_user(user_b)
+		self.assertFalse(frappe.has_permission("File", "read", doc=file_id))
+
+		with self.assertRaises(frappe.PermissionError):
+			audio_service._resolve_file_doc(file_id=file_id)
+
+	def test_owner_can_resolve_own_private_file(self):
+		user_a = self._make_user()
+		file_id = self._make_private_file_as(user_a)
+
+		frappe.set_user(user_a)
+		self.assertTrue(frappe.has_permission("File", "read", doc=file_id))
+
+		resolved = audio_service._resolve_file_doc(file_id=file_id)
+		self.assertEqual(resolved.name, file_id)
+
+	def test_transcribe_audio_file_denies_other_user_for_private_file(self):
+		user_a = self._make_user()
+		user_b = self._make_user()
+		file_id = self._make_private_file_as(user_a)
+		agent_name = self._make_agent()
+
+		frappe.set_user(user_b)
+		with self.assertRaises(frappe.PermissionError):
+			audio_service.transcribe_audio_file(file_id=file_id, agent_name=agent_name)


### PR DESCRIPTION
## Summary
- `huf.ai.audio_service._resolve_file_doc()` resolved any `file_id`/`file_url` to a `File` document with no permission check. Any authenticated user could pass another user's private File id to `huf.ai.audio_api.transcribe()` and get its contents transcribed back to them.
- Confirmed live on `pre-develop` before fixing: `_resolve_file_doc` returned another user's private file with no error.
- Fix scoped precisely to the existing-File-lookup path (`file_id`/`file_url`); the System-Manager-only `file_path` path and the fresh-upload `b64data` path (no existing File to check) are untouched.
- `transcribe_audio_file()`'s two `except Exception` blocks now explicitly re-raise `frappe.PermissionError` instead of swallowing it into a generic `{"success": False, ...}` payload indistinguishable from an unrelated failure.

## Test plan
- [x] New regression test `huf/ai/tests/test_transcribe_file_permission.py`: a user without read permission on another user's private File is denied (`frappe.PermissionError`) both at `_resolve_file_doc` and at `transcribe_audio_file`; the file's owner is not denied. 3/3 pass on a real bench.
- [x] Re-ran the original reproduction after the fix: permission error now raised correctly (previously succeeded).
- [x] `huf.ai.tests.test_phase1_security` (existing Phase-1 security suite) still passes: 17 tests, OK.