### PR TITLE
Fix three architecture-independent correctness bugs (tool param types, code-exec import, combobox labels)

### DIFF
--- a/frontend/src/components/ui/combobox.tsx
+++ b/frontend/src/components/ui/combobox.tsx
@@ -24,6 +24,13 @@ export interface ComboboxOption {
 }
 
 export interface ComboboxProps {
+  /**
+   * Rendered on the trigger so a sibling `<Label htmlFor>` actually resolves.
+   * Without it, `<Label htmlFor="x"><Combobox/></Label>` is a dangling
+   * association: clicking the label does nothing and assistive tech cannot
+   * pair the two.
+   */
+  id?: string;
   options: ComboboxOption[];
   value?: string;
   onValueChange?: (value: string) => void;
@@ -38,6 +45,7 @@ export interface ComboboxProps {
 }
 
 export function Combobox({
+  id,
   options,
   value,
   onValueChange,
@@ -60,6 +68,7 @@ export function Combobox({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          id={id}
           variant="outline"
           role="combobox"
           aria-expanded={open}

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -500,7 +500,7 @@ def sync_discovered_tools(apps_to_scan=None, use_cache=True):
                     {
                         "label": p.get("label") or p.get("name", "").replace("_", " ").title(),
                         "fieldname": p.get("fieldname") or p.get("name", ""),
-                        "param_type": p.get("type", "Data"),
+                        "type": p.get("type", "string"),
                         "required": int(p.get("required", False)),
                         "description": p.get("description", ""),
                     }

--- a/huf/ai/tools/code_execution.py
+++ b/huf/ai/tools/code_execution.py
@@ -38,6 +38,7 @@ import tempfile
 from typing import Any
 from urllib.parse import urlparse
 
+import frappe
 from frappe.utils.data import add_to_date, now_datetime
 
 


### PR DESCRIPTION
Three correctness bugs found while validating Huf's flow builder against a live bench. None depend on the flow/graph-IR architecture — all three reproduce identically on `pre-develop` and are safe to merge independently of that track.

## Tool parameter types were flattened to `string` product-wide

`sync_discovered_tools()` (`huf/ai/tool_registry.py`) wrote a child row's type as `"param_type"`, but `Agent Function Params` names the field `type`. Frappe silently drops unknown keys, so a required Select was left unset and persisted as its **first option**, `"string"` — regardless of what the tool registry actually declared (e.g. `_p("confirm", type="boolean", ...)`).

Measured live: of 127 tools with declared parameters, only 3 retained a non-string type. Since `create_agent_tools` feeds these schemas to the LLM for function calling, this was mis-describing the parameter contract of essentially every typed tool parameter in the product to the model — every boolean and number advertised as a string.

Fix is one line. Existing rows self-correct the next time `sync_discovered_tools()` runs (idempotent upsert); no migration needed.

## Every code-execution safety gate was unreachable

`huf/ai/tools/code_execution.py` references `frappe.` 79 times and never imports it. Any call raises `NameError` inside `_is_site_enabled()` — before the site kill-switch, the `allow_code_execution` capability check, the Execution Profile lookup, or the approval flow ever run.

This survived because nothing in the product currently calls into this module (`run_python` isn't registered as a tool). Found while investigating whether it could be wired up safely.

## Combobox labels were dangling app-wide

`ComboboxProps` had no `id` prop, so every `<Label htmlFor="x"><Combobox/></Label>` pairing was non-functional: clicking the label did nothing, and assistive technology couldn't associate label with control. Additive fix — `Combobox` now accepts and forwards `id` to its trigger button.

## Verification
Static: confirmed the identical bug shape on `pre-develop` for all three (same field names, same missing import, same missing prop) before patching. The parameter-type and code-execution fixes were additionally verified live on a separate bench built off `develop`, where the before/after schema and the newly-reachable safety gate were both confirmed directly.
