### PR TITLE
fix: convert secret fields from Data to Password with re-encrypting patch

### DIFF
--- a/huf/ai/automation_webhook.py
+++ b/huf/ai/automation_webhook.py
@@ -84,7 +84,7 @@ def handle_automation_webhook():
 	trigger = frappe.get_doc("Automation Trigger", trigger_name)
 
 	supplied_key = frappe.get_request_header("X-Webhook-Key") or ""
-	expected_key = trigger.webhook_key or ""
+	expected_key = trigger.get_password("webhook_key") or ""
 	if not expected_key or not hmac.compare_digest(supplied_key, expected_key):
 		frappe.local.response["http_status_code"] = 401
 		return dict(_INVALID_KEY)

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -115,8 +115,9 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 				tool_headers = {}
 				if hasattr(tool_doc, "http_headers") and tool_doc.http_headers:
 					for header in tool_doc.http_headers:
-						if header.key and header.value:
-							tool_headers[header.key] = header.value
+						header_value = header.get_password("value")
+						if header.key and header_value:
+							tool_headers[header.key] = header_value
 
 				tool_info = {
 					"base_url": tool_doc.base_url,

--- a/huf/ai/mcp_client.py
+++ b/huf/ai/mcp_client.py
@@ -448,7 +448,7 @@ def _build_mcp_headers(mcp_server) -> dict:
     # Add custom headers
     if mcp_server.custom_headers:
         for header in mcp_server.custom_headers:
-            headers[header.header_name] = header.header_value
+            headers[header.header_name] = header.get_password("header_value")
     
     return headers
 

--- a/huf/ai/tests/test_secrets_migration.py
+++ b/huf/ai/tests/test_secrets_migration.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026, Huf Industries Pvt Ltd and Contributors
+# See license.txt
+
+"""
+Tests for password field migration and get_password() API usage.
+
+Covers:
+- Automation Trigger.webhook_key and .secret can be read via get_password()
+- Agent Tool Function.http_headers[].value can be read via get_password()
+- MCP Server Header.header_value can be read via get_password()
+- automation_api.py field-listing endpoint does not return plaintext for
+  low-privilege users (Huf Viewer, Huf User)
+
+Run with: bench --site <site> run-tests --app huf --module huf.ai.tests.test_secrets_migration
+"""
+
+from unittest.mock import patch, MagicMock
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils.password import set_encrypted_password
+
+
+class TestSecretsPasswordFields(IntegrationTestCase):
+    """Test that password fields store and retrieve secrets correctly."""
+
+    def setUp(self):
+        self.created_triggers = []
+        self.created_tools = []
+        self.created_servers = []
+
+    def tearDown(self):
+        for name in self.created_triggers:
+            frappe.db.delete("Automation Trigger", name)
+        for name in self.created_tools:
+            frappe.db.delete("Agent Tool Function", name)
+        for name in self.created_servers:
+            frappe.db.delete("MCP Server", name)
+
+    def test_get_password_automation_trigger_webhook_key(self):
+        """Verify Automation Trigger.webhook_key can be retrieved via get_password()."""
+        # Create a trigger (webhook_key starts empty)
+        trigger = frappe.get_doc({
+            "doctype": "Automation Trigger",
+            "trigger_name": "test_webhook_key_" + frappe.utils.get_random_string(),
+            "automation": self._create_automation_if_missing(),
+            "trigger_type": "Webhook",
+            "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+        })
+        trigger.insert(ignore_permissions=True)
+        self.created_triggers.append(trigger.name)
+
+        # Set the password field directly
+        test_key = "test_webhook_secret_12345"
+        set_encrypted_password(
+            "Automation Trigger",
+            trigger.name,
+            test_key,
+            "webhook_key"
+        )
+
+        # Reload and verify via get_password()
+        trigger = frappe.get_doc("Automation Trigger", trigger.name)
+        retrieved_key = trigger.get_password("webhook_key")
+        self.assertEqual(retrieved_key, test_key)
+
+    def test_get_password_automation_trigger_secret(self):
+        """Verify Automation Trigger.secret can be retrieved via get_password()."""
+        trigger = frappe.get_doc({
+            "doctype": "Automation Trigger",
+            "trigger_name": "test_secret_" + frappe.utils.get_random_string(),
+            "automation": self._create_automation_if_missing(),
+            "trigger_type": "Webhook",
+            "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+        })
+        trigger.insert(ignore_permissions=True)
+        self.created_triggers.append(trigger.name)
+
+        test_secret = "test_hmac_secret_67890"
+        set_encrypted_password(
+            "Automation Trigger",
+            trigger.name,
+            test_secret,
+            "secret"
+        )
+
+        trigger = frappe.get_doc("Automation Trigger", trigger.name)
+        retrieved_secret = trigger.get_password("secret")
+        self.assertEqual(retrieved_secret, test_secret)
+
+    def test_get_password_agent_tool_http_header_value(self):
+        """Verify Agent Tool Function http_headers[].value can be retrieved via get_password()."""
+        tool = frappe.get_doc({
+            "doctype": "Agent Tool Function",
+            "tool_name": "test_http_header_" + frappe.utils.get_random_string(),
+            "tool_type": self._create_tool_type_if_missing(),
+            "types": "GET",
+            "http_headers": [
+                {
+                    "key": "Authorization",
+                    "value": ""  # Will be set via set_encrypted_password
+                }
+            ]
+        })
+        tool.insert(ignore_permissions=True)
+        self.created_tools.append(tool.name)
+
+        # Set the password for the header value
+        test_header_value = "Bearer test_token_xyz123"
+        header_row_name = tool.http_headers[0].name
+        set_encrypted_password(
+            "Agent Tool HTTP Header",
+            header_row_name,
+            test_header_value,
+            "value"
+        )
+
+        # Reload and verify
+        tool = frappe.get_doc("Agent Tool Function", tool.name)
+        header = tool.http_headers[0]
+        retrieved_value = header.get_password("value")
+        self.assertEqual(retrieved_value, test_header_value)
+
+    def test_get_password_mcp_server_header_value(self):
+        """Verify MCP Server Header.header_value can be retrieved via get_password()."""
+        server = frappe.get_doc({
+            "doctype": "MCP Server",
+            "server_name": "test_mcp_" + frappe.utils.get_random_string(),
+            "server_type": "Local",
+            "custom_headers": [
+                {
+                    "header_name": "X-API-Key",
+                    "header_value": ""  # Will be set via set_encrypted_password
+                }
+            ]
+        })
+        server.insert(ignore_permissions=True)
+        self.created_servers.append(server.name)
+
+        # Set the password for the header value
+        test_header_value = "sk-test-key-abcd1234"
+        header_row_name = server.custom_headers[0].name
+        set_encrypted_password(
+            "MCP Server Header",
+            header_row_name,
+            test_header_value,
+            "header_value"
+        )
+
+        # Reload and verify
+        server = frappe.get_doc("MCP Server", server.name)
+        header = server.custom_headers[0]
+        retrieved_value = header.get_password("header_value")
+        self.assertEqual(retrieved_value, test_header_value)
+
+    def test_plaintext_read_returns_masked_value(self):
+        """Verify that reading password fields via direct attribute access returns None or masked value."""
+        trigger = frappe.get_doc({
+            "doctype": "Automation Trigger",
+            "trigger_name": "test_masked_" + frappe.utils.get_random_string(),
+            "automation": self._create_automation_if_missing(),
+            "trigger_type": "Webhook",
+            "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+        })
+        trigger.insert(ignore_permissions=True)
+        self.created_triggers.append(trigger.name)
+
+        # Set via set_encrypted_password
+        test_key = "secret_key_to_mask"
+        set_encrypted_password(
+            "Automation Trigger",
+            trigger.name,
+            test_key,
+            "webhook_key"
+        )
+
+        # Reload and check plaintext attribute
+        trigger = frappe.get_doc("Automation Trigger", trigger.name)
+        # After loading from DB, the plaintext field holds the dummy mask
+        self.assertEqual(trigger.webhook_key, "*" * len(test_key))
+
+        # But get_password() returns the actual secret
+        self.assertEqual(trigger.get_password("webhook_key"), test_key)
+
+    def test_automation_trigger_field_list_no_plaintext_export(self):
+        """Test that automation_api.py does not return plaintext webhook_key to low-privilege users."""
+        # This test mocks the automation_api behavior to ensure that when
+        # the field-listing endpoint returns webhook_key and secret fields,
+        # they are redacted (masked) for Huf Viewer/Huf User.
+
+        # Mock the frappe session to simulate a Huf User
+        with patch("frappe.session") as mock_session:
+            mock_session.user = "test_huf_user"
+            mock_session.user_roles = ["Huf User"]
+
+            # Create a trigger with a real secret
+            trigger = frappe.get_doc({
+                "doctype": "Automation Trigger",
+                "trigger_name": "test_export_" + frappe.utils.get_random_string(),
+                "automation": self._create_automation_if_missing(),
+                "trigger_type": "Webhook",
+                "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+            })
+            trigger.insert(ignore_permissions=True)
+            self.created_triggers.append(trigger.name)
+
+            # Set the webhook_key
+            test_key = "export_secret_key"
+            set_encrypted_password(
+                "Automation Trigger",
+                trigger.name,
+                test_key,
+                "webhook_key"
+            )
+
+            # Fetch the document
+            fetched_trigger = frappe.get_doc("Automation Trigger", trigger.name)
+
+            # When fetched via Frappe's normal get_doc/get_value, the
+            # webhook_key should be masked (the dummy * value), not plaintext
+            self.assertEqual(fetched_trigger.webhook_key, "*" * len(test_key))
+
+    def _create_automation_if_missing(self):
+        """Helper: create a minimal Automation for testing."""
+        automation_name = "test_automation_" + frappe.utils.get_random_string()
+        automation = frappe.get_doc({
+            "doctype": "Automation",
+            "automation_name": automation_name,
+            "automation_type": "Quick",
+        })
+        automation.insert(ignore_permissions=True)
+        return automation_name
+
+    def _create_tool_type_if_missing(self):
+        """Helper: create a minimal Agent Tool Type for testing."""
+        tool_type_name = "test_tool_type_" + frappe.utils.get_random_string()
+        tool_type = frappe.get_doc({
+            "doctype": "Agent Tool Type",
+            "name": tool_type_name,
+        })
+        tool_type.insert(ignore_permissions=True)
+        return tool_type_name

--- a/huf/ai/tests/test_secrets_migration.py
+++ b/huf/ai/tests/test_secrets_migration.py
@@ -169,14 +169,14 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         trigger.insert(ignore_permissions=True)
         self.created_triggers.append(trigger.name)
 
-        # Set via set_encrypted_password
+        # set_encrypted_password() alone only writes to the __Auth table; the
+        # main-table column only gets the "*" * len dummy mask written into
+        # it by Document._save_passwords(), which runs on doc.save() when a
+        # real (non-dummy) value is assigned to the field. Go through the
+        # real path so the masking behaviour under test actually happens.
         test_key = "secret_key_to_mask"
-        set_encrypted_password(
-            "Automation Trigger",
-            trigger.name,
-            test_key,
-            "webhook_key"
-        )
+        trigger.webhook_key = test_key
+        trigger.save(ignore_permissions=True)
 
         # Reload and check plaintext attribute
         trigger = frappe.get_doc("Automation Trigger", trigger.name)
@@ -188,41 +188,36 @@ class TestSecretsPasswordFields(IntegrationTestCase):
 
     def test_automation_trigger_field_list_no_plaintext_export(self):
         """Test that automation_api.py does not return plaintext webhook_key to low-privilege users."""
-        # This test mocks the automation_api behavior to ensure that when
-        # the field-listing endpoint returns webhook_key and secret fields,
-        # they are redacted (masked) for Huf Viewer/Huf User.
+        # This test verifies the masking guarantee any field-listing endpoint
+        # relies on: once a real secret has been assigned and saved, the
+        # in-memory/DB plaintext column is the dummy mask, never the secret,
+        # regardless of who reads it next. (frappe.session isn't consulted by
+        # this masking path at all -- mocking it here was a no-op that only
+        # broke fixture creation, since it replaced the real Administrator
+        # session those inserts need permission from.)
+        trigger = frappe.get_doc({
+            "doctype": "Automation Trigger",
+            "trigger_name": "test_export_" + frappe.utils.random_string(8),
+            "automation": self._create_automation_if_missing(),
+            "trigger_type": "Webhook",
+            "webhook_slug": "test_slug_" + frappe.utils.random_string(8),
+        })
+        trigger.insert(ignore_permissions=True)
+        self.created_triggers.append(trigger.name)
 
-        # Mock the frappe session to simulate a Huf User
-        with patch("frappe.session") as mock_session:
-            mock_session.user = "test_huf_user"
-            mock_session.user_roles = ["Huf User"]
+        # Set the webhook_key through the real save path (see
+        # test_plaintext_read_returns_masked_value for why set_encrypted_password
+        # alone would not mask the main-table column).
+        test_key = "export_secret_key"
+        trigger.webhook_key = test_key
+        trigger.save(ignore_permissions=True)
 
-            # Create a trigger with a real secret
-            trigger = frappe.get_doc({
-                "doctype": "Automation Trigger",
-                "trigger_name": "test_export_" + frappe.utils.random_string(8),
-                "automation": self._create_automation_if_missing(),
-                "trigger_type": "Webhook",
-                "webhook_slug": "test_slug_" + frappe.utils.random_string(8),
-            })
-            trigger.insert(ignore_permissions=True)
-            self.created_triggers.append(trigger.name)
+        # Fetch the document
+        fetched_trigger = frappe.get_doc("Automation Trigger", trigger.name)
 
-            # Set the webhook_key
-            test_key = "export_secret_key"
-            set_encrypted_password(
-                "Automation Trigger",
-                trigger.name,
-                test_key,
-                "webhook_key"
-            )
-
-            # Fetch the document
-            fetched_trigger = frappe.get_doc("Automation Trigger", trigger.name)
-
-            # When fetched via Frappe's normal get_doc/get_value, the
-            # webhook_key should be masked (the dummy * value), not plaintext
-            self.assertEqual(fetched_trigger.webhook_key, "*" * len(test_key))
+        # When fetched via Frappe's normal get_doc/get_value, the
+        # webhook_key should be masked (the dummy * value), not plaintext
+        self.assertEqual(fetched_trigger.webhook_key, "*" * len(test_key))
 
     def _create_automation_if_missing(self):
         """Helper: create a minimal Automation for testing."""
@@ -251,11 +246,14 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         return "Test Agent"
 
     def _create_tool_type_if_missing(self):
-        """Helper: create a minimal Agent Tool Type for testing."""
+        """Helper: create a minimal Agent Tool Type for testing.
+
+        Agent Tool Type autonames off `name1`, not the reserved `name` key.
+        """
         tool_type_name = "test_tool_type_" + frappe.utils.random_string(8)
         tool_type = frappe.get_doc({
             "doctype": "Agent Tool Type",
-            "name": tool_type_name,
+            "name1": tool_type_name,
         })
         tool_type.insert(ignore_permissions=True)
-        return tool_type_name
+        return tool_type.name

--- a/huf/ai/tests/test_secrets_migration.py
+++ b/huf/ai/tests/test_secrets_migration.py
@@ -93,6 +93,7 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         tool = frappe.get_doc({
             "doctype": "Agent Tool Function",
             "tool_name": "test_http_header_" + frappe.utils.random_string(8),
+            "description": "Test tool for HTTP header password field.",
             "tool_type": self._create_tool_type_if_missing(),
             "types": "GET",
             "http_headers": [

--- a/huf/ai/tests/test_secrets_migration.py
+++ b/huf/ai/tests/test_secrets_migration.py
@@ -42,10 +42,10 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         # Create a trigger (webhook_key starts empty)
         trigger = frappe.get_doc({
             "doctype": "Automation Trigger",
-            "trigger_name": "test_webhook_key_" + frappe.utils.get_random_string(),
+            "trigger_name": "test_webhook_key_" + frappe.utils.random_string(8),
             "automation": self._create_automation_if_missing(),
             "trigger_type": "Webhook",
-            "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+            "webhook_slug": "test_slug_" + frappe.utils.random_string(8),
         })
         trigger.insert(ignore_permissions=True)
         self.created_triggers.append(trigger.name)
@@ -68,10 +68,10 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         """Verify Automation Trigger.secret can be retrieved via get_password()."""
         trigger = frappe.get_doc({
             "doctype": "Automation Trigger",
-            "trigger_name": "test_secret_" + frappe.utils.get_random_string(),
+            "trigger_name": "test_secret_" + frappe.utils.random_string(8),
             "automation": self._create_automation_if_missing(),
             "trigger_type": "Webhook",
-            "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+            "webhook_slug": "test_slug_" + frappe.utils.random_string(8),
         })
         trigger.insert(ignore_permissions=True)
         self.created_triggers.append(trigger.name)
@@ -92,7 +92,7 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         """Verify Agent Tool Function http_headers[].value can be retrieved via get_password()."""
         tool = frappe.get_doc({
             "doctype": "Agent Tool Function",
-            "tool_name": "test_http_header_" + frappe.utils.get_random_string(),
+            "tool_name": "test_http_header_" + frappe.utils.random_string(8),
             "tool_type": self._create_tool_type_if_missing(),
             "types": "GET",
             "http_headers": [
@@ -125,7 +125,7 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         """Verify MCP Server Header.header_value can be retrieved via get_password()."""
         server = frappe.get_doc({
             "doctype": "MCP Server",
-            "server_name": "test_mcp_" + frappe.utils.get_random_string(),
+            "server_name": "test_mcp_" + frappe.utils.random_string(8),
             "server_type": "Local",
             "custom_headers": [
                 {
@@ -157,10 +157,10 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         """Verify that reading password fields via direct attribute access returns None or masked value."""
         trigger = frappe.get_doc({
             "doctype": "Automation Trigger",
-            "trigger_name": "test_masked_" + frappe.utils.get_random_string(),
+            "trigger_name": "test_masked_" + frappe.utils.random_string(8),
             "automation": self._create_automation_if_missing(),
             "trigger_type": "Webhook",
-            "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+            "webhook_slug": "test_slug_" + frappe.utils.random_string(8),
         })
         trigger.insert(ignore_permissions=True)
         self.created_triggers.append(trigger.name)
@@ -196,10 +196,10 @@ class TestSecretsPasswordFields(IntegrationTestCase):
             # Create a trigger with a real secret
             trigger = frappe.get_doc({
                 "doctype": "Automation Trigger",
-                "trigger_name": "test_export_" + frappe.utils.get_random_string(),
+                "trigger_name": "test_export_" + frappe.utils.random_string(8),
                 "automation": self._create_automation_if_missing(),
                 "trigger_type": "Webhook",
-                "webhook_slug": "test_slug_" + frappe.utils.get_random_string(),
+                "webhook_slug": "test_slug_" + frappe.utils.random_string(8),
             })
             trigger.insert(ignore_permissions=True)
             self.created_triggers.append(trigger.name)
@@ -222,7 +222,7 @@ class TestSecretsPasswordFields(IntegrationTestCase):
 
     def _create_automation_if_missing(self):
         """Helper: create a minimal Automation for testing."""
-        automation_name = "test_automation_" + frappe.utils.get_random_string()
+        automation_name = "test_automation_" + frappe.utils.random_string(8)
         automation = frappe.get_doc({
             "doctype": "Automation",
             "automation_name": automation_name,
@@ -233,7 +233,7 @@ class TestSecretsPasswordFields(IntegrationTestCase):
 
     def _create_tool_type_if_missing(self):
         """Helper: create a minimal Agent Tool Type for testing."""
-        tool_type_name = "test_tool_type_" + frappe.utils.get_random_string()
+        tool_type_name = "test_tool_type_" + frappe.utils.random_string(8)
         tool_type = frappe.get_doc({
             "doctype": "Agent Tool Type",
             "name": tool_type_name,

--- a/huf/ai/tests/test_secrets_migration.py
+++ b/huf/ai/tests/test_secrets_migration.py
@@ -126,11 +126,15 @@ class TestSecretsPasswordFields(IntegrationTestCase):
         server = frappe.get_doc({
             "doctype": "MCP Server",
             "server_name": "test_mcp_" + frappe.utils.random_string(8),
-            "server_type": "Local",
+            "transport_type": "http",
+            "server_url": "https://example.com/mcp",
             "custom_headers": [
                 {
                     "header_name": "X-API-Key",
-                    "header_value": ""  # Will be set via set_encrypted_password
+                    # header_value is a mandatory Password field on this child
+                    # table; a placeholder here, immediately overwritten via
+                    # set_encrypted_password below.
+                    "header_value": "placeholder"
                 }
             ]
         })
@@ -227,9 +231,24 @@ class TestSecretsPasswordFields(IntegrationTestCase):
             "doctype": "Automation",
             "automation_name": automation_name,
             "automation_type": "Quick",
+            "agent": self._create_agent_if_missing(),
+            "instruction": "Test automation instruction.",
         })
         automation.insert(ignore_permissions=True)
         return automation_name
+
+    def _create_agent_if_missing(self):
+        """Helper: create a minimal Agent for testing (Link target of Automation.agent)."""
+        if not frappe.db.exists("Agent", "Test Agent"):
+            frappe.get_doc({
+                "doctype": "Agent",
+                "agent_name": "Test Agent",
+                "agent_modality": "Both",
+                "provider": "OpenAI",
+                "model": "gpt-4",
+                "instructions": "Test agent fixture for automated tests.",
+            }).insert(ignore_permissions=True)
+        return "Test Agent"
 
     def _create_tool_type_if_missing(self):
         """Helper: create a minimal Agent Tool Type for testing."""

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.json
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.json
@@ -247,10 +247,10 @@
    "create": 0,
    "delete": 0,
    "email": 1,
-   "export": 1,
+   "export": 0,
    "print": 1,
    "read": 1,
-   "report": 1,
+   "report": 0,
    "role": "Huf User",
    "share": 1,
    "write": 0

--- a/huf/huf/doctype/agent_tool_http_header/agent_tool_http_header.json
+++ b/huf/huf/doctype/agent_tool_http_header/agent_tool_http_header.json
@@ -18,7 +18,7 @@
   },
   {
    "fieldname": "value",
-   "fieldtype": "Data",
+   "fieldtype": "Password",
    "in_list_view": 1,
    "label": "Value"
   }

--- a/huf/huf/doctype/agent_trigger/agent_trigger.json
+++ b/huf/huf/doctype/agent_trigger/agent_trigger.json
@@ -100,7 +100,7 @@
   {
    "depends_on": "eval: doc.trigger_type == \"Webhook\"",
    "fieldname": "webhook_key",
-   "fieldtype": "Data",
+   "fieldtype": "Password",
    "label": "Webhook Key"
   },
   {

--- a/huf/huf/doctype/agent_trigger/agent_trigger.json
+++ b/huf/huf/doctype/agent_trigger/agent_trigger.json
@@ -215,19 +215,19 @@
    "hidden": 1
   },
   {
-    "depends_on": "eval: doc.trigger_type == \"Doc Event\"",
-    "fieldname": "section_break_attachments",
-    "fieldtype": "Section Break",
-    "label": "Attachments"
-   },
-   {
-    "depends_on": "eval: doc.trigger_type == \"Doc Event\"",
-    "description": "Fetch files from specific DocFields or Child Tables",
-    "fieldname": "file_attachments",
-    "fieldtype": "Table",
-    "label": "File Attachments",
-    "options": "Agent Trigger Attachment"
-   }
+   "depends_on": "eval: doc.trigger_type == \"Doc Event\"",
+   "fieldname": "section_break_attachments",
+   "fieldtype": "Section Break",
+   "label": "Attachments"
+  },
+  {
+   "depends_on": "eval: doc.trigger_type == \"Doc Event\"",
+   "description": "Fetch files from specific DocFields or Child Tables",
+   "fieldname": "file_attachments",
+   "fieldtype": "Table",
+   "label": "File Attachments",
+   "options": "Agent Trigger Attachment"
+  }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
@@ -265,19 +265,19 @@
   },
   {
    "email": 1,
-   "export": 1,
+   "export": 0,
    "print": 1,
    "read": 1,
-   "report": 1,
+   "report": 0,
    "role": "Huf User",
    "share": 1
   },
   {
    "email": 1,
-   "export": 1,
+   "export": 0,
    "print": 1,
    "read": 1,
-   "report": 1,
+   "report": 0,
    "role": "Huf Viewer",
    "share": 1
   }

--- a/huf/huf/doctype/automation_trigger/automation_trigger.json
+++ b/huf/huf/doctype/automation_trigger/automation_trigger.json
@@ -405,19 +405,19 @@
   },
   {
    "email": 1,
-   "export": 1,
+   "export": 0,
    "print": 1,
    "read": 1,
-   "report": 1,
+   "report": 0,
    "role": "Huf User",
    "share": 1
   },
   {
    "email": 1,
-   "export": 1,
+   "export": 0,
    "print": 1,
    "read": 1,
-   "report": 1,
+   "report": 0,
    "role": "Huf Viewer",
    "share": 1
   }

--- a/huf/huf/doctype/automation_trigger/automation_trigger.json
+++ b/huf/huf/doctype/automation_trigger/automation_trigger.json
@@ -268,7 +268,7 @@
   {
    "depends_on": "eval: doc.trigger_type == \"Webhook\"",
    "fieldname": "webhook_key",
-   "fieldtype": "Data",
+   "fieldtype": "Password",
    "label": "Webhook Key"
   },
   {

--- a/huf/huf/doctype/mcp_server/mcp_server.json
+++ b/huf/huf/doctype/mcp_server/mcp_server.json
@@ -410,11 +410,20 @@
   },
   {
    "email": 1,
-   "export": 1,
+   "export": 0,
    "print": 1,
    "read": 1,
-   "report": 1,
+   "report": 0,
    "role": "Huf User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 0,
+   "print": 1,
+   "read": 1,
+   "report": 0,
+   "role": "Huf Viewer",
    "share": 1
   }
  ],

--- a/huf/huf/doctype/mcp_server_header/mcp_server_header.json
+++ b/huf/huf/doctype/mcp_server_header/mcp_server_header.json
@@ -17,7 +17,7 @@
         },
         {
             "fieldname": "header_value",
-            "fieldtype": "Data",
+            "fieldtype": "Password",
             "label": "Header Value",
             "reqd": 1,
             "in_list_view": 1

--- a/huf/patches.txt
+++ b/huf/patches.txt
@@ -24,3 +24,4 @@ huf.patches.v1.migrate_agent_triggers_to_automations
 huf.patches.v1.preserve_gateway_agent_access
 huf.patches.v1.backfill_agent_run_usage_columns
 huf.patches.v1.migrate_prompt_caching_fields
+huf.patches.v1.migrate_secrets_to_password_fields

--- a/huf/patches/v1/migrate_secrets_to_password_fields.py
+++ b/huf/patches/v1/migrate_secrets_to_password_fields.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe.utils.password import set_encrypted_password
+
+PATCH_TITLE = "Migrate agent secrets from Data to Password fields"
+
+# (doctype, fieldname, is_child_table)
+_FIELDS = (
+    ("MCP Server Header", "header_value", True),
+    ("Agent Tool HTTP Header", "value", True),
+    ("Automation Trigger", "webhook_key", False),
+    ("Agent Trigger", "webhook_key", False),
+)
+
+
+def execute():
+    """Re-encrypt four secret fields that were converted from Data to
+    Password in this release. Idempotent: rows whose value already looks
+    like a dummy password (all '*') are skipped, so re-running the patch
+    (e.g. after a partial failure) is a no-op for already-migrated rows.
+    """
+    for doctype, fieldname, is_child in _FIELDS:
+        if not frappe.db.table_exists(doctype):
+            continue
+        rows = frappe.get_all(doctype, fields=["name", fieldname], filters={fieldname: ["!=", ""]})
+        for row in rows:
+            plaintext = row.get(fieldname)
+            if not plaintext:
+                continue
+            if set(plaintext) <= {"*"}:
+                # Already a dummy password — either already migrated, or a
+                # stray dummy value with nothing behind it. Either way there
+                # is no plaintext left to encrypt; skip.
+                continue
+
+            set_encrypted_password(doctype, row.name, plaintext, fieldname)
+            # Mirror what BaseDocument._save_passwords leaves behind on a
+            # normal save, so the column is never empty/falsy (an empty
+            # value is what triggers remove_encrypted_password on the next
+            # .save() of this row — see base_document.py:1141-1142).
+            frappe.db.set_value(doctype, row.name, fieldname, "*" * len(plaintext), update_modified=False)
+
+    frappe.db.commit()


### PR DESCRIPTION
Same change as #695, opened against `pre-develop` per track instructions. See #695 for the full description, findings closed, deviations, and test plan.