### PR TITLE
sec: validate App Provided tool paths against hook registry, gate fetch_tool_parameters_from_code

### DIFF
--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -482,7 +482,7 @@ def create_function_tool(
         FunctionTool: Function tool
     """
 
-    function = get_function_from_name(tool_name)
+    function = get_function_from_name(tool_name, tool_type=tool_type)
 
     if not function:
         return None
@@ -592,16 +592,26 @@ def create_function_tool(
         return None
 
 
-def get_function_from_name(tool_name: str) -> Callable:
+def get_function_from_name(tool_name: str, tool_type: str | None = None) -> Callable:
     """
     Get a function from its name
 
     Args:
-        function_name: Fully qualified function name (module.function)
+        tool_name: Fully qualified function name (module.function)
+        tool_type: Optional tool type ("App Provided", "Custom Function", etc.)
+                   When "App Provided", validates against the hook allow-set.
 
     Returns:
-        Callable: Function
+        Callable: Function, or None if not found or validation fails
     """
+
+    if tool_type == "App Provided":
+        from huf.ai.tool_registry import get_hook_declared_function_paths
+        if tool_name not in get_hook_declared_function_paths():
+            frappe.logger("huf").debug(
+                f"App Provided function path not in hook allow-set: {tool_name}"
+            )
+            return None
 
     try:
         try:

--- a/huf/ai/tests/test_agent_tool_function_validation.py
+++ b/huf/ai/tests/test_agent_tool_function_validation.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for Agent Tool Function validation, specifically:
+- ST-05.1: App Provided tool path validation against hook allow-set
+- ST-05.6: Regression tests for F-07 RCE scenario
+
+These tests patch get_hook_declared_function_paths to avoid real hook
+reads and follow the pure-mock convention per PR #597.
+
+Run with: bench --site <site> run-tests --app huf --module huf.ai.tests.test_agent_tool_function_validation
+"""
+import unittest
+from unittest import mock
+
+import frappe
+
+
+class TestAppProvidedToolValidation(unittest.TestCase):
+	"""Test ST-05.1: App Provided tool paths validated against hook allow-set."""
+
+	def test_app_provided_in_allow_set_passes(self):
+		"""
+		App Provided tool whose function_path is in the hook allow-set
+		should pass validation.
+		"""
+		with mock.patch(
+			"huf.huf.doctype.agent_tool_function.agent_tool_function.get_hook_declared_function_paths",
+			return_value={"huf.ai.tools.recipient.handle_get_recipient"},
+		):
+			tool = frappe.new_doc("Agent Tool Function")
+			tool.tool_name = "test_valid_app_provided"
+			tool.types = "App Provided"
+			tool.function_path = "huf.ai.tools.recipient.handle_get_recipient"
+
+			# Should not raise
+			tool.validate()
+
+	def test_app_provided_outside_allow_set_blocked(self):
+		"""
+		Regression test for F-07: an App Provided tool whose function_path is
+		not declared by any installed app's huf_tools hook is rejected at
+		validation time. This is a frappe.throw() with no explicit exception
+		class, i.e. frappe.ValidationError -- NOT frappe.PermissionError,
+		which is what is_whitelisted() raises for the (separate) Custom
+		Function branch. See ST-05.1.
+		"""
+		with mock.patch(
+			"huf.huf.doctype.agent_tool_function.agent_tool_function.get_hook_declared_function_paths",
+			return_value={"huf.ai.tools.recipient.handle_get_recipient"},
+		):
+			tool = frappe.new_doc("Agent Tool Function")
+			tool.tool_name = "test_rce"
+			tool.types = "App Provided"
+			tool.function_path = "subprocess.getoutput"
+
+			with self.assertRaises(frappe.ValidationError):
+				tool.save()
+
+	def test_custom_function_non_whitelisted_blocked(self):
+		"""
+		Pre-existing behaviour, confirm unchanged: Custom Function still
+		goes through is_whitelisted(), which raises frappe.PermissionError
+		(frappe/__init__.py:878-892), not frappe.ValidationError.
+		"""
+		tool = frappe.new_doc("Agent Tool Function")
+		tool.tool_name = "test_custom_rce"
+		tool.types = "Custom Function"
+		tool.function_path = "subprocess.getoutput"
+
+		with self.assertRaises(frappe.PermissionError):
+			tool.save()

--- a/huf/ai/tests/test_agent_tool_function_validation.py
+++ b/huf/ai/tests/test_agent_tool_function_validation.py
@@ -60,11 +60,19 @@ class TestAppProvidedToolValidation(unittest.TestCase):
 		Pre-existing behaviour, confirm unchanged: Custom Function still
 		goes through is_whitelisted(), which raises frappe.PermissionError
 		(frappe/__init__.py:878-892), not frappe.ValidationError.
+
+		function_path must be something frappe.get_attr() can actually
+		resolve -- it requires "<installed_app>.<module>...<attr>" and
+		raises AppNotInstalledError (a ValidationError subclass) before
+		is_whitelisted() is ever reached for a path like "subprocess.getoutput"
+		whose first segment isn't an installed app. Use a real, resolvable,
+		but never-whitelisted frappe function instead so this test actually
+		exercises is_whitelisted()'s PermissionError.
 		"""
 		tool = frappe.new_doc("Agent Tool Function")
 		tool.tool_name = "test_custom_rce"
 		tool.types = "Custom Function"
-		tool.function_path = "subprocess.getoutput"
+		tool.function_path = "frappe.utils.random_string"
 
 		with self.assertRaises(frappe.PermissionError):
 			tool.save()

--- a/huf/ai/tests/test_fetch_tool_parameters_authorization.py
+++ b/huf/ai/tests/test_fetch_tool_parameters_authorization.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for fetch_tool_parameters_from_code authorization, specifically:
+- ST-05.3: frappe.only_for("Huf Manager") gate
+- ST-05.7: Regression test for F-19 endpoint authorization
+
+The function is a module-level whitelisted endpoint, not an Agent Tool Function
+document method. It requires the Huf Manager role.
+
+Run with: bench --site <site> run-tests --app huf --module huf.ai.tests.test_fetch_tool_parameters_authorization
+"""
+import unittest
+
+import frappe
+
+
+class TestFetchToolParametersAuthorization(unittest.TestCase):
+	"""Test ST-05.3/ST-05.7: fetch_tool_parameters_from_code authorization."""
+
+	def setUp(self):
+		"""Save current user to restore after test."""
+		self.current_user = frappe.session.user
+
+	def tearDown(self):
+		"""Restore user after test."""
+		frappe.set_user(self.current_user)
+
+	def test_fetch_tool_parameters_requires_huf_manager(self):
+		"""
+		Regression test for F-19 (the fetch_tool_parameters_from_code slice):
+		the endpoint now requires the Huf Manager role. It is a module-level
+		function taking function_path, not an AgentToolFunction method --
+		huf/huf/doctype/agent_tool_function/agent_tool_function.py:124.
+		"""
+		from huf.huf.doctype.agent_tool_function.agent_tool_function import (
+			fetch_tool_parameters_from_code,
+		)
+
+		# Create or use a test user with only Huf User role
+		frappe.set_user("test_huf_user@example.com")
+		with self.assertRaises(frappe.PermissionError):
+			fetch_tool_parameters_from_code("frappe.throw")
+
+		# Create or use a test user with Huf Manager role
+		frappe.set_user("test_huf_manager@example.com")
+		result = fetch_tool_parameters_from_code("frappe.throw")
+		self.assertIsNotNone(result)

--- a/huf/ai/tests/test_fetch_tool_parameters_authorization.py
+++ b/huf/ai/tests/test_fetch_tool_parameters_authorization.py
@@ -20,9 +20,30 @@ class TestFetchToolParametersAuthorization(unittest.TestCase):
 		"""Save current user to restore after test."""
 		self.current_user = frappe.session.user
 
+		# frappe.only_for() unconditionally no-ops when frappe.flags.in_test
+		# is set (frappe/__init__.py:954), which bench run-tests sets for the
+		# whole run -- so this gate can never actually be exercised without
+		# temporarily clearing that flag around the calls under test.
+		self.original_in_test = frappe.flags.in_test
+		frappe.flags.in_test = False
+
+		for email, roles in (
+			("test_huf_user@example.com", ["Huf User"]),
+			("test_huf_manager@example.com", ["Huf Manager"]),
+		):
+			if not frappe.db.exists("User", email):
+				frappe.get_doc({
+					"doctype": "User",
+					"email": email,
+					"first_name": email.split("@")[0],
+					"send_welcome_email": 0,
+					"roles": [{"role": r} for r in roles],
+				}).insert(ignore_permissions=True)
+
 	def tearDown(self):
-		"""Restore user after test."""
+		"""Restore user and in_test flag after test."""
 		frappe.set_user(self.current_user)
+		frappe.flags.in_test = self.original_in_test
 
 	def test_fetch_tool_parameters_requires_huf_manager(self):
 		"""
@@ -35,12 +56,12 @@ class TestFetchToolParametersAuthorization(unittest.TestCase):
 			fetch_tool_parameters_from_code,
 		)
 
-		# Create or use a test user with only Huf User role
+		# User with only Huf User role must be rejected
 		frappe.set_user("test_huf_user@example.com")
 		with self.assertRaises(frappe.PermissionError):
 			fetch_tool_parameters_from_code("frappe.throw")
 
-		# Create or use a test user with Huf Manager role
+		# User with Huf Manager role must be allowed
 		frappe.set_user("test_huf_manager@example.com")
 		result = fetch_tool_parameters_from_code("frappe.throw")
 		self.assertIsNotNone(result)

--- a/huf/ai/tests/test_tool_invocation_runtime.py
+++ b/huf/ai/tests/test_tool_invocation_runtime.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for runtime tool invocation with the allow-set guard, specifically:
+- ST-05.2: Runtime allow-set guard in get_function_from_name()
+
+These tests use pure-mock for get_hook_declared_function_paths to avoid real
+hook reads and follow the pure-mock convention per PR #597.
+
+Run with: bench --site <site> run-tests --app huf --module huf.ai.tests.test_tool_invocation_runtime
+or standalone: PYTHONPATH=. python3 huf/ai/tests/test_tool_invocation_runtime.py -v
+"""
+import sys
+import unittest
+from unittest import mock
+
+# Standalone frappe stub (same pattern as test_test_tools.py)
+if "frappe" not in sys.modules:
+	frappe_mock = mock.MagicMock()
+	frappe_mock.logger = lambda *a, **k: mock.MagicMock()
+	sys.modules["frappe"] = frappe_mock
+
+
+class TestRuntimeAllowSetGuard(unittest.TestCase):
+	"""Test ST-05.2: get_function_from_name runtime allow-set validation."""
+
+	def test_app_provided_outside_allow_set_returns_none(self):
+		"""
+		When tool_type="App Provided" and function name is not in the hook
+		allow-set, get_function_from_name returns None (not found).
+		"""
+		from huf.ai.sdk_tools import get_function_from_name
+
+		with mock.patch(
+			"huf.ai.sdk_tools.get_hook_declared_function_paths",
+			return_value=set(),  # Empty allow-set
+		):
+			result = get_function_from_name(
+				"subprocess.getoutput",
+				tool_type="App Provided"
+			)
+			self.assertIsNone(result)
+
+	def test_app_provided_in_allow_set_returns_callable(self):
+		"""
+		When tool_type="App Provided" and function name is in the hook
+		allow-set, get_function_from_name returns the actual callable.
+		"""
+		from huf.ai.sdk_tools import get_function_from_name
+
+		with mock.patch(
+			"huf.ai.sdk_tools.get_hook_declared_function_paths",
+			return_value={"frappe.throw"},
+		):
+			result = get_function_from_name(
+				"frappe.throw",
+				tool_type="App Provided"
+			)
+			# frappe.throw should be callable (or None if frappe is mocked)
+			# Just verify it doesn't error out
+			self.assertIsNotNone(result)
+
+	def test_no_tool_type_backwards_compatibility(self):
+		"""
+		Existing call sites that don't pass tool_type should still work
+		(backwards compatibility). tool_type defaults to None, so no
+		allow-set check is performed.
+		"""
+		from huf.ai.sdk_tools import get_function_from_name
+
+		# Call with only one argument (old signature)
+		result = get_function_from_name("frappe.throw")
+		# If frappe is mocked, this may be None; if real, it's the function
+		# The important thing is it doesn't crash
+		self.assertIsNotNone(result) or True  # Both outcomes are acceptable

--- a/huf/ai/tests/test_tool_invocation_runtime.py
+++ b/huf/ai/tests/test_tool_invocation_runtime.py
@@ -30,7 +30,7 @@ class TestRuntimeAllowSetGuard(unittest.TestCase):
 		from huf.ai.sdk_tools import get_function_from_name
 
 		with mock.patch(
-			"huf.ai.sdk_tools.get_hook_declared_function_paths",
+			"huf.ai.tool_registry.get_hook_declared_function_paths",
 			return_value=set(),  # Empty allow-set
 		):
 			result = get_function_from_name(
@@ -47,7 +47,7 @@ class TestRuntimeAllowSetGuard(unittest.TestCase):
 		from huf.ai.sdk_tools import get_function_from_name
 
 		with mock.patch(
-			"huf.ai.sdk_tools.get_hook_declared_function_paths",
+			"huf.ai.tool_registry.get_hook_declared_function_paths",
 			return_value={"frappe.throw"},
 		):
 			result = get_function_from_name(

--- a/huf/ai/tool_invocation.py
+++ b/huf/ai/tool_invocation.py
@@ -290,7 +290,7 @@ class ToolResult:
 		return out
 
 
-def get_function_from_name(tool_name: str) -> Callable | None:
+def get_function_from_name(tool_name: str, tool_type: str | None = None) -> Callable | None:
 	"""Re-exported for callers that only need resolution, not invocation.
 	The real implementation stays single-sourced in sdk_tools.py (seam
 	audit §"Recommended target shape": "already single-sourced ... just
@@ -299,7 +299,7 @@ def get_function_from_name(tool_name: str) -> Callable | None:
 	import cycle (sdk_tools imports resolution helpers from this module).
 	"""
 	from huf.ai.sdk_tools import get_function_from_name as _impl
-	return _impl(tool_name)
+	return _impl(tool_name, tool_type=tool_type)
 
 
 async def invoke_tool(
@@ -338,7 +338,7 @@ async def invoke_tool(
 	if not function_path:
 		return ToolResult(success=False, error=f"Cannot resolve handler for tool type '{tool_type}'")
 
-	handler = get_function_from_name(function_path)
+	handler = get_function_from_name(function_path, tool_type=tool_type)
 	if not handler:
 		return ToolResult(success=False, error=f"Handler function not found: {function_path}")
 

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -352,12 +352,35 @@ def get_tools_by_app(apps_to_scan=None, use_cache=True):
 
         if app_tools:
             tools_by_app[app] = app_tools
-    
+
     # Update cache with scanned apps
     if use_cache and apps_to_scan:
         _update_cached_scans(apps_to_scan)
-    
+
     return tools_by_app
+
+
+_hook_function_paths_cache = None
+
+
+def get_hook_declared_function_paths(use_cache=True):
+    """Set of function_path values declared by any installed app's huf_tools
+    hook (the same source sync_discovered_tools reads). Used to validate
+    App Provided Agent Tool Function rows: a path outside this set was not
+    registered by the hook mechanism and must not be trusted (F-07)."""
+    global _hook_function_paths_cache
+    if use_cache and _hook_function_paths_cache is not None:
+        return _hook_function_paths_cache
+    tools_by_app = get_tools_by_app(apps_to_scan=None, use_cache=False)
+    paths = {
+        d.get("function_path")
+        for tools in tools_by_app.values()
+        for d in tools
+        if d.get("function_path")
+    }
+    if use_cache:
+        _hook_function_paths_cache = paths
+    return paths
 
 @frappe.whitelist()
 def sync_discovered_tools(apps_to_scan=None, use_cache=True):

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -125,6 +125,8 @@ def _inspect_function_parameters(function_path):
 @frappe.whitelist()
 def fetch_tool_parameters_from_code(function_path):
 	"""Return tool parameters inferred from a Python function signature (for React UI)."""
+	frappe.only_for("Huf Manager")
+
 	if not function_path:
 		frappe.throw(_("Please provide a Function Path first."))
 

--- a/huf/huf/doctype/agent_tool_function/agent_tool_function.py
+++ b/huf/huf/doctype/agent_tool_function/agent_tool_function.py
@@ -9,6 +9,7 @@ import typing
 import frappe
 from frappe import _, is_whitelisted
 from frappe.model.document import Document
+from huf.ai.tool_registry import get_hook_declared_function_paths
 
 
 def _json_schema_type(param_type):
@@ -812,6 +813,15 @@ class AgentToolFunction(Document):
 				frappe.throw(_("Function not found"))
 
 			is_whitelisted(f)
+
+		elif self.types == "App Provided":
+			allowed_paths = get_hook_declared_function_paths()
+			if self.function_path not in allowed_paths:
+				frappe.throw(
+					_("Function path {0} is not declared by any installed app's huf_tools hook.").format(
+						self.function_path
+					)
+				)
 
 	def before_save(self):
 

--- a/huf/patches/v1/audit_app_provided_tool_paths.py
+++ b/huf/patches/v1/audit_app_provided_tool_paths.py
@@ -1,0 +1,35 @@
+import frappe
+
+
+def execute():
+	"""
+	Audit App Provided tool functions against the hook-declared allow-set
+	(huf.ai.tool_registry.get_hook_declared_function_paths). Report only;
+	does not delete or modify data. Run manually before deploying ST-05.1/
+	ST-05.2 so any row that would start failing validation is known ahead
+	of time.
+	"""
+	from huf.ai.tool_registry import get_hook_declared_function_paths
+
+	allowed_paths = get_hook_declared_function_paths(use_cache=False)
+
+	offending = []
+	for tool_doc in frappe.get_all(
+		"Agent Tool Function",
+		filters={"types": "App Provided"},
+		fields=["name", "function_path", "tool_name"],
+	):
+		if tool_doc.function_path not in allowed_paths:
+			offending.append(
+				{"tool": tool_doc.name, "tool_name": tool_doc.tool_name, "path": tool_doc.function_path}
+			)
+
+	if offending:
+		frappe.log_error(
+			title="Security Audit: App Provided tool paths outside hook allow-set",
+			message=(
+				f"audit_app_provided_tool_paths: found {len(offending)} App Provided tool(s) "
+				f"whose function_path is not declared by any installed app's huf_tools hook:\n"
+				+ "\n".join(f"  {row}" for row in offending)
+			),
+		)


### PR DESCRIPTION
Same change as #697, opened against `pre-develop` per track instructions. See #697 for the full description, findings closed, deviations, and test plan.