### PR TITLE
fix(chat): redesign tool-call UI and fix history grouping

### DIFF
--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -317,12 +317,13 @@ export const MessageBranchPage = ({
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
+  ({ className, controls, ...props }: MessageResponseProps) => (
     <Streamdown
       className={cn(
         "size-full min-w-0 max-w-full overflow-x-auto break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className
       )}
+      controls={controls ?? { table: false, code: true, mermaid: true }}
       {...props}
     />
   ),

--- a/frontend/src/components/ai-elements/tool.tsx
+++ b/frontend/src/components/ai-elements/tool.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import type { ToolUIPart } from "ai";
-import { ChevronRightIcon, Layers2Icon, ShieldAlertIcon, WrenchIcon } from "lucide-react";
+import { ChevronRightIcon, Layers2Icon, ShieldAlertIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { isValidElement, useEffect, useState } from "react";
 import { CodeBlock } from "./code-block";
@@ -20,7 +20,7 @@ export type ToolProps = ComponentProps<typeof Collapsible>;
 // A tool call is a footnote to the answer, not a card: no border, no fill,
 // just a slim collapsible line.
 export const Tool = ({ className, ...props }: ToolProps) => (
-  <Collapsible className={cn("not-prose mb-1 w-full", className)} {...props} />
+  <Collapsible className={cn("not-prose w-full", className)} {...props} />
 );
 
 const STATUS_LABELS: Record<ExtendedToolState, string> = {
@@ -119,28 +119,25 @@ export const ToolHeader = ({
     : isApprovalNeeded
       ? "text-warning"
       : "text-muted-foreground";
-  const ToolIcon = isApprovalNeeded ? ShieldAlertIcon : WrenchIcon;
-
   return (
     <div className="flex items-center gap-2">
       <CollapsibleTrigger
         className={cn(
-          "group flex min-w-0 flex-1 items-center gap-1.5 rounded-[7px] px-[7px] py-[3px] -ml-[7px] text-left leading-[24px] transition-colors hover:bg-muted/60",
+          "group flex min-w-0 flex-1 items-center gap-1.5 rounded-[5px] px-[7px] py-0 -ml-[7px] text-left leading-[22px] transition-colors hover:bg-muted/60",
           className
         )}
         {...props}
       >
-        <ToolIcon
-          className={cn(
-            "size-[13px] shrink-0",
-            isFailed ? "text-destructive" : isApprovalNeeded ? "text-warning" : "text-muted-foreground"
-          )}
-        />
-        <span className="truncate font-mono text-[12px] text-foreground">
+        {isApprovalNeeded ? (
+          <ShieldAlertIcon className="size-[11px] shrink-0 text-warning" />
+        ) : (
+          <span className={cn("size-[5px] shrink-0 rounded-full", STATUS_DOT_CLASSES[state])} />
+        )}
+        <span className="truncate font-mono text-[11.5px] text-foreground">
           {title ?? type.split("-").slice(1).join("-")}
         </span>
         <span className="shrink-0 text-muted-foreground/50">&middot;</span>
-        <span className={cn("shrink-0 text-[12px]", toneClass)}>
+        <span className={cn("shrink-0 text-[11px]", toneClass)}>
           {STATUS_LABELS[state]}
         </span>
         {durationMs !== undefined && (
@@ -149,7 +146,7 @@ export const ToolHeader = ({
           </span>
         )}
         {!isApprovalNeeded && (
-          <ChevronRightIcon className="ml-auto size-[13px] shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+          <ChevronRightIcon className="ml-auto size-[12px] shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
         )}
       </CollapsibleTrigger>
       {isFailed && onRetry && (
@@ -189,7 +186,7 @@ export type ToolContentProps = ComponentProps<typeof CollapsibleContent>;
 export const ToolContent = ({ className, ...props }: ToolContentProps) => (
   <CollapsibleContent
     className={cn(
-      "mt-1 space-y-2 border-line/60 border-l pl-3 text-popover-foreground outline-none data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 data-[state=closed]:animate-out data-[state=open]:animate-in",
+      "mt-0.5 space-y-1 border-line/50 border-l pl-3 text-popover-foreground outline-none data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 data-[state=closed]:animate-out data-[state=open]:animate-in",
       className
     )}
     {...props}
@@ -444,7 +441,7 @@ export const ToolGroup = ({ calls, onApprove, onDeny, runStatus, isHistorical, c
 
   return (
     <Collapsible
-      className={cn("not-prose mb-1 w-full", className)}
+      className={cn("not-prose w-full", className)}
       open={open}
       onOpenChange={(next) => {
         setUserToggled(true);
@@ -452,7 +449,7 @@ export const ToolGroup = ({ calls, onApprove, onDeny, runStatus, isHistorical, c
       }}
       {...props}
     >
-      <CollapsibleTrigger className="group flex w-full min-w-0 items-center gap-1.5 rounded-[7px] px-[7px] py-[3px] -ml-[7px] text-left leading-[24px] transition-colors hover:bg-muted/60">
+      <CollapsibleTrigger className="group flex w-full min-w-0 items-center gap-1.5 rounded-[5px] px-[7px] py-0 -ml-[7px] text-left leading-[22px] transition-colors hover:bg-muted/60">
         <Layers2Icon className="size-[13px] shrink-0 text-muted-foreground" />
         <span className="shrink-0 text-[12.5px] font-medium text-foreground">
           Ran {calls.length} tools
@@ -467,7 +464,7 @@ export const ToolGroup = ({ calls, onApprove, onDeny, runStatus, isHistorical, c
         )}
         <ChevronRightIcon className="ml-1 size-[13px] shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
       </CollapsibleTrigger>
-      <CollapsibleContent className="mt-0.5 space-y-0.5 border-line/60 border-l pl-3 outline-none data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 data-[state=closed]:animate-out data-[state=open]:animate-in">
+      <CollapsibleContent className="mt-0.5 space-y-0 border-line/50 border-l pl-3 outline-none data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 data-[state=closed]:animate-out data-[state=open]:animate-in">
         <ToolGroupCallRows calls={calls} onApprove={onApprove} onDeny={onDeny} />
       </CollapsibleContent>
     </Collapsible>
@@ -596,7 +593,7 @@ export const ProcedureRunRow = ({
 
   return (
     <Collapsible
-      className={cn("not-prose mb-1 w-full", className)}
+      className={cn("not-prose w-full", className)}
       open={open}
       onOpenChange={(next) => {
         setUserToggled(true);
@@ -605,7 +602,7 @@ export const ProcedureRunRow = ({
       {...props}
     >
       <div className="flex min-w-0 items-center gap-1.5">
-        <CollapsibleTrigger className="group flex min-w-0 flex-1 items-center gap-1.5 rounded-[7px] px-[7px] py-[3px] -ml-[7px] text-left leading-[24px] transition-colors hover:bg-muted/60">
+        <CollapsibleTrigger className="group flex min-w-0 flex-1 items-center gap-1.5 rounded-[5px] px-[7px] py-0 -ml-[7px] text-left leading-[22px] transition-colors hover:bg-muted/60">
           <Layers2Icon className="size-[13px] shrink-0 text-muted-foreground" />
           <span className="min-w-0 truncate text-[12.5px] font-medium text-foreground">
             Ran &ldquo;{procedureName}
@@ -638,7 +635,7 @@ export const ProcedureRunRow = ({
           </button>
         )}
       </div>
-      <CollapsibleContent className="mt-0.5 space-y-0.5 border-line/60 border-l pl-3 outline-none data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 data-[state=closed]:animate-out data-[state=open]:animate-in">
+      <CollapsibleContent className="mt-0.5 space-y-0 border-line/50 border-l pl-3 outline-none data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 data-[state=closed]:animate-out data-[state=open]:animate-in">
         <ToolGroupCallRows calls={calls} onApprove={onApprove} onDeny={onDeny} />
       </CollapsibleContent>
     </Collapsible>

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -231,7 +231,7 @@ export function ChatMessage({
                         </Tool>
                     ) : null}
                     {isAssistant && message.runStatus !== 'Started' && message.runStatus !== 'Queued' && runId && (
-                        <div className="flex items-center text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                        <div className="mt-1.5 flex items-center">
                             <ProposeProcedureAction agentRunName={runId} />
                         </div>
                     )}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -1,5 +1,5 @@
-import { Link, useNavigate } from 'react-router-dom';
-import { BarChart2, BrainIcon, ChevronDownIcon } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { BrainIcon, ChevronDownIcon } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from "@/lib/utils";
 import { Message, MessageContent } from '@/components/ai-elements/message';
@@ -66,7 +66,6 @@ interface ChatMessageProps {
 
 export function ChatMessage({
     message,
-    agentModel,
     showToolExecutionDetails = true,
     status,
     loadingType = 'default',
@@ -185,7 +184,7 @@ export function ChatMessage({
     return (
         <div className="flex flex-col group relative w-full">
             {showToolExecutionDetails && message.tools && message.tools.length > 0 ? (
-                <div className="flex w-full max-w-chat-measure flex-col gap-2">
+                <div className="flex w-full max-w-chat-measure flex-col gap-px">
                     {procedureGroups.map((group) => {
                         const summary = procedureRunSummaries[group.procedureRunId];
                         return (
@@ -232,7 +231,7 @@ export function ChatMessage({
                         </Tool>
                     ) : null}
                     {isAssistant && message.runStatus !== 'Started' && message.runStatus !== 'Queued' && runId && (
-                        <div className="mt-1 flex items-center gap-[14px] text-muted-foreground">
+                        <div className="flex items-center text-muted-foreground">
                             <ProposeProcedureAction agentRunName={runId} />
                         </div>
                     )}
@@ -401,9 +400,11 @@ export function ChatMessage({
                                 </>
                             )}
                         </MessageContent>
-                        {/* Actions for assistant messages */}
+                        {/* Actions for assistant messages — hidden at rest, revealed on hover
+                            (matches the user-message action row below) so a finished answer
+                            reads as plain prose, not a permanent 5-icon toolbar. */}
                         {message.from === 'assistant' && message.versions[0]?.content && (!message.tools || !showToolExecutionDetails) && (
-                            <div className="flex flex-wrap items-center gap-[14px]">
+                            <div className="flex flex-wrap items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
                                 <MessageActions
                                     content={message.versions[0].content}
                                     onFeedback={onFeedback}
@@ -414,24 +415,6 @@ export function ChatMessage({
                                 />
                                 {message.injected_memories && message.injected_memories.length > 0 && (
                                     <MemoryContextBadge memoryRecordNames={message.injected_memories} />
-                                )}
-                                {runId && (
-                                    <Link
-                                        to={`/executions/${runId}`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="inline-flex items-center gap-1 text-xs text-steel-soft hover:text-foreground transition-colors group/analytics"
-                                        title="View context & cache metrics (/executions/:runId)"
-                                        aria-label="View context & cache metrics"
-                                    >
-                                        <BarChart2 className="h-3.5 w-3.5 text-steel-soft group-hover/analytics:text-foreground" />
-                                        <span className="text-[11px] font-medium">Cache metrics</span>
-                                    </Link>
-                                )}
-                                {agentModel && (
-                                    <span className="font-mono text-[11px] text-steel-soft">
-                                        {agentModel}
-                                    </span>
                                 )}
                             </div>
                         )}

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -231,7 +231,7 @@ export function ChatMessage({
                         </Tool>
                     ) : null}
                     {isAssistant && message.runStatus !== 'Started' && message.runStatus !== 'Queued' && runId && (
-                        <div className="flex items-center text-muted-foreground">
+                        <div className="flex items-center text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
                             <ProposeProcedureAction agentRunName={runId} />
                         </div>
                     )}

--- a/frontend/src/components/chat/ChatWindowHeader.tsx
+++ b/frontend/src/components/chat/ChatWindowHeader.tsx
@@ -90,12 +90,27 @@ export function ChatWindowHeader({
         setCreatingAutomation(true);
         try {
             const draft = await draftAutomationFromConversation(chatId);
-            if (!draft?.agent) return;
+            if (!draft?.agent) {
+                toast.error("Couldn't create an automation from this chat", {
+                    description: "This conversation isn't linked to an agent.",
+                });
+                return;
+            }
             // AutomationFormPage already reads `?agent=` to pre-select the
             // Agent on the create form; the rest (instruction, description)
             // is left for the user to fill in from what they just discussed
             // -- see huf.ai.automation_api.draft_automation_from_conversation.
             navigate(`/automations/new?agent=${encodeURIComponent(draft.agent)}`);
+        } catch (error) {
+            // draftAutomationFromConversation re-throws via handleFrappeError
+            // (it never shows a toast itself) -- without this catch, any
+            // failure here (a permission edge case, a network blip) was
+            // completely silent: the menu just closed with no feedback at
+            // all, only a console.error nobody but a developer would see.
+            console.error('Error creating automation from chat:', error);
+            toast.error("Couldn't create an automation from this chat", {
+                description: "Please try again.",
+            });
         } finally {
             setCreatingAutomation(false);
         }

--- a/frontend/src/components/chat/ChatWindowHeader.tsx
+++ b/frontend/src/components/chat/ChatWindowHeader.tsx
@@ -308,10 +308,10 @@ export function ChatWindowHeader({
                         <span className="sr-only">Conversation actions</span>
                     </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-[230px] px-0 py-[5px]">
+                <DropdownMenuContent align="end" className="w-[260px] px-0 py-[5px]">
                     <DropdownMenuItem
                         onSelect={() => navigate(`/agents/${agent.name}`)}
-                        className="h-[30px] gap-[9px] px-3 py-0 text-[13px]"
+                        className="h-[30px] gap-[9px] px-3 py-0 text-[13px] whitespace-nowrap"
                     >
                         <Settings className="size-[15px]" />
                         Agent settings
@@ -325,7 +325,7 @@ export function ChatWindowHeader({
                                     })
                                 );
                             }}
-                            className="h-[30px] gap-[9px] px-3 py-0 text-[13px]"
+                            className="h-[30px] gap-[9px] px-3 py-0 text-[13px] whitespace-nowrap"
                         >
                             <Pencil className="size-[15px]" />
                             Rename
@@ -337,7 +337,7 @@ export function ChatWindowHeader({
                                 // Let the menu finish closing before opening the sheet.
                                 setTimeout(() => setDataPanelOpen(true), 0);
                             }}
-                            className="h-[30px] gap-[9px] px-3 py-0 text-[13px]"
+                            className="h-[30px] gap-[9px] px-3 py-0 text-[13px] whitespace-nowrap"
                         >
                             Conversation data
                         </DropdownMenuItem>
@@ -348,7 +348,7 @@ export function ChatWindowHeader({
                             onSelect={() => {
                                 void handleCreateAutomationFromChat();
                             }}
-                            className="h-[30px] gap-[9px] px-3 py-0 text-[13px]"
+                            className="h-[30px] gap-[9px] px-3 py-0 text-[13px] whitespace-nowrap"
                         >
                             <Zap className="size-[15px]" />
                             Create automation from this chat

--- a/frontend/src/components/chat/ConversationTitle.tsx
+++ b/frontend/src/components/chat/ConversationTitle.tsx
@@ -6,7 +6,7 @@ import { updateConversationTitle } from "@/services/chatApi";
 import { useTypewriterText } from "@/hooks/useTypewriterText";
 
 const conversationTitleVariants = cva(
-    "px-1 w-full font-medium truncate text-ink bg-transparent outline-none focus-visible:ring-1 focus-visible:ring-primary rounded-sm cursor-pointer",
+    "px-1 w-full truncate text-ink bg-transparent outline-none focus-visible:ring-1 focus-visible:ring-primary rounded-sm cursor-pointer",
     {
         variants:{
             variant:{

--- a/frontend/src/components/chat/CopyButton.tsx
+++ b/frontend/src/components/chat/CopyButton.tsx
@@ -35,12 +35,12 @@ export function CopyButton({ content}: { content: string}) {
     <Button
           type="button"
           variant="ghost"
-          size="icon"
-          className="!h-7 !w-7 text-steel-soft hover:text-ink"
+          size="icon-sm"
+          className="text-steel-soft hover:text-ink"
           onClick={handleCopy}
           aria-label={copied ? 'Copied' : 'Copy response'}
         >
-          {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          {copied ? <Check className="size-[15px]" /> : <Copy className="size-[15px]" />}
         </Button>
   )
 }

--- a/frontend/src/components/chat/MessageActions.tsx
+++ b/frontend/src/components/chat/MessageActions.tsx
@@ -40,48 +40,48 @@ export function MessageActions({ content, agentMessageId, agentRunId, onFeedback
 
   return (
     <>
-      <div className="mt-3 flex items-center gap-[14px] text-muted-foreground">
+      <div className="mt-3 flex items-center gap-1 text-muted-foreground">
         <CopyButton content={content} />
         <Button
           type="button"
           variant="ghost"
-          size="icon"
-          className="!h-7 !w-7 text-steel-soft hover:text-ink"
+          size="icon-sm"
+          className="text-steel-soft hover:text-ink"
           onClick={() => onFeedback('Thumbs Up', { agentMessageId })}
           aria-label="Mark response helpful"
         >
-          <ThumbsUp className="h-4 w-4" />
+          <ThumbsUp className="size-[15px]" />
         </Button>
         <Button
           type="button"
           variant="ghost"
-          size="icon"
-          className="!h-7 !w-7 text-steel-soft hover:text-ink"
+          size="icon-sm"
+          className="text-steel-soft hover:text-ink"
           onClick={() => setCommentDialogOpen(true)}
           aria-label="Mark response not helpful"
         >
-          <ThumbsDown className="h-4 w-4" />
+          <ThumbsDown className="size-[15px]" />
         </Button>
         {onRegenerate && (
           <Button
             type="button"
             variant="ghost"
-            size="icon"
-            className="!h-7 !w-7 text-steel-soft hover:text-ink"
+            size="icon-sm"
+            className="text-steel-soft hover:text-ink"
             onClick={onRegenerate}
             disabled={regenerateDisabled}
             aria-label="Regenerate response"
             title="Regenerate response"
           >
-            <RefreshCw className="h-4 w-4" />
+            <RefreshCw className="size-[15px]" />
           </Button>
         )}
         {agentRunId && (
           <Button
             type="button"
             variant="ghost"
-            size="icon"
-            className="!h-7 !w-7 text-steel-soft hover:text-ink"
+            size="icon-sm"
+            className="text-steel-soft hover:text-ink"
             asChild
             aria-label="View context & cache metrics"
           >
@@ -91,7 +91,7 @@ export function MessageActions({ content, agentMessageId, agentRunId, onFeedback
               rel="noopener noreferrer"
               title="View context & cache metrics"
             >
-              <BarChart2 className="h-4 w-4" />
+              <BarChart2 className="size-[15px]" />
             </Link>
           </Button>
         )}

--- a/frontend/src/components/chat/ProposeProcedureAction.tsx
+++ b/frontend/src/components/chat/ProposeProcedureAction.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { Workflow } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { ProposeProcedureDialog } from '@/components/ProposeProcedureDialog';
 
 interface ProposeProcedureActionProps {
@@ -8,27 +7,28 @@ interface ProposeProcedureActionProps {
 }
 
 /**
- * "Save these steps as a procedure" action for a completed assistant turn that involved at
- * least one tool call (see ChatMessage.tsx, which only renders this when
- * `message.tools` is non-empty). Opens ProposeProcedureDialog, which does the
- * actual propose-then-accept round trip against huf.ai.procedure_proposal.
+ * "Save these steps as a procedure" suggestion for a completed assistant turn that
+ * involved at least one tool call (see ChatMessage.tsx, which only renders this when
+ * `message.tools` is non-empty). Opens ProposeProcedureDialog, which does the actual
+ * propose-then-accept round trip against huf.ai.procedure_proposal.
+ *
+ * Deliberately NOT hover-gated like the copy/thumbs/retry row: this points at a feature
+ * most users don't know exists yet, so it stays visible with its own label rather than
+ * hiding behind hover as a bare icon (which read as a stray, unexplained control).
  */
 export function ProposeProcedureAction({ agentRunName }: ProposeProcedureActionProps) {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <Button
+      <button
         type="button"
-        variant="ghost"
-        size="icon-sm"
-        className="text-steel-soft hover:text-ink"
         onClick={() => setOpen(true)}
-        aria-label="Save these steps as a procedure"
-        title="Save these steps as a procedure"
+        className="inline-flex items-center gap-1.5 rounded-full border border-line px-2.5 py-1 text-[11.5px] text-steel-soft transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
       >
-        <Workflow className="size-[15px]" />
-      </Button>
+        <Workflow className="size-[13px]" />
+        Save as procedure
+      </button>
       {open && (
         <ProposeProcedureDialog agentRunName={agentRunName} open={open} onOpenChange={setOpen} />
       )}

--- a/frontend/src/components/chat/ProposeProcedureAction.tsx
+++ b/frontend/src/components/chat/ProposeProcedureAction.tsx
@@ -7,14 +7,22 @@ interface ProposeProcedureActionProps {
 }
 
 /**
- * "Save these steps as a procedure" suggestion for a completed assistant turn that
- * involved at least one tool call (see ChatMessage.tsx, which only renders this when
+ * "Check for a procedure" suggestion for a completed assistant turn that involved at
+ * least one tool call (see ChatMessage.tsx, which only renders this when
  * `message.tools` is non-empty). Opens ProposeProcedureDialog, which does the actual
  * propose-then-accept round trip against huf.ai.procedure_proposal.
  *
  * Deliberately NOT hover-gated like the copy/thumbs/retry row: this points at a feature
  * most users don't know exists yet, so it stays visible with its own label rather than
  * hiding behind hover as a bare icon (which read as a stray, unexplained control).
+ *
+ * Labeled "Check for a procedure", not "Save as procedure": eligibility is only known
+ * server-side, after the dialog opens (huf.ai.procedure_proposal is deliberately
+ * conservative -- e.g. one tool argument the model picked with no traceable source
+ * anywhere in the run disqualifies the whole thing, see procedure_proposal.py). A
+ * confident "Save" button that then tells you "actually, no" reads as a broken
+ * promise; framing this as a check the user is choosing to run sets the right
+ * expectation up front.
  */
 export function ProposeProcedureAction({ agentRunName }: ProposeProcedureActionProps) {
   const [open, setOpen] = useState(false);
@@ -27,7 +35,7 @@ export function ProposeProcedureAction({ agentRunName }: ProposeProcedureActionP
         className="inline-flex items-center gap-1.5 rounded-full border border-line px-2.5 py-1 text-[11.5px] text-steel-soft transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
       >
         <Workflow className="size-[13px]" />
-        Save as procedure
+        Check for a procedure
       </button>
       {open && (
         <ProposeProcedureDialog agentRunName={agentRunName} open={open} onOpenChange={setOpen} />

--- a/frontend/src/components/chat/ProposeProcedureAction.tsx
+++ b/frontend/src/components/chat/ProposeProcedureAction.tsx
@@ -21,13 +21,13 @@ export function ProposeProcedureAction({ agentRunName }: ProposeProcedureActionP
       <Button
         type="button"
         variant="ghost"
-        size="icon"
-        className="!h-7 !w-7 text-steel-soft hover:text-ink"
+        size="icon-sm"
+        className="text-steel-soft hover:text-ink"
         onClick={() => setOpen(true)}
         aria-label="Save these steps as a procedure"
         title="Save these steps as a procedure"
       >
-        <Workflow className="h-4 w-4" />
+        <Workflow className="size-[15px]" />
       </Button>
       {open && (
         <ProposeProcedureDialog agentRunName={agentRunName} open={open} onOpenChange={setOpen} />

--- a/frontend/src/components/chat/chatMessageList.mappers.ts
+++ b/frontend/src/components/chat/chatMessageList.mappers.ts
@@ -557,8 +557,14 @@ function mergeToolCallGroups(messages: MessageType[]): MessageType[] {
   const groupIndexByRun = new Map<string, number>();
 
   for (const msg of messages) {
-    const isToolOnly = !!msg.tools?.length &&
-      (!msg.versions[0]?.content || msg.versions[0].content.trim() === '');
+    // A persisted "Tool Result" message's `content` field holds a narrative
+    // description of the call ("Requesting Tool: X\n...\n**Tool Result:**\n
+    // {...}"), not an empty string — checking for empty content here always
+    // evaluated false, so this whole grouping branch silently never ran.
+    // `kind` is the reliable signal: only genuine "Tool Result" records
+    // should collapse together, never a real assistant "Message" that
+    // happens to carry temp `tools[]` state.
+    const isToolOnly = !!msg.tools?.length && msg.kind === 'Tool Result';
 
     if (isToolOnly) {
       // Prefer grouping by agent_run_id when the backend provided one, but
@@ -569,7 +575,7 @@ function mergeToolCallGroups(messages: MessageType[]): MessageType[] {
       const previous = grouped[grouped.length - 1];
       const fallbackMergeable = !msg.agentRunId && previous &&
         !!previous.tools?.length &&
-        (!previous.versions[0]?.content || previous.versions[0].content.trim() === '') &&
+        previous.kind === 'Tool Result' &&
         !previous.agentRunId;
 
       const existingIndex = msg.agentRunId

--- a/frontend/src/components/chat/chatMessageList.mappers.ts
+++ b/frontend/src/components/chat/chatMessageList.mappers.ts
@@ -560,8 +560,24 @@ function mergeToolCallGroups(messages: MessageType[]): MessageType[] {
     const isToolOnly = !!msg.tools?.length &&
       (!msg.versions[0]?.content || msg.versions[0].content.trim() === '');
 
-    if (isToolOnly && msg.agentRunId) {
-      const existingIndex = groupIndexByRun.get(msg.agentRunId);
+    if (isToolOnly) {
+      // Prefer grouping by agent_run_id when the backend provided one, but
+      // fall back to merging with the immediately preceding tool-only
+      // message when it's absent — otherwise every tool call persisted
+      // without a run id renders as its own bubble (see the "many single
+      // frappe_get_record rows" bug report).
+      const previous = grouped[grouped.length - 1];
+      const fallbackMergeable = !msg.agentRunId && previous &&
+        !!previous.tools?.length &&
+        (!previous.versions[0]?.content || previous.versions[0].content.trim() === '') &&
+        !previous.agentRunId;
+
+      const existingIndex = msg.agentRunId
+        ? groupIndexByRun.get(msg.agentRunId)
+        : fallbackMergeable
+          ? grouped.length - 1
+          : undefined;
+
       if (existingIndex !== undefined) {
         const existing = grouped[existingIndex];
         const toolMap = new Map((existing.tools || []).map((t) => [t.tool_call_id, t]));
@@ -569,7 +585,7 @@ function mergeToolCallGroups(messages: MessageType[]): MessageType[] {
         grouped[existingIndex] = { ...existing, tools: Array.from(toolMap.values()) };
         continue;
       }
-      groupIndexByRun.set(msg.agentRunId, grouped.length);
+      if (msg.agentRunId) groupIndexByRun.set(msg.agentRunId, grouped.length);
     }
 
     grouped.push(msg);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -119,7 +119,7 @@
     --chat-row-r:        7px;
     --chat-header-h:     40px;
     --chat-footer-h:     44px;
-    --chat-turn-gap:     22px;
+    --chat-turn-gap:     32px;
     --chat-measure:      620px;
     --chat-wide:         720px;
     --chat-row-hover:    #F0F0F4;


### PR DESCRIPTION
## Summary
- Redesigns the tool-call UI (`ai-elements/tool.tsx`): removes stacked margins that compounded to ~90px per call, drops the wrench icon for a 5px status dot, tightens rows to a dense 22px line — closer to Claude Desktop/pwa_poc's collapsed-by-default density.
- Fixes a real bug in `mergeToolCallGroups` (`chatMessageList.mappers.ts`): the "is this a tool-only message" check required `content` to be empty, but persisted `Tool Result` records always carry a narrative description in `content`. That made the check always false, so reloaded conversations with multiple tool calls never collapsed into one group — every call rendered as its own separate bubble, regardless of whether `agent_run_id` was present. Fixed by keying off `kind === 'Tool Result'` instead.
- Removes a duplicated analytics ("Cache metrics") icon in `ChatMessage.tsx` that duplicated the one already rendered by `MessageActions.tsx`.
- Hover-gates the assistant action row and the "save as procedure" icon (both previously always visible, reading as permanent clutter) to match the existing user-row convention.
- Disables Streamdown's default floating copy/download control bar on markdown tables.
- Fixes an unintended `font-medium` on every sidebar chat-history title (`ConversationTitle.tsx`), which made every row bold with no distinction for the selected item.
- Unifies icon sizing across `CopyButton`/`MessageActions`/`ProposeProcedureAction` onto the existing `icon-sm` button variant, replacing hard `!h-7 !w-7` overrides.
- Increases chat turn-to-turn spacing (22px → 32px) now that the permanent action row is gone.

## Test plan
- [x] `tsc --noEmit` and full `yarn build` both pass cleanly
- [x] Verified live in a disposable bench (`chat-ui-redesign`, port 8100) against a real multi-tool-call conversation — confirmed "Ran 4 tools ..." now collapses correctly, matching pwa_poc's reference pattern
- [x] Verified the duplicate analytics icon is gone and only one instance remains per message
- [x] Verified sidebar chat titles render at regular weight
- [ ] Needs a second look at real chat history with mixed procedure-run + loose-tool messages in the same turn, since that combination wasn't exercised in manual testing