### PR TITLE
huf/ai: require authorization on maintenance and tool endpoints

### DIFF
--- a/huf/ai/automation_app_event.py
+++ b/huf/ai/automation_app_event.py
@@ -49,6 +49,7 @@ def trigger_app_event(app_name: str, event_name: str, payload: dict | None = Non
 					"event_name": event_name,
 					"payload": payload or {},
 				},
+				initiating_user=frappe.session.user,
 			)
 			triggered_automations.append(t["automation"])
 		except Exception:

--- a/huf/ai/automation_scheduler.py
+++ b/huf/ai/automation_scheduler.py
@@ -12,7 +12,6 @@ _LOCK_PREFIX = "huf:automation_scheduler:lock:"
 _LOCK_TTL_SEC = 60
 
 
-@frappe.whitelist()
 def run_due_automations():
 	"""Fire every due Schedule-type Automation Trigger.
 

--- a/huf/ai/batch_poll.py
+++ b/huf/ai/batch_poll.py
@@ -332,7 +332,6 @@ def _process_batch_job(job: dict) -> None:
 	frappe.db.commit()  # nosemgrep: justified background-job commit
 
 
-@frappe.whitelist()
 def poll_pending_batch_jobs():
 	"""Poll every Submitted/In Progress Batch Job and write back its status.
 

--- a/huf/ai/client_side_tool.py
+++ b/huf/ai/client_side_tool.py
@@ -118,6 +118,9 @@ def client_side_function(conversation_id=None, agent_run_id=None, function_name=
             "message": "Client-side tools are not available in guest conversations.",
         }
 
+    # Check permission to write to the conversation
+    frappe.has_permission("Agent Conversation", "write", conversation_id) or frappe.throw(_("Not permitted"), frappe.PermissionError)
+
     call = _get_or_create_call(conversation_id, agent_run_id, function_name, call_id, kwargs)
     correlation_id = call_id or call.name
 
@@ -138,6 +141,8 @@ def client_side_function(conversation_id=None, agent_run_id=None, function_name=
             "message": "Could not dispatch the tool call to the frontend (cache unavailable).",
         }
 
+    # Get the conversation owner to scope realtime delivery
+    conversation_owner = frappe.db.get_value("Agent Conversation", conversation_id, "owner")
     frappe.publish_realtime(
         event=f'conversation:{conversation_id}',
         message={
@@ -149,6 +154,7 @@ def client_side_function(conversation_id=None, agent_run_id=None, function_name=
             "tool_params": kwargs,
             "call_id": correlation_id,
         },
+        user=conversation_owner,
     )
 
     try:

--- a/huf/ai/client_side_tool.py
+++ b/huf/ai/client_side_tool.py
@@ -195,7 +195,13 @@ def client_side_function(conversation_id=None, agent_run_id=None, function_name=
     except Exception:
         pass
 
-    _, raw_payload = popped
+    # NOT `_, raw_payload = popped`: `_` is `frappe`'s translation function
+    # (imported at module level, `from frappe import _`, used earlier in this
+    # very function for frappe.throw(_("Not permitted"), ...)). Assigning to
+    # `_` anywhere in a function body makes Python treat it as local for the
+    # *whole* function -- shadowing the module-level import from the first
+    # line, and raising UnboundLocalError on the earlier reference.
+    _key, raw_payload = popped
     try:
         payload = json.loads(raw_payload)
     except (TypeError, ValueError):

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -64,6 +64,18 @@ def _is_public_ip(ip_str: str) -> bool:
 	return True
 
 
+def extract_origin(url_str):
+	"""
+	Extract (scheme, host, port) from a URL for origin matching.
+
+	Returns a tuple (scheme, hostname, port) where port is derived from
+	the URL's port attribute or defaults to 443 for https, 80 for http.
+	"""
+	parsed = urlparse(url_str)
+	port = parsed.port or (443 if parsed.scheme == "https" else 80)
+	return (parsed.scheme, parsed.hostname, port)
+
+
 def validate_url(url):
 	"""
 	Validate URL to prevent SSRF and other attacks.
@@ -163,10 +175,25 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 				"suggestion": "Ensure the URL points to a public, external service.",
 			}
 
-		# Merge tool headers with request headers
-		# Tool headers come first, then request headers can override them
+		# Merge tool headers with request headers, checking origin binding
 		tool_headers = tool_info.get("headers", {}) or {}
 		request_headers = headers or {}
+
+		# Only attach tool headers if the final URL's origin matches the tool's base_url origin
+		base_url = tool_info.get("base_url", "")
+		if base_url:
+			base_url_origin = extract_origin(base_url)
+			final_url_origin = extract_origin(final_url)
+			if base_url_origin != final_url_origin:
+				# Cross-origin: do not attach tool headers and strip Authorization-class headers
+				tool_headers = {}
+				auth_headers = [
+					"Authorization", "Proxy-Authorization", "X-API-Key",
+					"X-Auth-Token", "Authorization-Signature"
+				]
+				for auth_header in auth_headers:
+					request_headers.pop(auth_header, None)
+
 		final_headers = {**tool_headers, **request_headers}
 
 		# Prepare request parameters
@@ -187,6 +214,11 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 		request_kwargs["allow_redirects"] = False
 		current_url = final_url
 		max_redirects = 5
+		base_url_origin = extract_origin(base_url) if base_url else None
+		auth_headers = [
+			"Authorization", "Proxy-Authorization", "X-API-Key",
+			"X-Auth-Token", "Authorization-Signature"
+		]
 		for _hop in range(max_redirects + 1):
 			response = requests.request(method, current_url, **request_kwargs)
 			if response.status_code not in (301, 302, 303, 307, 308):
@@ -203,6 +235,13 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 					"error": f"Redirect blocked: {error_msg}",
 					"suggestion": "The server attempted to redirect to a private/internal address.",
 				}
+			# Check if redirect changes origin; strip auth headers if so
+			if base_url_origin:
+				next_url_origin = extract_origin(next_url)
+				if next_url_origin != base_url_origin:
+					# Cross-origin redirect: strip Authorization-class headers
+					for auth_header in auth_headers:
+						request_kwargs["headers"].pop(auth_header, None)
 			current_url = next_url
 		else:
 			# Loop exhausted without breaking — too many redirects.

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -201,6 +201,7 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 			"headers": final_headers,
 			"params": params or {},
 			"timeout": 30,
+			"stream": True,  # Stream response body to enforce size cap during read
 		}
 
 		# Add data or json based on what's provided
@@ -251,7 +252,7 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 				"suggestion": "The URL redirects in a loop or exceeds the redirect limit.",
 			}
 
-		# Check response size — pre-check via Content-Length header, then verify actual content
+		# Check response size — pre-check via Content-Length header (fast-path)
 		content_length = response.headers.get("Content-Length")
 		if content_length and content_length.isdigit() and int(content_length) > MAX_RESPONSE_SIZE:
 			return {
@@ -261,19 +262,32 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 				"suggestion": "The API indicates a response larger than 10MB. Try requesting less data.",
 			}
 
-		if len(response.content) > MAX_RESPONSE_SIZE:
-			return {
-				"success": False,
-				"error": "Response too large",
-				"status_code": response.status_code,
-				"suggestion": "The API response exceeds the 10MB size limit. Try requesting less data.",
-			}
+		# Stream response body and enforce size cap during read
+		total_read = 0
+		chunks = []
+		for chunk in response.iter_content(chunk_size=8192):
+			if not chunk:
+				continue
+			total_read += len(chunk)
+			if total_read > MAX_RESPONSE_SIZE:
+				return {
+					"success": False,
+					"error": "Response too large",
+					"status_code": response.status_code,
+					"suggestion": "The API response exceeds the 10MB size limit. Try requesting less data.",
+				}
+			chunks.append(chunk)
 
-		# Try to parse JSON response, fall back to text
+		response_body = b"".join(chunks)
+
+		# Parse JSON response from accumulated body, fall back to text
 		try:
-			response_data = response.json()
-		except ValueError:
-			response_data = response.text
+			response_data = json.loads(response_body)
+		except (json.JSONDecodeError, ValueError):
+			try:
+				response_data = response_body.decode(errors="replace")
+			except Exception:
+				response_data = str(response_body)
 
 		# Return standardized response
 		result = {

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import frappe
 import requests
 from requests.exceptions import RequestException
+from frappe.rate_limiter import rate_limit
 
 from frappe import _
 from huf.permissions import has_capability
@@ -107,6 +108,7 @@ def validate_url(url):
 	return True, None
 
 
+@rate_limit(key="tool_name", limit=100, seconds=60)
 @frappe.whitelist(allow_guest=True)
 def handle_http_request(method, url, headers=None, params=None, data=None, json_data=None, tool_name=None):
 	"""
@@ -316,6 +318,7 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 		}
 
 
+@rate_limit(key="tool_name", limit=100, seconds=60)
 @frappe.whitelist(allow_guest=True)
 def handle_get_request(url, headers=None, params=None, tool_name=None):
 	"""
@@ -331,6 +334,7 @@ def handle_get_request(url, headers=None, params=None, tool_name=None):
 	return handle_http_request("GET", url, headers=headers, params=params, tool_name=tool_name)
 
 
+@rate_limit(key="tool_name", limit=100, seconds=60)
 @frappe.whitelist(allow_guest=True)
 def handle_post_request(url, headers=None, data=None, json_data=None, tool_name=None):
 	"""

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -7,6 +7,9 @@ import frappe
 import requests
 from requests.exceptions import RequestException
 
+from frappe import _
+from huf.permissions import has_capability
+
 ALLOWED_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"}
 MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10MB
 DEFAULT_TIMEOUT = 30
@@ -97,6 +100,13 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 	"""
 	Generic HTTP request handler with support for tool-defined headers
 	"""
+	# Check agent.use capability (guest sessions are exempt)
+	if frappe.session.user != "Guest" and not has_capability(frappe.session.user, "agent.use"):
+		frappe.throw(
+			_("You are not authorized to use HTTP tools."),
+			frappe.PermissionError
+		)
+
 	# Validate HTTP method
 	if method.upper() not in ALLOWED_METHODS:
 		return {
@@ -258,6 +268,13 @@ def handle_get_request(url, headers=None, params=None, tool_name=None):
 	"""
 	Handle GET requests with tool-defined headers
 	"""
+	# Check agent.use capability (guest sessions are exempt)
+	if frappe.session.user != "Guest" and not has_capability(frappe.session.user, "agent.use"):
+		frappe.throw(
+			_("You are not authorized to use HTTP tools."),
+			frappe.PermissionError
+		)
+
 	return handle_http_request("GET", url, headers=headers, params=params, tool_name=tool_name)
 
 
@@ -266,6 +283,13 @@ def handle_post_request(url, headers=None, data=None, json_data=None, tool_name=
 	"""
 	Handle POST requests with JSON data support
 	"""
+	# Check agent.use capability (guest sessions are exempt)
+	if frappe.session.user != "Guest" and not has_capability(frappe.session.user, "agent.use"):
+		frappe.throw(
+			_("You are not authorized to use HTTP tools."),
+			frappe.PermissionError
+		)
+
 	# Convert string JSON to dict if needed
 	if isinstance(json_data, str):
 		try:

--- a/huf/ai/http_handler.py
+++ b/huf/ai/http_handler.py
@@ -189,12 +189,14 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 			if base_url_origin != final_url_origin:
 				# Cross-origin: do not attach tool headers and strip Authorization-class headers
 				tool_headers = {}
-				auth_headers = [
-					"Authorization", "Proxy-Authorization", "X-API-Key",
-					"X-Auth-Token", "Authorization-Signature"
-				]
-				for auth_header in auth_headers:
-					request_headers.pop(auth_header, None)
+				auth_headers = {
+					"authorization", "proxy-authorization", "x-api-key",
+					"x-auth-token", "authorization-signature"
+				}
+				request_headers = {
+					k: v for k, v in request_headers.items()
+					if k.lower() not in auth_headers
+				}
 
 		final_headers = {**tool_headers, **request_headers}
 
@@ -218,10 +220,10 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 		current_url = final_url
 		max_redirects = 5
 		base_url_origin = extract_origin(base_url) if base_url else None
-		auth_headers = [
-			"Authorization", "Proxy-Authorization", "X-API-Key",
-			"X-Auth-Token", "Authorization-Signature"
-		]
+		auth_headers = {
+			"authorization", "proxy-authorization", "x-api-key",
+			"x-auth-token", "authorization-signature"
+		}
 		for _hop in range(max_redirects + 1):
 			response = requests.request(method, current_url, **request_kwargs)
 			if response.status_code not in (301, 302, 303, 307, 308):
@@ -243,8 +245,10 @@ def handle_http_request(method, url, headers=None, params=None, data=None, json_
 				next_url_origin = extract_origin(next_url)
 				if next_url_origin != base_url_origin:
 					# Cross-origin redirect: strip Authorization-class headers
-					for auth_header in auth_headers:
-						request_kwargs["headers"].pop(auth_header, None)
+					request_kwargs["headers"] = {
+						k: v for k, v in request_kwargs["headers"].items()
+						if k.lower() not in auth_headers
+					}
 			current_url = next_url
 		else:
 			# Loop exhausted without breaking — too many redirects.

--- a/huf/ai/mcp_connection_resolver.py
+++ b/huf/ai/mcp_connection_resolver.py
@@ -19,6 +19,7 @@ import ipaddress
 import json
 import re
 import secrets
+import socket
 import urllib.parse
 from typing import Optional
 
@@ -59,6 +60,7 @@ def resolve_mcp_connection(server_url: str, callback_url: str) -> dict:
           scopes_supported, client_registration_method, client_id,
           discovery_status, discovery_error, metadata_json
     """
+    frappe.only_for("System Manager")
     try:
         server_url = _normalize_url(server_url)
         callback_url = _normalize_url(callback_url)
@@ -464,10 +466,40 @@ def _normalize_url(url: str) -> str:
     return urllib.parse.urlunparse(parsed)
 
 
+def _is_public_ip(ip_str: str) -> bool:
+    """Return True only if ip_str is a routable public address.
+
+    Unwraps IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) before classifying,
+    and rejects loopback/private/link-local/reserved/multicast/unspecified
+    for both IPv4 and IPv6.
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        # Not a parseable IP — fail closed.
+        return False
+
+    # Unwrap IPv4-mapped IPv6 so ::ffff:127.0.0.1 is judged as 127.0.0.1.
+    mapped = getattr(addr, "ipv4_mapped", None)
+    if mapped is not None:
+        addr = mapped
+
+    if (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    ):
+        return False
+    return True
+
+
 def _is_safe_url(url: str) -> bool:
     """
     Reject non-HTTP(S) URLs and private/internal addresses.
-    Allow localhost only for development.
+    Requires DNS resolution for hostnames (no implicit localhost).
     """
     if not url:
         return False
@@ -479,18 +511,17 @@ def _is_safe_url(url: str) -> bool:
     if not hostname:
         return False
 
-    # Allow localhost for development
-    if hostname.lower() in ("localhost", "127.0.0.1", "::1"):
-        return True
-
+    # Resolve hostname to IP(s) and reject if any resolved IP is private/internal.
     try:
-        ip = ipaddress.ip_address(hostname)
-        # Reject private, loopback, link-local, multicast, reserved
-        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved:
+        addr_info = socket.getaddrinfo(hostname, None)
+        ips = {info[4][0] for info in addr_info}
+    except socket.gaierror:
+        # Cannot resolve hostname
+        return False
+
+    for ip in ips:
+        if not _is_public_ip(ip):
             return False
-    except ValueError:
-        # hostname is not an IP, that's fine
-        pass
 
     return True
 

--- a/huf/ai/mcp_connection_resolver.py
+++ b/huf/ai/mcp_connection_resolver.py
@@ -15,11 +15,9 @@ The resolver keeps discovery and compatibility handling server-side so the UI
 only needs the MCP server URL.
 """
 
-import ipaddress
 import json
 import re
 import secrets
-import socket
 import urllib.parse
 from typing import Optional
 
@@ -466,64 +464,22 @@ def _normalize_url(url: str) -> str:
     return urllib.parse.urlunparse(parsed)
 
 
-def _is_public_ip(ip_str: str) -> bool:
-    """Return True only if ip_str is a routable public address.
-
-    Unwraps IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) before classifying,
-    and rejects loopback/private/link-local/reserved/multicast/unspecified
-    for both IPv4 and IPv6.
-    """
-    try:
-        addr = ipaddress.ip_address(ip_str)
-    except ValueError:
-        # Not a parseable IP — fail closed.
-        return False
-
-    # Unwrap IPv4-mapped IPv6 so ::ffff:127.0.0.1 is judged as 127.0.0.1.
-    mapped = getattr(addr, "ipv4_mapped", None)
-    if mapped is not None:
-        addr = mapped
-
-    if (
-        addr.is_private
-        or addr.is_loopback
-        or addr.is_link_local
-        or addr.is_reserved
-        or addr.is_multicast
-        or addr.is_unspecified
-    ):
-        return False
-    return True
-
-
 def _is_safe_url(url: str) -> bool:
     """
     Reject non-HTTP(S) URLs and private/internal addresses.
     Requires DNS resolution for hostnames (no implicit localhost).
+
+    Delegates to huf.ai.http_handler.validate_url so the SSRF-hardening
+    logic (public-IP classification, DNS resolution, IPv4-mapped IPv6
+    unwrapping) lives in one place instead of being duplicated here.
     """
     if not url:
         return False
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        return False
 
-    hostname = parsed.hostname
-    if not hostname:
-        return False
+    from huf.ai.http_handler import validate_url
 
-    # Resolve hostname to IP(s) and reject if any resolved IP is private/internal.
-    try:
-        addr_info = socket.getaddrinfo(hostname, None)
-        ips = {info[4][0] for info in addr_info}
-    except socket.gaierror:
-        # Cannot resolve hostname
-        return False
-
-    for ip in ips:
-        if not _is_public_ip(ip):
-            return False
-
-    return True
+    is_valid, _error_msg = validate_url(url)
+    return is_valid
 
 
 def _canonical_resource(url: str) -> str:

--- a/huf/ai/orchestration/orchestrator.py
+++ b/huf/ai/orchestration/orchestrator.py
@@ -1,6 +1,7 @@
 # huf/ai/orchestration/orchestrator.py
 
 import frappe
+from frappe import _
 from frappe.utils import now_datetime
 from huf.ai.orchestration.planning import run_planning
 from huf.ai.agent_integration import run_agent_sync

--- a/huf/ai/orchestration/orchestrator.py
+++ b/huf/ai/orchestration/orchestrator.py
@@ -74,6 +74,8 @@ def recreate_orchestration_plan(orch_name):
     Requirement 3 (Button): Recreates the plan based on current Agent instructions.
     """
     orch = frappe.get_doc("Agent Orchestration", orch_name)
+    if not frappe.has_permission("Agent Orchestration", "write"):
+        frappe.throw(_("Not permitted"), frappe.PermissionError)
     agent_doc = frappe.get_doc("Agent", orch.agent)
     
     from huf.ai.prompt_resolver import resolve_prompt

--- a/huf/ai/tests/test_http_handler_access.py
+++ b/huf/ai/tests/test_http_handler_access.py
@@ -1,0 +1,484 @@
+"""
+Unit tests for huf.ai.http_handler security hardening.
+
+Tests cover:
+- ST-07.1: Authorization checks (agent.use capability)
+- ST-07.2: Guest access gating (existing behavior verification)
+- ST-07.3: Header origin binding
+- ST-07.4: Response size cap enforcement via streaming
+- ST-07.5: Rate limit decorator presence (full testing deferred to bench/integration)
+
+These are pure unit tests using unittest.mock — they do not require a live
+Frappe site/bench.
+
+Run with: bench --site <site> run-tests --app huf --module huf.ai.tests.test_http_handler_access
+"""
+import json
+import unittest
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+from huf.ai.http_handler import (
+	handle_http_request,
+	handle_get_request,
+	handle_post_request,
+	extract_origin,
+)
+
+
+class TestExtractOrigin(unittest.TestCase):
+	"""Tests for the extract_origin helper."""
+
+	def test_extract_https_origin_with_default_port(self):
+		"""Default https port is 443."""
+		url = "https://api.example.com/path"
+		scheme, host, port = extract_origin(url)
+		self.assertEqual(scheme, "https")
+		self.assertEqual(host, "api.example.com")
+		self.assertEqual(port, 443)
+
+	def test_extract_http_origin_with_default_port(self):
+		"""Default http port is 80."""
+		url = "http://api.example.com/path"
+		scheme, host, port = extract_origin(url)
+		self.assertEqual(scheme, "http")
+		self.assertEqual(host, "api.example.com")
+		self.assertEqual(port, 80)
+
+	def test_extract_origin_with_explicit_port(self):
+		"""Explicit port is preserved."""
+		url = "https://api.example.com:8443/path"
+		scheme, host, port = extract_origin(url)
+		self.assertEqual(scheme, "https")
+		self.assertEqual(host, "api.example.com")
+		self.assertEqual(port, 8443)
+
+	def test_extract_origin_same_origin_comparison(self):
+		"""Same base_url and request URL have matching origins."""
+		base_url = "https://api.example.com/"
+		request_url = "https://api.example.com/endpoint"
+		base_origin = extract_origin(base_url)
+		request_origin = extract_origin(request_url)
+		self.assertEqual(base_origin, request_origin)
+
+	def test_extract_origin_cross_origin_comparison(self):
+		"""Different hostnames result in different origins."""
+		base_url = "https://api.example.com/"
+		request_url = "https://attacker.com/"
+		base_origin = extract_origin(base_url)
+		request_origin = extract_origin(request_url)
+		self.assertNotEqual(base_origin, request_origin)
+
+	def test_extract_origin_port_mismatch(self):
+		"""Different ports result in different origins."""
+		url1 = "https://api.example.com:443/"
+		url2 = "https://api.example.com:8443/"
+		origin1 = extract_origin(url1)
+		origin2 = extract_origin(url2)
+		self.assertNotEqual(origin1, origin2)
+
+
+class TestAuthorizationST071(unittest.TestCase):
+	"""Tests for ST-07.1: agent.use capability check."""
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	@patch("frappe.throw")
+	def test_non_guest_without_agent_use_capability_denied(
+		self, mock_throw, mock_has_capability, mock_session
+	):
+		"""Non-guest user without agent.use capability is denied."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = False
+		mock_throw.side_effect = Exception("PermissionError")
+
+		try:
+			handle_http_request("GET", "https://api.example.com/")
+		except Exception as e:
+			self.assertIn("PermissionError", str(e))
+
+		mock_throw.assert_called()
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	@patch("frappe.throw")
+	def test_non_guest_with_agent_use_capability_allowed_to_proceed(
+		self, mock_throw, mock_has_capability, mock_session
+	):
+		"""Non-guest user with agent.use capability proceeds past auth check."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = True
+
+		# Mock the rest of the flow to prevent further execution
+		with patch("huf.ai.http_handler.requests.request") as mock_request:
+			mock_response = Mock()
+			mock_response.status_code = 200
+			mock_response.headers = {}
+			mock_response.iter_content = Mock(return_value=[b"{}"])
+			mock_request.return_value = mock_response
+
+			result = handle_http_request(
+				"GET", "https://api.example.com/", tool_name="test_tool"
+			)
+
+			# Should not raise PermissionError
+			mock_throw.assert_not_called()
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	@patch("frappe.throw")
+	def test_guest_bypasses_capability_check(
+		self, mock_throw, mock_has_capability, mock_session
+	):
+		"""Guest user is exempt from agent.use capability check."""
+		mock_session.user = "Guest"
+
+		# Mock the rest to get past initial checks
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = []
+			mock_tool_doc.allowed_for_guest = True
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				mock_response = Mock()
+				mock_response.status_code = 200
+				mock_response.headers = {}
+				mock_response.iter_content = Mock(return_value=[b"{}"])
+				mock_request.return_value = mock_response
+
+				result = handle_http_request(
+					"GET", "https://api.example.com/", tool_name="test_tool"
+				)
+
+				# Guest should bypass capability check
+				mock_has_capability.assert_not_called()
+				mock_throw.assert_not_called()
+
+
+class TestGuestAccessST072(unittest.TestCase):
+	"""Tests for ST-07.2: Guest access gating (existing behavior verification)."""
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_guest_no_tool_specified_denied(self, mock_has_capability, mock_session):
+		"""Guest without tool_name is denied (tool_allowed_for_guest stays False)."""
+		mock_session.user = "Guest"
+
+		result = handle_http_request("GET", "https://api.example.com/")
+
+		self.assertFalse(result["success"])
+		self.assertEqual(result["status_code"], 403)
+		self.assertIn("does not allow guest access", result["error"])
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_guest_tool_with_allowed_for_guest_false_denied(
+		self, mock_has_capability, mock_session
+	):
+		"""Guest accessing a tool with allowed_for_guest=False is denied."""
+		mock_session.user = "Guest"
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
+
+			result = handle_http_request(
+				"GET", "https://api.example.com/", tool_name="test_tool"
+			)
+
+			self.assertFalse(result["success"])
+			self.assertEqual(result["status_code"], 403)
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_guest_tool_with_allowed_for_guest_true_proceeds(
+		self, mock_has_capability, mock_session
+	):
+		"""Guest accessing a tool with allowed_for_guest=True proceeds."""
+		mock_session.user = "Guest"
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = []
+			mock_tool_doc.allowed_for_guest = True
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				mock_response = Mock()
+				mock_response.status_code = 200
+				mock_response.headers = {}
+				mock_response.iter_content = Mock(return_value=[b"{}"])
+				mock_request.return_value = mock_response
+
+				result = handle_http_request(
+					"GET", "https://api.example.com/", tool_name="test_tool"
+				)
+
+				# Should proceed past guest check
+				self.assertTrue(result["success"])
+
+
+class TestHeaderOriginBindingST073(unittest.TestCase):
+	"""Tests for ST-07.3: Header binding to tool origin."""
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_same_origin_request_attaches_tool_headers(
+		self, mock_has_capability, mock_session
+	):
+		"""Request to same origin as base_url attaches tool headers."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = True
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = [
+				Mock(key="Authorization", value="Bearer token123")
+			]
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				mock_response = Mock()
+				mock_response.status_code = 200
+				mock_response.headers = {}
+				mock_response.iter_content = Mock(return_value=[b"{}"])
+				mock_request.return_value = mock_response
+
+				result = handle_http_request(
+					"GET",
+					"https://api.example.com/endpoint",
+					tool_name="test_tool",
+				)
+
+				# Verify request was made with tool headers
+				call_args = mock_request.call_args
+				self.assertIn("Authorization", call_args.kwargs["headers"])
+				self.assertEqual(
+					call_args.kwargs["headers"]["Authorization"], "Bearer token123"
+				)
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_cross_origin_request_does_not_attach_tool_headers(
+		self, mock_has_capability, mock_session
+	):
+		"""Request to different origin than base_url does not attach tool headers."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = True
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = [
+				Mock(key="Authorization", value="Bearer token123")
+			]
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				# Mock validate_url to allow the cross-origin request
+				with patch(
+					"huf.ai.http_handler.validate_url",
+					return_value=(True, None),
+				):
+					mock_response = Mock()
+					mock_response.status_code = 200
+					mock_response.headers = {}
+					mock_response.iter_content = Mock(return_value=[b"{}"])
+					mock_request.return_value = mock_response
+
+					result = handle_http_request(
+						"GET",
+						"https://attacker.com/",
+						tool_name="test_tool",
+					)
+
+					# Verify tool headers were NOT attached
+					call_args = mock_request.call_args
+					self.assertNotIn("Authorization", call_args.kwargs["headers"])
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_redirect_to_cross_origin_strips_auth_headers(
+		self, mock_has_capability, mock_session
+	):
+		"""Redirect to different origin strips Authorization-class headers."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = True
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = [
+				Mock(key="Authorization", value="Bearer token123")
+			]
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				with patch("huf.ai.http_handler.validate_url") as mock_validate:
+					mock_validate.return_value = (True, None)
+
+					# First response: 302 redirect to different origin
+					redirect_response = Mock()
+					redirect_response.status_code = 302
+					redirect_response.headers = {"Location": "https://attacker.com/"}
+					redirect_response.iter_content = Mock(return_value=[b""])
+
+					# Second response: final response from attacker.com
+					final_response = Mock()
+					final_response.status_code = 200
+					final_response.headers = {}
+					final_response.iter_content = Mock(return_value=[b"{}"])
+
+					mock_request.side_effect = [redirect_response, final_response]
+
+					result = handle_http_request(
+						"GET",
+						"https://api.example.com/endpoint",
+						tool_name="test_tool",
+					)
+
+					# Second request should have Authorization header stripped
+					second_call = mock_request.call_args_list[1]
+					self.assertNotIn("Authorization", second_call.kwargs["headers"])
+
+
+class TestResponseSizeCappingST074(unittest.TestCase):
+	"""Tests for ST-07.4: Response size cap enforcement via streaming."""
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_response_under_limit_succeeds(self, mock_has_capability, mock_session):
+		"""Response under MAX_RESPONSE_SIZE (10MB) succeeds."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = True
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = []
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				mock_response = Mock()
+				mock_response.status_code = 200
+				mock_response.headers = {"Content-Length": "1000"}
+				# Return a small response via iter_content
+				test_data = b'{"result": "success"}'
+				mock_response.iter_content = Mock(return_value=[test_data])
+				mock_request.return_value = mock_response
+
+				result = handle_http_request(
+					"GET", "https://api.example.com/", tool_name="test_tool"
+				)
+
+				self.assertTrue(result["success"])
+				self.assertEqual(result["status_code"], 200)
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_response_exceeding_limit_aborted(self, mock_has_capability, mock_session):
+		"""Response exceeding MAX_RESPONSE_SIZE aborts with error."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = True
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = []
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				mock_response = Mock()
+				mock_response.status_code = 200
+				# No Content-Length to pass fast-path check
+				mock_response.headers = {}
+				# Return chunks totaling > MAX_RESPONSE_SIZE
+				# MAX_RESPONSE_SIZE is 10MB, so return > 10MB
+				chunk_size = 8192
+				num_chunks = int((10 * 1024 * 1024) / chunk_size) + 2
+				chunks = [b"x" * chunk_size for _ in range(num_chunks)]
+				mock_response.iter_content = Mock(return_value=chunks)
+				mock_request.return_value = mock_response
+
+				result = handle_http_request(
+					"GET", "https://api.example.com/", tool_name="test_tool"
+				)
+
+				self.assertFalse(result["success"])
+				self.assertIn("Response too large", result["error"])
+
+	@patch("frappe.session")
+	@patch("huf.ai.http_handler.has_capability")
+	def test_content_length_pre_check_fast_path(
+		self, mock_has_capability, mock_session
+	):
+		"""Content-Length exceeding limit triggers fast-path rejection."""
+		mock_session.user = "user@example.com"
+		mock_has_capability.return_value = True
+
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = []
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
+
+			with patch("huf.ai.http_handler.requests.request") as mock_request:
+				mock_response = Mock()
+				mock_response.status_code = 200
+				# Set Content-Length > MAX_RESPONSE_SIZE
+				mock_response.headers = {"Content-Length": str(20 * 1024 * 1024)}
+				mock_request.return_value = mock_response
+
+				result = handle_http_request(
+					"GET", "https://api.example.com/", tool_name="test_tool"
+				)
+
+				self.assertFalse(result["success"])
+				self.assertIn("Content-Length exceeds 10MB limit", result["error"])
+				# iter_content should not be called (fast-path)
+				mock_response.iter_content.assert_not_called()
+
+
+class TestRateLimitingDecoratorST075(unittest.TestCase):
+	"""Tests for ST-07.5: Rate limiting decorator presence."""
+
+	def test_rate_limit_decorator_present_on_handle_http_request(self):
+		"""handle_http_request has @rate_limit decorator."""
+		# Check that the function has a __wrapped__ attribute from decorator
+		self.assertTrue(
+			hasattr(handle_http_request, "__wrapped__")
+			or hasattr(handle_http_request, "__name__")
+		)
+
+		# Check decorator metadata (if available)
+		# The real integration test is bench/integration only per the plan
+
+	def test_rate_limit_decorator_present_on_handle_get_request(self):
+		"""handle_get_request has @rate_limit decorator."""
+		self.assertTrue(
+			hasattr(handle_get_request, "__wrapped__")
+			or hasattr(handle_get_request, "__name__")
+		)
+
+	def test_rate_limit_decorator_present_on_handle_post_request(self):
+		"""handle_post_request has @rate_limit decorator."""
+		self.assertTrue(
+			hasattr(handle_post_request, "__wrapped__")
+			or hasattr(handle_post_request, "__name__")
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_http_handler_access.py
+++ b/huf/ai/tests/test_http_handler_access.py
@@ -110,20 +110,32 @@ class TestAuthorizationST071(unittest.TestCase):
 		mock_session.user = "user@example.com"
 		mock_has_capability.return_value = True
 
-		# Mock the rest of the flow to prevent further execution
-		with patch("huf.ai.http_handler.requests.request") as mock_request:
-			mock_response = Mock()
-			mock_response.status_code = 200
-			mock_response.headers = {}
-			mock_response.iter_content = Mock(return_value=[b"{}"])
-			mock_request.return_value = mock_response
+		# Mock the rest of the flow to prevent further execution. frappe.get_doc
+		# and validate_url both need mocking: real DNS resolution of
+		# api.example.com is not guaranteed (and fails in offline/CI
+		# environments), and frappe.get_doc would otherwise hit the real DB
+		# for a tool that doesn't exist.
+		with patch("frappe.get_doc") as mock_get_doc:
+			mock_tool_doc = Mock()
+			mock_tool_doc.base_url = "https://api.example.com/"
+			mock_tool_doc.http_headers = []
+			mock_tool_doc.allowed_for_guest = False
+			mock_get_doc.return_value = mock_tool_doc
 
-			result = handle_http_request(
-				"GET", "https://api.example.com/", tool_name="test_tool"
-			)
+			with patch("huf.ai.http_handler.validate_url", return_value=(True, None)):
+				with patch("huf.ai.http_handler.requests.request") as mock_request:
+					mock_response = Mock()
+					mock_response.status_code = 200
+					mock_response.headers = {}
+					mock_response.iter_content = Mock(return_value=[b"{}"])
+					mock_request.return_value = mock_response
 
-			# Should not raise PermissionError
-			mock_throw.assert_not_called()
+					result = handle_http_request(
+						"GET", "https://api.example.com/", tool_name="test_tool"
+					)
+
+					# Should not raise PermissionError
+					mock_throw.assert_not_called()
 
 	@patch("frappe.session")
 	@patch("huf.ai.http_handler.has_capability")
@@ -183,6 +195,7 @@ class TestGuestAccessST072(unittest.TestCase):
 
 		with patch("frappe.get_doc") as mock_get_doc:
 			mock_tool_doc = Mock()
+			mock_tool_doc.http_headers = []  # must be iterable, checked before the guest gate
 			mock_tool_doc.allowed_for_guest = False
 			mock_get_doc.return_value = mock_tool_doc
 
@@ -208,19 +221,20 @@ class TestGuestAccessST072(unittest.TestCase):
 			mock_tool_doc.allowed_for_guest = True
 			mock_get_doc.return_value = mock_tool_doc
 
-			with patch("huf.ai.http_handler.requests.request") as mock_request:
-				mock_response = Mock()
-				mock_response.status_code = 200
-				mock_response.headers = {}
-				mock_response.iter_content = Mock(return_value=[b"{}"])
-				mock_request.return_value = mock_response
+			with patch("huf.ai.http_handler.validate_url", return_value=(True, None)):
+				with patch("huf.ai.http_handler.requests.request") as mock_request:
+					mock_response = Mock()
+					mock_response.status_code = 200
+					mock_response.headers = {}
+					mock_response.iter_content = Mock(return_value=[b"{}"])
+					mock_request.return_value = mock_response
 
-				result = handle_http_request(
-					"GET", "https://api.example.com/", tool_name="test_tool"
-				)
+					result = handle_http_request(
+						"GET", "https://api.example.com/", tool_name="test_tool"
+					)
 
-				# Should proceed past guest check
-				self.assertTrue(result["success"])
+					# Should proceed past guest check
+					self.assertTrue(result["success"])
 
 
 class TestHeaderOriginBindingST073(unittest.TestCase):
@@ -244,25 +258,26 @@ class TestHeaderOriginBindingST073(unittest.TestCase):
 			mock_tool_doc.allowed_for_guest = False
 			mock_get_doc.return_value = mock_tool_doc
 
-			with patch("huf.ai.http_handler.requests.request") as mock_request:
-				mock_response = Mock()
-				mock_response.status_code = 200
-				mock_response.headers = {}
-				mock_response.iter_content = Mock(return_value=[b"{}"])
-				mock_request.return_value = mock_response
+			with patch("huf.ai.http_handler.validate_url", return_value=(True, None)):
+				with patch("huf.ai.http_handler.requests.request") as mock_request:
+					mock_response = Mock()
+					mock_response.status_code = 200
+					mock_response.headers = {}
+					mock_response.iter_content = Mock(return_value=[b"{}"])
+					mock_request.return_value = mock_response
 
-				result = handle_http_request(
-					"GET",
-					"https://api.example.com/endpoint",
-					tool_name="test_tool",
-				)
+					result = handle_http_request(
+						"GET",
+						"https://api.example.com/endpoint",
+						tool_name="test_tool",
+					)
 
-				# Verify request was made with tool headers
-				call_args = mock_request.call_args
-				self.assertIn("Authorization", call_args.kwargs["headers"])
-				self.assertEqual(
-					call_args.kwargs["headers"]["Authorization"], "Bearer token123"
-				)
+					# Verify request was made with tool headers
+					call_args = mock_request.call_args
+					self.assertIn("Authorization", call_args.kwargs["headers"])
+					self.assertEqual(
+						call_args.kwargs["headers"]["Authorization"], "Bearer token123"
+					)
 
 	@patch("frappe.session")
 	@patch("huf.ai.http_handler.has_capability")
@@ -368,21 +383,22 @@ class TestResponseSizeCappingST074(unittest.TestCase):
 			mock_tool_doc.allowed_for_guest = False
 			mock_get_doc.return_value = mock_tool_doc
 
-			with patch("huf.ai.http_handler.requests.request") as mock_request:
-				mock_response = Mock()
-				mock_response.status_code = 200
-				mock_response.headers = {"Content-Length": "1000"}
-				# Return a small response via iter_content
-				test_data = b'{"result": "success"}'
-				mock_response.iter_content = Mock(return_value=[test_data])
-				mock_request.return_value = mock_response
+			with patch("huf.ai.http_handler.validate_url", return_value=(True, None)):
+				with patch("huf.ai.http_handler.requests.request") as mock_request:
+					mock_response = Mock()
+					mock_response.status_code = 200
+					mock_response.headers = {"Content-Length": "1000"}
+					# Return a small response via iter_content
+					test_data = b'{"result": "success"}'
+					mock_response.iter_content = Mock(return_value=[test_data])
+					mock_request.return_value = mock_response
 
-				result = handle_http_request(
-					"GET", "https://api.example.com/", tool_name="test_tool"
-				)
+					result = handle_http_request(
+						"GET", "https://api.example.com/", tool_name="test_tool"
+					)
 
-				self.assertTrue(result["success"])
-				self.assertEqual(result["status_code"], 200)
+					self.assertTrue(result["success"])
+					self.assertEqual(result["status_code"], 200)
 
 	@patch("frappe.session")
 	@patch("huf.ai.http_handler.has_capability")
@@ -398,25 +414,26 @@ class TestResponseSizeCappingST074(unittest.TestCase):
 			mock_tool_doc.allowed_for_guest = False
 			mock_get_doc.return_value = mock_tool_doc
 
-			with patch("huf.ai.http_handler.requests.request") as mock_request:
-				mock_response = Mock()
-				mock_response.status_code = 200
-				# No Content-Length to pass fast-path check
-				mock_response.headers = {}
-				# Return chunks totaling > MAX_RESPONSE_SIZE
-				# MAX_RESPONSE_SIZE is 10MB, so return > 10MB
-				chunk_size = 8192
-				num_chunks = int((10 * 1024 * 1024) / chunk_size) + 2
-				chunks = [b"x" * chunk_size for _ in range(num_chunks)]
-				mock_response.iter_content = Mock(return_value=chunks)
-				mock_request.return_value = mock_response
+			with patch("huf.ai.http_handler.validate_url", return_value=(True, None)):
+				with patch("huf.ai.http_handler.requests.request") as mock_request:
+					mock_response = Mock()
+					mock_response.status_code = 200
+					# No Content-Length to pass fast-path check
+					mock_response.headers = {}
+					# Return chunks totaling > MAX_RESPONSE_SIZE
+					# MAX_RESPONSE_SIZE is 10MB, so return > 10MB
+					chunk_size = 8192
+					num_chunks = int((10 * 1024 * 1024) / chunk_size) + 2
+					chunks = [b"x" * chunk_size for _ in range(num_chunks)]
+					mock_response.iter_content = Mock(return_value=chunks)
+					mock_request.return_value = mock_response
 
-				result = handle_http_request(
-					"GET", "https://api.example.com/", tool_name="test_tool"
-				)
+					result = handle_http_request(
+						"GET", "https://api.example.com/", tool_name="test_tool"
+					)
 
-				self.assertFalse(result["success"])
-				self.assertIn("Response too large", result["error"])
+					self.assertFalse(result["success"])
+					self.assertIn("Response too large", result["error"])
 
 	@patch("frappe.session")
 	@patch("huf.ai.http_handler.has_capability")
@@ -434,21 +451,22 @@ class TestResponseSizeCappingST074(unittest.TestCase):
 			mock_tool_doc.allowed_for_guest = False
 			mock_get_doc.return_value = mock_tool_doc
 
-			with patch("huf.ai.http_handler.requests.request") as mock_request:
-				mock_response = Mock()
-				mock_response.status_code = 200
-				# Set Content-Length > MAX_RESPONSE_SIZE
-				mock_response.headers = {"Content-Length": str(20 * 1024 * 1024)}
-				mock_request.return_value = mock_response
+			with patch("huf.ai.http_handler.validate_url", return_value=(True, None)):
+				with patch("huf.ai.http_handler.requests.request") as mock_request:
+					mock_response = Mock()
+					mock_response.status_code = 200
+					# Set Content-Length > MAX_RESPONSE_SIZE
+					mock_response.headers = {"Content-Length": str(20 * 1024 * 1024)}
+					mock_request.return_value = mock_response
 
-				result = handle_http_request(
-					"GET", "https://api.example.com/", tool_name="test_tool"
-				)
+					result = handle_http_request(
+						"GET", "https://api.example.com/", tool_name="test_tool"
+					)
 
-				self.assertFalse(result["success"])
-				self.assertIn("Content-Length exceeds 10MB limit", result["error"])
-				# iter_content should not be called (fast-path)
-				mock_response.iter_content.assert_not_called()
+					self.assertFalse(result["success"])
+					self.assertIn("Content-Length exceeds 10MB limit", result["error"])
+					# iter_content should not be called (fast-path)
+					mock_response.iter_content.assert_not_called()
 
 
 class TestRateLimitingDecoratorST075(unittest.TestCase):

--- a/huf/ai/tests/test_maintenance_endpoints.py
+++ b/huf/ai/tests/test_maintenance_endpoints.py
@@ -209,6 +209,7 @@ class TestMaintenanceEndpointAuthorization(unittest.TestCase):
         self.assertEqual(args[1], frappe.PermissionError)
 
     @patch('frappe.session')
+    @patch('frappe.get_doc')
     @patch('frappe.db.get_value')
     @patch('frappe.has_permission')
     @patch('frappe.cache')
@@ -219,6 +220,7 @@ class TestMaintenanceEndpointAuthorization(unittest.TestCase):
         mock_cache,
         mock_has_permission,
         mock_get_value,
+        mock_get_doc,
         mock_session,
     ):
         """ST-06.5: publish_realtime should be scoped to conversation owner."""
@@ -231,6 +233,12 @@ class TestMaintenanceEndpointAuthorization(unittest.TestCase):
         mock_cache_obj.blpop = Mock(return_value=None)  # Timeout
         mock_cache.return_value = mock_cache_obj
         mock_get_value.return_value = "conversation_owner@example.com"
+        # call_id is None in this test, so _get_or_create_call always takes
+        # the "create" branch: frappe.get_doc({...}); call.insert(...). This
+        # must stay pure-mock (per the file's own docstring) rather than
+        # hitting a real, uncreated Agent Tool Call row.
+        mock_call_doc = Mock()
+        mock_get_doc.return_value = mock_call_doc
 
         result = client_side_tool.client_side_function(
             conversation_id="test_conv",
@@ -385,6 +393,13 @@ class TestMaintenanceEndpointAuthorization(unittest.TestCase):
         mock_automation.run_as_user = "admin@example.com"
         mock_get_doc.return_value = mock_automation
         mock_get_roles.return_value = ["Huf User"]  # No System Manager
+        # Without side_effect, the mocked frappe.throw silently returns None
+        # instead of raising, so execution would fall through past the
+        # permission check into instruction rendering (and crash there on
+        # unconfigured Mock attributes) instead of actually verifying the
+        # guard fires. See the sibling fix already applied above in this
+        # same file for test_st06_5_client_side_function_permission_check.
+        mock_throw.side_effect = frappe.PermissionError
 
         # Call with no initiating_user (webhook path)
         # Should trigger _check_run_as_user_permission guard

--- a/huf/ai/tests/test_maintenance_endpoints.py
+++ b/huf/ai/tests/test_maintenance_endpoints.py
@@ -1,0 +1,419 @@
+"""
+Tests for WP-06 authorization on maintenance and tool endpoints.
+
+Covers ST-06.1 through ST-06.8, and ST-06.9 (webhook path verification).
+"""
+
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+import frappe
+from frappe import _
+
+
+class TestMaintenanceEndpointAuthorization(unittest.TestCase):
+    """Pure-mock tests for endpoint permission checks."""
+
+    def setUp(self):
+        """Set up mock Frappe environment."""
+        self.patcher_session = patch('frappe.session')
+        self.mock_session = self.patcher_session.start()
+        self.mock_session.user = "test_user@example.com"
+
+        self.patcher_throw = patch('frappe.throw')
+        self.mock_throw = self.patcher_throw.start()
+
+    def tearDown(self):
+        """Clean up patches."""
+        self.patcher_session.stop()
+        self.patcher_throw.stop()
+
+    # ST-06.1 Tests: automation_scheduler.py - remove @frappe.whitelist()
+    @patch('huf.ai.automation_scheduler.now_datetime')
+    @patch('huf.ai.automation_scheduler.frappe.get_all')
+    @patch('huf.ai.automation_scheduler.frappe.db.exists')
+    @patch('huf.ai.automation_scheduler.automation_runtime_is_new')
+    def test_st06_1_run_due_automations_not_whitelisted(
+        self, mock_runtime_new, mock_db_exists, mock_get_all, mock_now
+    ):
+        """ST-06.1: run_due_automations should not be whitelisted for HTTP access."""
+        # This test verifies the decorator is removed by checking that
+        # the function exists and can be called directly.
+        from huf.ai import automation_scheduler
+
+        self.assertTrue(hasattr(automation_scheduler, 'run_due_automations'))
+        # Verify the function itself doesn't have a whitelist decorator
+        # (decorators would be in the function's __wrapped__ or similar).
+        self.assertFalse(hasattr(
+            automation_scheduler.run_due_automations,
+            '__self__'  # Would indicate a bound method decorator
+        ))
+
+    # ST-06.2 Tests: tool_registry.py - require System Manager
+    @patch('frappe.only_for')
+    @patch('huf.ai.tool_registry.get_tools_by_app')
+    def test_st06_2_sync_discovered_tools_system_manager_only(
+        self, mock_get_tools, mock_only_for
+    ):
+        """ST-06.2: sync_discovered_tools should require System Manager role."""
+        from huf.ai import tool_registry
+
+        # Set up mock to raise PermissionError when not System Manager
+        def only_for_side_effect(role):
+            if role != "System Manager":
+                frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+        mock_only_for.side_effect = only_for_side_effect
+        mock_get_tools.return_value = {}
+
+        # Call should invoke only_for with "System Manager"
+        try:
+            tool_registry.sync_discovered_tools(apps_to_scan=None)
+        except:
+            pass
+
+        # Verify frappe.only_for was called with "System Manager"
+        mock_only_for.assert_called_once_with("System Manager")
+
+    # ST-06.3 Tests: orchestrator.py - add permission check
+    @patch('frappe.has_permission')
+    @patch('frappe.throw')
+    @patch('frappe.get_doc')
+    def test_st06_3_recreate_orchestration_plan_permission_check(
+        self, mock_get_doc, mock_throw, mock_has_permission
+    ):
+        """ST-06.3: recreate_orchestration_plan should check write permission."""
+        from huf.ai.orchestration import orchestrator
+
+        mock_has_permission.return_value = False
+        mock_orch = Mock()
+        mock_orch.agent = "Test Agent"
+        mock_get_doc.return_value = mock_orch
+
+        orchestrator.recreate_orchestration_plan("test_orch")
+
+        # Verify permission check was performed
+        mock_has_permission.assert_called_with("Agent Orchestration", "write")
+        # Verify throw was called due to failed permission
+        mock_throw.assert_called_once()
+        args = mock_throw.call_args[0]
+        self.assertEqual(args[1], frappe.PermissionError)
+
+    @patch('frappe.has_permission')
+    @patch('frappe.get_doc')
+    @patch('huf.ai.orchestration.orchestrator.run_planning')
+    @patch('huf.ai.orchestration.orchestrator.parse_plan_steps')
+    def test_st06_3_recreate_orchestration_plan_allowed_with_permission(
+        self, mock_parse, mock_run_planning, mock_get_doc, mock_has_permission
+    ):
+        """ST-06.3: recreate_orchestration_plan should proceed when permitted."""
+        from huf.ai.orchestration import orchestrator
+
+        mock_has_permission.return_value = True
+        mock_orch = Mock()
+        mock_orch.agent = "Test Agent"
+        mock_orch.agent_orchestration_plan = []
+        mock_get_doc.side_effect = [mock_orch, Mock()]  # Two calls to get_doc
+        mock_run_planning.return_value = "1. Step one\n2. Step two"
+        mock_parse.return_value = ["Step one", "Step two"]
+
+        orchestrator.recreate_orchestration_plan("test_orch")
+
+        # Should not throw, should proceed with planning
+        mock_run_planning.assert_called_once()
+
+    # ST-06.4 Tests: memory_record.py - add permission check
+    @patch('frappe.get_doc')
+    def test_st06_4_queue_memory_knowledge_projection_permission_check(
+        self, mock_get_doc
+    ):
+        """ST-06.4: queue_memory_knowledge_projection should check write permission."""
+        from huf.huf.doctype.memory_record import memory_record
+
+        mock_doc = Mock()
+        mock_doc.check_permission = Mock(side_effect=frappe.PermissionError)
+        mock_get_doc.return_value = mock_doc
+
+        with self.assertRaises(frappe.PermissionError):
+            memory_record.queue_memory_knowledge_projection("test_record")
+
+        # Verify check_permission was called with "write"
+        mock_doc.check_permission.assert_called_once_with("write")
+
+    @patch('frappe.get_doc')
+    def test_st06_4_remove_memory_knowledge_projection_permission_check(
+        self, mock_get_doc
+    ):
+        """ST-06.4: remove_memory_knowledge_projection should check write permission."""
+        from huf.huf.doctype.memory_record import memory_record
+
+        mock_doc = Mock()
+        mock_doc.check_permission = Mock(side_effect=frappe.PermissionError)
+        mock_get_doc.return_value = mock_doc
+
+        with self.assertRaises(frappe.PermissionError):
+            memory_record.remove_memory_knowledge_projection("test_record")
+
+        # Verify check_permission was called with "write"
+        mock_doc.check_permission.assert_called_once_with("write")
+
+    @patch('frappe.get_doc')
+    def test_st06_4_queue_memory_allowed_with_permission(self, mock_get_doc):
+        """ST-06.4: queue_memory_knowledge_projection should proceed when permitted."""
+        from huf.huf.doctype.memory_record import memory_record
+
+        mock_doc = Mock()
+        mock_doc.check_permission = Mock()  # No exception
+        mock_doc.queue_knowledge_projection = Mock(
+            return_value={"status": "queued"}
+        )
+        mock_get_doc.return_value = mock_doc
+
+        result = memory_record.queue_memory_knowledge_projection("test_record")
+
+        self.assertEqual(result["status"], "queued")
+        mock_doc.check_permission.assert_called_once_with("write")
+        mock_doc.queue_knowledge_projection.assert_called_once()
+
+    # ST-06.5 Tests: client_side_tool.py - permission check and user scoping
+    @patch('frappe.session')
+    @patch('frappe.has_permission')
+    @patch('frappe.throw')
+    def test_st06_5_client_side_function_permission_check(
+        self, mock_throw, mock_has_permission, mock_session
+    ):
+        """ST-06.5: client_side_function should check write permission on conversation."""
+        from huf.ai import client_side_tool
+
+        mock_session.user = "test_user"
+        mock_has_permission.return_value = False
+
+        result = client_side_tool.client_side_function(
+            conversation_id="test_conv",
+            agent_run_id="test_run",
+            function_name="test_func",
+        )
+
+        # Should throw permission error
+        mock_throw.assert_called_once()
+        args = mock_throw.call_args[0]
+        self.assertEqual(args[1], frappe.PermissionError)
+
+    @patch('frappe.session')
+    @patch('frappe.db.get_value')
+    @patch('frappe.has_permission')
+    @patch('frappe.cache')
+    @patch('frappe.publish_realtime')
+    def test_st06_5_client_side_function_publish_realtime_scoped_to_owner(
+        self,
+        mock_publish,
+        mock_cache,
+        mock_has_permission,
+        mock_get_value,
+        mock_session,
+    ):
+        """ST-06.5: publish_realtime should be scoped to conversation owner."""
+        from huf.ai import client_side_tool
+
+        mock_session.user = "test_user"
+        mock_has_permission.return_value = True
+        mock_cache_obj = MagicMock()
+        mock_cache_obj.set_value = Mock()
+        mock_cache_obj.blpop = Mock(return_value=None)  # Timeout
+        mock_cache.return_value = mock_cache_obj
+        mock_get_value.return_value = "conversation_owner@example.com"
+
+        result = client_side_tool.client_side_function(
+            conversation_id="test_conv",
+            agent_run_id="test_run",
+            function_name="test_func",
+        )
+
+        # Verify publish_realtime was called with user=conversation_owner
+        mock_publish.assert_called_once()
+        call_kwargs = mock_publish.call_args[1]
+        self.assertEqual(call_kwargs["user"], "conversation_owner@example.com")
+        self.assertNotEqual(call_kwargs["user"], "test_user")
+
+    # ST-06.6 Tests: mcp_connection_resolver.py - System Manager only + hardened URL check
+    @patch('frappe.only_for')
+    def test_st06_6_resolve_mcp_connection_system_manager_only(
+        self, mock_only_for
+    ):
+        """ST-06.6: resolve_mcp_connection should require System Manager."""
+        from huf.ai import mcp_connection_resolver
+
+        mock_only_for.side_effect = frappe.PermissionError
+
+        with self.assertRaises(frappe.PermissionError):
+            mcp_connection_resolver.resolve_mcp_connection(
+                "https://example.com", "https://callback.com"
+            )
+
+        mock_only_for.assert_called_once_with("System Manager")
+
+    def test_st06_6_is_safe_url_rejects_localhost(self):
+        """ST-06.6: _is_safe_url should reject localhost."""
+        from huf.ai.mcp_connection_resolver import _is_safe_url
+
+        self.assertFalse(_is_safe_url("http://localhost:8080/mcp"))
+        self.assertFalse(_is_safe_url("http://127.0.0.1:8080/mcp"))
+        self.assertFalse(_is_safe_url("http://[::1]:8080/mcp"))
+
+    def test_st06_6_is_safe_url_rejects_private_ips(self):
+        """ST-06.6: _is_safe_url should reject private IP ranges."""
+        from huf.ai.mcp_connection_resolver import _is_safe_url
+
+        self.assertFalse(_is_safe_url("http://10.0.0.1/mcp"))
+        self.assertFalse(_is_safe_url("http://192.168.1.1/mcp"))
+        self.assertFalse(_is_safe_url("http://172.16.0.1/mcp"))
+
+    @patch('socket.getaddrinfo')
+    def test_st06_6_is_safe_url_requires_dns_resolution(
+        self, mock_getaddrinfo
+    ):
+        """ST-06.6: _is_safe_url should require successful DNS resolution."""
+        from huf.ai.mcp_connection_resolver import _is_safe_url
+        import socket
+
+        # Test DNS failure
+        mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
+        self.assertFalse(_is_safe_url("http://invalid-unknown-domain.invalid/mcp"))
+
+    @patch('socket.getaddrinfo')
+    def test_st06_6_is_safe_url_allows_public_ips(
+        self, mock_getaddrinfo
+    ):
+        """ST-06.6: _is_safe_url should allow public IP addresses."""
+        from huf.ai.mcp_connection_resolver import _is_safe_url
+
+        # Mock DNS resolution to return a public IP
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, '', ('8.8.8.8', 443))  # Public IP
+        ]
+
+        self.assertTrue(_is_safe_url("https://example.com/mcp"))
+
+    # ST-06.7 Tests: automation_app_event.py - keep read gate, add initiating_user
+    @patch('frappe.session')
+    @patch('frappe.has_permission')
+    @patch('frappe.throw')
+    def test_st06_7_trigger_app_event_read_permission_gate(
+        self, mock_throw, mock_has_permission, mock_session
+    ):
+        """ST-06.7: trigger_app_event should gate on Automation read permission."""
+        from huf.ai import automation_app_event
+
+        mock_session.user = "test_user"
+        mock_has_permission.return_value = False
+
+        automation_app_event.trigger_app_event("test_app", "test_event", {})
+
+        # Verify read permission was checked
+        mock_has_permission.assert_called_with("Automation", "read")
+        mock_throw.assert_called_once()
+
+    @patch('frappe.session')
+    @patch('frappe.has_permission')
+    @patch('frappe.get_all')
+    @patch('huf.ai.automation_app_event.run_automation')
+    @patch('huf.ai.automation_app_event.automation_runtime_is_new')
+    def test_st06_7_trigger_app_event_passes_initiating_user(
+        self,
+        mock_runtime_new,
+        mock_run_automation,
+        mock_get_all,
+        mock_has_permission,
+        mock_session,
+    ):
+        """ST-06.7: trigger_app_event should pass initiating_user to run_automation."""
+        from huf.ai import automation_app_event
+
+        mock_session.user = "test_user@example.com"
+        mock_has_permission.return_value = True
+        mock_runtime_new.return_value = True
+        mock_get_all.return_value = [
+            {"name": "trigger1", "automation": "auto1"}
+        ]
+
+        automation_app_event.trigger_app_event("test_app", "test_event", {})
+
+        # Verify run_automation was called with initiating_user
+        mock_run_automation.assert_called_once()
+        call_kwargs = mock_run_automation.call_args[1]
+        self.assertEqual(call_kwargs["initiating_user"], "test_user@example.com")
+
+    # ST-06.8 Tests: batch_poll.py - remove @frappe.whitelist()
+    def test_st06_8_poll_pending_batch_jobs_not_whitelisted(self):
+        """ST-06.8: poll_pending_batch_jobs should not be whitelisted."""
+        from huf.ai import batch_poll
+
+        self.assertTrue(hasattr(batch_poll, 'poll_pending_batch_jobs'))
+        # Verify the function doesn't have a whitelist decorator
+        self.assertFalse(hasattr(
+            batch_poll.poll_pending_batch_jobs,
+            '__self__'
+        ))
+
+    # ST-06.9 Tests: automation_webhook.py - verify existing guard works
+    @patch('frappe.get_doc')
+    @patch('frappe.throw')
+    @patch('huf.ai.automation_runner.frappe.get_roles')
+    def test_st06_9_webhook_run_as_user_guard_fires(
+        self, mock_get_roles, mock_throw, mock_get_doc
+    ):
+        """ST-06.9: webhook's run_automation should use existing _check_run_as_user_permission guard."""
+        from huf.ai.automation_runner import run_automation
+
+        # Create an Automation where owner lacks System Manager
+        # and run_as_user != owner (the violation condition)
+        mock_automation = Mock()
+        mock_automation.name = "test_auto"
+        mock_automation.disabled = False
+        mock_automation.status = "Active"
+        mock_automation.agent = "test_agent"
+        mock_automation.owner = "regular_user@example.com"
+        mock_automation.run_as_user = "admin@example.com"
+        mock_get_doc.return_value = mock_automation
+        mock_get_roles.return_value = ["Huf User"]  # No System Manager
+
+        # Call with no initiating_user (webhook path)
+        # Should trigger _check_run_as_user_permission guard
+        try:
+            run_automation("test_auto", trigger_name="webhook", commit=False)
+        except frappe.PermissionError:
+            pass  # Expected
+
+        # Verify the throw was called due to permission check
+        mock_throw.assert_called_once()
+        args = mock_throw.call_args[0]
+        self.assertEqual(args[1], frappe.PermissionError)
+
+    @patch('frappe.get_doc')
+    @patch('huf.ai.automation_runner.frappe.get_roles')
+    @patch('huf.ai.automation_runner._execute')
+    def test_st06_9_webhook_run_as_user_allowed_for_owner(
+        self, mock_execute, mock_get_roles, mock_get_doc
+    ):
+        """ST-06.9: webhook automation should proceed when run_as_user == owner."""
+        from huf.ai.automation_runner import run_automation
+
+        mock_automation = Mock()
+        mock_automation.name = "test_auto"
+        mock_automation.disabled = False
+        mock_automation.status = "Active"
+        mock_automation.agent = "test_agent"
+        mock_automation.owner = "user@example.com"
+        mock_automation.run_as_user = "user@example.com"  # Same as owner
+        mock_get_doc.return_value = mock_automation
+        mock_execute.return_value = {"success": True}
+        mock_get_roles.return_value = ["Huf User"]
+
+        result = run_automation("test_auto", trigger_name="webhook", commit=False)
+
+        # Should proceed without error
+        self.assertIsNotNone(result)
+        mock_execute.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/huf/ai/tests/test_maintenance_endpoints.py
+++ b/huf/ai/tests/test_maintenance_endpoints.py
@@ -85,11 +85,16 @@ class TestMaintenanceEndpointAuthorization(unittest.TestCase):
         from huf.ai.orchestration import orchestrator
 
         mock_has_permission.return_value = False
+        mock_throw.side_effect = frappe.PermissionError
         mock_orch = Mock()
         mock_orch.agent = "Test Agent"
         mock_get_doc.return_value = mock_orch
 
-        orchestrator.recreate_orchestration_plan("test_orch")
+        # frappe.throw must actually stop execution (as it does for real);
+        # without side_effect, the mock would silently fall through into
+        # the unmocked planning code below the permission check.
+        with self.assertRaises(frappe.PermissionError):
+            orchestrator.recreate_orchestration_plan("test_orch")
 
         # Verify permission check was performed
         mock_has_permission.assert_called_with("Agent Orchestration", "write")
@@ -186,12 +191,17 @@ class TestMaintenanceEndpointAuthorization(unittest.TestCase):
 
         mock_session.user = "test_user"
         mock_has_permission.return_value = False
+        mock_throw.side_effect = frappe.PermissionError
 
-        result = client_side_tool.client_side_function(
-            conversation_id="test_conv",
-            agent_run_id="test_run",
-            function_name="test_func",
-        )
+        # frappe.throw must actually stop execution (as it does for real);
+        # without side_effect, the mock would silently fall through into
+        # the unmocked _get_or_create_call below the permission check.
+        with self.assertRaises(frappe.PermissionError):
+            client_side_tool.client_side_function(
+                conversation_id="test_conv",
+                agent_run_id="test_run",
+                function_name="test_func",
+            )
 
         # Should throw permission error
         mock_throw.assert_called_once()

--- a/huf/ai/tool_registry.py
+++ b/huf/ai/tool_registry.py
@@ -363,15 +363,16 @@ def get_tools_by_app(apps_to_scan=None, use_cache=True):
 def sync_discovered_tools(apps_to_scan=None, use_cache=True):
     """
     Sync discovered tools from hooks.
-    
+
     Args:
         apps_to_scan: List of app names to scan, or None for all installed apps
                      (None = full scan, used for manual sync and after_migrate)
         use_cache: If True, use cache to skip unchanged apps (only when apps_to_scan is None)
-    
+
     Returns:
         dict: Summary of sync results
     """
+    frappe.only_for("System Manager")
     # For manual sync, don't use cache (force full scan)
     # For incremental sync (apps_to_scan specified), always scan those apps
     cache_enabled = use_cache and apps_to_scan is None

--- a/huf/huf/doctype/memory_record/memory_record.py
+++ b/huf/huf/doctype/memory_record/memory_record.py
@@ -138,10 +138,12 @@ def project_memory_to_knowledge(memory_record: str):
 @frappe.whitelist()
 def queue_memory_knowledge_projection(memory_record: str):
     doc = frappe.get_doc("Memory Record", memory_record)
+    doc.check_permission("write")
     return doc.queue_knowledge_projection()
 
 
 @frappe.whitelist()
 def remove_memory_knowledge_projection(memory_record: str):
     doc = frappe.get_doc("Memory Record", memory_record)
+    doc.check_permission("write")
     return doc.remove_knowledge_projection()


### PR DESCRIPTION
Same change as #702, opened against `pre-develop` per track instructions (stacked on fix/http-handler-hardening, same stacking note as #702). See #702 for the full description, findings closed, deviations, and test plan.