### PR TITLE
Guide agents to compensate for sqlite_fts's literal keyword matching

### DIFF
--- a/huf/huf/erpnext_knowledge_seed.py
+++ b/huf/huf/erpnext_knowledge_seed.py
@@ -40,6 +40,20 @@ import frappe
 
 logger = frappe.logger("huf")
 
+# knowledge_search on these sources runs against sqlite_fts (keyword search, no embeddings -- see
+# the "knowledge_type" comment below for why). Keyword search only matches terms that actually
+# appear in the text, so a query in the user's own words can miss a chunk that says the same thing
+# differently. Appended to every section's instructions so the agent compensates for that instead
+# of concluding "no docs on this" after one literal query.
+FTS_SEARCH_GUIDANCE = (
+	"\n\nThis knowledge search is keyword-based (FTS), not semantic -- it only matches terms "
+	"that literally appear in the text, so it won't catch a paraphrase on its own. If your first "
+	"query returns nothing useful, don't conclude the docs don't cover it: retry with the exact "
+	"ERPNext DocType or field name (e.g. 'Sales Order' not 'customer order'), try synonyms and "
+	"related terms the user's question implies, and try 2-3 different phrasings of the same "
+	"question before giving up on a topic that's plausibly in scope for this section."
+)
+
 # One Knowledge Source + Skill per scraped section. Keys match the directory
 # names under huf/huf/data/erpnext_docs/.
 SECTIONS = {
@@ -191,7 +205,7 @@ def _ensure_skill(section_key, cfg):
 			# every agent's context, and this function never attaches it to
 			# any Agent. A user opts an agent into it via Agent > Skills.
 			"auto_load": 0,
-			"instructions": cfg["instructions"],
+			"instructions": cfg["instructions"] + FTS_SEARCH_GUIDANCE,
 			"skill_knowledge": [
 				{
 					"knowledge_source": cfg["source_name"],


### PR DESCRIPTION
## Summary
sqlite_fts (the knowledge_type used by the ERPNext knowledge seed, #682) only matches terms that literally appear in the text. Appends shared guidance to every ERPNext skill's instructions telling the agent to retry with exact DocType names, synonyms, and multiple phrasings before concluding a topic isn't covered.

## Provenance
Ported from `sources-local/feat/erpnext-knowledge-skill` (commit `03b27f63`), an earlier, never-merged branch that independently built the same seeding feature before #682 shipped. Rather than merging that whole branch — which duplicates the SECTIONS dict, after_migrate wiring, and Skill/Knowledge Source creation logic for skill_names #682 already created, becoming permanent no-op dead code — this ports just the one improvement it had that #682 lacked. The old branch should be archived/deleted as superseded.

## Test plan
- [x] `py_compile` clean
- [ ] Live-verify the updated instructions reach a real agent's skill (needs a `bench migrate` on a bench with #682 already applied — the guidance only affects newly-created Skills going forward, since Skill creation is idempotent-create-only by design; existing installs need a manual instructions update, noted as a known limitation of the create-only idempotency pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)