### PR TITLE
sync: back-merge develop into pre-develop (#691)

### DIFF
--- a/frontend/src/components/ProposeProcedureDialog.test.tsx
+++ b/frontend/src/components/ProposeProcedureDialog.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+vi.mock('@/services/procedureProposalApi', () => ({
+  proposeProcedureFromRun: vi.fn(),
+  acceptProcedureProposal: vi.fn(),
+}));
+
+import { proposeProcedureFromRun } from '@/services/procedureProposalApi';
+import { ProposeProcedureDialog } from './ProposeProcedureDialog';
+
+describe('ProposeProcedureDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders confirmed-only proposal with plain badges and no warning copy', async () => {
+    const mockProposal = {
+      proposable: true,
+      procedure_graph: {
+        entry: 'node-0',
+        nodes: [
+          {
+            id: 'node-0',
+            type: 'tool.call',
+            config: {
+              tool_id: 'erpnext.get_customer',
+              input: {
+                customer_id: { $from: 'input.customer_id' },
+              },
+            },
+          },
+          {
+            id: 'node-1',
+            type: 'output',
+          },
+        ],
+      },
+      input_schema: {
+        properties: {
+          customer_id: {
+            type: 'string',
+            'x-confidence': 'prompt' as const,
+          },
+        },
+        required: ['customer_id'],
+      },
+      unconfirmed_input_fields: [],
+      step_count: 1,
+      source_run: 'AR-0001',
+    };
+
+    vi.mocked(proposeProcedureFromRun).mockResolvedValue(mockProposal);
+
+    render(
+      <BrowserRouter>
+        <ProposeProcedureDialog agentRunName="AR-0001" open={true} onOpenChange={() => {}} />
+      </BrowserRouter>
+    );
+
+    // Wait for the async load to resolve by waiting for the name input to appear
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('e.g. Draft weekly invoice')).toBeInTheDocument();
+    });
+
+    // Assert field badge is present (get all customer_id elements and verify the badge one exists)
+    const customerIdBadges = screen.getAllByText(/customer_id/);
+    expect(customerIdBadges.length).toBeGreaterThan(0);
+    // The badge should have the secondary variant classes
+    const badgeElement = customerIdBadges.find((el) => el.className.includes('bg-paper-deep'));
+    expect(badgeElement).toBeDefined();
+
+    // Assert the warning text is NOT present
+    expect(screen.queryByText(/couldn't confirm where/i)).not.toBeInTheDocument();
+  });
+
+  it('renders proposal with unconfirmed field and shows warning copy', async () => {
+    const mockProposal = {
+      proposable: true,
+      procedure_graph: {
+        entry: 'node-0',
+        nodes: [
+          {
+            id: 'node-0',
+            type: 'tool.call',
+            config: {
+              tool_id: 'erpnext.create_invoice',
+              input: {
+                customer_id: { $from: 'input.customer_id' },
+                raw_doctype: { $from: 'input.raw_doctype' },
+              },
+            },
+          },
+          {
+            id: 'node-1',
+            type: 'output',
+          },
+        ],
+      },
+      input_schema: {
+        properties: {
+          customer_id: {
+            type: 'string',
+            'x-confidence': 'prompt' as const,
+          },
+          raw_doctype: {
+            type: 'string',
+            'x-confidence': 'unconfirmed' as const,
+          },
+        },
+        required: ['customer_id', 'raw_doctype'],
+      },
+      unconfirmed_input_fields: ['raw_doctype'],
+      step_count: 1,
+      source_run: 'AR-0003',
+    };
+
+    vi.mocked(proposeProcedureFromRun).mockResolvedValue(mockProposal);
+
+    render(
+      <BrowserRouter>
+        <ProposeProcedureDialog agentRunName="AR-0003" open={true} onOpenChange={() => {}} />
+      </BrowserRouter>
+    );
+
+    // Wait for the async load to resolve by waiting for the name input to appear
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('e.g. Draft weekly invoice')).toBeInTheDocument();
+    });
+
+    // Assert warning text IS present (for 1 unconfirmed field: "this value came")
+    expect(screen.getByText(/couldn't confirm where this value came from/i)).toBeInTheDocument();
+
+    // Assert both badges are present
+    const customerIdBadges = screen.getAllByText(/customer_id/);
+    const rawDocBadges = screen.getAllByText(/raw_doctype/);
+    expect(customerIdBadges.length).toBeGreaterThan(0);
+    expect(rawDocBadges.length).toBeGreaterThan(0);
+
+    // Assert they have different classes: customer_id should have 'bg-paper-deep' (secondary),
+    // raw_doctype should have 'bg-warning-tint' (pill-warning)
+    const customerBadge = customerIdBadges.find((el) => el.className.includes('bg-paper-deep'));
+    const rawDocBadge = rawDocBadges.find((el) => el.className.includes('bg-warning-tint'));
+    expect(customerBadge).toBeDefined();
+    expect(rawDocBadge).toBeDefined();
+  });
+
+  it('renders non-proposable response and shows refusal branch only', async () => {
+    const mockProposal = {
+      proposable: false,
+      reason: 'Step 2 (some_tool) did not finish cleanly.',
+      source_run: 'AR-0002',
+    };
+
+    vi.mocked(proposeProcedureFromRun).mockResolvedValue(mockProposal);
+
+    render(
+      <BrowserRouter>
+        <ProposeProcedureDialog agentRunName="AR-0002" open={true} onOpenChange={() => {}} />
+      </BrowserRouter>
+    );
+
+    // Wait for the async load to resolve
+    await waitFor(() => {
+      expect(screen.getByText("These steps can't be saved as a procedure.")).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    // Assert refusal text is shown
+    expect(screen.getByText("Step 2 (some_tool) did not finish cleanly.")).toBeInTheDocument();
+
+    // Assert new unconfirmed-input UI is NOT present
+    expect(screen.queryByText(/couldn't confirm where/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/need confirming/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/You'll be asked for/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ProposeProcedureDialog.tsx
+++ b/frontend/src/components/ProposeProcedureDialog.tsx
@@ -76,16 +76,16 @@ function describeArg(name: string, raw: unknown, stepsById: Map<string, DisplayS
   return `${name}: always ${JSON.stringify(raw)}`;
 }
 
-function inputFieldList(inputSchema: ProcedureProposal['input_schema']): { name: string; type?: string; required?: boolean }[] {
+function inputFieldList(inputSchema: ProcedureProposal['input_schema']): { name: string; type?: string; required?: boolean; confidence?: 'prompt' | 'unconfirmed' }[] {
   if (!inputSchema) return [];
   if (Array.isArray(inputSchema)) {
-    return inputSchema.map((field) => ({ name: field.name, type: field.type, required: field.required }));
+    return inputSchema.map((field) => ({ name: field.name, type: field.type, required: field.required, confidence: field['x-confidence'] }));
   }
   // JSON-schema object with a `properties` map -- what the backend actually returns.
-  const props = (inputSchema as Record<string, unknown>).properties as Record<string, { type?: string }> | undefined;
+  const props = (inputSchema as Record<string, unknown>).properties as Record<string, { type?: string; 'x-confidence'?: 'prompt' | 'unconfirmed' }> | undefined;
   if (props && typeof props === 'object') {
     const required = new Set(((inputSchema as Record<string, unknown>).required as string[] | undefined) ?? []);
-    return Object.entries(props).map(([name, def]) => ({ name, type: def?.type, required: required.has(name) }));
+    return Object.entries(props).map(([name, def]) => ({ name, type: def?.type, required: required.has(name), confidence: def?.['x-confidence'] }));
   }
   return [];
 }
@@ -181,7 +181,7 @@ export function ProposeProcedureDialog({ agentRunName, open, onOpenChange }: Pro
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-[960px] max-h-[85vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Workflow className="w-4 h-4 text-primary" />
@@ -192,6 +192,8 @@ export function ProposeProcedureDialog({ agentRunName, open, onOpenChange }: Pro
             the agent deciding anything again -- so it runs faster and the same way every time.
           </DialogDescription>
         </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto min-h-0">
 
         {loading && <div className="py-6 text-sm text-muted-foreground">Checking what this answer did...</div>}
 
@@ -240,7 +242,7 @@ export function ProposeProcedureDialog({ agentRunName, open, onOpenChange }: Pro
           <div className="space-y-4 py-2 text-sm">
             {sourceLine}
 
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 max-w-md">
               <label htmlFor="procedure-name" className="font-medium">
                 Name it
               </label>
@@ -257,6 +259,9 @@ export function ProposeProcedureDialog({ agentRunName, open, onOpenChange }: Pro
 
             <div className="text-muted-foreground">
               {stepCount} step{stepCount === 1 ? '' : 's'} will be saved
+              {(proposal?.unconfirmed_input_fields?.length ?? 0) > 0 && (
+                <span> -- {proposal!.unconfirmed_input_fields!.length} input{proposal!.unconfirmed_input_fields!.length === 1 ? '' : 's'} need{proposal!.unconfirmed_input_fields!.length === 1 ? 's' : ''} confirming</span>
+              )}
             </div>
 
             {inputFields.length > 0 && (
@@ -264,7 +269,7 @@ export function ProposeProcedureDialog({ agentRunName, open, onOpenChange }: Pro
                 <div className="font-medium mb-1">You&apos;ll be asked for</div>
                 <div className="flex flex-wrap gap-1.5">
                   {inputFields.map((field) => (
-                    <Badge key={field.name} variant="secondary" className="font-normal">
+                    <Badge key={field.name} variant={field.confidence === 'unconfirmed' ? 'pill-warning' : 'secondary'} className="font-normal">
                       {field.name}
                       {field.type ? `: ${field.type}` : ''}
                       {field.required ? ' *' : ''}
@@ -274,13 +279,20 @@ export function ProposeProcedureDialog({ agentRunName, open, onOpenChange }: Pro
                 <p className="mt-1 text-xs text-muted-foreground">
                   These change each time you run it -- everything else stays fixed.
                 </p>
+                {(proposal?.unconfirmed_input_fields?.length ?? 0) > 0 && (
+                  <p className="mt-1 text-xs text-warning">
+                    We couldn&apos;t confirm where {(proposal?.unconfirmed_input_fields?.length ?? 0) === 1 ? 'this value came' : 'these values came'} from, so
+                    you&apos;ll need to provide {(proposal?.unconfirmed_input_fields?.length ?? 0) === 1 ? 'it' : 'them'} each time -- same as the fields above, but
+                    we can&apos;t tell you {(proposal?.unconfirmed_input_fields?.length ?? 0) === 1 ? 'it matches' : 'they match'} your request.
+                  </p>
+                )}
               </div>
             )}
 
             {steps.length > 0 && (
               <div>
                 <div className="font-medium mb-1">What it will do, every time</div>
-                <ol className="space-y-2">
+                <ol className="grid grid-cols-1 md:grid-cols-2 gap-2">
                   {steps.map((step) => (
                     <li key={step.id} className="rounded-md border border-line p-2">
                       <div className="font-medium">
@@ -319,6 +331,8 @@ export function ProposeProcedureDialog({ agentRunName, open, onOpenChange }: Pro
             </p>
           </div>
         )}
+
+        </div>
 
         <DialogFooter>
           {accepted ? (

--- a/frontend/src/services/procedureProposalApi.ts
+++ b/frontend/src/services/procedureProposalApi.ts
@@ -44,6 +44,7 @@ export interface ProcedureProposalInputField {
   type?: string;
   description?: string;
   required?: boolean;
+  'x-confidence'?: 'prompt' | 'unconfirmed';
   [key: string]: unknown;
 }
 
@@ -65,6 +66,10 @@ export interface ProcedureProposal {
   input_schema?: ProcedureProposalInputField[] | Record<string, unknown>;
   step_count?: number;
   source_run?: string;
+  /** Names of input_schema fields whose value could not be traced to the run's prompt or an
+   * earlier step's output -- the user still supplies these each run, but their origin is
+   * unconfirmed (see each field's `x-confidence` in input_schema). */
+  unconfirmed_input_fields?: string[];
 }
 
 /** Result of actually creating the procedure from an accepted proposal. */

--- a/huf/ai/procedure_proposal.py
+++ b/huf/ai/procedure_proposal.py
@@ -112,6 +112,7 @@ class ProposalResult:
 	procedure_graph: dict | None = None
 	input_schema: dict | None = None
 	step_count: int = 0
+	unconfirmed_input_fields: tuple[str, ...] = ()
 
 	def as_dict(self, *, source_run: str) -> dict:
 		return {
@@ -121,6 +122,7 @@ class ProposalResult:
 			"input_schema": self.input_schema,
 			"step_count": self.step_count,
 			"source_run": source_run,
+			"unconfirmed_input_fields": list(self.unconfirmed_input_fields),
 		}
 
 
@@ -244,26 +246,36 @@ def _bind_argument_value(
 	prompt: str | None,
 	earlier_calls: list[dict],
 	earlier_node_ids: list[str],
-) -> tuple[Any, str | None]:
+	allow_unconfirmed_inputs: bool = True,
+) -> tuple[Any, str | None, str | None]:
 	"""Decide where one ``tool_args`` value came from (task point 2), in the task's own
 	priority order: (a) the run's prompt, (b) an earlier tool call's result, (c) a trivial
-	constant, else (d) refuse. Returns ``(bound_value, input_field_name_or_None)`` --
-	``input_field_name`` is set only for an (a) binding, telling the caller which
-	``input_schema`` field to register.
+	constant, else (d) bind as unconfirmed input (if allowed) or refuse.
 
-	Raises :class:`ProcedureNotProposableError` for (d), with the exact wording the task
-	spec asks for so the user sees precisely which step/tool/argument was unexplainable.
+	Returns ``(bound_value, input_field_name_or_None, confidence_or_None)`` where:
+	- ``input_field_name`` is set for (a) and (d) bindings, telling the caller which
+	  ``input_schema`` field to register.
+	- ``confidence`` indicates the binding's reliability: ``"prompt"`` for (a),
+	  ``"unconfirmed"`` for (d), ``None`` for (b) and (c).
+
+	Raises :class:`ProcedureNotProposableError` for (d) when ``allow_unconfirmed_inputs``
+	is False, with the exact wording the task spec asks for so the user sees precisely
+	which step/tool/argument was unexplainable.
 	"""
 	if _appears_in_prompt(value, prompt):
 		field = _snake_case(arg_name)
-		return {"$from": f"input.{field}"}, field
+		return {"$from": f"input.{field}"}, field, "prompt"
 
 	ref = _find_earlier_reference(value, earlier_calls, earlier_node_ids)
 	if ref is not None:
-		return {"$from": ref}, None
+		return {"$from": ref}, None, None
 
 	if _is_trivial_constant(value):
-		return value, None
+		return value, None, None
+
+	if allow_unconfirmed_inputs:
+		field = _snake_case(arg_name)
+		return {"$from": f"input.{field}"}, field, "unconfirmed"
 
 	raise ProcedureNotProposableError(  # noqa: TRY003 -- user-facing refusal reason, not exception boilerplate
 		f"This run made a judgment call at step {step_index} ({tool_id}) when it chose the value "
@@ -331,6 +343,7 @@ def compile_procedure_from_trace(
 	response: str | None,
 	tool_calls: list[dict],
 	classify_tool: ToolClassifier = default_tool_classifier,
+	allow_unconfirmed_inputs: bool = True,
 ) -> ProposalResult:
 	"""Compile ``tool_calls`` (already ordered oldest-first, as recorded for one Agent
 	Run) into a candidate Procedure graph, or refuse with a specific reason. Pure: no
@@ -381,10 +394,50 @@ def compile_procedure_from_trace(
 				step_count=len(tool_calls),
 			)
 
+	def _register_input_field(
+		base_field: str, confidence: str | None, value: Any
+	) -> str:
+		"""Register or reuse an input field. Two occurrences of the same
+		``_snake_case`` name reuse one field ONLY when they were bound from the same
+		underlying value (``_values_equal``) -- confidence matching alone is not
+		enough, because two different tool-call arguments can share a generic name
+		(e.g. two ``doctype`` arguments, both unconfirmed, for two different
+		doctypes) while meaning genuinely different things. Merging those under one
+		user-supplied field would silently discard the second value and feed both
+		tool calls whatever the user types once -- exactly the "looks deterministic
+		but bakes in a wrong assumption" failure this module exists to avoid. When
+		the values differ, disambiguate by suffixing (customer_id, customer_id_2,
+		...). Returns the final (possibly suffixed) field name to use in ``$from``
+		references and in ``input_props``.
+		"""
+		if base_field not in input_props:
+			field = base_field
+		elif _values_equal(field_values[base_field], value):
+			return base_field  # same field, same underlying value -- reuse as today
+		else:
+			field = base_field
+			n = 2
+			while field in input_props:
+				field = f"{base_field}_{n}"
+				n += 1
+		# Register the field with its type and confidence
+		type_info = {"type": _json_type(value)}
+		if confidence is not None:
+			type_info["x-confidence"] = confidence
+		input_props[field] = type_info
+		input_required.append(field)
+		field_values[field] = value
+		# Track unconfirmed fields
+		if confidence == "unconfirmed":
+			unconfirmed_fields.append(field)
+		return field
+
 	node_ids: list[str] = []
 	nodes: list[dict] = []
 	input_props: dict[str, dict] = {}
 	input_required: list[str] = []
+	unconfirmed_fields: list[str] = []
+	field_values: dict[str, Any] = {}
 
 	for i, call in enumerate(tool_calls, start=1):
 		tool_id = call["tool"]
@@ -402,7 +455,7 @@ def compile_procedure_from_trace(
 		bound_input: dict[str, Any] = {}
 		try:
 			for arg_name, value in args.items():
-				bound_value, input_field = _bind_argument_value(
+				bound_value, input_field, confidence = _bind_argument_value(
 					step_index=i,
 					tool_id=tool_id,
 					arg_name=arg_name,
@@ -410,11 +463,13 @@ def compile_procedure_from_trace(
 					prompt=prompt,
 					earlier_calls=tool_calls[: i - 1],
 					earlier_node_ids=node_ids,
+					allow_unconfirmed_inputs=allow_unconfirmed_inputs,
 				)
+				# Update bound_value with the final field name if it's an input reference
+				if input_field is not None:
+					final_field = _register_input_field(input_field, confidence, value)
+					bound_value = {"$from": f"input.{final_field}"}
 				bound_input[arg_name] = bound_value
-				if input_field is not None and input_field not in input_props:
-					input_props[input_field] = {"type": _json_type(value)}
-					input_required.append(input_field)
 		except ProcedureNotProposableError as exc:
 			return ProposalResult(proposable=False, reason=exc.reason, step_count=len(tool_calls))
 
@@ -485,6 +540,7 @@ def compile_procedure_from_trace(
 		procedure_graph=procedure_graph,
 		input_schema=input_schema,
 		step_count=len(tool_calls),
+		unconfirmed_input_fields=tuple(unconfirmed_fields),
 	)
 
 

--- a/huf/ai/tests/test_procedure_proposal.py
+++ b/huf/ai/tests/test_procedure_proposal.py
@@ -197,7 +197,7 @@ class TestCompileProcedureFromTraceRefusals(unittest.TestCase):
 		self.assertEqual(result.step_count, 0)
 		self.assertIn("no tool calls", result.reason.lower())
 
-	def test_unexplained_argument_value_refuses_with_specific_reason(self):
+	def test_unexplained_argument_value_refuses_when_unconfirmed_inputs_disabled(self):
 		tool_calls = [
 			_completed_call(
 				"get_customer",
@@ -210,6 +210,7 @@ class TestCompileProcedureFromTraceRefusals(unittest.TestCase):
 			response="",
 			tool_calls=tool_calls,
 			classify_tool=_fake_classify_tool,
+			allow_unconfirmed_inputs=False,
 		)
 		self.assertFalse(result.proposable)
 		self.assertIsNone(result.procedure_graph)
@@ -275,6 +276,257 @@ class TestCompileProcedureFromTraceRefusals(unittest.TestCase):
 			classify_tool=_fake_classify_tool,
 		)
 		self.assertFalse(result.proposable)
+
+
+class TestUnconfirmedInputBindings(unittest.TestCase):
+	"""Tests for the new unconfirmed input binding feature (default allow_unconfirmed_inputs=True)."""
+
+	def test_untraceable_argument_compiles_successfully_by_default(self):
+		"""An opaque value not in prompt, not from earlier output, not a trivial constant
+		should compile successfully by default as an unconfirmed input."""
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "some-opaque-id-not-explained-anywhere"},
+				{"name": "Customer Inc"},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="Look up a customer.",
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable, result.reason)
+		self.assertIsNotNone(result.procedure_graph)
+		self.assertIsNotNone(result.input_schema)
+
+		# The binding should reference an input field
+		first_node = result.procedure_graph["nodes"][0]
+		binding = first_node["config"]["input"]["customer_id"]
+		self.assertEqual(binding, {"$from": "input.customer_id"})
+
+		# The field should be registered with x-confidence: unconfirmed
+		self.assertIn("customer_id", result.input_schema["properties"])
+		self.assertEqual(result.input_schema["properties"]["customer_id"]["x-confidence"], "unconfirmed")
+
+	def test_unconfirmed_input_fields_tracked_in_result(self):
+		"""result.unconfirmed_input_fields should contain the names of all unconfirmed fields."""
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "opaque-id-1"},
+				{"name": "Customer Inc"},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="Look up a customer.",
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable)
+		self.assertIn("customer_id", result.unconfirmed_input_fields)
+
+	def test_clean_trace_has_empty_unconfirmed_input_fields(self):
+		"""A trace with all bindings explained (prompt/earlier-output/trivial) should have
+		empty unconfirmed_input_fields."""
+		prompt = "Look up customer ACME-001 and list their invoices."
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "ACME-001"},
+				{"name": "ACME-001", "customer_name": "Acme Corp"},
+			),
+			_completed_call(
+				"get_sales_invoices",
+				{"customer": "ACME-001", "limit": 0},
+				{"rows": []},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt=prompt,
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable)
+		self.assertEqual(result.unconfirmed_input_fields, ())
+
+	def test_multiple_unconfirmed_inputs_tracked(self):
+		"""Multiple unconfirmed inputs should all appear in unconfirmed_input_fields."""
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "opaque-id-1"},
+				{"name": "Customer Inc"},
+			),
+			_completed_call(
+				"get_sales_invoices",
+				{"customer": "ACME-001", "limit": 50},
+				{"rows": []},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="Look up some info.",  # doesn't mention the opaque IDs or limit value
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable)
+		# customer_id should be unconfirmed (opaque)
+		# customer should be unconfirmed (not in prompt, not from earlier output)
+		# limit should NOT be unconfirmed (it's a trivial constant: 0 is in trivial list? no, 50 is not trivial)
+		# Actually, 50 is not a trivial constant, and not in prompt, and not from earlier output
+		# So both customer_id, customer, and limit should be unconfirmed
+		self.assertIn("customer_id", result.unconfirmed_input_fields)
+		# customer appears in result prompt so it might not be unconfirmed -- let me check
+		# The prompt is "Look up some info" which doesn't contain "ACME-001" or "50"
+		# So customer (ACME-001) should be unconfirmed
+		# And limit (50) should be unconfirmed since 50 is not trivial
+		self.assertIn("customer", result.unconfirmed_input_fields)
+		self.assertIn("limit", result.unconfirmed_input_fields)
+
+	def test_x_confidence_always_present_in_input_schema(self):
+		"""Even prompt-derived fields should always have 'x-confidence' key present in properties."""
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "ACME-001"},
+				{"name": "ACME-001"},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="Look up customer ACME-001.",
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable)
+
+		# customer_id is prompt-derived
+		customer_id_prop = result.input_schema["properties"]["customer_id"]
+		self.assertIn("x-confidence", customer_id_prop)
+		self.assertEqual(customer_id_prop["x-confidence"], "prompt")
+
+	def test_field_name_collision_with_different_confidence_levels(self):
+		"""When two arguments both snake_case to the same field name but have different
+		confidence levels, they should get distinct suffixed names."""
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "ACME-001"},  # from prompt
+				{"name": "ACME-001", "internal_id": "INT-123"},
+			),
+			_completed_call(
+				"get_sales_invoices",
+				{"customer_id": "some-opaque-id"},  # unconfirmed (not in prompt, not from earlier output)
+				{"rows": []},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="Look up customer ACME-001 and their invoices.",
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable)
+
+		# Should have two distinct fields: customer_id (prompt) and customer_id_2 (unconfirmed)
+		self.assertIn("customer_id", result.input_schema["properties"])
+		self.assertIn("customer_id_2", result.input_schema["properties"])
+
+		# Check confidence levels
+		self.assertEqual(
+			result.input_schema["properties"]["customer_id"]["x-confidence"],
+			"prompt"
+		)
+		self.assertEqual(
+			result.input_schema["properties"]["customer_id_2"]["x-confidence"],
+			"unconfirmed"
+		)
+
+		# Check that the nodes reference the correct fields
+		first_node = result.procedure_graph["nodes"][0]
+		second_node = result.procedure_graph["nodes"][1]
+
+		self.assertEqual(
+			first_node["config"]["input"]["customer_id"],
+			{"$from": "input.customer_id"}
+		)
+		self.assertEqual(
+			second_node["config"]["input"]["customer_id"],
+			{"$from": "input.customer_id_2"}
+		)
+
+	def test_field_name_collision_with_same_value_reuses_field(self):
+		"""When two arguments both snake_case to the same field name AND were bound
+		from the SAME underlying value, they should reuse the same field (no suffix)
+		-- it's genuinely one input, just referenced from two steps."""
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "ACME-001"},  # from prompt
+				{"name": "ACME-001"},
+			),
+			_completed_call(
+				"create_todo",
+				{"customer_id": "ACME-001"},  # also from earlier output (first node's name)
+				{"name": "TODO-001"},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="Look up customer ACME-001 and create a todo.",
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable)
+
+		# Should have only one customer_id field (both bindings reuse it)
+		self.assertIn("customer_id", result.input_schema["properties"])
+		# Count occurrences of customer_id_* fields
+		customer_id_fields = [k for k in result.input_schema["properties"].keys() if k.startswith("customer_id")]
+		self.assertEqual(len(customer_id_fields), 1, "Should have exactly one customer_id field")
+
+	def test_field_name_collision_with_same_confidence_but_different_values_disambiguates(self):
+		"""Regression guard: two DIFFERENT tool-call arguments can share both a
+		snake_case name AND a confidence level (e.g. two ``doctype`` args, both
+		unconfirmed, for two different doctypes) while meaning genuinely different
+		things. Confidence-only matching would silently merge them into one
+		user-supplied field, discarding the second call's own value and feeding
+		both tool calls whatever the user types once at run time -- exactly the
+		"looks deterministic but bakes in a wrong assumption" failure this module
+		exists to avoid. They must get distinct fields instead."""
+		tool_calls = [
+			_completed_call(
+				"frappe_list_records",
+				{"doctype": "User"},  # unconfirmed: not in prompt, no earlier output, not trivial
+				{"rows": []},
+			),
+			_completed_call(
+				"frappe_list_records",
+				{"doctype": "Role"},  # unconfirmed too, but a genuinely different value
+				{"rows": []},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="List some records for me.",
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable, result.reason)
+
+		self.assertIn("doctype", result.input_schema["properties"])
+		self.assertIn("doctype_2", result.input_schema["properties"])
+		self.assertEqual(result.input_schema["properties"]["doctype"]["x-confidence"], "unconfirmed")
+		self.assertEqual(result.input_schema["properties"]["doctype_2"]["x-confidence"], "unconfirmed")
+		self.assertEqual(set(result.unconfirmed_input_fields), {"doctype", "doctype_2"})
+
+		first_node, second_node = result.procedure_graph["nodes"][0], result.procedure_graph["nodes"][1]
+		self.assertEqual(first_node["config"]["input"]["doctype"], {"$from": "input.doctype"})
+		self.assertEqual(second_node["config"]["input"]["doctype"], {"$from": "input.doctype_2"})
 
 
 class TestSnakeCase(unittest.TestCase):
@@ -353,6 +605,43 @@ class TestBuildProcedureDocumentPayload(unittest.TestCase):
 				procedure_name="Look up a customer",
 				classify_tool=_fake_classify_tool,
 			)
+
+	def test_graph_with_unconfirmed_inputs_builds_payload(self):
+		"""Verify that a graph with unconfirmed input fields (containing x-confidence key)
+		successfully passes re-validation and builds a payload."""
+		tool_calls = [
+			_completed_call(
+				"get_customer",
+				{"customer_id": "some-opaque-id"},
+				{"name": "Customer Inc"},
+			),
+		]
+		result = compile_procedure_from_trace(
+			prompt="Look up a customer.",
+			response="",
+			tool_calls=tool_calls,
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertTrue(result.proposable, result.reason)
+		self.assertIn("customer_id", result.unconfirmed_input_fields)
+
+		# The graph should have x-confidence in the input_schema properties
+		self.assertEqual(
+			result.procedure_graph["contract"]["input_schema"]["properties"]["customer_id"]["x-confidence"],
+			"unconfirmed"
+		)
+
+		# _build_procedure_document_payload should accept the graph without error
+		payload = _build_procedure_document_payload(
+			agent_run_name="AR-0001",
+			procedure_graph=result.procedure_graph,
+			procedure_name="Look up customer",
+			classify_tool=_fake_classify_tool,
+		)
+		self.assertEqual(payload["doctype"], "Agent Procedure")
+		self.assertEqual(payload["procedure_id"], "AR-0001-procedure")
+		self.assertEqual(payload["tier"], "Draft")
+		self.assertEqual(payload["status"], "Draft")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #692. #691 (`fix(procedure-proposal): unconfirmed-input binding instead of all-or-nothing refusal`) landed directly on `develop` while #692 was in flight, re-opening a 566-line gap across 7 files in the procedure-proposal path.

Clean merge, no conflicts.

- [x] `npm ci`
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 238 tests across 27 files, all passing
- [x] `npm run build` — full production build succeeds