### PR TITLE
fix(security): resolve 13 react-router Dependabot alerts + 2 CodeQL findings

### DIFF
--- a/.github/workflows/deploy-huf.yml
+++ b/.github/workflows/deploy-huf.yml
@@ -9,6 +9,9 @@ on:
       #- stage-2
       #- test-1
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,7 @@
         "react-icons": "^5.7.0",
         "react-jsx-parser": "^2.4.1",
         "react-resizable-panels": "^2.1.3",
-        "react-router-dom": "7.9.4",
+        "react-router-dom": "7.18.3",
         "reactflow": "^11.11.4",
         "recharts": "^2.12.7",
         "socket.io-client": "^4.7.5",
@@ -12354,9 +12354,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.4.tgz",
-      "integrity": "sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -12376,12 +12376,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.4.tgz",
-      "integrity": "sha512-f30P6bIkmYvnHHa5Gcu65deIXoA2+r3Eb6PJIAddvsT9aGlchMatJ51GgpU470aSqRRbFX22T70yQNUGuW3DfA==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.9.4"
+        "react-router": "7.18.3"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,7 @@
     "react-icons": "^5.7.0",
     "react-jsx-parser": "^2.4.1",
     "react-resizable-panels": "^2.1.3",
-    "react-router-dom": "7.9.4",
+    "react-router-dom": "7.18.3",
     "reactflow": "^11.11.4",
     "recharts": "^2.12.7",
     "socket.io-client": "^4.7.5",
@@ -128,7 +128,7 @@
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.25.0",
     "vite": "^6.4.3",
-    "react-router": "7.9.4",
+    "react-router": "7.18.3",
     "minimatch": "^10.2.6"
   },
   "//resolutions": "Yarn 1 equivalent of `overrides` above — keep the two in sync. bench get-app runs `yarn install --check-files`, which ignores `overrides` and otherwise resolves vite@8 nested under vitest, failing to link.",
@@ -142,7 +142,7 @@
     "brace-expansion": "^5.0.8",
     "esbuild": "^0.25.0",
     "vite": "^6.4.3",
-    "react-router": "7.9.4",
+    "react-router": "7.18.3",
     "minimatch": "^10.2.6"
   }
 }

--- a/frontend/src/lib/frappe-error.ts
+++ b/frontend/src/lib/frappe-error.ts
@@ -99,6 +99,22 @@ export function extractFrappeServerMessages(error: unknown): FrappeServerMessage
 }
 
 /**
+ * Strip HTML tags by repeatedly applying the tag regex until a pass makes
+ * no further change, so nested/malformed markup (e.g. `<<script>script>`)
+ * can't survive a single incomplete pass. Only used server-side, where
+ * DOMPurify has no DOM to sanitize against.
+ */
+function stripTagsFully(input: string): string {
+  let previous = input;
+  let current = previous.replace(/<[^>]*>/g, '');
+  while (current !== previous) {
+    previous = current;
+    current = current.replace(/<[^>]*>/g, '');
+  }
+  return current;
+}
+
+/**
  * Get the primary error message from Frappe error
  * @param error - The error object from Frappe API (can be original or wrapped Error)
  * @returns User-friendly error message string
@@ -118,7 +134,7 @@ export function getFrappeErrorMessage(error: unknown): string {
     const clean =
       typeof window !== 'undefined'
         ? DOMPurify.sanitize(message, { ALLOWED_TAGS: [] }).trim()
-        : message.replace(/<[^>]*>/g, '').trim();
+        : stripTagsFully(message).trim();
     return clean || 'An error occurred';
   }
 


### PR DESCRIPTION
## Summary

Resolves all 13 open Dependabot alerts (all on `react-router`/`react-router-dom` in `frontend/package-lock.json`) plus 2 of the 4 open CodeQL code-scanning alerts.

### Dependabot (`react-router` 7.9.4 -> 7.18.3)

All 13 alerts are the same package at different vulnerable-range ceilings; 7.18.3 (latest 7.x) clears every one of them:

| Alert | Severity | Summary | Patched at |
|---|---|---|---|
| #140 | High | Unauthenticated DoS via inefficient route matching | 7.18.0 |
| #95 | High | Vendored turbo-stream v2 arbitrary constructor invocation -> unauth RCE | 7.14.2 |
| #97 | High | DoS via unbounded path expansion in `__manifest` | 7.15.0 |
| #98 | High | DoS via reflected user input in single-fetch | 7.14.0 |
| #144 | High | SSR XSS in ScrollRestoration | 7.12.0 |
| #145 | High | XSS via open redirects | 7.12.0 |
| #148 | High | XSS in unstable RSC redirect handling via `javascript:` targets | 7.13.2 |
| #96 | Moderate | Open redirect via protocol-relative `//` path | 7.14.1 |
| #137 | Moderate | Arbitrary constructor injection via `deserializeErrors()` | 7.18.0 |
| #139 | Moderate | Open redirect via backslash bypass (CVE-2025-68470 bypass) | 7.18.0 |
| #143 | Moderate | Unexpected external redirect via untrusted paths | 7.9.6 |
| #146 | Moderate | CSRF in action/server-action request processing | 7.12.0 |
| #147 | Moderate | Stored XSS via unescaped Location header in prerendered redirect HTML | 7.13.2 |

Stayed on the 7.x line (not 8.x) to avoid an unrelated major-version migration in this fix. Verified: `npm run build` and `tsc -b` both pass; `npm audit`-equivalent lockfile now shows 0 known vulnerabilities for this package.

### CodeQL

- **#28** `deploy-huf.yml` missing workflow permissions -> added explicit `permissions: contents: read` at the workflow level (the job only checks out code via SSH deploy, needs nothing else).
- **#22** `frappe-error.ts:121` incomplete multi-character sanitization -> the non-browser fallback path (no DOM/DOMPurify available) stripped HTML tags with a single regex pass, which can leave residue on nested/malformed markup (e.g. `<<script>script>`). Replaced with a loop that reapplies the regex until a pass is a no-op.

### Not changed in this PR (flagged for maintainer triage, not code fixes)

- **#23** `web-preview.tsx:211` (DOM text reinterpreted as HTML, iframe `src`) — this is the intentional AI-preview iframe, already hardened: protocol allowlist (http/https/blob/about only), `sandbox="allow-scripts allow-forms allow-popups-to-escape-sandbox"` with **no** `allow-same-origin`, and `referrerPolicy="no-referrer"`. CodeQL's generic sink pattern doesn't model the sandbox mitigation. Recommend dismissing as a false positive rather than further restricting the preview feature — but leaving that call to a maintainer since it's a security accept-risk decision, not a code change.
- **#29** `huf_api_key.py:66` (weak/broken hashing) — SHA-256 is used deliberately on a 256-bit machine-generated secret (not a low-entropy password), matching the documented rationale already in that file's module docstring (GitHub/Stripe-style API key hashing). Recommend dismissing as a false positive rather than swapping in a slow KDF that adds no real protection here — again leaving the accept/dismiss call to a maintainer.

## Test plan

- [x] `npm install --package-lock-only` in `frontend/` — lockfile updated, 0 vulnerabilities reported
- [x] `npm run build` in `frontend/` — succeeds
- [x] `npx tsc -b` in `frontend/` — clean
- [ ] Smoke-test the app in a bench (routing, redirects, error toasts) before merging