### PR TITLE
fix(security): close two regressions the merged agent-security-residual hardening PR left open

### DIFF
--- a/huf/ai/sdk_tools.py
+++ b/huf/ai/sdk_tools.py
@@ -533,9 +533,11 @@ def create_function_tool(
                         })
                     args_dict["ignore_permissions"] = True
 
-                # Override report_name with reference_report if pinned for guest
-                if _extra_args.get("reference_report"):
-                    args_dict["report_name"] = _extra_args["reference_report"]
+                    # Override report_name with reference_report if pinned for guest.
+                    # Scoped to this branch only -- a non-guest caller's LLM-supplied
+                    # report_name must not be silently overwritten by a guest pin.
+                    if _extra_args.get("reference_report"):
+                        args_dict["report_name"] = _extra_args["reference_report"]
 
                 if _function.__name__ in ["handle_get_request", "handle_post_request"]:
                     args_dict["tool_name"] = name

--- a/huf/ai/tests/test_guest_report_pinning.py
+++ b/huf/ai/tests/test_guest_report_pinning.py
@@ -198,35 +198,46 @@ class TestGuestDenialWithoutPin(unittest.TestCase):
 
 
 class TestNonGuestUnaffected(unittest.TestCase):
-	"""Test that non-guest sessions are not affected by report pinning."""
+	"""Test that non-guest sessions are not affected by report pinning.
 
+	Regression test for a real bug found during live verification: the
+	``args_dict["report_name"] = extra_args["reference_report"]`` override in
+	``invoke_tool`` originally sat OUTSIDE the
+	``if allowed_for_guest and frappe.session.user == "Guest":`` block, so it
+	silently overwrote a non-guest caller's LLM-supplied ``report_name`` too --
+	the exact opposite of the "non-guest session is unaffected" acceptance
+	criterion. This test drives the REAL ``invoke_tool`` (not a hand-copied
+	simulation of its logic) with a non-guest session and a pinned
+	``reference_report``, and asserts the handler actually receives the
+	LLM-supplied ``report_name``, unmodified.
+	"""
+
+	@patch("huf.ai.tool_invocation.get_function_from_name")
 	@patch("huf.ai.tool_invocation.frappe")
-	async def test_non_guest_uses_llm_supplied_report_name(self, mock_frappe):
+	def test_non_guest_uses_llm_supplied_report_name(self, mock_frappe, mock_get_fn):
 		"""Non-guest: report_name from args_dict is honored, not overridden."""
 		mock_frappe.session.user = "user@example.com"
 
-		# Simulate: tool has reference_report, but guest check is skipped for non-guest
 		spec = _make_get_report_result_tool_spec(
 			reference_report="Pinned Report",
-			allowed_for_guest=0,
+			allowed_for_guest=1,
+		)
+		mock_frappe.db.get_value.return_value = spec
+
+		received_kwargs = {}
+
+		async def fake_handler(**kwargs):
+			received_kwargs.update(kwargs)
+			return {"success": True}
+
+		mock_get_fn.return_value = fake_handler
+
+		result = asyncio.run(
+			invoke_tool("get_my_report", {"report_name": "LLM-Supplied Report"})
 		)
 
-		# The guest-specific override only happens inside:
-		#   if allowed_for_guest and frappe.session.user == "Guest":
-		# For non-guests, extra_args are injected but report_name is NOT overridden
-
-		extra_args = {"reference_report": "Pinned Report"}
-		args_dict = {"report_name": "LLM-Supplied Report"}
-
-		# For non-guest, the override should NOT happen
-		# (it only happens in the guest branch of the code)
-		# So args_dict should retain its original value
-		if not mock_frappe.session.user == "Guest":
-			# The override is skipped, so report_name stays as supplied
-			pass
-
-		# After the guest check is skipped, the handler gets called with original args
-		self.assertEqual(args_dict["report_name"], "LLM-Supplied Report")
+		self.assertTrue(result.success)
+		self.assertEqual(received_kwargs.get("report_name"), "LLM-Supplied Report")
 
 
 class TestSdkToolsGuestCheck(unittest.TestCase):

--- a/huf/ai/tests/test_media_handlers.py
+++ b/huf/ai/tests/test_media_handlers.py
@@ -317,71 +317,104 @@ class TestHandleGenerateAudioPrivatization(IntegrationTestCase):
 
 
 class TestPrivatizeGeneratedMediaFilesPatch(IntegrationTestCase):
-	"""Test ST-R3.1b: privatize_generated_media_files patch flips is_private and rewrites URLs."""
+	"""Test ST-R3.1b: privatize_generated_media_files patch flips is_private and rewrites URLs.
+
+	Regression test for a real bug found during live verification: the
+	original patch flipped ``is_private`` via a raw ``frappe.db.set_value``
+	write, which only changes the DB column -- it bypasses
+	``File.validate()`` -> ``File.handle_is_private_changed()``, the
+	controller method that actually MOVES the file's bytes from
+	``public/files`` to ``private/files`` on disk. Live-tested: the old
+	public URL kept serving the file with a 200 even after the "fix" ran.
+	The patch now flips the flag via ``File.save()`` so the real move runs.
+	These tests assert the mocked File Document's ``is_private`` attribute
+	and ``.save()`` are used, not a bypassing ``frappe.db.set_value`` call for
+	the File doc's own flag.
+	"""
 
 	def test_patch_flips_is_private_and_rewrites_urls(self):
-		"""The patch should flip is_private=1 on Files and rewrite /files/ to /private/files/ in Agent Messages."""
+		"""The patch should flip is_private=1 via File.save() (not db.set_value) and rewrite the Agent Message URL to the File doc's own post-save file_url."""
 		from huf.patches.v1.privatize_generated_media_files import execute as run_patch
 
-		# Create a mock File and Agent Message representing the old state.
 		# frappe.db.get_list(fields=[...]) returns plain dict-like rows, not
-		# objects with attribute access — a MagicMock here doesn't behave like
-		# a dict (mock_file["x"] = "y" only records a __setitem__ call; reading
-		# mock_file["x"] back returns a fresh MagicMock, not "y"), so use a
-		# real dict to match what the patch actually receives in production.
-		mock_file = {
+		# objects with attribute access — use a real dict to match production.
+		mock_file_row = {
 			"name": "test-file",
-			"file_name": "generated_image_1.png",
 			"attached_to_name": "test-msg",
 			"attached_to_field": "generated_image",
 		}
 
-		mock_message = MagicMock()
-		mock_message.generated_image = "/files/generated_image_1.png"
+		# frappe.get_doc("File", name) must return an object whose .save()
+		# call is what the patch relies on to trigger the real move; simulate
+		# that save() flips file_url the way File.handle_is_private_changed does.
+		mock_file_doc = MagicMock()
+		mock_file_doc.is_private = 0
 
-		with patch("frappe.db.get_list", return_value=[mock_file]):
+		def _fake_save(**kwargs):
+			mock_file_doc.file_url = "/private/files/generated_image_1.png"
+
+		mock_file_doc.save.side_effect = _fake_save
+
+		with patch("frappe.db.get_list", return_value=[mock_file_row]):
 			with patch("frappe.db.set_value") as mock_set_value:
-				with patch("frappe.get_doc", return_value=mock_message):
+				with patch("frappe.get_doc", return_value=mock_file_doc):
 					run_patch()
 
-		# Verify set_value was called to flip is_private
-		calls = mock_set_value.call_args_list
-		is_private_set = any(
-			call[0] == ("File", "test-file", "is_private", 1)
-			for call in calls
-		)
-		self.assertTrue(is_private_set, "Patch should set is_private=1 on File")
+		# The File doc's is_private must be set via attribute + save(), which
+		# is what triggers the real move -- not a raw db.set_value bypass.
+		self.assertEqual(mock_file_doc.is_private, 1, "Patch should set File.is_private=1 via the Document, not db.set_value")
+		mock_file_doc.save.assert_called_once()
 
-		# Verify set_value was called to rewrite the URL
+		# The Agent Message URL must be rewritten to the File doc's OWN
+		# post-save file_url (not a blind string substitution), since that's
+		# what handle_is_private_changed actually produced.
+		calls = mock_set_value.call_args_list
 		url_set = any(
 			call[0] == ("Agent Message", "test-msg", "generated_image", "/private/files/generated_image_1.png")
 			for call in calls
 		)
-		self.assertTrue(url_set, "Patch should rewrite /files/ to /private/files/ in Agent Message")
+		self.assertTrue(url_set, "Patch should rewrite the Agent Message field to the File doc's post-save file_url")
+
+		# The File doc's own is_private flag must NOT be set via db.set_value
+		# (that's the exact bug this test guards against).
+		file_is_private_via_set_value = any(
+			call[0][:3] == ("File", "test-file", "is_private")
+			for call in calls
+		)
+		self.assertFalse(
+			file_is_private_via_set_value,
+			"Patch must not flip File.is_private via db.set_value -- it bypasses the physical file move",
+		)
 
 	def test_patch_handles_generated_audio_urls(self):
-		"""The patch should also handle generated_audio field URLs."""
+		"""The patch should also handle generated_audio field URLs, via the same save()-based flip."""
 		from huf.patches.v1.privatize_generated_media_files import execute as run_patch
 
-		mock_file = {
+		mock_file_row = {
 			"name": "test-audio-file",
-			"file_name": "generated_audio_1.mp3",
 			"attached_to_name": "test-msg-audio",
 			"attached_to_field": "generated_audio",
 		}
 
-		mock_message = MagicMock()
-		mock_message.generated_audio = "/files/generated_audio_1.mp3"
+		mock_file_doc = MagicMock()
+		mock_file_doc.is_private = 0
 
-		with patch("frappe.db.get_list", return_value=[mock_file]):
+		def _fake_save(**kwargs):
+			mock_file_doc.file_url = "/private/files/generated_audio_1.mp3"
+
+		mock_file_doc.save.side_effect = _fake_save
+
+		with patch("frappe.db.get_list", return_value=[mock_file_row]):
 			with patch("frappe.db.set_value") as mock_set_value:
-				with patch("frappe.get_doc", return_value=mock_message):
+				with patch("frappe.get_doc", return_value=mock_file_doc):
 					run_patch()
 
-		# Verify set_value was called to rewrite the audio URL
+		self.assertEqual(mock_file_doc.is_private, 1)
+		mock_file_doc.save.assert_called_once()
+
 		calls = mock_set_value.call_args_list
 		url_set = any(
 			call[0] == ("Agent Message", "test-msg-audio", "generated_audio", "/private/files/generated_audio_1.mp3")
 			for call in calls
 		)
-		self.assertTrue(url_set, "Patch should rewrite generated_audio URLs from /files/ to /private/files/")
+		self.assertTrue(url_set, "Patch should rewrite generated_audio URLs to the File doc's post-save file_url")

--- a/huf/ai/tests/test_tool_invocation.py
+++ b/huf/ai/tests/test_tool_invocation.py
@@ -319,7 +319,7 @@ class InvokeToolSecurityTests(_FrappeDoubleTestCase):
 			captured.update(kwargs)
 			return {"ok": True}
 
-		ti.get_function_from_name = lambda path: fake_handler
+		ti.get_function_from_name = lambda path, tool_type=None: fake_handler
 		self._register_tool("dangerous_tool", "Update Document", reference_doctype="Task")
 
 		result = _run(ti.invoke_tool(
@@ -339,7 +339,7 @@ class InvokeToolSecurityTests(_FrappeDoubleTestCase):
 			captured.update(kwargs)
 			return {"ok": True}
 
-		ti.get_function_from_name = lambda path: fake_handler
+		ti.get_function_from_name = lambda path, tool_type=None: fake_handler
 		self.frappe.session.user = "Administrator"
 
 		result = _run(ti.invoke_tool(
@@ -351,7 +351,7 @@ class InvokeToolSecurityTests(_FrappeDoubleTestCase):
 		self.assertNotIn("ignore_permissions", captured)
 
 	def test_guest_blocked_from_mutating_alias_with_no_backing_doc(self):
-		ti.get_function_from_name = lambda path: (lambda **kw: {"ok": True})
+		ti.get_function_from_name = lambda path, tool_type=None: (lambda **kw: {"ok": True})
 		self.frappe.session.user = "Guest"
 
 		result = _run(ti.invoke_tool("delete_document", {"name": "TASK-0001"}))
@@ -360,7 +360,7 @@ class InvokeToolSecurityTests(_FrappeDoubleTestCase):
 		self.assertTrue(result.denied)
 
 	def test_guest_pinned_type_without_pin_is_refused(self):
-		ti.get_function_from_name = lambda path: (lambda **kw: {"ok": True})
+		ti.get_function_from_name = lambda path, tool_type=None: (lambda **kw: {"ok": True})
 		self._register_tool("open_lookup", "Get Document", reference_doctype=None, allowed_for_guest=1)
 		self.frappe.session.user = "Guest"
 
@@ -377,7 +377,7 @@ class InvokeToolSecurityTests(_FrappeDoubleTestCase):
 			captured.update(kwargs)
 			return {"ok": True}
 
-		ti.get_function_from_name = lambda path: fake_handler
+		ti.get_function_from_name = lambda path, tool_type=None: fake_handler
 		self._register_tool("public_faq", "Get Document", reference_doctype="FAQ", allowed_for_guest=1)
 		self.frappe.session.user = "Guest"
 
@@ -398,7 +398,7 @@ class InvokeToolSecurityTests(_FrappeDoubleTestCase):
 			captured.update(kwargs)
 			return {"ok": True}
 
-		ti.get_function_from_name = lambda path: fake_handler
+		ti.get_function_from_name = lambda path, tool_type=None: fake_handler
 		self._register_tool("pinned_tool", "Get List", reference_doctype="Task")
 
 		_run(ti.invoke_tool("pinned_tool", {"reference_doctype": "User"}))
@@ -418,7 +418,7 @@ class SignatureFilteringTests(_FrappeDoubleTestCase):
 			captured["kwargs"] = {"name": name, "reference_doctype": reference_doctype}
 			return {"ok": True}
 
-		ti.get_function_from_name = lambda path: fake_handler
+		ti.get_function_from_name = lambda path, tool_type=None: fake_handler
 		self.frappe.db.tool_function_rows["strict_tool"] = {
 			"name": "ATF-strict", "tool_name": "strict_tool", "types": "Get Document",
 			"function_path": None, "reference_doctype": "Task", "agent": None,
@@ -439,7 +439,7 @@ class SignatureFilteringTests(_FrappeDoubleTestCase):
 			captured.update(kwargs)
 			return {"ok": True}
 
-		ti.get_function_from_name = lambda path: fake_handler
+		ti.get_function_from_name = lambda path, tool_type=None: fake_handler
 		self.frappe.db.tool_function_rows["loose_tool"] = {
 			"name": "ATF-loose", "tool_name": "loose_tool", "types": "Get Document",
 			"function_path": None, "reference_doctype": None, "agent": None,
@@ -482,7 +482,7 @@ class TelemetryTests(_FrappeDoubleTestCase):
 	"""
 
 	def test_telemetry_off_by_default_creates_no_doc(self):
-		ti.get_function_from_name = lambda path: (lambda **kw: {"ok": True})
+		ti.get_function_from_name = lambda path, tool_type=None: (lambda **kw: {"ok": True})
 		self.frappe.db.tool_function_rows["quiet_tool"] = {
 			"name": "ATF-quiet", "tool_name": "quiet_tool", "types": "Get Document",
 			"function_path": None, "reference_doctype": None, "agent": None,
@@ -494,7 +494,7 @@ class TelemetryTests(_FrappeDoubleTestCase):
 		self.assertEqual(len(self.frappe.docs), 0)
 
 	def test_telemetry_on_creates_started_then_finalizes_completed(self):
-		ti.get_function_from_name = lambda path: (lambda **kw: {"value": 42})
+		ti.get_function_from_name = lambda path, tool_type=None: (lambda **kw: {"value": 42})
 		self.frappe.db.tool_function_rows["loud_tool"] = {
 			"name": "ATF-loud", "tool_name": "loud_tool", "types": "Get Document",
 			"function_path": None, "reference_doctype": None, "agent": None,
@@ -517,7 +517,7 @@ class TelemetryTests(_FrappeDoubleTestCase):
 		def raising_handler(**kwargs):
 			raise ValueError("boom")
 
-		ti.get_function_from_name = lambda path: raising_handler
+		ti.get_function_from_name = lambda path, tool_type=None: raising_handler
 		self.frappe.db.tool_function_rows["failing_tool"] = {
 			"name": "ATF-fail", "tool_name": "failing_tool", "types": "Get Document",
 			"function_path": None, "reference_doctype": None, "agent": None,
@@ -537,7 +537,7 @@ class InvokeToolSyncTests(_FrappeDoubleTestCase):
 	"""
 
 	def test_sync_wrapper_runs_to_completion(self):
-		ti.get_function_from_name = lambda path: (lambda **kw: {"value": 1})
+		ti.get_function_from_name = lambda path, tool_type=None: (lambda **kw: {"value": 1})
 		self.frappe.db.tool_function_rows["sync_tool"] = {
 			"name": "ATF-sync", "tool_name": "sync_tool", "types": "Get Document",
 			"function_path": None, "reference_doctype": None, "agent": None,
@@ -553,7 +553,7 @@ class InvokeToolSyncTests(_FrappeDoubleTestCase):
 		async def async_handler(**kwargs):
 			return {"async": True}
 
-		ti.get_function_from_name = lambda path: async_handler
+		ti.get_function_from_name = lambda path, tool_type=None: async_handler
 		self.frappe.db.tool_function_rows["async_tool"] = {
 			"name": "ATF-async", "tool_name": "async_tool", "types": "Get Document",
 			"function_path": None, "reference_doctype": None, "agent": None,

--- a/huf/ai/tool_invocation.py
+++ b/huf/ai/tool_invocation.py
@@ -384,9 +384,11 @@ async def invoke_tool(
 			)
 		args_dict["ignore_permissions"] = True
 
-	# Override report_name with reference_report if pinned for guest
-	if extra_args.get("reference_report"):
-		args_dict["report_name"] = extra_args["reference_report"]
+		# Override report_name with reference_report if pinned for guest.
+		# Scoped to this branch only -- a non-guest caller's LLM-supplied
+		# report_name must not be silently overwritten by a guest pin.
+		if extra_args.get("reference_report"):
+			args_dict["report_name"] = extra_args["reference_report"]
 
 	telemetry_doc = None
 	if telemetry:

--- a/huf/patches/v1/privatize_generated_media_files.py
+++ b/huf/patches/v1/privatize_generated_media_files.py
@@ -16,6 +16,16 @@ def execute():
 	This ensures all existing generated media files are marked private and their URLs updated to
 	the private path, matching the new save_file behavior (ST-R3.1) which writes with is_private=True
 	and /private/files/... fallback URLs.
+
+	IMPORTANT: the File doc's ``is_private`` flag must be flipped via a real Document
+	save (``file_obj.save()``), not ``frappe.db.set_value``. Frappe's own
+	``File.validate()`` only physically moves the underlying bytes from
+	``public/files`` to ``private/files`` (``File.handle_is_private_changed``,
+	triggered on ``has_value_changed("is_private")``) when the value is changed
+	through the controller. A raw ``frappe.db.set_value`` write flips the DB column
+	without moving the file, so the old public URL keeps serving the file (verified
+	live: returns 200, not 404, after the naive patch runs) even though the DB now
+	says ``is_private=1``.
 	"""
 
 	# Find all public media files linked to Agent Messages
@@ -26,7 +36,7 @@ def execute():
 			"attached_to_field": ["in", ["generated_image", "generated_audio"]],
 			"is_private": 0,
 		},
-		fields=["name", "file_name", "attached_to_name", "attached_to_field"],
+		fields=["name", "attached_to_name", "attached_to_field"],
 		limit_page_length=None,  # Get all matching files
 	)
 
@@ -35,20 +45,33 @@ def execute():
 
 	frappe.msgprint(f"Privatizing {len(files)} generated media files...")
 
+	privatized = 0
 	for file_doc in files:
 		file_name = file_doc["name"]
 		attached_to_name = file_doc["attached_to_name"]
 		attached_to_field = file_doc["attached_to_field"]
 
-		# Set the File doc to private
-		frappe.db.set_value("File", file_name, "is_private", 1)
+		# Flip via a real Document save so File.validate() ->
+		# handle_is_private_changed() actually moves the bytes on disk and
+		# rewrites File.file_url, not just the DB column.
+		try:
+			file_obj = frappe.get_doc("File", file_name)
+			file_obj.is_private = 1
+			file_obj.save(ignore_permissions=True)
+		except Exception:
+			frappe.log_error(
+				title="privatize_generated_media_files: failed to privatize File",
+				message=frappe.get_traceback(),
+			)
+			continue
 
-		# Rewrite the Agent Message's URL field from /files/... to /private/files/...
-		message_doc = frappe.get_doc("Agent Message", attached_to_name)
-		current_url = getattr(message_doc, attached_to_field, None)
-
-		if current_url and current_url.startswith("/files/"):
-			new_url = current_url.replace("/files/", "/private/files/", 1)
+		# Rewrite the Agent Message's URL field to match the File doc's own
+		# (now-updated) file_url, rather than assuming the /files/ -> /private/files/
+		# string substitution always matches what handle_is_private_changed produced.
+		new_url = file_obj.file_url
+		if new_url:
 			frappe.db.set_value("Agent Message", attached_to_name, attached_to_field, new_url)
 
-	frappe.msgprint(f"Successfully privatized {len(files)} generated media files")
+		privatized += 1
+
+	frappe.msgprint(f"Successfully privatized {privatized} of {len(files)} generated media files")


### PR DESCRIPTION
## Summary

Two real bugs found while running the live/manual verification steps for #715 (agent-security-residual hardening) against the actual merged code on a real bench — both survived because their existing unit tests asserted against a hand-copied simulation of the logic instead of driving the real functions. Fixed the production code and rewrote both tests to exercise the real code paths; confirmed each new test actually fails against the reverted buggy version before confirming it passes against the fix.

## What's broken and what changed

### 1. Media-privacy patch doesn't actually close the exposure on existing files

`huf/patches/v1/privatize_generated_media_files.py` (ST-R3.1b) flips `File.is_private` via a raw `frappe.db.set_value` write. That only changes the database column — it bypasses `File.validate()` → `File.handle_is_private_changed()`, the controller method that physically moves the file's bytes from `public/files` to `private/files` on disk.

Live-tested on a real bench: seeded a pre-fix public file, ran the patch, then requested the *old* public URL with no auth. It still returned the file's actual bytes with a **200**, even though the database now said `is_private=1`. The exposure the patch was supposed to close on already-persisted media stayed open.

**Fix:** flip the flag via a real `File.save()` so the controller's move logic actually runs. The Agent Message's stored URL is now rewritten to the File doc's own post-save `file_url` instead of a blind `/files/` → `/private/files/` string substitution.

### 2. Report-name pin leaks outside the guest branch, breaking non-guest calls

Both `huf/ai/sdk_tools.py`'s `on_invoke_tool` closure and `huf/ai/tool_invocation.py`'s `invoke_tool` had the `reference_report` override — `args_dict["report_name"] = extra_args["reference_report"]` — sitting **outside** the `if allowed_for_guest and frappe.session.user == "Guest":` block. Whenever a "Get Report Result" tool had a pinned report configured, this silently overwrote `report_name` for **every** caller, not just guests — the exact opposite of that feature's own "non-guest session is unaffected" acceptance criterion (ST-R3.3). A regular authenticated user's LLM-chosen report would get silently discarded and replaced by the pin.

**Fix:** moved both copies of the override inside the guest-only branch.

### Also included
`huf/ai/tests/test_tool_invocation.py`: 13 mock lambdas for `get_function_from_name` needed a `tool_type=None` parameter to match the real call signature added by #715 — this fix existed locally from an earlier verification pass but was never actually committed.

## Verification

Both bugs were caught by an agent live-verifying #715's own acceptance criteria on a real Frappe/MariaDB bench, not by writing new code speculatively. For each fix: reverted the source change, confirmed the accompanying (rewritten) unit test actually fails, then restored the fix and confirmed it passes — so these tests are proven regression guards, not more of the same tautological pattern. Full 34-module test suite for this track passes clean on the merged branch after these fixes. The frontend build (`tsc -b` + vite) and all six work packages' manual/live-bench verification steps for #715 were also completed in this same pass — no other issues found across ~40 individual acceptance checks; full detail in `Tracks/safwan-erooth.AgentSecurityResidual/plan/verification/` in the internal workspace repo.