### PR TITLE
fix: return to Automations list after creating/cancelling an automation

### DIFF
--- a/frontend/src/pages/automation/AutomationFormPage.tsx
+++ b/frontend/src/pages/automation/AutomationFormPage.tsx
@@ -358,7 +358,7 @@ export function AutomationFormPage() {
 
       toast.success(isNew ? 'Automation created' : 'Automation saved');
       if (isNew) {
-        navigate(`/automations/${encodeURIComponent(automationName_)}`, { replace: true });
+        navigate(agent ? `/agents/${encodeURIComponent(agent)}#triggers` : '/automations', { replace: true });
       }
     } catch {
       // createAutomation/updateAutomation/createTrigger/updateTrigger
@@ -388,7 +388,13 @@ export function AutomationFormPage() {
           </p>
         </div>
         <div className="flex gap-2">
-          <Button type="button" variant="outline" onClick={() => navigate(-1)}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              navigate(agent ? `/agents/${encodeURIComponent(agent)}#triggers` : '/automations', { replace: true })
+            }
+          >
             Cancel
           </Button>
           <Button type="button" onClick={handleSave} disabled={saving}>


### PR DESCRIPTION
## Problem

In the Agent Builder's Automations tab, clicking **Add automation**, filling the form, and saving does not return the user to the list of existing automations. It navigates to the newly created automation's own edit page, which is visually near-identical to the create form (same fields/layout, same button position). From the user's perspective the flow looks like it "redirects back to creation" instead of confirming the automation was added and showing it in context — unlike the Tools & MCP and Knowledge tabs, which stay list-first.

Cancelling from a directly-linked `/automations/new?agent=X` (e.g. no browser history) had the same class of problem: `navigate(-1)` has nowhere reliable to go back to.

## Fix

`AutomationFormPage.tsx`: after a successful create, and on Cancel, navigate deterministically to the agent's Automations tab (`/agents/:id#triggers`), falling back to `/automations` when no agent is selected yet. Edit-mode save is unchanged (stays on the form, as before).

## Testing

Live-verified against a disposable bench (`frappe-multihand`, blank site): created a new automation on an agent with zero existing automations, confirmed the flow lands back on the Automations tab showing the new automation in the list (not the edit form); repeated for Cancel on a fresh `/automations/new` — also returns to the list.

Reviewed with an Opus 5 Low UX pass before implementation, which confirmed the root cause and additionally flagged the Cancel-button edge case (bookmarked/direct URL with no history) that's now also fixed.