### PR TITLE
fix(knowledge): overhaul Knowledge Source/Input UX per review findings

### DIFF
--- a/frontend/src/components/knowledge/GeneralTab.tsx
+++ b/frontend/src/components/knowledge/GeneralTab.tsx
@@ -5,9 +5,14 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Combobox } from '@/components/ui/combobox';
 import { Checkbox } from '@/components/ui/checkbox';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { ChevronDown } from 'lucide-react';
 import { UseFormReturn } from 'react-hook-form';
-import { useMemo } from 'react';
-import { knowledgeTypes, knowledgeScopes, knowledgeStorageModes, chromaModes, isVectorKnowledgeType } from '@/data/knowledge';
+import { useMemo, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { knowledgeTypes, knowledgeScopes, knowledgeTypePresets, chromaModes, isVectorKnowledgeType } from '@/data/knowledge';
+import type { KnowledgeTypePresetId } from '@/data/knowledge';
 import { linkRoutes } from '@/lib/link-routes';
 import type { KnowledgeSourceFormValues } from './types';
 import { AdvancedConfigFields } from './AdvancedConfigFields';
@@ -23,22 +28,53 @@ interface GeneralTabProps {
   providers?: ProviderOption[];
 }
 
+const scopeDescriptions: Record<string, string> = {
+  Site: 'Only agents and users on this site can query this knowledge base.',
+  Workspace: 'Shared across agents within the same workspace on this site.',
+  Agent: 'Private to a single agent — other agents cannot query it.',
+  Global: 'Available to every agent and site that can reach this instance.',
+};
+
+function presetIdForKnowledgeType(knowledgeType: string | undefined): KnowledgeTypePresetId {
+  const preset = knowledgeTypePresets.find((p) => p.knowledgeType === knowledgeType);
+  return preset ? preset.id : 'custom';
+}
+
 export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
   const watchKnowledgeType = form.watch('knowledge_type');
   const watchChromaMode = form.watch('chroma_mode');
   const watchPGVectorConnectionMode = form.watch('pgvector_connection_mode');
+
+  const [presetId, setPresetId] = useState<KnowledgeTypePresetId>(() =>
+    presetIdForKnowledgeType(form.getValues('knowledge_type')),
+  );
 
   const providerOptions = useMemo(
     () => providers.map((p) => ({ value: p.name, label: p.provider_name || p.name })),
     [providers],
   );
 
+  const handlePresetChange = (id: KnowledgeTypePresetId) => {
+    setPresetId(id);
+    const preset = knowledgeTypePresets.find((p) => p.id === id);
+    if (!preset || preset.knowledgeType === null) return;
+    form.setValue('knowledge_type', preset.knowledgeType, { shouldDirty: true, shouldValidate: true });
+    if ('defaults' in preset && preset.defaults) {
+      if (!form.getValues('embedding_model')?.trim()) {
+        form.setValue('embedding_model', preset.defaults.embedding_model, { shouldDirty: true });
+      }
+      if (!form.getValues('vector_dimension')) {
+        form.setValue('vector_dimension', preset.defaults.vector_dimension, { shouldDirty: true });
+      }
+    }
+  };
+
   return (
     <div className="space-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>Configuration</CardTitle>
-          <CardDescription>Basic settings for this knowledge source</CardDescription>
+          <CardTitle>Details</CardTitle>
+          <CardDescription>Name and description for this knowledge source</CardDescription>
         </CardHeader>
         <CardContent className="grid gap-6">
           {isNew && (
@@ -47,11 +83,11 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
               name="source_name"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Source name</FormLabel>
+                  <FormLabel>Name</FormLabel>
                   <FormControl>
-                    <Input placeholder="my-knowledge-source" {...field} />
+                    <Input placeholder="e.g. Product documentation" {...field} />
                   </FormControl>
-                  <FormDescription>Unique identifier for this knowledge source</FormDescription>
+                  <FormDescription>A friendly title for this knowledge source, shown throughout the app</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -77,7 +113,66 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
             )}
           />
 
-          <div className="grid gap-6 sm:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="scope"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Scope</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select scope" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {knowledgeScopes.map((scope) => (
+                      <SelectItem key={scope.value} value={scope.value}>
+                        {scope.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  Controls who can query this knowledge base. {scopeDescriptions[field.value] ?? ''}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Search type</CardTitle>
+          <CardDescription>How this knowledge source is indexed and searched</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6">
+          <RadioGroup
+            value={presetId}
+            onValueChange={(value) => handlePresetChange(value as KnowledgeTypePresetId)}
+            className="grid gap-3 sm:grid-cols-3"
+          >
+            {knowledgeTypePresets.map((preset) => (
+              <label
+                key={preset.id}
+                htmlFor={`knowledge-type-preset-${preset.id}`}
+                className={cn(
+                  'flex cursor-pointer flex-col gap-2 rounded-lg border p-4 text-sm transition-colors',
+                  presetId === preset.id ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/50',
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value={preset.id} id={`knowledge-type-preset-${preset.id}`} />
+                  <span className="font-medium">{preset.label}</span>
+                </div>
+                <span className="text-muted-foreground">{preset.description}</span>
+              </label>
+            ))}
+          </RadioGroup>
+
+          {presetId === 'custom' && (
             <FormField
               control={form.control}
               name="knowledge_type"
@@ -103,57 +198,7 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
                 </FormItem>
               )}
             />
-
-            <FormField
-              control={form.control}
-              name="scope"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Scope</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select scope" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {knowledgeScopes.map((scope) => (
-                        <SelectItem key={scope.value} value={scope.value}>
-                          {scope.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="storage_mode"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Storage mode</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select storage mode" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {knowledgeStorageModes.map((mode) => (
-                        <SelectItem key={mode.value} value={mode.value}>
-                          {mode.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
+          )}
         </CardContent>
       </Card>
 
@@ -559,7 +604,7 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-6">
-
+            <h4 className="text-sm font-medium mb-2">Advanced Configuration</h4>
             <AdvancedConfigFields knowledgeType={watchKnowledgeType} />
           </CardContent>
         </Card>
@@ -617,53 +662,64 @@ export function GeneralTab({ form, isNew, providers = [] }: GeneralTabProps) {
         </Card>
       )}
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Chunking settings</CardTitle>
-          <CardDescription>Control how content is split into chunks for indexing</CardDescription>
-        </CardHeader>
-        <CardContent className="grid gap-6 sm:grid-cols-2">
-          <FormField
-            control={form.control}
-            name="chunk_size"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Chunk size</FormLabel>
-                <FormControl>
-                  <Input
-                    type="number"
-                    placeholder="512"
-                    {...field}
-                    onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 512)}
-                  />
-                </FormControl>
-                <FormDescription>Number of characters per chunk (minimum 100)</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+      <Collapsible defaultOpen={false}>
+        <Card>
+          <CollapsibleTrigger asChild>
+            <CardHeader className="cursor-pointer select-none">
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>Advanced settings</CardTitle>
+                  <CardDescription>Control how content is split into chunks for indexing</CardDescription>
+                </div>
+                <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 [[data-state=open]_&]:rotate-180" />
+              </div>
+            </CardHeader>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <CardContent className="grid gap-6 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="chunk_size"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Chunk size</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        placeholder="512"
+                        {...field}
+                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 512)}
+                      />
+                    </FormControl>
+                    <FormDescription>Number of tokens per chunk (minimum 100)</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-          <FormField
-            control={form.control}
-            name="chunk_overlap"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Chunk overlap</FormLabel>
-                <FormControl>
-                  <Input
-                    type="number"
-                    placeholder="50"
-                    {...field}
-                    onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 50)}
-                  />
-                </FormControl>
-                <FormDescription>Overlap between adjacent chunks</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </CardContent>
-      </Card>
+              <FormField
+                control={form.control}
+                name="chunk_overlap"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Chunk overlap</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        placeholder="50"
+                        {...field}
+                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 50)}
+                      />
+                    </FormControl>
+                    <FormDescription>Overlap between adjacent chunks</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
     </div>
   );
 }

--- a/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
+++ b/frontend/src/components/knowledge/KnowledgeInputsModal.tsx
@@ -16,7 +16,17 @@ import { Textarea } from '@/components/ui/textarea';
 import { Progress } from '@/components/ui/progress';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
-import { Plus, Trash2, RefreshCw, FileText, Link, Type, Loader2, Upload, X, AlertCircle } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Plus, Trash2, RefreshCw, FileText, Link, Type, Loader2, Upload, X, AlertCircle, Info } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { knowledgeInputTypes } from '@/data/knowledge';
@@ -35,6 +45,14 @@ interface QueuedUpload {
   progress: number;
   status: 'uploading' | 'creating' | 'error';
   error?: string;
+}
+
+const INPUTS_POLL_INTERVAL_MS = 4000;
+
+const SETTLED_INPUT_STATUSES: ReadonlySet<string> = new Set(['Indexed', 'Error']);
+
+function hasUnsettledInput(list: KnowledgeInputDoc[]): boolean {
+  return list.some((input) => !SETTLED_INPUT_STATUSES.has(input.status));
 }
 
 interface KnowledgeInputsModalProps {
@@ -93,6 +111,13 @@ export function KnowledgeInputsModal({
   const [creating, setCreating] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   const [uploadQueue, setUploadQueue] = useState<QueuedUpload[]>([]);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [closeGuardOpen, setCloseGuardOpen] = useState(false);
+  const inputsRef = useRef<KnowledgeInputDoc[]>([]);
+  inputsRef.current = inputs;
+
+  const uploading = uploadQueue.some((item) => item.status === 'uploading' || item.status === 'creating');
 
   // Create form state
   const [inputType, setInputType] = useState<KnowledgeInputType>('File');
@@ -117,6 +142,36 @@ export function KnowledgeInputsModal({
       loadInputs();
     }
   }, [open, knowledgeSource, loadInputs]);
+
+  // Poll the inputs list while anything is still Pending/Processing so
+  // status badges (and the "safe to close" banner) settle on their own,
+  // mirroring the fallback-polling approach in useRunStatusPolling.
+  useEffect(() => {
+    if (!open || !knowledgeSource) return;
+    if (!hasUnsettledInput(inputsRef.current)) return;
+
+    let cancelled = false;
+    const intervalId = setInterval(async () => {
+      if (cancelled) return;
+      try {
+        const data = await getKnowledgeInputs(knowledgeSource);
+        if (cancelled) return;
+        setInputs(data);
+        if (!hasUnsettledInput(data)) {
+          onSourceChanged();
+        }
+      } catch (error) {
+        // A failed poll must not kill the fallback; the next tick retries.
+        console.error('Error polling knowledge inputs:', error);
+      }
+    }, INPUTS_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, knowledgeSource, inputs, onSourceChanged]);
 
   const resetForm = () => {
     setInputType('File');
@@ -224,15 +279,33 @@ export function KnowledgeInputsModal({
     }
   };
 
-  const handleDelete = async (name: string) => {
+  const handleDeleteConfirmed = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
     try {
-      await deleteKnowledgeInput(name);
+      await deleteKnowledgeInput(deleteTarget);
       toast.success('Knowledge input deleted');
+      setDeleteTarget(null);
       await loadInputs();
       onSourceChanged();
     } catch {
       toast.error('Failed to delete knowledge input');
+    } finally {
+      setDeleting(false);
     }
+  };
+
+  const handleModalOpenChange = (next: boolean) => {
+    if (!next && uploading) {
+      setCloseGuardOpen(true);
+      return;
+    }
+    onOpenChange(next);
+  };
+
+  const confirmCloseWhileUploading = () => {
+    setCloseGuardOpen(false);
+    onOpenChange(false);
   };
 
   const handleReprocess = async (name: string) => {
@@ -246,8 +319,10 @@ export function KnowledgeInputsModal({
     }
   };
 
+  const hasProcessingInput = inputs.some((input) => input.status === 'Processing' || input.status === 'Pending');
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleModalOpenChange}>
       <DialogScrollContent className="max-w-2xl">
         <DialogScrollHeader>
           <DialogTitle>Knowledge inputs</DialogTitle>
@@ -258,9 +333,20 @@ export function KnowledgeInputsModal({
 
         <DialogScrollBody className="space-y-4 py-2">
           <div className="flex items-center justify-between">
-            <p className="text-sm text-steel">
-              {inputs.length} {inputs.length === 1 ? 'input' : 'inputs'}
-            </p>
+            <div className="flex items-center gap-2">
+              <p className="text-sm text-steel">
+                {inputs.length} {inputs.length === 1 ? 'input' : 'inputs'}
+              </p>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => void loadInputs()}
+                disabled={loading}
+                title="Refresh"
+              >
+                <RefreshCw className={cn('w-3.5 h-3.5', loading && 'animate-spin')} />
+              </Button>
+            </div>
             <Button
               size="sm"
               variant={showCreate ? 'secondary' : 'default'}
@@ -270,6 +356,16 @@ export function KnowledgeInputsModal({
               New input
             </Button>
           </div>
+
+          {hasProcessingInput && (
+            <div className="flex items-start gap-2 rounded-md border bg-muted/40 p-2.5 text-xs text-steel-soft">
+              <Info className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+              <p>
+                Indexing runs in the background. Once your files finish uploading, it&apos;s safe to close
+                this dialog or navigate away — processing will continue.
+              </p>
+            </div>
+          )}
 
           {showCreate && (
             <div className="rounded-lg border p-4 space-y-4">
@@ -444,7 +540,7 @@ export function KnowledgeInputsModal({
                       <Button
                         variant="ghost"
                         size="icon-sm"
-                        onClick={() => handleDelete(input.name)}
+                        onClick={() => setDeleteTarget(input.name)}
                         title="Delete"
                         className="text-destructive hover:text-destructive"
                       >
@@ -458,6 +554,55 @@ export function KnowledgeInputsModal({
           )}
         </DialogScrollBody>
       </DialogScrollContent>
+
+      <AlertDialog open={deleteTarget !== null} onOpenChange={(next) => { if (!next && !deleting) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this input?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove the input and any chunks indexed from it. This action cannot
+              be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                void handleDeleteConfirmed();
+              }}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={closeGuardOpen} onOpenChange={setCloseGuardOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel upload in progress?</AlertDialogTitle>
+            <AlertDialogDescription>
+              A file is still uploading. Closing this dialog now will interrupt the upload before it
+              finishes.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep uploading</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                confirmCloseWhileUploading();
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Cancel upload and close
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   );
 }

--- a/frontend/src/components/knowledge/StatusTab.tsx
+++ b/frontend/src/components/knowledge/StatusTab.tsx
@@ -1,20 +1,43 @@
+import { useMemo, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { AlertCircle, ChevronDown, Loader2, RefreshCw, Search, Trash2 } from 'lucide-react';
 import { formatTimeAgo } from '@/utils/time';
-import type { KnowledgeSourceDoc } from '@/types/knowledge.types';
+import { cn } from '@/lib/utils';
+import { testSearch } from '@/services/knowledgeApi';
+import { getFrappeErrorMessage } from '@/lib/frappe-error';
+import type { KnowledgeInputDoc, KnowledgeSourceDoc } from '@/types/knowledge.types';
 
 interface StatusTabProps {
   source: KnowledgeSourceDoc | null;
+  inputs: KnowledgeInputDoc[];
+  inputsLoading: boolean;
+  onReprocessInput: (name: string) => Promise<void> | void;
+  onDeleteInput: (name: string) => Promise<void> | void;
+}
+
+interface TestSearchResultChunk {
+  text?: string;
+  content?: string;
+  score?: number;
+  relevance?: number;
+  source?: string;
+  file_name?: string;
+  [key: string]: unknown;
 }
 
 function getStatusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'success' | 'outline' {
   switch (status) {
     case 'Ready':
+    case 'Indexed':
       return 'success';
     case 'Indexing':
     case 'Rebuilding':
+    case 'Processing':
       return 'outline';
     case 'Error':
       return 'destructive';
@@ -31,7 +54,65 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }
 
-export function StatusTab({ source }: StatusTabProps) {
+function getInputLabel(input: KnowledgeInputDoc): string {
+  switch (input.input_type) {
+    case 'File':
+      return input.file_name || input.file || 'Untitled file';
+    case 'URL':
+      return input.url || 'Untitled URL';
+    case 'Text':
+      return input.text?.slice(0, 60) || 'Text input';
+    default:
+      return input.name;
+  }
+}
+
+function normalizeTestSearchResults(raw: unknown): TestSearchResultChunk[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw as TestSearchResultChunk[];
+  if (typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>;
+    if (Array.isArray(obj.results)) return obj.results as TestSearchResultChunk[];
+    if (Array.isArray(obj.chunks)) return obj.chunks as TestSearchResultChunk[];
+  }
+  return [];
+}
+
+export function StatusTab({ source, inputs, inputsLoading, onReprocessInput, onDeleteInput }: StatusTabProps) {
+  const [query, setQuery] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<TestSearchResultChunk[] | null>(null);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [expandedError, setExpandedError] = useState<string | null>(null);
+
+  const counts = useMemo(() => {
+    const result = { indexed: 0, processing: 0, pending: 0, error: 0 };
+    for (const input of inputs) {
+      if (input.status === 'Indexed') result.indexed += 1;
+      else if (input.status === 'Processing') result.processing += 1;
+      else if (input.status === 'Pending') result.pending += 1;
+      else if (input.status === 'Error') result.error += 1;
+    }
+    return result;
+  }, [inputs]);
+
+  const failedInputs = useMemo(() => inputs.filter((input) => input.status === 'Error'), [inputs]);
+
+  const handleTestSearch = async () => {
+    if (!source || !query.trim()) return;
+    setSearching(true);
+    setSearchError(null);
+    try {
+      const result = await testSearch(source.name, query.trim());
+      setSearchResults(normalizeTestSearchResults(result));
+    } catch (error) {
+      const msg = getFrappeErrorMessage(error);
+      setSearchError(msg || 'Failed to run test search');
+    } finally {
+      setSearching(false);
+    }
+  };
+
   if (!source) {
     return (
       <Card>
@@ -42,6 +123,10 @@ export function StatusTab({ source }: StatusTabProps) {
     );
   }
 
+  const inputsSummary = `${inputs.length} ${inputs.length === 1 ? 'input' : 'inputs'} · ${counts.indexed} indexed${
+    counts.processing ? ` · ${counts.processing} processing` : ''
+  }${counts.pending ? ` · ${counts.pending} pending` : ''}${counts.error ? ` · ${counts.error} failed` : ''}`;
+
   return (
     <div className="space-y-6">
       {source.status === 'Error' && source.error_message && (
@@ -50,6 +135,24 @@ export function StatusTab({ source }: StatusTabProps) {
           <AlertTitle>Indexing Error</AlertTitle>
           <AlertDescription className="mt-2 whitespace-pre-wrap">
             {source.error_message}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {failedInputs.length > 0 && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>
+            {failedInputs.length} {failedInputs.length === 1 ? 'input' : 'inputs'} failed to process
+          </AlertTitle>
+          <AlertDescription className="mt-2">
+            <ul className="list-disc pl-4 space-y-0.5">
+              {failedInputs.map((input) => (
+                <li key={input.name} className="text-sm">
+                  {getInputLabel(input)}
+                </li>
+              ))}
+            </ul>
           </AlertDescription>
         </Alert>
       )}
@@ -79,8 +182,8 @@ export function StatusTab({ source }: StatusTabProps) {
             </div>
 
             <div className="space-y-1">
-              <p className="text-sm font-medium text-steel">Total Inputs</p>
-              <p className="text-sm">{source.total_inputs.toLocaleString()}</p>
+              <p className="text-sm font-medium text-steel">Inputs</p>
+              <p className="text-sm">{inputsSummary}</p>
             </div>
 
             <div className="space-y-1">
@@ -105,14 +208,167 @@ export function StatusTab({ source }: StatusTabProps) {
                 )}
               </div>
             )}
-
-            {source.sqlite_file_path && source.knowledge_type !== 'chroma' && (
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-steel">SQLite File</p>
-                <p className="text-sm font-mono text-xs break-all">{source.sqlite_file_path}</p>
-              </div>
-            )}
           </div>
+
+          {source.sqlite_file_path && source.knowledge_type !== 'chroma' && (
+            <Collapsible className="mt-6 border-t pt-4">
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center gap-1.5 text-sm font-medium text-steel hover:text-foreground"
+                >
+                  <ChevronDown className="h-3.5 w-3.5" />
+                  Advanced / technical details
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-3 space-y-1">
+                <p className="text-xs text-steel-soft">Internal storage path (server filesystem)</p>
+                <p className="text-sm font-mono text-xs break-all">{source.sqlite_file_path}</p>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Inputs</CardTitle>
+          <CardDescription>Individual content items and their processing status</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {inputsLoading && inputs.length === 0 ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-5 h-5 animate-spin text-steel-soft" />
+            </div>
+          ) : inputs.length === 0 ? (
+            <div className="text-center py-8 font-body text-steel text-sm">
+              No knowledge inputs yet. Add one to get started.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {inputs.map((input) => {
+                const isErrored = input.status === 'Error';
+                const isExpanded = expandedError === input.name;
+                return (
+                  <div key={input.name} className="rounded-md border p-3 space-y-2">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">{getInputLabel(input)}</p>
+                        <div className="flex items-center gap-2 mt-1">
+                          <Badge variant={getStatusVariant(input.status)} size="sm">
+                            {input.status}
+                          </Badge>
+                          <span className="text-xs text-steel-soft">
+                            {input.chunks_created.toLocaleString()} chunks
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        {isErrored && input.error_message && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setExpandedError(isExpanded ? null : input.name)}
+                          >
+                            {isExpanded ? 'Hide error' : 'Show error'}
+                          </Button>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => void onReprocessInput(input.name)}
+                          title="Retry"
+                          disabled={input.status === 'Pending' || input.status === 'Processing'}
+                        >
+                          <RefreshCw
+                            className={cn('w-3.5 h-3.5', input.status === 'Processing' && 'animate-spin')}
+                          />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => void onDeleteInput(input.name)}
+                          title="Remove"
+                          className="text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                    {isErrored && isExpanded && input.error_message && (
+                      <p className="text-xs text-destructive whitespace-pre-wrap break-words rounded bg-destructive/5 p-2">
+                        {input.error_message}
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Test search</CardTitle>
+          <CardDescription>Run a query against this knowledge source to verify it returns useful results</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Input
+              placeholder="Ask a question or enter search terms..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void handleTestSearch();
+                }
+              }}
+            />
+            <Button onClick={() => void handleTestSearch()} disabled={searching || !query.trim()}>
+              {searching ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Search className="w-4 h-4 mr-2" />}
+              Search
+            </Button>
+          </div>
+
+          {searchError && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{searchError}</AlertDescription>
+            </Alert>
+          )}
+
+          {!searchError && searchResults !== null && (
+            searchResults.length === 0 ? (
+              <p className="text-sm text-steel py-4 text-center">No matching results found.</p>
+            ) : (
+              <div className="space-y-2">
+                {searchResults.map((result, index) => {
+                  const text = result.text ?? result.content ?? '';
+                  const score = result.score ?? result.relevance;
+                  const label = result.file_name ?? result.source;
+                  return (
+                    <div key={index} className="rounded-md border p-3 space-y-1">
+                      <div className="flex items-center justify-between gap-2">
+                        {label ? (
+                          <p className="text-xs font-medium text-steel truncate">{String(label)}</p>
+                        ) : (
+                          <span />
+                        )}
+                        {typeof score === 'number' && (
+                          <Badge variant="outline" size="sm">
+                            score {score.toFixed(3)}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-sm whitespace-pre-wrap">{String(text)}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            )
+          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/data/knowledge.ts
+++ b/frontend/src/data/knowledge.ts
@@ -17,6 +17,38 @@ export const knowledgeTypes = [
 
 ] as const;
 
+/**
+ * Preset options shown on the Knowledge Source form to steer first-time users
+ * away from raw backend names. "Connect my own vector database" reveals the
+ * full `knowledgeTypes` select plus per-backend advanced settings.
+ */
+export const knowledgeTypePresets = [
+	{
+		id: 'keyword',
+		label: 'Keyword search (no setup)',
+		description: 'Fast full-text search out of the box. No embedding model or extra configuration required.',
+		knowledgeType: 'sqlite_fts' as const,
+	},
+	{
+		id: 'semantic',
+		label: 'Semantic search (recommended)',
+		description: 'Understands meaning, not just keywords. Runs in-process with a portable file — no server to run.',
+		knowledgeType: 'zvec' as const,
+		defaults: {
+			embedding_model: 'text-embedding-3-small',
+			vector_dimension: 1536,
+		},
+	},
+	{
+		id: 'custom',
+		label: 'Connect my own vector database',
+		description: 'Choose a specific backend (ChromaDB, PGVector, Redis, Weaviate, FAISS, Pinecone, etc.) and configure its connection directly.',
+		knowledgeType: null,
+	},
+] as const;
+
+export type KnowledgeTypePresetId = (typeof knowledgeTypePresets)[number]['id'];
+
 export type KnowledgeTypeOption = (typeof knowledgeTypes)[number]['value'];
 
 export const VECTOR_KNOWLEDGE_TYPES = [

--- a/frontend/src/pages/KnowledgeSourceFormPage.tsx
+++ b/frontend/src/pages/KnowledgeSourceFormPage.tsx
@@ -10,7 +10,11 @@ import {
   createKnowledgeSource,
   updateKnowledgeSource,
   rebuildIndex,
+  getKnowledgeInputs,
+  reprocessInput,
+  deleteKnowledgeInput,
 } from '../services/knowledgeApi';
+import type { KnowledgeInputDoc } from '../types/knowledge.types';
 import { getProviders } from '../services/providerApi';
 import type { AIProvider } from '../types/agent.types';
 import { getFrappeErrorMessage } from '../lib/frappe-error';
@@ -181,6 +185,8 @@ function KnowledgeSourceFormPage() {
   const [inputsModalOpen, setInputsModalOpen] = useState(false);
   const [sourceDoc, setSourceDoc] = useState<KnowledgeSourceDoc | null>(null);
   const [providers, setProviders] = useState<AIProvider[]>([]);
+  const [inputs, setInputs] = useState<KnowledgeInputDoc[]>([]);
+  const [inputsLoading, setInputsLoading] = useState(false);
   const allowNavigationRef = useRef(false);
 
   const form = useForm<KnowledgeSourceFormValues>({
@@ -232,6 +238,21 @@ function KnowledgeSourceFormPage() {
     [form],
   );
 
+  const loadInputs = useCallback(
+    async (name: string) => {
+      setInputsLoading(true);
+      try {
+        const data = await getKnowledgeInputs(name);
+        setInputs(data);
+      } catch (error) {
+        console.error('Error loading knowledge inputs:', error);
+      } finally {
+        setInputsLoading(false);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     getProviders()
       .then((data) => setProviders(data as AIProvider[]))
@@ -240,11 +261,30 @@ function KnowledgeSourceFormPage() {
 
   useEffect(() => {
     if (id && !isNew) {
-      loadSource(id).then(() => setLoading(false));
+      Promise.all([loadSource(id), loadInputs(id)]).then(() => setLoading(false));
     } else if (isNew) {
       setLoading(false);
     }
-  }, [id, isNew, loadSource]);
+  }, [id, isNew, loadSource, loadInputs]);
+
+  // Poll source status + inputs while indexing/rebuilding is in flight, so the
+  // Status tab reflects progress without the user manually refreshing.
+  const IN_PROGRESS_SOURCE_STATUSES = useMemo(() => new Set(['Indexing', 'Rebuilding']), []);
+  const IN_PROGRESS_INPUT_STATUSES = useMemo(() => new Set(['Pending', 'Processing']), []);
+  const isSourceInProgress = !!sourceDoc && IN_PROGRESS_SOURCE_STATUSES.has(sourceDoc.status);
+  const hasInProgressInput = inputs.some((input) => IN_PROGRESS_INPUT_STATUSES.has(input.status));
+  const STATUS_POLL_INTERVAL_MS = 4000;
+
+  useEffect(() => {
+    if (isNew || !id) return;
+    if (!isSourceInProgress && !hasInProgressInput) return;
+
+    const intervalId = setInterval(() => {
+      void Promise.all([loadSource(id), loadInputs(id)]);
+    }, STATUS_POLL_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [isNew, id, isSourceInProgress, hasInProgressInput, loadSource, loadInputs]);
 
   // After a freshly-created source redirects here with ?upload=1, jump straight
   // into the inputs modal so uploading files doesn't need an extra click.
@@ -354,8 +394,8 @@ function KnowledgeSourceFormPage() {
     setRebuilding(true);
     try {
       await rebuildIndex(id);
-      toast.success('Rebuild started. Refresh to check progress.');
-      await loadSource(id);
+      toast.success('Rebuild started');
+      await Promise.all([loadSource(id), loadInputs(id)]);
     } catch (error) {
       const msg = getFrappeErrorMessage(error);
       toast.error(msg || 'Failed to start rebuild');
@@ -368,7 +408,7 @@ function KnowledgeSourceFormPage() {
     if (!id || isNew) return;
     setRefreshing(true);
     try {
-      await loadSource(id);
+      await Promise.all([loadSource(id), loadInputs(id)]);
       toast.success('Refreshed');
     } catch {
       toast.error('Failed to refresh');
@@ -379,7 +419,29 @@ function KnowledgeSourceFormPage() {
 
   const handleSourceChanged = async () => {
     if (id && !isNew) {
-      await loadSource(id);
+      await Promise.all([loadSource(id), loadInputs(id)]);
+    }
+  };
+
+  const handleReprocessInput = async (name: string) => {
+    try {
+      await reprocessInput(name);
+      toast.success('Reprocessing started');
+      if (id) await Promise.all([loadSource(id), loadInputs(id)]);
+    } catch (error) {
+      const msg = getFrappeErrorMessage(error);
+      toast.error(msg || 'Failed to reprocess knowledge input');
+    }
+  };
+
+  const handleDeleteInput = async (name: string) => {
+    try {
+      await deleteKnowledgeInput(name);
+      toast.success('Knowledge input deleted');
+      if (id) await Promise.all([loadSource(id), loadInputs(id)]);
+    } catch (error) {
+      const msg = getFrappeErrorMessage(error);
+      toast.error(msg || 'Failed to delete knowledge input');
     }
   };
 
@@ -431,7 +493,13 @@ function KnowledgeSourceFormPage() {
               </TabsContent>
 
               <TabsContent value="status" className="space-y-4">
-                <StatusTab source={sourceDoc} />
+                <StatusTab
+                  source={sourceDoc}
+                  inputs={inputs}
+                  inputsLoading={inputsLoading}
+                  onReprocessInput={handleReprocessInput}
+                  onDeleteInput={handleDeleteInput}
+                />
               </TabsContent>
             </Tabs>
           </form>


### PR DESCRIPTION
## Problem

An internal UX review of the Knowledge Source / Input flow found three areas that exposed raw backend implementation details, gave no live feedback during indexing, and had no per-file visibility into failures:

1. **Config form** — a no-op "Storage mode" dropdown, a raw `knowledge_type` backend-name picker (`sqlite_fts`, `zvec`, `pgvector`, ...) with no guidance on what to choose, chunking settings mixed in with everything else, an inaccurate "characters" description on chunk size (it's actually tokens), and a "Configuration" section title/Name field framed like a slug rather than the page's own title.
2. **Upload modal** — no live status updates while files indexed (had to manually reload), no guard against closing mid-upload, and inputs were deleted immediately on clicking the trash icon with no confirmation.
3. **Status tab** — just a bare "Total Inputs: N" stat with no per-file breakdown, no visibility into which specific file failed or why, and the existing `testSearch` API was wired up server-side but never exposed in the UI.

## Changes

**Configuration form** (`GeneralTab.tsx`, `data/knowledge.ts`):
- Removed the no-op "Storage mode" dropdown
- Replaced the raw `knowledge_type` dropdown with three outcome-framed presets — "Keyword search (no setup)", "Semantic search (recommended)", "Connect my own vector database" — the last of which reveals the original backend dropdown (SQLite FTS/Vec/Hybrid, ChromaDB, PGVector, zvec, Redis, Weaviate, FAISS, Pinecone) and its per-backend advanced cards, unchanged
- Collapsed chunk size/overlap behind an "Advanced settings" section, and fixed the chunk size help text to say "tokens" (verified against LlamaIndex's `SentenceSplitter`)
- Added a description to the Scope field, retitled "Configuration" → "Details", and reframed the Name field as a friendly title
- Added an "Advanced Configuration" heading to the Redis card for parity with Chroma/PGVector/zvec

**Upload modal** (`KnowledgeInputsModal.tsx`):
- Polls the inputs list while anything is Pending/Processing, plus a manual refresh button
- Guards modal close against an in-flight browser upload; shows a "safe to close, indexing continues in the background" banner while server-side indexing is running
- Multi-file select uploads and creates each input in one step (no separate Upload-then-Create click), each file getting its own row/status
- Added a delete confirmation dialog (previously deleted immediately)

**Status tab + page wiring** (`StatusTab.tsx`, `KnowledgeSourceFormPage.tsx`):
- Lifted the knowledge-inputs fetch to page level, shared with the modal
- Replaced the bare aggregate stat with a real status breakdown, a per-input list (full error text, inline Retry/Remove), and a destructive alert summarizing failed files
- Auto-polls source + inputs while indexing/rebuilding is in flight
- Moved the raw `sqlite_file_path` into a collapsed "Advanced / technical details" section
- Added a "Test search" panel wired to the existing (previously unused) `testSearch` API

## Testing

`yarn typecheck` and `yarn build` pass clean in `frontend/`.

Live-verified end-to-end on a disposable bench (`frappe-multihand`, bench `nltk-pathsec-fix`, this branch built via `bench build --app huf`), authenticated as Administrator:

- **New source / preset flow**: `/huf/knowledge/new` shows the "Details" card, friendly Name field, and a real Scope description. All three Search type preset cards render; selecting "Semantic search" reveals a prefilled embedding model (`text-embedding-3-small`) + vector dimension (`1536`); selecting "Connect my own vector database" reveals the full backend dropdown and, on selecting Redis, an "Advanced Configuration" heading above its connection fields. "Advanced settings" is collapsed by default and its chunk size field now reads "Number of tokens per chunk (minimum 100)".
- **Existing source regression**: opened the pre-existing `PathsecPdfTest` source (backend `sqlite_fts`) — loads and edits fine, correctly shows "Keyword search" selected, no broken fields.
- **Upload modal**: uploaded 2 files at once via a multi-select file picker — each got its own row (Pending → auto-polled to Indexed with no manual refresh), a single step with no separate Upload/Create click, and the "indexing continues in background" banner appeared. Clicking the trash icon on an input shows a "Delete this input?" confirmation dialog before it actually deletes; confirmed both cancel and confirm paths, then cleaned up the test uploads.
- **Status tab**: shows the per-input breakdown (file name, status, chunk count, Retry/Remove) rather than a bare aggregate. Ran "Test search" with a real query against the indexed PDF content — returned actual scored results from the search API.
- **Console check**: no new JS errors introduced; only the pre-existing "Socket connection failed" toast (expected — this bench has no socketio running).
