### PR TITLE
Add-ons settings tab: DeskAI enable toggle and pitch card

### DIFF
--- a/frontend/src/components/settings/AddOnsTab.tsx
+++ b/frontend/src/components/settings/AddOnsTab.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Bot, PackageX } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { FeatureCard } from '@/components/settings/FeatureCard';
+import { getDeskAiSettings, updateDeskAiSettings } from '@/services/deskAiSettingsApi';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+
+export { AddOnsTab };
+export default AddOnsTab;
+
+const DESKAI_BULLETS = [
+  'Works on any Desk page — forms, lists, reports',
+  'Understands what you’re pointing at — fields, sections, tabs, buttons',
+  'Backed by the same knowledge and tools as your Huf agents',
+  'No context switching — assistance where the work happens',
+];
+
+const DESKAI_PITCH =
+  'DeskAI puts an AI assistant directly inside Frappe Desk — navigate, fill forms, answer questions ' +
+  'about ERPNext data, and act on documents without leaving the page you’re on. It brings the same ' +
+  'intelligence powering your Huf agents right into the tools your team already uses every day.';
+
+type LoadState = 'loading' | 'ready' | 'not-installed';
+
+function AddOnsTab() {
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [enabled, setEnabled] = useState(false);
+  const [toggling, setToggling] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getDeskAiSettings()
+      .then((settings) => {
+        if (cancelled) return;
+        setEnabled(settings.enabled === 1);
+        setLoadState('ready');
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        // The `deskai` app is optional. If its `DeskAI Settings` doctype
+        // doesn't exist on this site, the read 404s — treat that as
+        // "not installed" rather than a failure to surface.
+        console.warn('DeskAI Settings unavailable (deskai app likely not installed):', error);
+        setLoadState('not-installed');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = async (next: boolean) => {
+    const previous = enabled;
+    setEnabled(next);
+    setToggling(true);
+    try {
+      await updateDeskAiSettings({ enabled: next ? 1 : 0 });
+      toast.success(`DeskAI ${next ? 'enabled' : 'disabled'}`);
+    } catch (error) {
+      setEnabled(previous);
+      toast.error('Failed to update DeskAI settings', {
+        description: getFrappeErrorMessage(error),
+        duration: 8000,
+      });
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  if (loadState === 'loading') {
+    return null;
+  }
+
+  if (loadState === 'not-installed') {
+    return (
+      <Card className="border-dashed">
+        <CardHeader>
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+              <PackageX className="h-4.5 w-4.5 text-steel-soft" />
+            </div>
+            <div>
+              <h3 className="text-[14px] font-semibold text-ink">DeskAI</h3>
+              <p className="font-body text-[13px] text-steel mt-1 max-w-prose">
+                DeskAI brings an AI assistant into Frappe Desk. Install the DeskAI app on this site to
+                enable it here.
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0" />
+      </Card>
+    );
+  }
+
+  return (
+    <FeatureCard
+      icon={Bot}
+      title="DeskAI"
+      pitch={DESKAI_PITCH}
+      bullets={DESKAI_BULLETS}
+      enabled={enabled}
+      onToggle={handleToggle}
+      toggleLoading={toggling}
+    />
+  );
+}

--- a/frontend/src/components/settings/AddOnsTab.tsx
+++ b/frontend/src/components/settings/AddOnsTab.tsx
@@ -5,6 +5,23 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { FeatureCard } from '@/components/settings/FeatureCard';
 import { getDeskAiSettings, updateDeskAiSettings } from '@/services/deskAiSettingsApi';
 import { getFrappeErrorMessage } from '@/lib/frappe-error';
+import type { FrappeErrorShape } from '@/lib/frappe-error';
+
+/**
+ * True only for "the DeskAI Settings doctype doesn't exist" (deskai app not
+ * installed) — NOT for permission errors, network failures, or other bugs,
+ * which should surface as a real error rather than the misleading
+ * "not installed" card.
+ */
+function isDocTypeMissingError(error: unknown): boolean {
+  const err = error as FrappeErrorShape | null | undefined;
+  const excType = err?.exc_type ?? '';
+  const message = err?.message ?? '';
+  return (
+    excType.includes('DoesNotExistError') ||
+    /doctype.*(not found|does not exist)/i.test(message)
+  );
+}
 
 export { AddOnsTab };
 export default AddOnsTab;
@@ -21,7 +38,7 @@ const DESKAI_PITCH =
   'about ERPNext data, and act on documents without leaving the page you’re on. It brings the same ' +
   'intelligence powering your Huf agents right into the tools your team already uses every day.';
 
-type LoadState = 'loading' | 'ready' | 'not-installed';
+type LoadState = 'loading' | 'ready' | 'not-installed' | 'error';
 
 function AddOnsTab() {
   const [loadState, setLoadState] = useState<LoadState>('loading');
@@ -34,16 +51,26 @@ function AddOnsTab() {
     getDeskAiSettings()
       .then((settings) => {
         if (cancelled) return;
-        setEnabled(settings.enabled === 1);
+        setEnabled(Number(settings.enabled) === 1);
         setLoadState('ready');
       })
       .catch((error) => {
         if (cancelled) return;
-        // The `deskai` app is optional. If its `DeskAI Settings` doctype
-        // doesn't exist on this site, the read 404s — treat that as
-        // "not installed" rather than a failure to surface.
-        console.warn('DeskAI Settings unavailable (deskai app likely not installed):', error);
-        setLoadState('not-installed');
+        if (isDocTypeMissingError(error)) {
+          // The `deskai` app is optional — its `DeskAI Settings` doctype
+          // doesn't exist on this site, so treat this as "not installed"
+          // rather than a failure to surface.
+          console.warn('DeskAI Settings unavailable (deskai app not installed):', error);
+          setLoadState('not-installed');
+        } else {
+          // A real failure (permissions, network, bug) — don't tell the
+          // user to "install the app" when it's actually installed.
+          console.error('Failed to load DeskAI settings:', error);
+          toast.error('Failed to load DeskAI settings', {
+            description: getFrappeErrorMessage(error),
+          });
+          setLoadState('error');
+        }
       });
 
     return () => {

--- a/frontend/src/components/settings/AddOnsTab.tsx
+++ b/frontend/src/components/settings/AddOnsTab.tsx
@@ -122,6 +122,32 @@ function AddOnsTab() {
     );
   }
 
+  if (loadState === 'error') {
+    // A real failure (permissions, network) -- never fall through to a live
+    // toggle here: it would render as confidently "off" and any click would
+    // just fail again. Most likely cause is that DeskAI Settings write
+    // access is restricted (e.g. System Manager only) for this user.
+    return (
+      <Card className="border-dashed">
+        <CardHeader>
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+              <Bot className="h-4.5 w-4.5 text-steel-soft" />
+            </div>
+            <div>
+              <h3 className="text-[14px] font-semibold text-ink">DeskAI</h3>
+              <p className="font-body text-[13px] text-steel mt-1 max-w-prose">
+                Couldn&rsquo;t load DeskAI settings — you may not have access to change them, or the
+                request failed. Ask a System Manager, or try again.
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0" />
+      </Card>
+    );
+  }
+
   return (
     <FeatureCard
       icon={Bot}

--- a/frontend/src/components/settings/FeatureCard.tsx
+++ b/frontend/src/components/settings/FeatureCard.tsx
@@ -1,0 +1,97 @@
+import type { ComponentType, ReactNode } from 'react';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+
+export interface FeatureCardProps {
+  /** A lucide icon component, or any custom ReactNode to use as the leading icon. */
+  icon: ComponentType<{ className?: string }> | ReactNode;
+  title: string;
+  /** Short, benefit-focused marketing copy (2-3 sentences). */
+  pitch: string;
+  /** Value-prop bullets shown under the pitch. */
+  bullets?: string[];
+  enabled: boolean;
+  onToggle: (next: boolean) => void | Promise<void>;
+  /** Disables the toggle, e.g. while the async onToggle call is in flight. */
+  toggleDisabled?: boolean;
+  /** Shows a spinner next to the toggle instead of its normal state. */
+  toggleLoading?: boolean;
+  learnMoreHref?: string;
+}
+
+function isComponentIcon(
+  icon: FeatureCardProps['icon']
+): icon is ComponentType<{ className?: string }> {
+  return typeof icon === 'function';
+}
+
+/**
+ * A reusable "feature pitch" card: icon + title + marketing copy + value-prop
+ * bullets + an on/off toggle. Used for optional add-on features (like DeskAI)
+ * that are configured elsewhere but explained and toggled from Huf's settings.
+ */
+export function FeatureCard({
+  icon,
+  title,
+  pitch,
+  bullets,
+  enabled,
+  onToggle,
+  toggleDisabled,
+  toggleLoading,
+  learnMoreHref,
+}: FeatureCardProps) {
+  const Icon = isComponentIcon(icon) ? icon : null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[color-mix(in_srgb,var(--signal)_10%,white)]">
+              {Icon ? <Icon className="h-4.5 w-4.5 text-signal" /> : (icon as ReactNode)}
+            </div>
+            <div>
+              <h3 className="text-[14px] font-semibold text-ink">{title}</h3>
+              <p className="font-body text-[13px] text-steel mt-1 max-w-prose">{pitch}</p>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {toggleLoading && <Loader2 className="h-4 w-4 animate-spin text-steel-soft" />}
+            <Switch
+              checked={enabled}
+              disabled={toggleDisabled || toggleLoading}
+              onCheckedChange={onToggle}
+              aria-label={`${enabled ? 'Disable' : 'Enable'} ${title}`}
+            />
+          </div>
+        </div>
+      </CardHeader>
+      {(bullets?.length || learnMoreHref) && (
+        <CardContent className="pt-0">
+          {bullets?.length ? (
+            <ul className="space-y-1.5">
+              {bullets.map((bullet) => (
+                <li key={bullet} className="flex items-start gap-2 font-body text-[13px] text-steel">
+                  <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-steel-soft" />
+                  {bullet}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {learnMoreHref && (
+            <a
+              className="mt-3 inline-flex items-center gap-1 text-sm text-primary hover:underline"
+              href={learnMoreHref}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Learn more<ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/data/doctypes.ts
+++ b/frontend/src/data/doctypes.ts
@@ -4,6 +4,7 @@ export const doctype = {
   Agent: "Agent",
   "AI Provider": "AI Provider",
   "AI Model": "AI Model",
+  "DeskAI Settings": "DeskAI Settings",
   "Agent Tool Function": "Agent Tool Function",
   "Agent Tool Type": "Agent Tool Type",
   "Agent Trigger": "Agent Trigger",

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AgentSettingsTab } from '@/components/settings/AgentSettingsTab';
 import { VoiceSettingsTab } from '@/components/settings/VoiceSettingsTab';
+import { AddOnsTab } from '@/components/settings/AddOnsTab';
 import { PageFrame } from '@/layouts/PageFrame';
 
 export { SettingsPage };
 export default SettingsPage;
 
-const VALID_TABS = ['agent', 'voice'];
+const VALID_TABS = ['agent', 'voice', 'addons'];
 
 function SettingsPage() {
   const [activeTab, setActiveTab] = useState<string>(() => {
@@ -33,6 +34,7 @@ function SettingsPage() {
           <TabsList>
             <TabsTrigger value="agent">Agent defaults</TabsTrigger>
             <TabsTrigger value="voice">Voice / STT</TabsTrigger>
+            <TabsTrigger value="addons">Add-ons</TabsTrigger>
           </TabsList>
         }
       >
@@ -43,6 +45,10 @@ function SettingsPage() {
 
           <TabsContent value="voice" className="mt-0">
             <VoiceSettingsTab />
+          </TabsContent>
+
+          <TabsContent value="addons" className="mt-0">
+            <AddOnsTab />
           </TabsContent>
         </div>
       </PageFrame>

--- a/frontend/src/services/deskAiSettingsApi.ts
+++ b/frontend/src/services/deskAiSettingsApi.ts
@@ -1,0 +1,25 @@
+import { db } from '@/lib/frappe-sdk';
+import { doctype } from '@/data/doctypes';
+
+/** The `DeskAI Settings` Single doctype, owned by the separate `deskai` Frappe app. */
+export interface DeskAiSettingsDoc {
+  enabled: 0 | 1;
+  default_agent?: string;
+}
+
+/**
+ * Fetch the `DeskAI Settings` singleton.
+ *
+ * The `deskai` app is optional — if it isn't installed on this site, the
+ * doctype doesn't exist and the read throws (404 / "DocType not found").
+ * Callers should treat a thrown error here as "DeskAI is not installed"
+ * rather than a generic failure.
+ */
+export async function getDeskAiSettings(): Promise<DeskAiSettingsDoc> {
+  return await db.getDoc(doctype['DeskAI Settings'], doctype['DeskAI Settings']);
+}
+
+/** Update the `DeskAI Settings` singleton. Throws if the `deskai` app isn't installed. */
+export async function updateDeskAiSettings(data: Partial<DeskAiSettingsDoc>): Promise<void> {
+  await db.updateDoc(doctype['DeskAI Settings'], doctype['DeskAI Settings'], data);
+}


### PR DESCRIPTION
## Summary
- New "Add-ons" tab in Huf's existing `/settings` page (no new top-level route, no backend migration) with a reusable `FeatureCard` component: pitch copy + value-prop bullets + a live enable toggle for DeskAI.
- Toggle reads/writes the real cross-app `DeskAI Settings` singleton (owned by the separate `deskai` app) via `frappe-js-sdk`, with a graceful fallback when `deskai` isn't installed on the site — distinct from a genuine permission/network error, which now surfaces honestly instead of showing a misleading "install the app" message or a silently-broken toggle.

## Review process
Two independent Haiku verification passes (cross-repo field-name match against DeskAI's actual doctype JSON confirmed clean) plus a final Opus adversarial review, which found two real issues — both fixed in follow-up commits: a Check-field type-coercion risk, and a missing render branch for a genuine load error.

## Known scope gap, flagged deliberately
This does **not** establish a proper "global settings paradigm" — `/settings` is now three ad-hoc tabs with no scope model (site vs. user) or shared registry, and this feature's own admin-toggle + per-user-snooze requirement can't be fully expressed by Huf settings today (the snooze lives entirely in the DeskAI widget's own localStorage). Recommend a follow-up track for a real settings registry.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `yarn build` clean
- [x] Independent review of cross-repo field assumptions (verified correct)
- [ ] Manual click-through (see test URL in the accompanying message) — needs the companion `deskai` app installed to exercise the "installed" path

🤖 Generated with [Claude Code](https://claude.com/claude-code)