### PR TITLE
fix(ai): read Agent Settings via get_single_value in RunBudget

### DIFF
--- a/huf/ai/run_budget.py
+++ b/huf/ai/run_budget.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta
 import frappe
-from frappe.utils import get_datetime
+from frappe.utils import get_datetime, cint, flt
 from huf.ai.cost_calculator import get_model_pricing, _calculate_from_custom_pricing
 
 
@@ -37,7 +37,7 @@ class RunBudget:
     def check_depth(self, max_depth: int = None):
         """Raise if recursion depth ceiling exceeded."""
         if max_depth is None:
-            max_depth = frappe.get_value("Agent Settings", None, "max_depth") or 5
+            max_depth = cint(frappe.db.get_single_value("Agent Settings", "max_depth")) or 5
         if self.current_depth >= max_depth:
             frappe.throw(f"Recursion depth {self.current_depth} exceeds ceiling {max_depth}",
                        RunBudgetExceeded)
@@ -63,17 +63,16 @@ class RunBudget:
         has neither today).
         """
         if deadline_secs is None:
-            deadline_secs = frappe.get_value("Agent Settings", None,
-                                            "deadline_seconds") or 900
-        settings_max_turns_ceiling = frappe.get_value("Agent Settings", None,
-                                            "max_turns_ceiling") or 20
-        max_turns = min(agent_doc.max_turns or 10, settings_max_turns_ceiling)
+            deadline_secs = cint(frappe.db.get_single_value("Agent Settings",
+                                            "deadline_seconds")) or 900
+        settings_max_turns_ceiling = cint(frappe.db.get_single_value("Agent Settings",
+                                            "max_turns_ceiling")) or 20
+        max_turns = min(cint(agent_doc.max_turns) or 10, settings_max_turns_ceiling)
         # spend_cap_usd == 0 means unlimited (see ST-09.4); do not coalesce
         # a falsy site-wide value into a non-zero default — that inverts
         # "unlimited" into a hard cap (reviewer item 12).
-        spend_cap = frappe.get_value("Agent Settings", None, "spend_cap_usd")
-        if spend_cap is None:
-            spend_cap = 0
+        spend_cap = frappe.db.get_single_value("Agent Settings", "spend_cap_usd")
+        spend_cap = flt(spend_cap) if spend_cap is not None else 0
 
         ancestry = []
         current_depth = 0
@@ -113,9 +112,8 @@ class RunBudget:
             ancestry = []
 
         # Fetch settings for spend cap
-        spend_cap = frappe.get_value("Agent Settings", None, "spend_cap_usd")
-        if spend_cap is None:
-            spend_cap = 0
+        spend_cap = frappe.db.get_single_value("Agent Settings", "spend_cap_usd")
+        spend_cap = flt(spend_cap) if spend_cap is not None else 0
 
         budget = RunBudget(
             deadline_at=deadline_at,

--- a/huf/ai/tests/test_agent_settings.py
+++ b/huf/ai/tests/test_agent_settings.py
@@ -14,11 +14,11 @@ from huf.ai.run_budget import RunBudget
 class TestAgentSettingsBudgetFields(IntegrationTestCase):
     """Test Agent Settings budget configuration fields."""
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_runbudget_from_agent_reads_settings(self, mock_get_value):
         """RunBudget.from_agent reads budget fields from Agent Settings."""
         # Mock Agent Settings values
-        def get_value_side_effect(doctype, name, field):
+        def get_value_side_effect(doctype, field):
             settings_defaults = {
                 "deadline_seconds": 900,
                 "max_turns_ceiling": 20,
@@ -41,10 +41,10 @@ class TestAgentSettingsBudgetFields(IntegrationTestCase):
         assert budget.max_turns_ceiling == 15  # min(15, 20)
         assert budget.spend_cap_usd == 50.0
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_runbudget_clamps_max_turns_to_ceiling(self, mock_get_value):
         """RunBudget clamps agent.max_turns to Agent Settings ceiling."""
-        def get_value_side_effect(doctype, name, field):
+        def get_value_side_effect(doctype, field):
             if field == "max_turns_ceiling":
                 return 10
             elif field == "deadline_seconds":
@@ -65,10 +65,10 @@ class TestAgentSettingsBudgetFields(IntegrationTestCase):
         # Should clamp to ceiling
         assert budget.max_turns_ceiling == 10
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_agent_below_ceiling_unclamped(self, mock_get_value):
         """Agent with max_turns below ceiling is not clamped."""
-        def get_value_side_effect(doctype, name, field):
+        def get_value_side_effect(doctype, field):
             if field == "max_turns_ceiling":
                 return 20
             elif field == "deadline_seconds":
@@ -93,10 +93,10 @@ class TestAgentSettingsBudgetFields(IntegrationTestCase):
 class TestAgentSettingsSpendCap(IntegrationTestCase):
     """Test spend cap field behavior."""
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_spend_cap_zero_means_unlimited(self, mock_get_value):
         """spend_cap_usd=0 is treated as unlimited."""
-        def get_value_side_effect(doctype, name, field):
+        def get_value_side_effect(doctype, field):
             if field == "spend_cap_usd":
                 return 0  # Explicitly unlimited
             elif field == "deadline_seconds":
@@ -120,10 +120,10 @@ class TestAgentSettingsSpendCap(IntegrationTestCase):
         budget.spend_so_far_usd = 10000.0
         budget.check_spend(5000.0)  # Should not raise
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_spend_cap_none_defaults_to_zero(self, mock_get_value):
         """Unset spend_cap defaults to 0 (unlimited), not a hard cap."""
-        def get_value_side_effect(doctype, name, field):
+        def get_value_side_effect(doctype, field):
             if field == "spend_cap_usd":
                 return None  # Unset
             elif field == "deadline_seconds":
@@ -148,10 +148,10 @@ class TestAgentSettingsSpendCap(IntegrationTestCase):
 class TestAgentSettingsDeadline(IntegrationTestCase):
     """Test deadline field configuration."""
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_deadline_seconds_respected(self, mock_get_value):
         """deadline_seconds from Agent Settings is used."""
-        def get_value_side_effect(doctype, name, field):
+        def get_value_side_effect(doctype, field):
             if field == "deadline_seconds":
                 return 600  # 10 minutes
             elif field == "max_turns_ceiling":
@@ -179,10 +179,10 @@ class TestAgentSettingsDeadline(IntegrationTestCase):
 class TestAgentSettingsMaxDepth(IntegrationTestCase):
     """Test max_depth configuration."""
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_max_depth_used_for_checks(self, mock_get_value):
         """max_depth from Agent Settings is used in check_depth."""
-        def get_value_side_effect(doctype, name, field):
+        def get_value_side_effect(doctype, field):
             if field == "max_depth":
                 return 3
             elif field == "deadline_seconds":

--- a/huf/ai/tests/test_agent_settings.py
+++ b/huf/ai/tests/test_agent_settings.py
@@ -206,3 +206,122 @@ class TestAgentSettingsMaxDepth(IntegrationTestCase):
         # Should use default from Agent Settings
         with self.assertRaises(frappe.ValidationError):
             budget.check_depth()  # Uses default from settings
+
+
+class TestAgentSettingsRealSingleTyping(IntegrationTestCase):
+    """Unmocked reads of the Agent Settings Single doctype.
+
+    Every other test in this module mocks the settings accessor and hands
+    back a Python int or float. The real Single stores each value as a
+    string in the generic ``tabSingles`` table, so a mock that returns
+    ``0`` asserts against a value shape the database never produces.
+
+    That gap let a total-outage bug ship: ``RunBudget.from_agent`` read
+    the settings with ``frappe.get_value("Agent Settings", None, field)``,
+    which does not apply the field's type cast, so ``max_turns_ceiling``
+    arrived as the string ``"0"`` and ``min(int, str)`` raised TypeError on
+    every agent run, on every site, whatever the configured values. The
+    whole suite stayed green throughout.
+
+    These tests therefore write real values and read them back through the
+    real accessor. They must never be converted to mocks.
+    """
+
+    def setUp(self):
+        self.settings = frappe.get_single("Agent Settings")
+        self._saved = {
+            f: self.settings.get(f)
+            for f in ("max_turns_ceiling", "deadline_seconds",
+                      "spend_cap_usd", "max_depth")
+        }
+
+    def tearDown(self):
+        for field, value in self._saved.items():
+            frappe.db.set_single_value("Agent Settings", field, value)
+        frappe.db.commit()
+
+    def _configure(self, **values):
+        for field, value in values.items():
+            frappe.db.set_single_value("Agent Settings", field, value)
+        frappe.db.commit()
+
+    def _agent(self, max_turns=15):
+        agent_doc = Mock()
+        agent_doc.name = "test_agent"
+        agent_doc.max_turns = max_turns
+        agent_doc.model = "gpt-4o"
+        return agent_doc
+
+    def test_settings_read_returns_numbers_not_strings(self):
+        """The accessor RunBudget uses must apply the field's type cast."""
+        self._configure(max_turns_ceiling=20, deadline_seconds=900,
+                        spend_cap_usd=50.0, max_depth=3)
+
+        for field in ("max_turns_ceiling", "deadline_seconds", "max_depth"):
+            value = frappe.db.get_single_value("Agent Settings", field)
+            self.assertIsInstance(
+                value, int,
+                f"{field} came back as {type(value).__name__} ({value!r}); "
+                "Singles store strings, so RunBudget needs the cast")
+
+        self.assertIsInstance(
+            frappe.db.get_single_value("Agent Settings", "spend_cap_usd"), float)
+
+    def test_from_agent_against_real_settings(self):
+        """from_agent must not raise TypeError on real, unmocked settings."""
+        self._configure(max_turns_ceiling=20, deadline_seconds=900,
+                        spend_cap_usd=50.0, max_depth=3)
+
+        budget = RunBudget.from_agent(self._agent(max_turns=15))
+
+        self.assertEqual(budget.max_turns_ceiling, 15)  # min(15, 20)
+        self.assertIsInstance(budget.max_turns_ceiling, int)
+        self.assertEqual(budget.spend_cap_usd, 50.0)
+        self.assertIsInstance(budget.spend_cap_usd, float)
+        self.assertGreater(budget.deadline_at, datetime.now())
+
+    def test_zero_ceiling_does_not_crash(self):
+        """A stored 0 is the regression trigger: it round-trips as "0"."""
+        self._configure(max_turns_ceiling=0, deadline_seconds=0,
+                        spend_cap_usd=0, max_depth=0)
+
+        budget = RunBudget.from_agent(self._agent(max_turns=15))
+
+        # 0 is falsy, so each read falls through to its coded default.
+        self.assertIsInstance(budget.max_turns_ceiling, int)
+        self.assertEqual(budget.max_turns_ceiling, 15)  # min(15, 20 default)
+
+    def test_zero_spend_cap_is_unlimited_not_a_hard_cap(self):
+        """The quiet half of the bug: "0" is truthy, 0 is not.
+
+        spend_cap_usd == 0 means unlimited (ST-09.4). Read untyped, the
+        stored 0 arrived as the truthy string "0", so it never hit the
+        ``is None`` branch and never read as falsy in check_spend's guard
+        — silently inverting "unlimited" into a hard cap. This one never
+        raised TypeError, so no crash would have revealed it.
+        """
+        self._configure(max_turns_ceiling=20, deadline_seconds=900,
+                        spend_cap_usd=0, max_depth=3)
+
+        budget = RunBudget.from_agent(self._agent())
+
+        self.assertEqual(budget.spend_cap_usd, 0)
+        self.assertFalse(
+            budget.spend_cap_usd,
+            "spend_cap_usd must be falsy for check_spend's unlimited guard")
+
+        budget.spend_so_far_usd = 10_000.0
+        budget.check_spend(9_999.0)  # must not raise
+
+    def test_check_depth_against_real_settings(self):
+        """check_depth compares current_depth >= max_depth numerically."""
+        self._configure(max_depth=3, max_turns_ceiling=20,
+                        deadline_seconds=900, spend_cap_usd=0)
+
+        budget = RunBudget.from_agent(self._agent())
+        budget.current_depth = 1
+        budget.check_depth()  # below ceiling, must not raise
+
+        budget.current_depth = 5
+        with self.assertRaises(frappe.ValidationError):
+            budget.check_depth()

--- a/huf/ai/tests/test_recursion_depth.py
+++ b/huf/ai/tests/test_recursion_depth.py
@@ -132,7 +132,7 @@ class TestDepthCheckBehavior(IntegrationTestCase):
 class TestDepthCheckUsesDefaults(IntegrationTestCase):
     """Test that check_depth uses Agent Settings defaults when no arg provided."""
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_check_depth_default_from_settings(self, mock_get_value):
         """check_depth() with no arg uses Agent Settings.max_depth."""
         mock_get_value.return_value = 4  # Default from settings
@@ -153,7 +153,7 @@ class TestDepthCheckUsesDefaults(IntegrationTestCase):
         with self.assertRaises(frappe.ValidationError):
             budget.check_depth()
 
-    @patch("frappe.get_value")
+    @patch("frappe.db.get_single_value")
     def test_check_depth_fallback_to_hardcoded_default(self, mock_get_value):
         """check_depth() falls back to 5 if Agent Settings not available."""
         mock_get_value.return_value = None  # Settings not available


### PR DESCRIPTION
## Summary
- `RunBudget` was reading Agent Settings (a Single doctype) with the untyped `frappe.get_value("Agent Settings", None, field)` form, which returns raw strings instead of type-cast values (e.g. `"0"` instead of `int 0`). This broke `min(agent_doc.max_turns or 10, settings_max_turns_ceiling)` with a `TypeError`, and separately caused `spend_cap_usd == 0` ("unlimited") to be silently misread as truthy since a string `"0"` is truthy in Python.
- Switched all five affected reads (`max_depth`, `deadline_seconds`, `max_turns_ceiling`, and both `spend_cap_usd` reads) to `frappe.db.get_single_value`, wrapped in `cint`/`flt` for defensive coercion.
- A repo-wide grep confirms no other untyped `get_value(doctype, None, field)` Single reads remain in the app.
- Added `TestAgentSettingsRealSingleTyping`, an unmocked regression test class that exercises the real DB round trip — proven to fail against the pre-fix code and pass against the fix, closing the gap where existing mocked tests (which hand back already-typed values) passed against the broken code.

## Test plan
- [x] `test_run_budget.py`, `test_agent_settings.py`, `test_spend_cap.py`, `test_recursion_depth.py`, `test_run_budget_enforcement.py`, `test_litellm_budget.py` (63 tests total) pass
- [x] `run_agent_sync` verified end-to-end against a real Agent on bench `intg-gw-audit`, no TypeError
- [x] New unmocked tests confirmed to fail pre-fix and pass post-fix