### PR TITLE
fix(automations): distinct status-action icons, real Draft→Active transition, dedupe icon mapping

### DIFF
--- a/frontend/src/components/agent/AutomationsTab.tsx
+++ b/frontend/src/components/agent/AutomationsTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Play, Pause, Copy, Archive, ExternalLink, Loader2, Workflow, AlertCircle } from 'lucide-react';
+import { Plus, Play, Pause, Zap, RotateCcw, Copy, Archive, ExternalLink, Loader2, Workflow, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -29,6 +29,8 @@ import {
   formatAutomationTimestamp,
   automationStatusBadgeVariant,
   automationTriggerTypesLabel,
+  automationStatusToggleAction,
+  automationCanRunNow,
 } from '@/utils/automationDisplay';
 
 interface AutomationsTabProps {
@@ -215,32 +217,48 @@ export function AutomationsTab({ agentId }: AutomationsTabProps) {
                         >
                           <ExternalLink className="w-4 h-4" />
                         </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          title="Run now"
-                          onClick={() => handleRunNow(automation)}
-                          disabled={rowBusy}
-                        >
-                          {busyRun ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          title={isActive ? 'Pause' : 'Resume'}
-                          onClick={() => handleTogglePause(automation)}
-                          disabled={rowBusy}
-                        >
-                          {busyPause ? (
-                            <Loader2 className="w-4 h-4 animate-spin" />
-                          ) : isActive ? (
-                            <Pause className="w-4 h-4" />
-                          ) : (
-                            <Play className="w-4 h-4" />
-                          )}
-                        </Button>
+                        {automationCanRunNow(automation.status) && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            title="Run now"
+                            onClick={() => handleRunNow(automation)}
+                            disabled={rowBusy}
+                          >
+                            {busyRun ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                          </Button>
+                        )}
+                        {(() => {
+                          const toggleAction = automationStatusToggleAction(automation.status);
+                          if (!toggleAction) return null;
+
+                          let icon;
+                          switch (toggleAction.kind) {
+                            case 'activate':
+                              icon = <Zap className="w-4 h-4" />;
+                              break;
+                            case 'pause':
+                              icon = <Pause className="w-4 h-4" />;
+                              break;
+                            case 'resume':
+                              icon = <RotateCcw className="w-4 h-4" />;
+                              break;
+                          }
+
+                          return (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              title={toggleAction.label}
+                              onClick={() => handleTogglePause(automation)}
+                              disabled={rowBusy}
+                            >
+                              {busyPause ? <Loader2 className="w-4 h-4 animate-spin" /> : icon}
+                            </Button>
+                          );
+                        })()}
                         <Button
                           type="button"
                           variant="ghost"

--- a/frontend/src/components/agent/AutomationsTab.tsx
+++ b/frontend/src/components/agent/AutomationsTab.tsx
@@ -189,7 +189,6 @@ export function AutomationsTab({ agentId }: AutomationsTabProps) {
             </TableHeader>
             <TableBody>
               {rows.map((automation) => {
-                const isActive = automation.status === 'Active';
                 const busyRun = pendingAction === `run:${automation.name}`;
                 const busyPause = pendingAction === `pause:${automation.name}`;
                 const busyArchive = pendingAction === `archive:${automation.name}`;

--- a/frontend/src/pages/AutomationsPage.tsx
+++ b/frontend/src/pages/AutomationsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Zap, Play, Pause, Archive, ExternalLink, Loader2 } from 'lucide-react';
+import { Zap, Play, Pause, Archive, ExternalLink, Loader2, RotateCcw } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { PageFrame } from '@/layouts/PageFrame';
@@ -18,6 +18,8 @@ import {
   formatAutomationTimestamp,
   automationStatusBadgeVariant,
   automationTriggerTypesLabel,
+  automationStatusToggleAction,
+  automationCanRunNow,
 } from '@/utils/automationDisplay';
 import type { Automation, AutomationTriggerType } from '@/types/automation.types';
 
@@ -172,7 +174,16 @@ export function AutomationsPage() {
         }
         renderItem={(automation) => {
           const busy = pendingAction?.endsWith(`:${automation.name}`);
-          const isActive = automation.status === 'Active';
+          const toggleAction = automationStatusToggleAction(automation.status);
+          const canRunNow = automationCanRunNow(automation.status);
+
+          // Map toggle action kind to icon
+          const toggleActionIconMap: Record<string, any> = {
+            activate: Zap,
+            pause: Pause,
+            resume: RotateCcw,
+          };
+
           return (
             <ItemCard
               title={automation.automation_name}
@@ -193,18 +204,26 @@ export function AutomationsPage() {
                   label: 'Open',
                   onClick: () => navigate(`/automations/${automation.name}`),
                 },
-                {
-                  icon: busy && pendingAction === `run:${automation.name}` ? Loader2 : Play,
-                  label: 'Run now',
-                  onClick: () => handleRunNow(automation),
-                },
+                ...(canRunNow
+                  ? [
+                      {
+                        icon: busy && pendingAction === `run:${automation.name}` ? Loader2 : Play,
+                        label: 'Run now',
+                        onClick: () => handleRunNow(automation),
+                      },
+                    ]
+                  : []),
               ]}
               menuActions={[
-                {
-                  icon: isActive ? Pause : Play,
-                  label: isActive ? 'Pause' : 'Resume',
-                  onClick: () => handleTogglePause(automation),
-                },
+                ...(toggleAction
+                  ? [
+                      {
+                        icon: toggleActionIconMap[toggleAction.kind],
+                        label: toggleAction.label,
+                        onClick: () => handleTogglePause(automation),
+                      },
+                    ]
+                  : []),
                 ...(automation.status === 'Archived'
                   ? []
                   : [

--- a/frontend/src/pages/AutomationsPage.tsx
+++ b/frontend/src/pages/AutomationsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Zap, Play, Pause, Archive, ExternalLink, Loader2, RotateCcw } from 'lucide-react';
+import { Zap, Play, Pause, Archive, ExternalLink, Loader2, RotateCcw, type LucideIcon } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { PageFrame } from '@/layouts/PageFrame';
@@ -20,6 +20,7 @@ import {
   automationTriggerTypesLabel,
   automationStatusToggleAction,
   automationCanRunNow,
+  type AutomationRowAction,
 } from '@/utils/automationDisplay';
 import type { Automation, AutomationTriggerType } from '@/types/automation.types';
 
@@ -178,7 +179,7 @@ export function AutomationsPage() {
           const canRunNow = automationCanRunNow(automation.status);
 
           // Map toggle action kind to icon
-          const toggleActionIconMap: Record<string, any> = {
+          const toggleActionIconMap: Record<AutomationRowAction['kind'], LucideIcon> = {
             activate: Zap,
             pause: Pause,
             resume: RotateCcw,

--- a/frontend/src/pages/automation/AutomationFormPage.tsx
+++ b/frontend/src/pages/automation/AutomationFormPage.tsx
@@ -24,11 +24,14 @@ import {
 } from '@/components/automation/TriggerEditor';
 import { AUTOMATION_TRIGGER_TYPES } from '@/components/automation/TriggerFieldsConfig';
 import {
+  archiveAutomation,
   createAutomation,
   createTrigger,
   deleteTrigger,
   getAutomation,
   listTriggers,
+  pauseAutomation,
+  resumeAutomation,
   updateAutomation,
   updateTrigger,
 } from '@/services/automationApi';
@@ -36,16 +39,15 @@ import { getAgents, getAIModels, type AIModelItem } from '@/services/agentApi';
 import { listProjects } from '@/services/projectApi';
 import { db } from '@/lib/frappe-sdk';
 import { doctype } from '@/data/doctypes';
+import { automationStatusBadgeVariant, automationStatusToggleAction } from '@/utils/automationDisplay';
 import type {
   Automation,
   AutomationConversationMode,
-  AutomationStatus,
   AutomationTrigger as AutomationTriggerDoc,
 } from '@/types/automation.types';
 import type { AgentDoc } from '@/types/agent.types';
 import type { HufProject } from '@/services/projectApi';
 
-const AUTOMATION_STATUSES: AutomationStatus[] = ['Draft', 'Active', 'Paused', 'Error', 'Archived'];
 const CONVERSATION_MODES: AutomationConversationMode[] = ['New', 'Dedicated', 'No-UI'];
 
 let localTriggerCounter = 0;
@@ -127,6 +129,7 @@ export function AutomationFormPage() {
 
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
+  const [statusActionPending, setStatusActionPending] = useState<'toggle' | 'archive' | null>(null);
   const [activeTab, setActiveTab] = useState('general');
   const [automation, setAutomation] = useState<Automation | null>(null);
 
@@ -135,7 +138,6 @@ export function AutomationFormPage() {
   const [description, setDescription] = useState('');
   const [agent, setAgent] = useState(preselectedAgent || '');
   const [project, setProject] = useState('');
-  const [status, setStatus] = useState<AutomationStatus>('Draft');
 
   // Task
   const [instruction, setInstruction] = useState('');
@@ -188,7 +190,6 @@ export function AutomationFormPage() {
       setDescription(automationDoc.description || '');
       setAgent(automationDoc.agent);
       setProject(automationDoc.project || '');
-      setStatus(automationDoc.status);
       setInstruction(automationDoc.instruction || '');
       setModelOverride(automationDoc.model_override || '');
       setConversationMode(automationDoc.conversation_mode || 'New');
@@ -241,6 +242,40 @@ export function AutomationFormPage() {
     setTriggerRows((rows) => rows.filter((r) => r._localId !== row._localId));
   };
 
+  const handleStatusToggle = async () => {
+    if (!automation || !automationId) return;
+    const action = automationStatusToggleAction(automation.status);
+    if (!action) return;
+    setStatusActionPending('toggle');
+    try {
+      if (action.kind === 'pause') {
+        await pauseAutomation(automationId);
+      } else {
+        await resumeAutomation(automationId);
+      }
+      toast.success(`Automation ${action.kind === 'pause' ? 'paused' : 'activated'}`);
+      await loadExisting(automationId);
+    } catch {
+      // pauseAutomation/resumeAutomation already surface a toast on failure.
+    } finally {
+      setStatusActionPending(null);
+    }
+  };
+
+  const handleArchive = async () => {
+    if (!automationId) return;
+    setStatusActionPending('archive');
+    try {
+      await archiveAutomation(automationId);
+      toast.success('Automation archived');
+      await loadExisting(automationId);
+    } catch {
+      // archiveAutomation already surfaces a toast on failure.
+    } finally {
+      setStatusActionPending(null);
+    }
+  };
+
   const validate = (): string | null => {
     if (!automationName.trim()) return 'Name is required.';
     if (!agent) return 'Select an Agent.';
@@ -291,7 +326,6 @@ export function AutomationFormPage() {
           description: description.trim(),
           agent,
           project: project || undefined,
-          status,
           model_override: modelOverride || undefined,
           run_as_user: runAsUser || undefined,
           instruction: instruction.trim(),
@@ -462,25 +496,40 @@ export function AutomationFormPage() {
               />
             </div>
           </div>
-          {!isNew && (
+          {!isNew && automation && (
             <div className="space-y-1.5">
               <Label>Status</Label>
-              <Select onValueChange={(v) => setStatus(v as AutomationStatus)} value={status}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {AUTOMATION_STATUSES.map((s) => (
-                    <SelectItem key={s} value={s}>
-                      {s}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-steel-soft">
-                Prefer the Automations tab&apos;s Pause/Resume actions for normal use -- this is a direct
-                override.
-              </p>
+              <div className="flex items-center gap-2">
+                <Badge variant={automationStatusBadgeVariant(automation.status)}>{automation.status}</Badge>
+                {(() => {
+                  const action = automationStatusToggleAction(automation.status);
+                  if (!action) return null;
+                  return (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={handleStatusToggle}
+                      disabled={statusActionPending !== null}
+                    >
+                      {statusActionPending === 'toggle' && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                      {action.label}
+                    </Button>
+                  );
+                })()}
+                {automation.status !== 'Archived' && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleArchive}
+                    disabled={statusActionPending !== null}
+                  >
+                    {statusActionPending === 'archive' && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+                    Archive
+                  </Button>
+                )}
+              </div>
             </div>
           )}
         </CardContent>

--- a/frontend/src/utils/automationDisplay.ts
+++ b/frontend/src/utils/automationDisplay.ts
@@ -1,6 +1,11 @@
-import type { Automation, AutomationTriggerType } from '@/types/automation.types';
+import type { Automation, AutomationStatus, AutomationTriggerType } from '@/types/automation.types';
 
 const MAX_TRIGGER_TYPES_SHOWN = 2;
+
+export type AutomationRowAction =
+  | { kind: 'activate'; label: 'Activate' }
+  | { kind: 'pause'; label: 'Pause' }
+  | { kind: 'resume'; label: 'Resume' };
 
 export function formatAutomationTimestamp(value?: string): string {
   if (!value) return '—';
@@ -32,4 +37,25 @@ export function automationTriggerTypesLabel(types: AutomationTriggerType[]): str
   const shown = types.slice(0, MAX_TRIGGER_TYPES_SHOWN);
   const overflow = types.length - shown.length;
   return overflow > 0 ? `${shown.join(', ')} +${overflow} more` : shown.join(', ');
+}
+
+export function automationStatusToggleAction(status: AutomationStatus): AutomationRowAction | null {
+  switch (status) {
+    case 'Draft':
+    case 'Error':
+      return { kind: 'activate', label: 'Activate' };
+    case 'Active':
+      return { kind: 'pause', label: 'Pause' };
+    case 'Paused':
+      return { kind: 'resume', label: 'Resume' };
+    case 'Archived':
+      return null;
+    default:
+      const _exhaustive: never = status;
+      return _exhaustive;
+  }
+}
+
+export function automationCanRunNow(status: AutomationStatus): boolean {
+  return status !== 'Archived';
 }

--- a/frontend/src/utils/automationDisplay.ts
+++ b/frontend/src/utils/automationDisplay.ts
@@ -50,9 +50,10 @@ export function automationStatusToggleAction(status: AutomationStatus): Automati
       return { kind: 'resume', label: 'Resume' };
     case 'Archived':
       return null;
-    default:
+    default: {
       const _exhaustive: never = status;
       return _exhaustive;
+    }
   }
 }
 


### PR DESCRIPTION
## Context

Four issues raised against the Agent Builder's Automations feature:

1. **Architecture question**: is Automation a first-class object or agent-owned (like a Tool/Knowledge source)?
2. Two visually-identical Play icons in the automations list actions.
3. Editing an automation's Status (Draft→Active) and trigger fields appeared to not persist.
4. General "form persistence, state etc seems to have many issues" concern.

## 1. Architecture — investigated, no structural change needed

`Automation` is a standalone top-level DocType (not a child table) with a required `Link` field to `Agent` — genuinely first-class, not agent-owned. A full top-level `/automations` list page (`AutomationsPage.tsx`, card grid, search, status filter) already exists and is the canonical list.

The per-agent `AutomationsTab.tsx` is a second, independent list implementation (table layout) of the same object — creation is already shared (`/automations/new?agent=X`), only the list rendering was duplicated. Decision (confirmed via a design review before implementing): **keep the per-agent tab** — it's genuinely useful contextual UX ("what runs this agent") and removing it in favor of linking out would cost a full navigation away mid-configuration, with no real reduction in engineering surface. Scope for this PR: deduplicate the one piece of logic that had actually drifted between the two list views (the status→action icon mapping, see #2) via a shared utility. A fuller consolidation (one shared `AutomationsList` component/hook used by both pages) was considered and is a reasonable follow-up, but is a larger refactor out of scope here.

## 2. Duplicate Play icons — fixed

`AutomationsTab.tsx` and `AutomationsPage.tsx` (the latter has the identical bug, found during implementation) both rendered `Play` for "Run now" AND for the Pause/Resume toggle whenever an automation wasn't Active — e.g. a Draft automation showed two indistinguishable Play buttons, one of which was actually "Activate."

Added `automationStatusToggleAction(status)` / `automationCanRunNow(status)` to `frontend/src/utils/automationDisplay.ts` — a single source of truth mapping status → the correct action + distinct icon (Draft/Error → Activate/Zap, Active → Pause, Paused → Resume/RotateCcw, Archived → hidden). Both list views now use it.

## 3. Status field was a no-op — fixed

The edit form's Status `<Select>` looked editable but the backend's `update_automation` deliberately excludes `status` from its updatable-fields allowlist (state transitions are meant to go through dedicated `pause_automation`/`resume_automation`/`archive_automation` endpoints, by design). So changing Draft→Active and saving silently did nothing — no error, but the status never changed.

Removed the editable dropdown; replaced with a **read-only status badge** plus **Activate/Pause/Resume/Archive buttons** that call the dedicated endpoints directly (outside the generic save flow), with their own loading state and toast, refetching on success.

Trigger field edits (schedule interval, "every N") were also suspected lost — investigated and **not actually broken**: the frontend sends the right fields, the backend persists them correctly. Live-verified: set Interval=Weekly, Every=3, saved, confirmed via direct API read that both fields persisted server-side.

## 4. Breadth of "form persistence has many issues"

This pass addressed the two specific symptoms reported (status no-op, suspected trigger loss). It did **not** do a broader audit of the form's other fields, add an unsaved-changes guard, or add backend tests — flagging this explicitly rather than implying the general concern is fully closed.

## Testing

- `tsc --noEmit` and the real `yarn build` both pass clean; `eslint` on all four touched files passes (one pre-existing unused-var warning on `origin/pre-develop`, not introduced here).
- Live-verified on a disposable `frappe-multihand` bench:
  - Draft automation shows three visually distinct actions: Open, Run now, Activate.
  - Clicking Activate: toast fires, list status flips Draft→Active, confirmed via direct API call.
  - Edit form for an Active automation shows a read-only badge + Pause/Archive (no dead dropdown).
  - Added a Schedule trigger (Weekly, every 3), saved, confirmed `scheduled_interval`/`interval_count` persisted via a direct REST read of the Automation Trigger doc.
- Reviewed by an Opus 5 Low pass at the architecture-decision stage and again as a final adversarial review before this PR — both rounds' findings are incorporated (icon-mapping type safety, exhaustiveness check bracing, and the caveats noted above).

## Note on scope

One noteworthy side effect worth calling out explicitly: "Run now" is now hidden for Archived automations (previously always shown but would error) — this is intentional and matches backend behavior (`resume_automation`/`pause_automation` both reject Archived).