### PR TITLE
fix(flow): add output/foreach/parallel/validate executors, fix transform config

### DIFF
--- a/huf/ai/flow_engine.py
+++ b/huf/ai/flow_engine.py
@@ -68,6 +68,10 @@ from huf.ai.graph.executor import (
 	RoutingMode,
 	Router,
 )
+from huf.ai.graph.expressions import evaluate_bool, parse_expression
+from huf.ai.graph.transforms import Limits as TransformLimits
+from huf.ai.graph.transforms import run_transform
+from huf.ai.output_budget import OutputBudget, OutputBudgetExceeded, enforce_output_budget
 from huf.ai.tool_invocation import RunContext
 from huf.ai.transaction import commit_if_background
 
@@ -90,6 +94,9 @@ NODE_ROUTING = {
 	"router.llm": RoutingMode.SELF_ROUTED,
 	"loop": RoutingMode.SELF_ROUTED_OPTIONAL,
 	"end": RoutingMode.TERMINAL,
+	# "output" is always terminal per spec/graph-ir.md section 2 ("next must be
+	# absent or null") -- true for both the Procedure and Flow profiles.
+	"output": RoutingMode.TERMINAL,
 }
 
 #: Node types whose handler may be paused by another subsystem writing the
@@ -1243,39 +1250,33 @@ def _exec_condition(flow_run, node: dict, config: dict, settings: dict) -> dict:
 
 def _exec_transform(flow_run, node: dict, config: dict, settings: dict) -> dict:
 	"""
-	Execute transform node - applies data transformations to context.
+	Execute transform node - applies one of the shared graph-IR's
+	:class:`~huf.ai.graph.transforms.TransformOp` operations to a resolved
+	input mapping.
 
-	Config keys:
-	    transformations (list): source_field, target_field, operation
-	        (copy|map|template)
+	Config keys (graph_ir.schema.json ``TransformNode``, ``additionalProperties: false``):
+	    op (str): a ``TransformOp`` name (see ``huf.ai.graph.transforms``)
+	    input (dict): values, each resolved via ``GraphContext.resolve`` against
+	        the run's context, then passed to ``run_transform``
 
-	``copy``, ``map``, and ``template`` are all the same dotted-path read of
-	``source_field`` against the context; they differ only in the author's
-	intent, not in mechanism (F-2 -- ``template`` used to run its source
-	through the now-removed ``{{...}}`` string interpolator).
+	This used to read ``config.get("transformations")`` -- a Flow-only
+	``[{source_field, target_field, operation}]`` shape that the schema never
+	defined (``additionalProperties: false`` on ``TransformNode.config``
+	rejects it outright), so every schema-valid ``transform`` node's ``op``/
+	``input`` were silently ignored. ``run_transform`` is the same function
+	:mod:`huf.ai.graph.procedure_runtime` uses for the Procedure profile's
+	``transform`` node -- one implementation of the operation, shared by both
+	profiles, per graph_ir.schema.json's single ``TransformNode`` definition.
 	"""
 	ctx = _context_of(flow_run, settings)
-	data = ctx.as_dict()
-	transformations = config.get("transformations", [])
+	resolved_input = ctx.resolve(config.get("input") or {})
+	result = run_transform(config.get("op"), resolved_input, TransformLimits())
 
-	results = {}
-	for t in transformations:
-		source = t.get("source_field", "")
-		target = t.get("target_field", "")
+	if not result.ok:
+		err = result.error
+		return {"status": "failed", "error": err.message if err else f"transform '{config.get('op')}' failed"}
 
-		if not source or not target:
-			continue
-
-		try:
-			value = _resolve_context_path(data, source)
-			ctx.set(target, value)
-			results[target] = value
-		except Exception as e:
-			results[target] = f"Error: {str(e)}"
-
-	_persist_context(flow_run, ctx, settings)
-
-	return {"status": "success", "result": results}
+	return {"status": "success", "result": result.value, "output": result.value}
 
 
 def _exec_loop_node(flow_run, node: dict, config: dict, settings: dict) -> dict:
@@ -1336,6 +1337,226 @@ def _exec_end(flow_run, node: dict, config: dict, settings: dict) -> dict:
 	return {"status": "success", "output": "flow_complete"}
 
 
+def _flow_nodes_by_id(settings: dict) -> dict:
+	"""Every node in the pinned graph, by id -- for looking up a ``foreach``
+	``body`` or ``parallel`` ``branches`` member, which per spec/graph-ir.md
+	section 2 lives in the same top-level ``nodes`` array as the main chain.
+	"""
+	run_ctx = _run_context(settings)
+	graph = run_ctx.definition if run_ctx is not None else {}
+	return {n["id"]: n for n in graph.get("nodes", []) if isinstance(n, dict) and "id" in n}
+
+
+def _run_sub_chain(flow_run, settings: dict, node_ids: list) -> dict:
+	"""Walk one self-contained chain of node ids (a ``foreach`` body or a
+	``parallel`` branch) to completion, re-using :func:`_execute_node`'s own
+	dispatch table so every node type -- including a nested ``condition`` --
+	behaves exactly as it would on the main chain. Bounded by the chain's own
+	length (+2 headroom, mirroring ``procedure_runtime._sub_executor``): this
+	is a distinct budget from the run's ``max_hops``, never charged against it.
+
+	Records each visited node's output into the shared ``GraphContext`` (the
+	same ``node_id -> output`` bookkeeping ``GraphExecutor.run`` does for the
+	main chain, executor.py:744) so a ``foreach.config.collect`` reference
+	into a body node's output -- or any ``{"$from": "<node_id>...."}`` inside
+	the chain itself -- resolves, instead of silently returning ``None``.
+	"""
+	ctx = _context_of(flow_run, settings)
+	by_id = _flow_nodes_by_id(settings)
+	cursor = node_ids[0] if node_ids else None
+	max_hops = len(node_ids) + 2
+	hops = 0
+	last_result = {"status": "success"}
+
+	while cursor is not None:
+		hops += 1
+		if hops > max_hops:
+			return {"status": "failed", "error": f"sub-chain exceeded its hop budget ({max_hops})"}
+
+		node = by_id.get(cursor)
+		if node is None:
+			return {"status": "failed", "error": f"sub-chain references unknown node '{cursor}'"}
+
+		last_result = _execute_node(flow_run, node, settings)
+		ctx.record_output(cursor, last_result.get("output", last_result.get("result")))
+		if last_result.get("status") == "failed":
+			on_error = node.get("on_error")
+			if not on_error:
+				return last_result
+			cursor = on_error
+			continue
+
+		if NODE_ROUTING.get(node.get("type")) == RoutingMode.SELF_ROUTED:
+			cursor = last_result.get("next_node_id")
+		else:
+			cursor = node.get("next")
+
+	return last_result
+
+
+def _exec_foreach(flow_run, node: dict, config: dict, settings: dict) -> dict:
+	"""
+	Execute foreach node - a bounded batch over ``config.items``, running
+	``config.body`` once per item (graph_ir.schema.json ``ForeachNode``).
+
+	Unlike the old ``loop`` node (still registered below for any run pinned
+	before this fix, but no longer schema-reachable), ``foreach`` never
+	re-enters the main chain -- its body is a self-contained chain walked by
+	:func:`_run_sub_chain`, and its iteration cap is its own budget, never the
+	run's ``max_hops`` (spec/graph-ir.md section 2.1).
+	"""
+	node_id = node.get("id")
+	ctx = _context_of(flow_run, settings)
+	items = ctx.resolve(config.get("items"))
+	if not isinstance(items, list):
+		return {"status": "failed", "error": f"foreach node '{node_id}' 'items' did not resolve to a list"}
+
+	run_ctx = _run_context(settings)
+	contract_limits = ((run_ctx.definition.get("contract") or {}).get("limits") or {}) if run_ctx is not None else {}
+	caps = [c for c in (config.get("max_iterations"), contract_limits.get("max_foreach_iterations")) if c is not None]
+	effective_cap = min(caps) if caps else len(items)
+	if len(items) > effective_cap:
+		return {
+			"status": "failed",
+			"error": f"foreach '{node_id}' has {len(items)} items, exceeds max_iterations ({effective_cap})",
+		}
+
+	body_ids = config.get("body") or []
+	collect_ref = config.get("collect")
+	on_item_error = config.get("on_item_error", "fail")
+
+	results = []
+	for index, item in enumerate(items):
+		ctx.push_foreach(item, index)
+		try:
+			outcome = _run_sub_chain(flow_run, settings, body_ids)
+			if outcome.get("status") != "success":
+				if on_item_error == "skip":
+					continue
+				return {"status": "failed", "error": f"foreach '{node_id}' item {index} failed: {outcome.get('error')}"}
+			results.append(ctx.resolve(collect_ref) if collect_ref is not None else None)
+		finally:
+			ctx.pop_foreach()
+
+	_persist_context(flow_run, ctx, settings)
+	return {"status": "success", "result": results, "output": results}
+
+
+def _exec_parallel(flow_run, node: dict, config: dict, settings: dict) -> dict:
+	"""
+	Execute parallel node - bounded fan-out over ``config.branches``
+	(graph_ir.schema.json ``ParallelNode``). ``join`` is always ``"all"``: the
+	node completes only once every branch has completed or failed.
+
+	Branches run sequentially, in declaration order -- not concurrently. Real
+	bounded concurrency (mirroring ``huf.ai.graph.scheduler.run_parallel_branches``,
+	used by the Procedure profile's own ``parallel`` node) is future work; this
+	keeps Flow's ``parallel`` schema-valid and runnable today without adding
+	threading to a runtime whose steps are already persisted and replayed one
+	at a time (``_FlowStateStore``), and produces the same per-branch results a
+	concurrent run would, just not concurrently.
+	"""
+	node_id = node.get("id")
+	branches = config.get("branches") or []
+	if not branches:
+		return {"status": "success", "result": {"branches_completed": 0, "join": config.get("join", "all")}}
+
+	for index, branch_ids in enumerate(branches):
+		outcome = _run_sub_chain(flow_run, settings, branch_ids)
+		if outcome.get("status") != "success":
+			return {"status": "failed", "error": f"parallel '{node_id}' branch {index} failed: {outcome.get('error')}"}
+
+	return {
+		"status": "success",
+		"result": {"branches_completed": len(branches), "join": config.get("join", "all")},
+	}
+
+
+def _exec_validate(flow_run, node: dict, config: dict, settings: dict) -> dict:
+	"""
+	Execute validate node - fails closed if any ``config.assertions`` entry
+	evaluates falsy (graph_ir.schema.json ``ValidateNode``).
+
+	``expression`` is a ``$defs/Expression`` -- "evaluated by the shared
+	expression evaluator (graph-ir.md section 4)" per the schema's own
+	description, i.e. ``huf.ai.graph.expressions.evaluate_bool``/
+	``parse_expression`` against ``GraphContext.reference_roots()`` (the same
+	evaluator ``procedure_runtime._handle_validate`` uses for the Procedure
+	profile), never Flow's older ``flow_eval.safe_eval_expression`` (a
+	different, ``context["key"]``-subscript grammar predating the shared IR).
+	"""
+	ctx = _context_of(flow_run, settings)
+	bindings = ctx.reference_roots()
+	failures = []
+	for assertion in config.get("assertions", []):
+		try:
+			parsed = parse_expression(assertion["expression"])
+			truthy = evaluate_bool(parsed, bindings)
+		except Exception as e:
+			return {
+				"status": "failed",
+				"error": f"validate node '{node.get('id')}' assertion expression failed: {e}",
+			}
+		if not truthy:
+			failures.append({"code": assertion["code"], "message": assertion["message"]})
+
+	if failures:
+		return {"status": "failed", "error": json.dumps(failures)}
+	return {"status": "success", "result": {"assertions_passed": len(config.get("assertions", []))}}
+
+
+def _exec_output(flow_run, node: dict, config: dict, settings: dict) -> dict:
+	"""
+	Execute output node - always terminal (see ``NODE_ROUTING``). Resolves
+	``config.value`` and enforces the graph's output budget (I7, mirroring
+	``procedure_runtime._Runner._handle_output``): a value that breaches
+	``max_rows``/``max_output_bytes`` fails the node rather than being
+	silently truncated.
+	"""
+	ctx = _context_of(flow_run, settings)
+	value = ctx.resolve(config.get("value"))
+
+	run_ctx = _run_context(settings)
+	limits = ((run_ctx.definition.get("contract") or {}).get("limits") or {}) if run_ctx is not None else {}
+	budget_kwargs = {}
+	if limits.get("max_rows") is not None:
+		budget_kwargs["max_rows"] = limits["max_rows"]
+	if limits.get("max_output_bytes") is not None:
+		budget_kwargs["max_bytes"] = limits["max_output_bytes"]
+	budget = OutputBudget(**budget_kwargs) if budget_kwargs else OutputBudget()
+
+	if isinstance(value, list):
+		try:
+			enforce_output_budget(value, budget=budget)
+		except OutputBudgetExceeded as exc:
+			return {"status": "failed", "error": str(exc)}
+	elif isinstance(value, dict):
+		size = len(json.dumps(value, default=str, ensure_ascii=False).encode("utf-8"))
+		if size > budget.max_bytes:
+			return {
+				"status": "failed",
+				"error": f"output node '{node.get('id')}' value is {size} bytes, exceeds max_output_bytes ({budget.max_bytes}); refusing to truncate",
+			}
+		for key, field_value in value.items():
+			if isinstance(field_value, list) and len(field_value) > budget.max_rows:
+				return {
+					"status": "failed",
+					"error": f"output node '{node.get('id')}' field '{key}' has {len(field_value)} rows, exceeds max_rows ({budget.max_rows}); refusing to truncate",
+				}
+
+	return {"status": "success", "output": value, "result": value}
+
+
+#: "http_request", "loop" and "end" are not in FLOW_NODE_TYPES
+#: (huf.ai.graph.validator) at all -- no schema-valid Flow Definition can be
+#: *saved* with one of these types any more (superseded by "tool.call",
+#: "foreach" and a plain no-``next`` chain end, respectively). They stay
+#: registered here, not removed, because a ``Flow Run`` created before this
+#: schema existed pins its graph at creation (``PinnedVersion``, F-1 in this
+#: module's docstring) and keeps executing that exact graph for its whole
+#: life -- an already-running or paused run using one of these types must
+#: still be able to advance. Remove an entry here only once no such pinned
+#: run can still be outstanding.
 _NODE_EXECUTORS = {
 	"trigger.webhook": _exec_trigger_webhook,
 	"trigger.schedule": _exec_trigger_schedule,
@@ -1349,6 +1570,10 @@ _NODE_EXECUTORS = {
 	"transform": _exec_transform,
 	"loop": _exec_loop_node,
 	"end": _exec_end,
+	"foreach": _exec_foreach,
+	"parallel": _exec_parallel,
+	"validate": _exec_validate,
+	"output": _exec_output,
 }
 
 _NODE_TYPES = tuple(_NODE_EXECUTORS)

--- a/huf/ai/tests/test_flow_engine.py
+++ b/huf/ai/tests/test_flow_engine.py
@@ -408,54 +408,50 @@ class TestExecCondition(unittest.TestCase):
 
 
 class TestExecTransform(unittest.TestCase):
-	def test_copy_operation(self):
+	"""GW-34: graph_ir.schema.json's ``TransformNode.config`` requires exactly
+	``op``/``input`` (``additionalProperties: false``) -- the old
+	``transformations: [{source_field, target_field, operation}]`` shape
+	tested here previously was never a schema-valid config a Flow Definition
+	could actually be saved with, so ``_exec_transform`` silently ignoring a
+	real ``op``/``input`` config was the bug (see
+	huf.ai.tests.test_flow_gw34_node_type_gap for the fuller regression
+	suite). These tests now pin the schema's own shape, dispatched through
+	``huf.ai.graph.transforms.run_transform`` -- the same function
+	``procedure_runtime`` uses for the Procedure profile's ``transform`` node.
+	"""
+
+	def test_select_operation(self):
+		flow_run = FakeFlowRun()
+		_ctx(flow_run, rows=[{"name": "Ada", "age": 30}])
+		config = {"op": "select", "input": {"rows": {"$from": "input.rows"}, "fields": ["name"]}}
+		result = flow_engine._exec_transform(flow_run, {}, config, {})
+		self.assertEqual(result["status"], "success")
+		self.assertEqual(result["result"], [{"name": "Ada"}])
+
+	def test_coalesce_operation_resolves_nested_reference(self):
+		flow_run = FakeFlowRun()
+		_ctx(flow_run, user={"name": "Ada"})
+		config = {"op": "coalesce", "input": {"values": [None, {"$from": "input.user.name"}]}}
+		result = flow_engine._exec_transform(flow_run, {}, config, {})
+		self.assertEqual(result["status"], "success")
+		self.assertEqual(result["result"], "Ada")
+
+	def test_unknown_op_fails_closed(self):
+		flow_run = FakeFlowRun()
+		_ctx(flow_run)
+		config = {"op": "not_a_real_op", "input": {}}
+		result = flow_engine._exec_transform(flow_run, {}, config, {})
+		self.assertEqual(result["status"], "failed")
+
+	def test_legacy_transformations_shape_no_longer_applies(self):
+		"""``config.transformations`` predates the shared graph-IR schema and can
+		never be saved through FlowDefinition.validate() any more -- it has no
+		``op``, so run_transform fails closed rather than silently no-op'ing."""
 		flow_run = FakeFlowRun()
 		_ctx(flow_run, source_field="hello")
 		config = {"transformations": [{"source_field": "source_field", "target_field": "dest", "operation": "copy"}]}
 		result = flow_engine._exec_transform(flow_run, {}, config, {})
-		self.assertEqual(result["status"], "success")
-		new_ctx = json.loads(flow_run.context_json)
-		self.assertEqual(new_ctx["dest"], "hello")
-
-	def test_template_operation_resolves_source_path(self):
-		# F-2: "template" used to run source_field through the now-removed
-		# {{...}} string interpolator, letting it compose a string out of
-		# several context values. That composition capability is gone with
-		# the templating syntax; "template" is now the same dotted-path read
-		# as "copy"/"map" -- this pins that it still resolves a nested path.
-		flow_run = FakeFlowRun()
-		_ctx(flow_run, user={"name": "Ada"})
-		config = {
-			"transformations": [
-				{"source_field": "user.name", "target_field": "greeting", "operation": "template"}
-			]
-		}
-		flow_engine._exec_transform(flow_run, {}, config, {})
-		new_ctx = json.loads(flow_run.context_json)
-		self.assertEqual(new_ctx["greeting"], "Ada")
-
-	def test_map_operation_renames(self):
-		flow_run = FakeFlowRun()
-		_ctx(flow_run, old_key="value")
-		config = {"transformations": [{"source_field": "old_key", "target_field": "new_key", "operation": "map"}]}
-		flow_engine._exec_transform(flow_run, {}, config, {})
-		new_ctx = json.loads(flow_run.context_json)
-		self.assertEqual(new_ctx["new_key"], "value")
-
-	def test_transformation_missing_fields_is_skipped(self):
-		flow_run = FakeFlowRun()
-		_ctx(flow_run)
-		config = {"transformations": [{"operation": "copy"}]}
-		result = flow_engine._exec_transform(flow_run, {}, config, {})
-		self.assertEqual(result["status"], "success")
-		self.assertEqual(result["result"], {})
-
-	def test_context_is_persisted_via_db_set(self):
-		flow_run = FakeFlowRun()
-		_ctx(flow_run, a="x")
-		config = {"transformations": [{"source_field": "a", "target_field": "b", "operation": "copy"}]}
-		flow_engine._exec_transform(flow_run, {}, config, {})
-		self.assertTrue(any("context_json" in call for call in flow_run.db_set_calls))
+		self.assertEqual(result["status"], "failed")
 
 
 class TestExecLoopNode(unittest.TestCase):
@@ -761,7 +757,7 @@ class TestHopLimitAndEndCompletion(unittest.TestCase):
 	def test_no_outgoing_edges_from_non_end_node_completes_run(self):
 		flow_run = FakeFlowRun(current_node_id="n1", hop_count=0, max_hops=10, mode="Normal")
 		_ctx(flow_run)
-		nodes_map = {"n1": {"id": "n1", "type": "transform", "config": {"transformations": []}}}
+		nodes_map = {"n1": {"id": "n1", "type": "transform", "config": {"op": "coalesce", "input": {"values": []}}}}
 		with patch.object(flow_engine, "_publish_flow_event"):
 			flow_engine._execute_loop(flow_run, nodes_map, [], {})
 		self.assertEqual(flow_run.status, "Success")
@@ -770,7 +766,7 @@ class TestHopLimitAndEndCompletion(unittest.TestCase):
 		flow_run = FakeFlowRun(current_node_id="n1", hop_count=0, max_hops=10, mode="Normal")
 		_ctx(flow_run)
 		nodes_map = {
-			"n1": {"id": "n1", "type": "transform", "config": {"transformations": []}},
+			"n1": {"id": "n1", "type": "transform", "config": {"op": "coalesce", "input": {"values": []}}},
 			"n2": {"id": "n2", "type": "end", "config": {}},
 		}
 		edges = [{"from": "n1", "to": "n2", "type": "always"}]
@@ -937,7 +933,7 @@ class TestKnownDefects(unittest.TestCase):
 					"max_iterations": 1000,
 				},
 			},
-			"body": {"id": "body", "type": "transform", "config": {"transformations": []}},
+			"body": {"id": "body", "type": "transform", "config": {"op": "coalesce", "input": {"values": []}}},
 			"finish": {"id": "finish", "type": "end", "config": {}},
 		}
 		edges = [{"from": "body", "to": "loop", "type": "always"}]
@@ -980,7 +976,7 @@ class TestKnownDefects(unittest.TestCase):
 		flow_run.db_set = tracking_db_set
 
 		nodes_map = {
-			"n1": {"id": "n1", "type": "transform", "config": {"transformations": []}},
+			"n1": {"id": "n1", "type": "transform", "config": {"op": "coalesce", "input": {"values": []}}},
 			"n2": {"id": "n2", "type": "end", "config": {}},
 		}
 		edges = [{"from": "n1", "to": "n2", "type": "always"}]

--- a/huf/ai/tests/test_flow_gw34_node_type_gap.py
+++ b/huf/ai/tests/test_flow_gw34_node_type_gap.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, Tridz Technologies Pvt Ltd
+# For license information, please see license.txt
+
+"""GW-34: Flow's node type allow-list must match what flow_engine can execute.
+
+``huf/ai/graph/validator.py``'s ``FLOW_NODE_TYPES`` (the schema-enforced allow-list
+``FlowDefinition.validate()`` uses) is ``PROCEDURE_NODE_TYPES | FLOW_ONLY_NODE_TYPES`` --
+by design (spec/graph-ir.md section 1: "the same seven [Procedure types], plus" the six
+Flow-only types). ``PROCEDURE_NODE_TYPES`` includes ``foreach``, ``parallel``, ``validate``
+and ``output`` -- so a schema-valid Flow Definition can save a node of any of these four
+types. But ``huf.ai.flow_engine._NODE_EXECUTORS`` had no entry for any of them: at runtime
+``GraphExecutor`` (via ``_execute_node``) raised "Unknown node type" the instant one ran,
+even though ``huf/huf/doctype/flow_definition/test_flow_definition_schema.py``'s own
+``_valid_flow_definition()`` fixture uses an ``output`` node as its valid example.
+
+Separately, ``_exec_transform`` read ``config.get("transformations")`` (a
+``[{source_field, target_field, operation}]`` list) that graph_ir.schema.json's
+``TransformNode`` never defined -- the schema requires ``config.op``/``config.input``
+(``additionalProperties: false`` rejects everything else), so a schema-valid ``transform``
+node's actual config was silently ignored.
+
+This module round-trips each of the four missing node types, plus the corrected
+``transform``, through their executors directly (frappe-free, mirroring
+test_flow_tool_call_gw01.py's Layer A) using exactly the schema's required config field
+names -- proving the executor now consumes them instead of raising "Unknown node type" or
+reading a field that is never there.
+
+Run with:
+    bench --site <site> run-tests --app huf --module huf.ai.tests.test_flow_gw34_node_type_gap
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mirrors test_flow_tool_call_gw01.py's frappe-free stub setup -- huf.ai.flow_engine does
+# `from frappe.<submodule> import X` at import time, which a bare top-level MagicMock
+# cannot satisfy.
+if "frappe" not in sys.modules:
+	sys.modules["frappe"] = MagicMock()
+for _mod_name in (
+	"frappe.utils",
+	"frappe.desk",
+	"frappe.desk.doctype",
+	"frappe.desk.doctype.notification_log",
+	"frappe.desk.doctype.notification_log.notification_log",
+	"frappe.desk.doctype.notification_settings",
+	"frappe.desk.doctype.notification_settings.notification_settings",
+):
+	if _mod_name not in sys.modules:
+		sys.modules[_mod_name] = MagicMock()
+if isinstance(sys.modules.get("frappe"), MagicMock):
+	sys.modules["frappe"].whitelist = lambda *a, **k: (lambda f: f)
+
+from huf.ai import flow_engine  # noqa: E402
+from huf.ai.graph.executor import GraphContext, PinnedVersion  # noqa: E402
+from huf.ai.graph.validator import FLOW_NODE_TYPES, PROCEDURE_NODE_TYPES  # noqa: E402
+
+
+class _FakeFlowRun:
+	def __init__(self, **fields):
+		defaults = dict(name="FR-TEST-GW34", flow_id="test-flow-gw34", conversation=None, context_json="{}")
+		defaults.update(fields)
+		for key, value in defaults.items():
+			setattr(self, key, value)
+
+	def db_set(self, key, value=None):
+		if isinstance(key, dict):
+			for k, v in key.items():
+				setattr(self, k, v)
+		else:
+			setattr(self, key, value)
+
+
+def _settings_for(nodes: list, data: dict | None = None) -> flow_engine.FlowRunContext:
+	"""A minimal FlowRunContext whose ``.definition`` exposes ``nodes`` -- everything
+	``_flow_nodes_by_id``/foreach/parallel need to look up a body/branch node, and
+	everything ``_exec_output``/``_exec_foreach`` need for ``contract.limits``.
+	"""
+	graph = {
+		"schema_version": "1.0.0",
+		"profile": "flow",
+		"entry": nodes[0]["id"] if nodes else None,
+		"nodes": nodes,
+		"contract": {"limits": {"max_rows": 1000, "max_output_bytes": 100_000, "max_foreach_iterations": 50}},
+	}
+	version = PinnedVersion.pin(graph)
+	return flow_engine.FlowRunContext(context=GraphContext(data or {}), version=version)
+
+
+class TestNodeTypeAllowListMatchesSchemaIntent(unittest.TestCase):
+	"""spec/graph-ir.md section 1: FlowGraph is the Procedure profile's seven node types
+	plus the six Flow-only ones -- output/foreach/parallel/validate are Procedure types,
+	so they are (and must remain) Flow-usable too."""
+
+	def test_output_foreach_parallel_validate_are_flow_usable(self):
+		for node_type in ("output", "foreach", "parallel", "validate"):
+			self.assertIn(node_type, PROCEDURE_NODE_TYPES)
+			self.assertIn(node_type, FLOW_NODE_TYPES)
+
+	def test_every_flow_node_type_has_an_executor(self):
+		missing = sorted(FLOW_NODE_TYPES - set(flow_engine._NODE_EXECUTORS))
+		self.assertEqual(missing, [], f"FLOW_NODE_TYPES has no flow_engine executor for: {missing}")
+
+
+class TestExecOutput(unittest.TestCase):
+	def test_resolves_value_and_is_terminal(self):
+		node = {"id": "finish", "type": "output", "config": {"value": {"$from": "input.total"}}}
+		settings = _settings_for([node], data={"total": 42})
+
+		result = flow_engine._exec_output(_FakeFlowRun(), node, node["config"], settings)
+
+		self.assertEqual(result["status"], "success")
+		self.assertEqual(result["output"], 42)
+		self.assertEqual(flow_engine.NODE_ROUTING["output"], flow_engine.RoutingMode.TERMINAL)
+
+	def test_over_budget_list_fails_closed(self):
+		node = {"id": "finish", "type": "output", "config": {"value": {"$from": "input.rows"}}}
+		settings = _settings_for([node], data={"rows": list(range(5000))})
+		# Force a tiny budget so the over-budget path is exercised deterministically.
+		settings.version.graph["contract"]["limits"] = {"max_rows": 10, "max_output_bytes": 100_000}
+
+		result = flow_engine._exec_output(_FakeFlowRun(), node, node["config"], settings)
+
+		self.assertEqual(result["status"], "failed")
+		self.assertIn("error", result)
+
+
+class TestExecValidate(unittest.TestCase):
+	def test_all_assertions_pass(self):
+		config = {"assertions": [{"expression": 'input["total"] > 0', "code": "positive", "message": "must be positive"}]}
+		node = {"id": "check", "type": "validate", "config": config}
+		settings = _settings_for([node], data={"total": 5})
+
+		result = flow_engine._exec_validate(_FakeFlowRun(), node, config, settings)
+
+		self.assertEqual(result["status"], "success")
+		self.assertEqual(result["result"]["assertions_passed"], 1)
+
+	def test_failed_assertion_fails_closed(self):
+		config = {"assertions": [{"expression": 'input["total"] > 0', "code": "positive", "message": "must be positive"}]}
+		node = {"id": "check", "type": "validate", "config": config}
+		settings = _settings_for([node], data={"total": -1})
+
+		result = flow_engine._exec_validate(_FakeFlowRun(), node, config, settings)
+
+		self.assertEqual(result["status"], "failed")
+		self.assertIn("positive", result["error"])
+
+
+class TestExecTransform(unittest.TestCase):
+	def test_reads_schema_op_and_input_not_legacy_transformations(self):
+		"""The schema's TransformNode requires config.op/config.input
+		(additionalProperties: false) -- config.transformations was never a valid shape."""
+		config = {"op": "coalesce", "input": {"values": [{"$from": "input.missing"}, {"$from": "input.total"}]}}
+		node = {"id": "t1", "type": "transform", "config": config}
+		settings = _settings_for([node], data={"total": 7})
+
+		result = flow_engine._exec_transform(_FakeFlowRun(), node, config, settings)
+
+		self.assertEqual(result["status"], "success")
+		self.assertEqual(result["result"], 7)
+
+	def test_legacy_transformations_field_is_ignored_not_crashed_on(self):
+		"""A schema-invalid config (impossible to save any more, but defence in depth)
+		must not raise -- run_transform fails closed on a missing/invalid op instead."""
+		config = {"transformations": [{"source_field": "total", "target_field": "out", "operation": "copy"}]}
+		node = {"id": "t1", "type": "transform", "config": config}
+		settings = _settings_for([node], data={"total": 7})
+
+		result = flow_engine._exec_transform(_FakeFlowRun(), node, config, settings)
+
+		self.assertEqual(result["status"], "failed")
+
+
+class TestExecForeach(unittest.TestCase):
+	def test_iterates_body_and_collects_output(self):
+		body_node = {
+			"id": "double",
+			"type": "transform",
+			"config": {"op": "coalesce", "input": {"values": [{"$from": "foreach.item"}]}},
+		}
+		foreach_node = {
+			"id": "each",
+			"type": "foreach",
+			"config": {
+				"items": {"$from": "input.numbers"},
+				"body": ["double"],
+				"max_iterations": 10,
+				"on_item_error": "fail",
+				"collect": {"$from": "double"},
+			},
+		}
+		settings = _settings_for([foreach_node, body_node], data={"numbers": [1, 2, 3]})
+
+		result = flow_engine._exec_foreach(_FakeFlowRun(), foreach_node, foreach_node["config"], settings)
+
+		self.assertEqual(result["status"], "success")
+		self.assertEqual(result["result"], [1, 2, 3])
+
+	def test_exceeding_max_iterations_fails_closed(self):
+		foreach_node = {
+			"id": "each",
+			"type": "foreach",
+			"config": {
+				"items": {"$from": "input.numbers"},
+				"body": ["noop"],
+				"max_iterations": 2,
+				"on_item_error": "fail",
+				"collect": None,
+			},
+		}
+		noop_node = {"id": "noop", "type": "transform", "config": {"op": "coalesce", "input": {"values": []}}}
+		settings = _settings_for([foreach_node, noop_node], data={"numbers": [1, 2, 3]})
+
+		result = flow_engine._exec_foreach(_FakeFlowRun(), foreach_node, foreach_node["config"], settings)
+
+		self.assertEqual(result["status"], "failed")
+		self.assertIn("max_iterations", result["error"])
+
+
+class TestExecParallel(unittest.TestCase):
+	def test_runs_every_branch_to_completion(self):
+		branch_a = {
+			"id": "a1",
+			"type": "transform",
+			"config": {"op": "coalesce", "input": {"values": [{"$from": "input.x"}]}},
+		}
+		branch_b = {
+			"id": "b1",
+			"type": "transform",
+			"config": {"op": "coalesce", "input": {"values": [{"$from": "input.y"}]}},
+		}
+		parallel_node = {
+			"id": "fan_out",
+			"type": "parallel",
+			"config": {"branches": [["a1"], ["b1"]], "join": "all"},
+		}
+		settings = _settings_for([parallel_node, branch_a, branch_b], data={"x": 1, "y": 2})
+
+		result = flow_engine._exec_parallel(_FakeFlowRun(), parallel_node, parallel_node["config"], settings)
+
+		self.assertEqual(result["status"], "success")
+		self.assertEqual(result["result"]["branches_completed"], 2)
+
+	def test_one_failing_branch_fails_the_node(self):
+		branch_a = {"id": "a1", "type": "transform", "config": {"op": "coalesce", "input": {"values": []}}}
+		branch_b = {"id": "b1", "type": "transform", "config": {"op": "not_a_real_op", "input": {}}}
+		parallel_node = {
+			"id": "fan_out",
+			"type": "parallel",
+			"config": {"branches": [["a1"], ["b1"]], "join": "all"},
+		}
+		settings = _settings_for([parallel_node, branch_a, branch_b], data={})
+
+		result = flow_engine._exec_parallel(_FakeFlowRun(), parallel_node, parallel_node["config"], settings)
+
+		self.assertEqual(result["status"], "failed")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/huf/ai/tests/test_run_budget.py
+++ b/huf/ai/tests/test_run_budget.py
@@ -172,3 +172,73 @@ class TestRunBudgetSpendCheck(IntegrationTestCase):
 
         # Should not raise
         budget.check_spend(999999.0)
+
+
+class TestAgentSettingsSinglesStringCoercion(IntegrationTestCase):
+    """Regression test for HK-01.
+
+    frappe.db.get_single_value on a Singles doctype like ``Agent Settings``
+    can return raw strings pulled straight from ``tabSingles`` (no type
+    coercion happens there the way it does for a normal DocField on a
+    regular table). Passing those uncoerced strings into ``min()``/``max()``
+    alongside real ints, or into arithmetic with real floats, raises
+    ``TypeError``. RunBudget must coerce every Agent Settings value it reads
+    (via cint/flt) before using it.
+    """
+
+    @patch("frappe.db.get_single_value")
+    def test_from_agent_survives_stringy_singles_values(self, mock_get_single_value):
+        """RunBudget.from_agent must not raise TypeError when Agent Settings
+        fields come back as strings (as they do from tabSingles)."""
+
+        def get_single_value_side_effect(doctype, field):
+            # Simulate the raw string values tabSingles can return.
+            stringy_defaults = {
+                "deadline_seconds": "900",
+                "max_turns_ceiling": "20",
+                "spend_cap_usd": "50.5",
+                "max_depth": "3",
+            }
+            return stringy_defaults.get(field)
+
+        mock_get_single_value.side_effect = get_single_value_side_effect
+
+        agent_doc = Mock()
+        agent_doc.name = "test_agent"
+        agent_doc.max_turns = 15  # int, as it would come off a real DocField
+        agent_doc.model = "gpt-4o"
+
+        # Must not raise TypeError: '<' not supported between instances of
+        # 'int' and 'str' (the min() call in from_agent).
+        budget = RunBudget.from_agent(agent_doc)
+
+        assert budget.max_turns_ceiling == 15  # min(15, 20)
+        assert budget.spend_cap_usd == 50.5
+        assert isinstance(budget.spend_cap_usd, float)
+
+        # check_depth() must also coerce a stringy max_depth before the
+        # `self.current_depth >= max_depth` comparison.
+        budget.current_depth = 3
+        with self.assertRaises(frappe.ValidationError):
+            budget.check_depth()
+
+    @patch("frappe.db.get_single_value")
+    def test_from_run_doc_survives_stringy_spend_cap(self, mock_get_single_value):
+        """RunBudget.from_run_doc must not raise TypeError when spend_cap_usd
+        comes back as a string from tabSingles."""
+        mock_get_single_value.return_value = "25.0"
+
+        run_doc = {
+            "budget_deadline_at": datetime.now() + timedelta(seconds=900),
+            "budget_depth": 1,
+            "budget_ancestry": "[]",
+            "budget_spend_usd": 0.0,
+        }
+
+        budget = RunBudget.from_run_doc(run_doc)
+
+        assert budget.spend_cap_usd == 25.0
+        assert isinstance(budget.spend_cap_usd, float)
+
+        # Should not raise TypeError comparing float spend to float cap.
+        budget.check_spend(10.0)


### PR DESCRIPTION
## Summary
- `FLOW_NODE_TYPES` (`huf.ai.graph.validator`) allows `output`/`foreach`/`parallel`/`validate` per `spec/graph-ir.md` section 1 (the Flow profile is the Procedure profile's node types plus six Flow-only ones), but `flow_engine._NODE_EXECUTORS` had no entry for any of them — a schema-valid Flow Definition using one failed at runtime with "Unknown node type".
- Adds executors for all four, reusing the same primitives `huf.ai.graph.procedure_runtime` already uses for the Procedure profile (`run_transform`, `evaluate_bool`/`parse_expression`, `enforce_output_budget`) instead of reimplementing them. `parallel` runs branches sequentially — documented as a deliberate simplification, mirroring `procedure_runtime`'s own pre-T-30 precedent — rather than adding threading to Flow's persisted, replay-driven runtime.
- Fixes `_exec_transform`, which read `config.transformations` (never a valid `TransformNode` shape — the schema requires `config.op`/`config.input`, `additionalProperties: false`) and silently ignored a schema-valid node's actual config.
- `http_request`/`loop`/`end` stay registered even though they're outside `FLOW_NODE_TYPES`: a Flow Run pins its graph at creation, so an already-running/paused run from before this fix may still use one of them.

## Test plan
- [x] New `huf/ai/tests/test_flow_gw34_node_type_gap.py`: 12 frappe-free tests covering all four new executors, the transform fix, and an allow-list/executor-coverage check.
- [x] Updated `TestExecTransform` and three other `test_flow_engine.py` cases that depended on the old `transformations` shape.
- [x] All 80 frappe-free tests in `test_flow_engine.py` + the new file pass.
- [ ] Bench-level round trip (save a Flow Definition with an `output`/`foreach` node through `flow_api.save_flow_definition` and run it) — not exercised in this PR; frappe-free coverage only.