### PR TITLE
refactor(automations): consolidate tab and top-level list onto one shared data/action layer

### DIFF
--- a/frontend/src/components/agent/AutomationsTab.tsx
+++ b/frontend/src/components/agent/AutomationsTab.tsx
@@ -1,7 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Plus, Play, Pause, Zap, RotateCcw, Copy, Archive, ExternalLink, Loader2, Workflow, AlertCircle } from 'lucide-react';
-import { toast } from 'sonner';
+import { useNavigate, Link } from 'react-router-dom';
+import { Plus, Loader2, Workflow, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -15,31 +13,17 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { EmptyState } from '@/components/dashboard/views/EmptyState';
-import {
-  listAutomations,
-  listTriggers,
-  runAutomationNow,
-  pauseAutomation,
-  resumeAutomation,
-  archiveAutomation,
-  getAutomationRuntimeMode,
-} from '@/services/automationApi';
-import type { Automation, AutomationTriggerType } from '@/types/automation.types';
+import { useAutomationsList } from '@/hooks/useAutomationsList';
+import { buildAutomationActions } from '@/utils/automationActions';
+import type { AutomationRow } from '@/types/automation.types';
 import {
   formatAutomationTimestamp,
   automationStatusBadgeVariant,
   automationTriggerTypesLabel,
-  automationStatusToggleAction,
-  automationCanRunNow,
 } from '@/utils/automationDisplay';
 
 interface AutomationsTabProps {
   agentId: string;
-}
-
-/** Automation rows shown in the tab, each carrying its resolved trigger types. */
-interface AutomationRow extends Automation {
-  triggerTypes: AutomationTriggerType[];
 }
 
 const formatTimestamp = formatAutomationTimestamp;
@@ -48,34 +32,7 @@ const triggerTypesLabel = automationTriggerTypesLabel;
 
 export function AutomationsTab({ agentId }: AutomationsTabProps) {
   const navigate = useNavigate();
-  const [rows, setRows] = useState<AutomationRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [pendingAction, setPendingAction] = useState<string | null>(null);
-  const [runtimeMode, setRuntimeMode] = useState<'new' | 'legacy'>('new');
-
-  const loadAutomations = useCallback(async () => {
-    setLoading(true);
-    try {
-      const automations = await listAutomations({ agent: agentId });
-      const withTriggers = await Promise.all(
-        automations.map(async (automation) => {
-          const triggers = await listTriggers(automation.name);
-          const triggerTypes = triggers
-            .map((trigger) => trigger.trigger_type)
-            .filter((type): type is AutomationTriggerType => !!type);
-          return { ...automation, triggerTypes };
-        })
-      );
-      setRows(withTriggers);
-    } finally {
-      setLoading(false);
-    }
-  }, [agentId]);
-
-  useEffect(() => {
-    loadAutomations();
-    getAutomationRuntimeMode().then((response) => setRuntimeMode(response.mode));
-  }, [loadAutomations]);
+  const list = useAutomationsList({ agent: agentId });
 
   const handleAddAutomation = () => {
     navigate(`/automations/new?agent=${encodeURIComponent(agentId)}`);
@@ -85,67 +42,13 @@ export function AutomationsTab({ agentId }: AutomationsTabProps) {
     navigate(`/automations/${encodeURIComponent(automation.name)}`);
   };
 
-  const handleRunNow = async (automation: AutomationRow) => {
-    setPendingAction(`run:${automation.name}`);
-    try {
-      await runAutomationNow(automation.name);
-      toast.success(`${automation.automation_name} started`);
-      await loadAutomations();
-    } catch {
-      // runAutomationNow already surfaces a toast via handleFrappeError.
-    } finally {
-      setPendingAction(null);
-    }
-  };
-
-  const handleTogglePause = async (automation: AutomationRow) => {
-    const isActive = automation.status === 'Active';
-    setPendingAction(`pause:${automation.name}`);
-    try {
-      if (isActive) {
-        await pauseAutomation(automation.name);
-        toast.success(`${automation.automation_name} paused`);
-      } else {
-        await resumeAutomation(automation.name);
-        toast.success(`${automation.automation_name} resumed`);
-      }
-      await loadAutomations();
-    } catch {
-      // pauseAutomation/resumeAutomation already surface a toast on failure.
-    } finally {
-      setPendingAction(null);
-    }
-  };
-
-  const handleDuplicate = (automation: AutomationRow) => {
-    // TODO: duplicating an Automation means cloning it plus every one of its
-    // Automation Trigger child rows (create_automation + create_trigger per
-    // row, since the API has no single "duplicate" endpoint). Deferred --
-    // out of scope for S12/S13; wire this up alongside the Automation form
-    // page (S17) where the trigger editor it needs already lives.
-    toast.info(`Duplicate for "${automation.automation_name}" is not available yet`);
-  };
-
-  const handleArchive = async (automation: AutomationRow) => {
-    setPendingAction(`archive:${automation.name}`);
-    try {
-      await archiveAutomation(automation.name);
-      toast.success(`${automation.automation_name} archived`);
-      await loadAutomations();
-    } catch {
-      // archiveAutomation already surfaces a toast on failure.
-    } finally {
-      setPendingAction(null);
-    }
-  };
-
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
         <div className="space-y-1.5">
-          <CardTitle>Automations</CardTitle>
+          <CardTitle>Automations using this agent</CardTitle>
           <p className="font-body text-[13px] text-steel-soft max-w-[60ch]">
-            Automations run this agent automatically — on a schedule, when a document changes, or from an external event.
+            These automations reference this agent. Changing or deprecating the agent affects every automation listed here.
           </p>
         </div>
         <Button onClick={handleAddAutomation} size="sm" type="button">
@@ -154,7 +57,7 @@ export function AutomationsTab({ agentId }: AutomationsTabProps) {
         </Button>
       </CardHeader>
       <CardContent>
-        {runtimeMode === 'legacy' && (
+        {list.runtimeMode === 'legacy' && (
           <Alert variant="destructive" className="mb-4">
             <AlertCircle className="h-4 w-4" />
             <AlertTitle>Legacy Automation Runtime Active</AlertTitle>
@@ -163,128 +66,80 @@ export function AutomationsTab({ agentId }: AutomationsTabProps) {
             </AlertDescription>
           </Alert>
         )}
-        {loading ? (
+        {list.loading ? (
           <div className="flex items-center justify-center py-12 text-steel-soft">
             <Loader2 className="w-5 h-5 animate-spin" />
           </div>
-        ) : rows.length === 0 ? (
+        ) : list.rows.length === 0 ? (
           <EmptyState
             variant="create"
             icon={Workflow}
-            title="No automations yet"
-            description="Add an automation to run this agent on a schedule, a document change, or an external event."
+            title="No automations use this agent"
+            description="Nothing runs this agent automatically yet. Create an automation to run it on a schedule, a document change, or an external event."
             action={{ label: 'Add automation', onClick: handleAddAutomation }}
           />
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Trigger type(s)</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Last Run</TableHead>
-                <TableHead>Next Run</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map((automation) => {
-                const busyRun = pendingAction === `run:${automation.name}`;
-                const busyPause = pendingAction === `pause:${automation.name}`;
-                const busyArchive = pendingAction === `archive:${automation.name}`;
-                const rowBusy = busyRun || busyPause || busyArchive;
-                return (
-                  <TableRow key={automation.name}>
-                    <TableCell className="font-medium max-w-xs truncate">
-                      {automation.automation_name}
-                    </TableCell>
-                    <TableCell>{triggerTypesLabel(automation.triggerTypes)}</TableCell>
-                    <TableCell>
-                      <Badge variant={statusBadgeVariant(automation.status)}>{automation.status}</Badge>
-                    </TableCell>
-                    <TableCell>{formatTimestamp(automation.last_execution)}</TableCell>
-                    <TableCell>{formatTimestamp(automation.next_execution)}</TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex justify-end gap-1">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          title="Open"
-                          onClick={() => handleOpen(automation)}
-                          disabled={rowBusy}
-                        >
-                          <ExternalLink className="w-4 h-4" />
-                        </Button>
-                        {automationCanRunNow(automation.status) && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            title="Run now"
-                            onClick={() => handleRunNow(automation)}
-                            disabled={rowBusy}
-                          >
-                            {busyRun ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
-                          </Button>
-                        )}
-                        {(() => {
-                          const toggleAction = automationStatusToggleAction(automation.status);
-                          if (!toggleAction) return null;
-
-                          let icon;
-                          switch (toggleAction.kind) {
-                            case 'activate':
-                              icon = <Zap className="w-4 h-4" />;
-                              break;
-                            case 'pause':
-                              icon = <Pause className="w-4 h-4" />;
-                              break;
-                            case 'resume':
-                              icon = <RotateCcw className="w-4 h-4" />;
-                              break;
-                          }
-
-                          return (
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Trigger type(s)</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Run</TableHead>
+                  <TableHead>Next Run</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {list.rows.map((automation) => {
+                  const actions = buildAutomationActions(automation, {
+                    list,
+                    onOpen: handleOpen,
+                  });
+                  return (
+                    <TableRow key={automation.name}>
+                      <TableCell className="font-medium max-w-xs truncate">
+                        {automation.automation_name}
+                      </TableCell>
+                      <TableCell>{triggerTypesLabel(automation.triggerTypes)}</TableCell>
+                      <TableCell>
+                        <Badge variant={statusBadgeVariant(automation.status)}>{automation.status}</Badge>
+                      </TableCell>
+                      <TableCell>{formatTimestamp(automation.last_execution)}</TableCell>
+                      <TableCell>{formatTimestamp(automation.next_execution)}</TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-1">
+                          {actions.map((action) => (
                             <Button
+                              key={action.key}
                               type="button"
                               variant="ghost"
                               size="sm"
-                              title={toggleAction.label}
-                              onClick={() => handleTogglePause(automation)}
-                              disabled={rowBusy}
+                              title={action.label}
+                              onClick={action.onClick}
+                              disabled={action.disabled}
                             >
-                              {busyPause ? <Loader2 className="w-4 h-4 animate-spin" /> : icon}
+                              {action.busy ? (
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                              ) : (
+                                <action.icon className="w-4 h-4" />
+                              )}
                             </Button>
-                          );
-                        })()}
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          title="Duplicate"
-                          onClick={() => handleDuplicate(automation)}
-                          disabled={rowBusy}
-                        >
-                          <Copy className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          title="Archive"
-                          onClick={() => handleArchive(automation)}
-                          disabled={rowBusy || automation.status === 'Archived'}
-                        >
-                          {busyArchive ? <Loader2 className="w-4 h-4 animate-spin" /> : <Archive className="w-4 h-4" />}
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
+                          ))}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+            <div className="mt-3 flex justify-end">
+              <Link to="/automations" className="text-sm text-muted-foreground hover:underline">
+                View all automations
+              </Link>
+            </div>
+          </>
         )}
       </CardContent>
     </Card>

--- a/frontend/src/hooks/useAutomationsList.ts
+++ b/frontend/src/hooks/useAutomationsList.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  listAutomations,
+  listTriggers,
+  runAutomationNow,
+  pauseAutomation,
+  resumeAutomation,
+  archiveAutomation,
+  getAutomationRuntimeMode,
+} from '@/services/automationApi';
+import type { Automation, AutomationRow, AutomationTriggerType } from '@/types/automation.types';
+import { automationStatusToggleAction } from '@/utils/automationDisplay';
+
+export interface UseAutomationsListResult {
+  rows: AutomationRow[];
+  loading: boolean;
+  error: Error | null;
+  pendingAction: string | null;
+  isBusy: (name: string, verb?: 'run' | 'pause' | 'archive') => boolean;
+  refresh: () => Promise<void>;
+  runNow: (automation: AutomationRow) => Promise<void>;
+  toggleStatus: (automation: AutomationRow) => Promise<void>;
+  archive: (automation: AutomationRow) => Promise<void>;
+  runtimeMode: 'new' | 'legacy';
+}
+
+/**
+ * Shared data layer for the top-level /automations list page and the
+ * per-agent Automations tab. Fetches Automations (optionally scoped to a
+ * single agent), resolves each row's trigger types, and exposes the
+ * run-now / pause-resume / archive actions with consistent toast and
+ * pending-state handling.
+ */
+export function useAutomationsList(opts?: { agent?: string }): UseAutomationsListResult {
+  const agent = opts?.agent;
+  const [rows, setRows] = useState<AutomationRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [runtimeMode, setRuntimeMode] = useState<'new' | 'legacy'>('new');
+
+  const fetchRows = useCallback(async (): Promise<AutomationRow[]> => {
+    const automations = await listAutomations(agent ? { agent } : undefined);
+    return Promise.all(
+      automations.map(async (automation: Automation) => {
+        const triggers = await listTriggers(automation.name);
+        const triggerTypes = triggers
+          .map((trigger) => trigger.trigger_type)
+          .filter((type): type is AutomationTriggerType => !!type);
+        return { ...automation, triggerTypes } as AutomationRow;
+      })
+    );
+  }, [agent]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const withTriggers = await fetchRows();
+      setRows(withTriggers);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchRows]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setLoading(true);
+    fetchRows()
+      .then((withTriggers) => {
+        if (cancelled) return;
+        setRows(withTriggers);
+        setError(null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchRows]);
+
+  useEffect(() => {
+    getAutomationRuntimeMode().then((response) => setRuntimeMode(response.mode));
+  }, []);
+
+  const isBusy = useCallback(
+    (name: string, verb?: 'run' | 'pause' | 'archive') => {
+      if (!pendingAction) return false;
+      if (verb) return pendingAction === `${verb}:${name}`;
+      return pendingAction.split(':')[1] === name;
+    },
+    [pendingAction]
+  );
+
+  const runNow = useCallback(
+    async (automation: AutomationRow) => {
+      setPendingAction(`run:${automation.name}`);
+      try {
+        await runAutomationNow(automation.name);
+        toast.success(`${automation.automation_name} started`);
+        await refresh();
+      } catch {
+        // runAutomationNow already surfaces a toast via handleFrappeError.
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [refresh]
+  );
+
+  const toggleStatus = useCallback(
+    async (automation: AutomationRow) => {
+      const action = automationStatusToggleAction(automation.status);
+      if (!action) {
+        console.warn(`No toggle action available for automation "${automation.name}" with status "${automation.status}"`);
+        return;
+      }
+
+      setPendingAction(`pause:${automation.name}`);
+      try {
+        if (action.kind === 'pause') {
+          await pauseAutomation(automation.name);
+          toast.success(`${automation.automation_name} paused`);
+        } else {
+          await resumeAutomation(automation.name);
+          toast.success(`${automation.automation_name} resumed`);
+        }
+        await refresh();
+      } catch {
+        // pauseAutomation/resumeAutomation already surface a toast on failure.
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [refresh]
+  );
+
+  const archive = useCallback(
+    async (automation: AutomationRow) => {
+      setPendingAction(`archive:${automation.name}`);
+      try {
+        await archiveAutomation(automation.name);
+        toast.success(`${automation.automation_name} archived`);
+        await refresh();
+      } catch {
+        // archiveAutomation already surfaces a toast on failure.
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [refresh]
+  );
+
+  return {
+    rows,
+    loading,
+    error,
+    pendingAction,
+    isBusy,
+    refresh,
+    runNow,
+    toggleStatus,
+    archive,
+    runtimeMode,
+  };
+}

--- a/frontend/src/pages/AutomationsPage.tsx
+++ b/frontend/src/pages/AutomationsPage.tsx
@@ -1,32 +1,19 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Zap, Play, Pause, Archive, ExternalLink, Loader2, RotateCcw, type LucideIcon } from 'lucide-react';
+import { Zap, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { PageFrame } from '@/layouts/PageFrame';
 import { FilterBar, GridView, ItemCard, EmptyState } from '@/components/dashboard';
 import { usePageData } from '@/hooks/dashboard/usePageData';
-import {
-  listAutomations,
-  listTriggers,
-  runAutomationNow,
-  pauseAutomation,
-  resumeAutomation,
-  archiveAutomation,
-} from '@/services/automationApi';
+import { useAutomationsList } from '@/hooks/useAutomationsList';
+import { buildAutomationActions } from '@/utils/automationActions';
 import {
   formatAutomationTimestamp,
   automationStatusBadgeVariant,
   automationTriggerTypesLabel,
-  automationStatusToggleAction,
-  automationCanRunNow,
-  type AutomationRowAction,
 } from '@/utils/automationDisplay';
-import type { Automation, AutomationTriggerType } from '@/types/automation.types';
-
-interface AutomationRow extends Automation {
-  triggerTypes: AutomationTriggerType[];
-}
+import type { AutomationRow } from '@/types/automation.types';
 
 const statusOptions = [
   { label: 'All statuses', value: 'all' },
@@ -39,88 +26,32 @@ const statusOptions = [
 
 export function AutomationsPage() {
   const navigate = useNavigate();
-  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const list = useAutomationsList();
 
-  const fetchAutomations = useCallback(async () => {
-    const automations = await listAutomations();
-    const withTriggers = await Promise.all(
-      automations.map(async (automation) => {
-        const triggers = await listTriggers(automation.name);
-        const triggerTypes = triggers
-          .map((trigger) => trigger.trigger_type)
-          .filter((type): type is AutomationTriggerType => !!type);
-        return { ...automation, triggerTypes };
-      })
-    );
-    return withTriggers;
-  }, []);
-
-  const { data: rows, allData, loading, error, search, setSearch, filters, setFilters, refresh } =
+  const { data: rows, allData, search, setSearch, filters, setFilters, setData } =
     usePageData<AutomationRow>({
-      fetchFn: fetchAutomations,
       searchFields: ['automation_name', 'description'],
       filterFn: (item, activeFilters) =>
         !activeFilters.status || activeFilters.status === 'all' || item.status === activeFilters.status,
     });
 
+  // usePageData's fetch effect has [] deps and can't compose with a hook
+  // that also fetches, so useAutomationsList() owns the actual fetch here
+  // and usePageData is kept only for the search/filter layer on top --
+  // seed it from list.rows whenever the shared hook's data changes.
   useEffect(() => {
-    if (error) {
+    setData(list.rows);
+  }, [list.rows, setData]);
+
+  useEffect(() => {
+    if (list.error) {
       toast.error('Failed to load automations', {
-        description: error.message || 'An error occurred while fetching automations.',
+        description: list.error.message || 'An error occurred while fetching automations.',
       });
     }
-  }, [error]);
+  }, [list.error]);
 
   const setStatusFilter = (value: string) => setFilters((prev) => ({ ...prev, status: value }));
-
-  const handleRunNow = async (automation: AutomationRow) => {
-    setPendingAction(`run:${automation.name}`);
-    try {
-      await runAutomationNow(automation.name);
-      toast.success(`Running "${automation.automation_name}"`);
-    } catch (err) {
-      toast.error('Failed to run automation', {
-        description: err instanceof Error ? err.message : 'An error occurred.',
-      });
-    } finally {
-      setPendingAction(null);
-    }
-  };
-
-  const handleTogglePause = async (automation: AutomationRow) => {
-    setPendingAction(`pause:${automation.name}`);
-    try {
-      if (automation.status === 'Active') {
-        await pauseAutomation(automation.name);
-        toast.success('Automation paused');
-      } else {
-        await resumeAutomation(automation.name);
-        toast.success('Automation resumed');
-      }
-      await refresh();
-    } catch (err) {
-      toast.error('Failed to update automation', {
-        description: err instanceof Error ? err.message : 'An error occurred.',
-      });
-    } finally {
-      setPendingAction(null);
-    }
-  };
-
-  const handleArchive = async (automation: AutomationRow) => {
-    setPendingAction(`archive:${automation.name}`);
-    try {
-      await archiveAutomation(automation.name);
-      toast.success('Automation archived');
-      await refresh();
-    } catch (err) {
-      toast.error('Failed to archive automation', {
-        description: err instanceof Error ? err.message : 'An error occurred.',
-      });
-    } finally {
-      setPendingAction(null);
-    }
-  };
 
   const hasActiveFilters = !!search || (filters.status && filters.status !== 'all');
 
@@ -147,7 +78,7 @@ export function AutomationsPage() {
       <GridView
         items={rows}
         columns={{ sm: 1, md: 2, lg: 3 }}
-        loading={loading}
+        loading={list.loading}
         emptyState={
           hasActiveFilters ? (
             <EmptyState
@@ -174,16 +105,28 @@ export function AutomationsPage() {
           )
         }
         renderItem={(automation) => {
-          const busy = pendingAction?.endsWith(`:${automation.name}`);
-          const toggleAction = automationStatusToggleAction(automation.status);
-          const canRunNow = automationCanRunNow(automation.status);
+          const descriptors = buildAutomationActions(automation, {
+            list,
+            onOpen: (a) => navigate(`/automations/${a.name}`),
+          });
+          const byKey = Object.fromEntries(descriptors.map((d) => [d.key, d]));
 
-          // Map toggle action kind to icon
-          const toggleActionIconMap: Record<AutomationRowAction['kind'], LucideIcon> = {
-            activate: Zap,
-            pause: Pause,
-            resume: RotateCcw,
-          };
+          const inlineActions = [byKey.open, byKey.run]
+            .filter((d): d is NonNullable<typeof d> => !!d)
+            .map((d) => ({
+              icon: d.busy ? Loader2 : d.icon,
+              label: d.label,
+              onClick: d.onClick,
+            }));
+
+          const menuActions = [byKey.toggle, byKey.archive]
+            .filter((d): d is NonNullable<typeof d> => !!d)
+            .map((d) => ({
+              icon: d.icon,
+              label: d.label,
+              onClick: d.onClick,
+              ...(d.key === 'archive' ? { variant: 'destructive' as const } : {}),
+            }));
 
           return (
             <ItemCard
@@ -199,50 +142,15 @@ export function AutomationsPage() {
                 { label: 'Agent', value: automation.agent },
                 { label: 'Last run', value: formatAutomationTimestamp(automation.last_execution) },
               ]}
-              actions={[
-                {
-                  icon: ExternalLink,
-                  label: 'Open',
-                  onClick: () => navigate(`/automations/${automation.name}`),
-                },
-                ...(canRunNow
-                  ? [
-                      {
-                        icon: busy && pendingAction === `run:${automation.name}` ? Loader2 : Play,
-                        label: 'Run now',
-                        onClick: () => handleRunNow(automation),
-                      },
-                    ]
-                  : []),
-              ]}
-              menuActions={[
-                ...(toggleAction
-                  ? [
-                      {
-                        icon: toggleActionIconMap[toggleAction.kind],
-                        label: toggleAction.label,
-                        onClick: () => handleTogglePause(automation),
-                      },
-                    ]
-                  : []),
-                ...(automation.status === 'Archived'
-                  ? []
-                  : [
-                      {
-                        icon: Archive,
-                        label: 'Archive',
-                        variant: 'destructive' as const,
-                        onClick: () => handleArchive(automation),
-                      },
-                    ]),
-              ]}
+              actions={inlineActions}
+              menuActions={menuActions}
               onClick={() => navigate(`/automations/${automation.name}`)}
             />
           );
         }}
         keyExtractor={(automation) => automation.name}
       />
-      {!loading && allData.length > 0 && (
+      {!list.loading && allData.length > 0 && (
         <div className="text-center py-4 text-sm text-muted-foreground">
           Showing {rows.length} of {allData.length} automation{allData.length === 1 ? '' : 's'}
         </div>

--- a/frontend/src/pages/AutomationsPage.tsx
+++ b/frontend/src/pages/AutomationsPage.tsx
@@ -111,8 +111,12 @@ export function AutomationsPage() {
           });
           const byKey = Object.fromEntries(descriptors.map((d) => [d.key, d]));
 
+          // ItemCard's ActionButton has no `disabled` field, so a descriptor
+          // that's disabled (e.g. Archive on an already-Archived automation,
+          // or any action while another is in flight for this row) must be
+          // filtered out here rather than rendered-but-inert.
           const inlineActions = [byKey.open, byKey.run]
-            .filter((d): d is NonNullable<typeof d> => !!d)
+            .filter((d): d is NonNullable<typeof d> => !!d && !d.disabled)
             .map((d) => ({
               icon: d.busy ? Loader2 : d.icon,
               label: d.label,
@@ -120,7 +124,7 @@ export function AutomationsPage() {
             }));
 
           const menuActions = [byKey.toggle, byKey.archive]
-            .filter((d): d is NonNullable<typeof d> => !!d)
+            .filter((d): d is NonNullable<typeof d> => !!d && !d.disabled)
             .map((d) => ({
               icon: d.icon,
               label: d.label,

--- a/frontend/src/types/automation.types.ts
+++ b/frontend/src/types/automation.types.ts
@@ -78,6 +78,11 @@ export interface Automation {
   modified?: string;
 }
 
+/** An Automation as rendered in a list, with its trigger types resolved. */
+export interface AutomationRow extends Automation {
+  triggerTypes: AutomationTriggerType[];
+}
+
 /**
  * Automation Trigger doctype
  * (huf/huf/doctype/automation_trigger/automation_trigger.json).

--- a/frontend/src/utils/automationActions.ts
+++ b/frontend/src/utils/automationActions.ts
@@ -1,0 +1,84 @@
+import { ExternalLink, Play, Zap, Pause, RotateCcw, Copy, Archive } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { AutomationRow } from '@/types/automation.types';
+import { automationStatusToggleAction, automationCanRunNow, type AutomationRowAction } from '@/utils/automationDisplay';
+import type { UseAutomationsListResult } from '@/hooks/useAutomationsList';
+
+export interface AutomationActionDescriptor {
+  key: 'open' | 'run' | 'toggle' | 'archive' | 'duplicate';
+  icon: LucideIcon;
+  label: string;
+  busy: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+export interface BuildAutomationActionsCtx {
+  list: Pick<UseAutomationsListResult, 'isBusy' | 'runNow' | 'toggleStatus' | 'archive'>;
+  onOpen: (automation: AutomationRow) => void;
+  onDuplicate?: (automation: AutomationRow) => void; // omit to exclude the Duplicate action entirely
+}
+
+const TOGGLE_ICON_MAP: Record<AutomationRowAction['kind'], LucideIcon> = {
+  activate: Zap,
+  pause: Pause,
+  resume: RotateCcw,
+};
+
+export function buildAutomationActions(
+  automation: AutomationRow,
+  ctx: BuildAutomationActionsCtx
+): AutomationActionDescriptor[] {
+  const actions: AutomationActionDescriptor[] = [];
+
+  actions.push({
+    key: 'open',
+    icon: ExternalLink,
+    label: 'Open',
+    busy: false,
+    onClick: () => ctx.onOpen(automation),
+  });
+
+  if (automationCanRunNow(automation.status)) {
+    actions.push({
+      key: 'run',
+      icon: Play,
+      label: 'Run now',
+      busy: ctx.list.isBusy(automation.name, 'run'),
+      disabled: ctx.list.isBusy(automation.name),
+      onClick: () => ctx.list.runNow(automation),
+    });
+  }
+
+  const toggleAction = automationStatusToggleAction(automation.status);
+  if (toggleAction) {
+    actions.push({
+      key: 'toggle',
+      icon: TOGGLE_ICON_MAP[toggleAction.kind],
+      label: toggleAction.label,
+      busy: ctx.list.isBusy(automation.name, 'pause'),
+      onClick: () => ctx.list.toggleStatus(automation),
+    });
+  }
+
+  if (ctx.onDuplicate) {
+    actions.push({
+      key: 'duplicate',
+      icon: Copy,
+      label: 'Duplicate',
+      busy: false,
+      onClick: () => ctx.onDuplicate!(automation),
+    });
+  }
+
+  actions.push({
+    key: 'archive',
+    icon: Archive,
+    label: 'Archive',
+    busy: ctx.list.isBusy(automation.name, 'archive'),
+    disabled: ctx.list.isBusy(automation.name) || automation.status === 'Archived',
+    onClick: () => ctx.list.archive(automation),
+  });
+
+  return actions;
+}

--- a/frontend/src/utils/automationActions.ts
+++ b/frontend/src/utils/automationActions.ts
@@ -57,6 +57,7 @@ export function buildAutomationActions(
       icon: TOGGLE_ICON_MAP[toggleAction.kind],
       label: toggleAction.label,
       busy: ctx.list.isBusy(automation.name, 'pause'),
+      disabled: ctx.list.isBusy(automation.name),
       onClick: () => ctx.list.toggleStatus(automation),
     });
   }


### PR DESCRIPTION
## Context

Follow-up to #725. That PR fixed a duplicate-icon bug caused by the per-agent Automations tab (`AutomationsTab.tsx`) having an entirely independent implementation from the canonical top-level `/automations` page (`AutomationsPage.tsx`) — same object, two drifted list implementations.

Deeper architecture question raised in review: is Automation even correctly placed as a tab inside the Agent editor at all? Investigated and settled:

- `Automation` is a first-class standalone DocType with a `Link` field to `Agent` — the relationship is **inverted** from Tools/Prompts/Knowledge (which the Agent consumes/owns). Automation *references* the Agent; the Agent has no field pointing back.
- That makes the per-agent tab a legitimate **"used by" / backlinks panel** (the same pattern as GitHub's "used by N repos" on a package page), not an owned sub-resource — genuinely useful for impact assessment before changing/deprecating an agent, and as a create-shortcut. Removing it would cost real discoverability value for no engineering win (`AutomationsPage` has no agent-filter URL param today).
- What WAS wrong: the tab was implemented as a second full CRUD surface (own fetch, own handlers, own action-icon logic) instead of a thin, correctly-labeled filtered view — exactly the shape that let it silently drift and produce the bug #725 fixed.

## What changed

1. **`frontend/src/types/automation.types.ts`**: added a shared `AutomationRow` type (both files previously declared their own identical copy).
2. **`frontend/src/hooks/useAutomationsList.ts`** (new): single data layer — fetch, per-row trigger resolution, `runNow`/`toggleStatus`/`archive` handlers, busy-state tracking, toasts. Takes an optional `{ agent }` filter. Used by both surfaces now.
3. **`frontend/src/utils/automationActions.ts`** (new): single source of truth for which actions (Open/Run now/Activate-Pause-Resume/Archive) apply to a given automation, with icon/label/busy/disabled state — closes the exact class of bug that caused the duplicate-icon issue, generalized from just the toggle icon (#725's fix) to every action.
4. **`frontend/src/components/agent/AutomationsTab.tsx`**: rewritten to consume both shared modules — all local fetch/handler logic deleted. Reframed to communicate it's a filtered "used by" view, not ownership:
   - Heading: "Automations" → **"Automations using this agent"**
   - Description: **"These automations reference this agent. Changing or deprecating the agent affects every automation listed here."**
   - Empty state: **"No automations use this agent"** / **"Nothing runs this agent automatically yet..."**
   - Added a **"View all automations"** link to the canonical list, shown whenever the agent has any.
   - Dropped the "Duplicate" action — it was a permanent `toast.info(...)` no-op stub that never existed on the canonical page.
5. **`frontend/src/pages/AutomationsPage.tsx`**: refactored onto the same two shared modules. Kept `usePageData` for search/filter only — its fetch effect (`[]` deps) can't compose with a hook that also fetches, so `usePageData` is called with no `fetchFn` and seeded via `useEffect(() => setData(list.rows), [list.rows, setData])`. Search, status filter, and card-grid rendering are otherwise unchanged.
6. **Fix from final review** (see below): `ItemCard`'s action-button type has no `disabled` field, so a descriptor computed as disabled (e.g. Archive on an already-Archived automation) was silently rendered anyway on the card view. Fixed by filtering disabled descriptors out before mapping, instead of relying on a prop the component doesn't support. Also added a missing `disabled` guard on the toggle (Activate/Pause/Resume) descriptor so it can't fire while another action is in flight for the same row.

## Process

This was planned with Opus 5 Low at two points: an architecture-decision consult before implementation (confirmed: keep the tab, extract a shared data/action layer, keep two separate *renderers* — table for the compact tab, card grid for the full page — since unifying rendering too would make the tab either too tall or lose the "Next run" column the table has room for), and a final adversarial review after implementation, which caught the Archive/disabled regression above (now fixed and re-verified) before it reached review.

## Testing

- `tsc --noEmit`, `eslint`, and the real `yarn build` all pass clean on every touched file.
- Live-verified on a disposable `frappe-multihand` bench:
  - Top-level `/automations`: search, status filter, empty states (no-results and no-automations-at-all), inline Open/Run-now, "More actions" menu (Pause + Archive, Archive styled destructive) all work as before.
  - Per-agent tab: confirmed the exact new copy above on both a populated agent (Demo Assistant, one Active automation) and an empty one (Hub Orchestrator, zero automations); confirmed "View all automations" link present only when rows exist.
  - **Regression re-verified fixed**: archived the test automation via the top-level page's menu, reloaded — the card now shows only "Open" (no Run now, no toggle, no Archive), matching the `automationCanRunNow`/`automationStatusToggleAction` contracts from #725.